### PR TITLE
Dockerfile, Dockerfile.dev: use Debian trixie as base

### DIFF
--- a/docker/matterjs-server/Dockerfile
+++ b/docker/matterjs-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim
+FROM node:22-trixie-slim
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/docker/matterjs-server/Dockerfile.dev
+++ b/docker/matterjs-server/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:22-bookworm-slim
+FROM node:22-trixie-slim
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
Debian bookworm will not receive security updates after June 10, 2026.