### PR TITLE
Update alpha/beta docs for official HA Matter add-on beta

### DIFF
--- a/ALPHABETATESTS.md
+++ b/ALPHABETATESTS.md
@@ -16,9 +16,9 @@ The main goals of this phase are to:
 * (If possible) Add the temporary server location as a Home Assistant Matter integration to a (test?) HA instance and validate functionality there too (all entities are discovered correctly, data updates, etc.)
 * (If possible) After deleting/adding nodes in the Matter Server, copy back the `<long-number>.json` to the Python server, and new nodes should connect there too and show up in HA; deleted nodes should disappear from HA
 
-### Phase 2: Official Release for all "Beta" HA Addon Users
+### Phase 2: Official Release for all "Beta" HA Addon Users (released 22.01.2026)
 
-Once we have verified the basic functionality of the new Matter Server, we will officially release the HA add-on as a beta version. All users of the HA add-on who chose "Beta" will use this as their main Matter Server. If issues occur, it can be switched back to the python-matter-server by disabling the beta version in the HA add-on.
+The Matter Server add-on version 8.2.0 was released with a beta toggle for the Matter.js-based server. All users of the HA add-on who enable "Beta" will use this as their main Matter Server. If issues occur, it can be switched back to the python-matter-server by disabling the beta version in the HA add-on.
 
 
 ### Phase 3: Official Release for all "Stable" HA Addon Users


### PR DESCRIPTION
This PR updates the alpha/beta documentation with the most recent information on how to install the new Matter server based on Matter.js with the version 8.2.0 of the official Matter server add-on and the "Beta" switch.

- The section for that is also moved further to the top, as this is the information most (HA) beta users will need to migrate and test.
- The "Alpha Test Instructions" section was renamed to "Manual Test Instructions" to indicate the sections following are mostly relevant when manually installing the Matter.js-server from Git on a separate system, not via the HA add-on.
- Lastly, "Phase 2" at the top of the document was updated to indicate the beta phase, with Matter.js being included in the official HA add-on as an option, has now started.
