### PR TITLE
docker.md: add new troubleshooting item about device discovery via host BLE

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -85,22 +85,22 @@ For all available options, see the [CLI documentation](cli.md).
 
 All CLI options can be configured via environment variables, making it easy to configure the server without passing command-line arguments.
 
-| Variable              | Description                                          | Default              | Values / Notes                                           |
-|-----------------------|------------------------------------------------------|----------------------|----------------------------------------------------------|
-| `STORAGE_PATH`        | Path to store Matter fabric data                     | `/data`              | Any valid path                                           |
-| `PORT`                | WebSocket server port                                | `5580`               | Any valid port number                                    |
-| `LISTEN_ADDRESS`      | IP address to bind WebSocket server                  | (all interfaces)     | Single IP address (use CLI for multiple)                 |
-| `LOG_LEVEL`           | Server logging verbosity                             | `info`               | `critical`, `error`, `warning`, `info`, `debug`, `verbose` |
-| `LOG_FILE`            | Log file path                                        | (none)               | Any valid file path                                      |
-| `PRIMARY_INTERFACE`   | Primary network interface for mDNS                   | (auto-detect)        | e.g., `eth0`, `en0`                                      |
-| `ENABLE_TEST_NET_DCL` | Enable test-net DCL certificates                     | `false`              | `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`          |
-| `BLUETOOTH_ADAPTER`   | Bluetooth adapter HCI ID                             | (none)               | e.g., `0` for `hci0`                                     |
-| `DISABLE_OTA`         | Disable OTA update functionality                     | `false`              | `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`          |
-| `OTA_PROVIDER_DIR`    | Directory for OTA Provider files                     | (none)               | Any valid directory path                                 |
-| `DISABLE_DASHBOARD`   | Disable the web dashboard                            | `false`              | `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`          |
-| `PRODUCTION_MODE`     | Force dashboard production mode (reverse proxy)      | `false`              | `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`          |
-| `VENDOR_ID`           | Vendor ID for the Fabric                             | `0xfff1`             | Any valid vendor ID                                      |
-| `FABRIC_ID`           | Fabric ID for the Fabric                             | `1`                  | Any valid fabric ID                                      |
+| Variable              | Description                                          | Default              | Values / Notes                                                                  |
+|-----------------------|------------------------------------------------------|----------------------|---------------------------------------------------------------------------------|
+| `STORAGE_PATH`        | Path to store Matter fabric data                     | `/data`              | Any valid path                                                                  |
+| `PORT`                | WebSocket server port                                | `5580`               | Any valid port number                                                           |
+| `LISTEN_ADDRESS`      | IP address to bind WebSocket server                  | (all interfaces)     | Single IP address (use CLI for multiple)                                        |
+| `LOG_LEVEL`           | Server logging verbosity                             | `info`               | `critical`, `error`, `warning`, `info`, `debug`, `verbose`                      |
+| `LOG_FILE`            | Log file path                                        | (none)               | Any valid file path                                                             |
+| `PRIMARY_INTERFACE`   | Primary network interface for mDNS                   | (auto-detect)        | e.g., `eth0`, `en0`                                                             |
+| `ENABLE_TEST_NET_DCL` | Enable test-net DCL certificates                     | `false`              | `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`                                 |
+| `BLUETOOTH_ADAPTER`   | Bluetooth adapter HCI ID                             | (none)               | e.g., `0` for `hci0`, but see [this workaround](#device-discovery-via-host-ble) |
+| `DISABLE_OTA`         | Disable OTA update functionality                     | `false`              | `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`                                 |
+| `OTA_PROVIDER_DIR`    | Directory for OTA Provider files                     | (none)               | Any valid directory path                                                        |
+| `DISABLE_DASHBOARD`   | Disable the web dashboard                            | `false`              | `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`                                 |
+| `PRODUCTION_MODE`     | Force dashboard production mode (reverse proxy)      | `false`              | `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`                                 |
+| `VENDOR_ID`           | Vendor ID for the Fabric                             | `0xfff1`             | Any valid vendor ID                                                             |
+| `FABRIC_ID`           | Fabric ID for the Fabric                             | `1`                  | Any valid fabric ID                                                             |
 
 > [!NOTE]
 > The `LISTEN_ADDRESS` environment variable only supports a single address. Use the CLI `--listen-address` option (repeatable) to bind to multiple addresses.
@@ -206,3 +206,14 @@ docker logs -f matterjs-server
 # Docker Compose
 docker compose logs -f
 ```
+
+### Device discovery via host BLE
+
+For security reasons, by default the matter.js server is run as an unprivileged user in Docker. Unfortunately, up to now we didn't find a way to grant access to a specific HCI device to unprivileged users.
+
+If you need to discover Matter devices via the hosts BLE, you can use this workaround:
+1. Stop the docker container
+2. Use `chown -R 0:0 /path-to-data-volume`
+3. Run docker with the root user `docker run --user=0:0 …` (for compose: `user: 0:0`)
+
+However, be aware this workaround effectively disables container isolation. For this reason, using other means of device commissioning (e.g. via the Home Assistant app) are preferred to applying this workaround.


### PR DESCRIPTION
This also links the new item from the description of the `BLUETOOTH_ADAPTER` variable.