### PR TITLE
Add README and project URLs to pyproject.toml for PyPI

### DIFF
--- a/python_client/pyproject.toml
+++ b/python_client/pyproject.toml
@@ -21,9 +21,16 @@ dependencies = [
 description = "Python Client for the OHF Matter Server"
 license = "Apache-2.0"
 name = "matter-python-client"
+readme = "README.md"
 requires-python = ">=3.12"
 # The version is set by CI on release
 version = "0.0.0"
+
+[project.urls]
+"Homepage" = "https://github.com/matter-js/matterjs-server"
+"Source" = "https://github.com/matter-js/matterjs-server/tree/main/python_client"
+"Bug Tracker" = "https://github.com/matter-js/matterjs-server/issues"
+"Changelog" = "https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
Wire up README.md as the package description so PyPI shows the project info page, and add homepage/source/issue tracker/changelog URLs.