### PR TITLE
Replace console.log with logger.debug in WebSocketControllerHandler

### DIFF
--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -361,7 +361,7 @@ export class WebSocketControllerHandler implements WebServerHandler {
                 }
             }
         });
-        console.log("send close to clients");
+        logger.debug("Sending close message to clients");
 
         const wss = this.#wss;
         // Wait for the WebSocket server to close properly


### PR DESCRIPTION
## Summary
- Replaces stray `console.log("send close to clients")` with `logger.debug("Sending close message to clients")` for consistency with the rest of the file

Fixes #422

## Test plan
- [x] Verified `logger` is already imported and initialized at line 44
- [x] Build passes
- [x] Lint passes
- [x] Format passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)