### PR TITLE
Combine dep install, compile and cleanup in a single image layer

### DIFF
--- a/docker/matterjs-server/Dockerfile
+++ b/docker/matterjs-server/Dockerfile
@@ -5,6 +5,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 WORKDIR /app
 
+# Version of matter-server to install from npm
+ARG MATTERJS_SERVER_VERSION
+
 # Install required system dependencies
 # Runtime dependencies:
 # - iputils-ping: Required for node ping functionality
@@ -27,16 +30,8 @@ RUN \
         bluez \
         libbluetooth-dev \
         libudev-dev \
-    && rm -rf \
-        /var/lib/apt/lists/* \
-        /usr/src/*
-
-# Version of matter-server to install from npm
-ARG MATTERJS_SERVER_VERSION
-
-# Install matter-server from npm and optimize image size
-RUN \
-    set -x \
+    # Install matter-server from npm and optimize image size
+    && set -x \
     && npm install "matter-server@${MATTERJS_SERVER_VERSION}" \
     # Remove build dependencies (no longer needed after native modules are compiled)
     && apt-get purge -y --auto-remove \
@@ -46,7 +41,9 @@ RUN \
         g++ \
         libbluetooth-dev \
         libudev-dev \
-    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /usr/src/* \
     # Remove corepack (not needed at runtime)
     && npm uninstall -g corepack \
     # Clean npm cache


### PR DESCRIPTION
This PR (made against the dev branch `add-ble-deps`) combines the build dep install, npm install and build dep cleanup steps into the same `RUN` directive (single docker image layer) to reduce image size significantly.

Background info:
Docker images are a series of layers (tarballs). Each `RUN` directive results in a separate layer/tarball. Installing build deps in one layer and then removing them in a different layer will result in the build deps being unnecessarily included in the final image (earlier layer/tarball).

This PR makes sure the deps are removed and cleaned up in the same image layer and thus not being included in the final image.

I tested a locally built image and ble works.