### PR TITLE
Add endpoint icons to MatterNodeView

### DIFF
--- a/packages/dashboard/src/pages/matter-node-view.ts
+++ b/packages/dashboard/src/pages/matter-node-view.ts
@@ -14,7 +14,7 @@ import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { guard } from "lit/directives/guard.js";
 import "../components/ha-svg-icon";
-import { getDeviceIcon } from "../util/device-icons.js";
+import { getDeviceIcon, getEndpointIcon } from "../util/device-icons.js";
 import { formatNodeAddress, getEffectiveFabricIndex } from "../util/format_hex.js";
 import "./components/header";
 import "./components/node-details";
@@ -101,6 +101,11 @@ class MatterNodeView extends LitElement {
                         getUniqueEndpoints(this.node!).map(endPointId => {
                             return html`
                                 <md-list-item type="link" href=${`#node/${this.node!.node_id}/${endPointId}`}>
+                                    <ha-svg-icon
+                                        slot="start"
+                                        class="endpoint-icon"
+                                        .path=${getEndpointIcon(this.node!, endPointId)}
+                                    ></ha-svg-icon>
                                     <div slot="headline">Endpoint ${endPointId}</div>
                                     <div slot="supporting-text">
                                         Device Type(s):
@@ -164,6 +169,10 @@ class MatterNodeView extends LitElement {
         .node-icon {
             --icon-primary-color: var(--md-sys-color-on-surface-variant, #666);
             --mdc-icon-size: 28px;
+        }
+
+        .endpoint-icon {
+            --icon-primary-color: var(--md-sys-color-on-surface-variant, #666);
         }
 
         .node-title-bar h2 {

--- a/packages/dashboard/src/util/device-icons.ts
+++ b/packages/dashboard/src/util/device-icons.ts
@@ -369,6 +369,36 @@ export function getPrimaryDeviceType(node: MatterNode): number | undefined {
 }
 
 /**
+ * Gets the appropriate MDI icon path for a specific endpoint on a node.
+ * Prefers non-utility device types when present.
+ */
+export function getEndpointIcon(node: MatterNode, endpoint: number): string {
+    const deviceTypeList = node.attributes[`${endpoint}/29/0`] as Array<Record<string, number>> | undefined;
+    if (!deviceTypeList?.length) {
+        return mdiChip;
+    }
+
+    let firstFound: number | undefined;
+
+    for (const entry of deviceTypeList) {
+        const deviceType = extractDeviceType(entry);
+        if (deviceType === undefined) continue;
+
+        firstFound ??= deviceType;
+
+        if (deviceTypeToIcon[deviceType] && !UTILITY_TYPES.has(deviceType)) {
+            return deviceTypeToIcon[deviceType];
+        }
+    }
+
+    if (firstFound !== undefined && deviceTypeToIcon[firstFound]) {
+        return deviceTypeToIcon[firstFound];
+    }
+
+    return mdiChip;
+}
+
+/**
  * Gets the appropriate MDI icon path for a node.
  * Considers device type and Thread role.
  */


### PR DESCRIPTION
**PR Summary**  
- Add endpoint-level icon selection to the dashboard by deriving icons from each endpoint’s `DeviceTypeList`, with sensible fallbacks.  
- Render those endpoint icons in the node endpoints list to make the Endpoint panel visually informative.  

**Files Changed**  
- device-icons.ts  
- matter-node-view.ts  

**Tests**  
- `npm run build`

**Issue**
- https://github.com/matter-js/matterjs-server/issues/256

<img width="466" height="1154" alt="image" src="https://github.com/user-attachments/assets/5a35889b-af1e-44a8-9f10-4012ffa47660" />

