### PR TITLE
Standardize empty response types across WS protocol

### DIFF
--- a/packages/ws-client/src/models/model.ts
+++ b/packages/ws-client/src/models/model.ts
@@ -49,11 +49,11 @@ export interface APICommands {
     };
     set_wifi_credentials: {
         requestArgs: { ssid: string; credentials: string };
-        response: Record<string, never>;
+        response: null;
     };
     set_thread_dataset: {
         requestArgs: { dataset: string };
-        response: Record<string, never>;
+        response: null;
     };
     open_commissioning_window: {
         requestArgs: {
@@ -96,7 +96,7 @@ export interface APICommands {
     };
     subscribe_attribute: {
         requestArgs: Record<string, never>;
-        response: Record<string, never>;
+        response: null;
     };
     read_attribute: {
         requestArgs: {
@@ -147,7 +147,7 @@ export interface APICommands {
     };
     remove_matter_fabric: {
         requestArgs: { node_id: number | bigint; fabric_index: number };
-        response: Record<string, never>;
+        response: null;
     };
     set_acl_entry: {
         requestArgs: { node_id: number | bigint; entry: AccessControlEntry[] };
@@ -159,7 +159,7 @@ export interface APICommands {
     };
     set_default_fabric_label: {
         requestArgs: { label: string | null };
-        response: Record<string, never>;
+        response: null;
     };
     get_loglevel: {
         requestArgs: Record<string, never>;

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -867,7 +867,7 @@ export class WebSocketControllerHandler implements WebServerHandler {
         } catch (error) {
             logger.warn("Failed to broadcast server info update", error);
         }
-        return {};
+        return null;
     }
 
     async #handleSetThreadDataset(args: ArgsOf<"set_thread_dataset">): Promise<ResponseOf<"set_thread_dataset">> {
@@ -879,7 +879,7 @@ export class WebSocketControllerHandler implements WebServerHandler {
         } catch (error) {
             logger.warn("Failed to broadcast server info update", error);
         }
-        return {};
+        return null;
     }
 
     async #handleOpenCommissioningWindow(
@@ -958,7 +958,7 @@ export class WebSocketControllerHandler implements WebServerHandler {
     async #handleRemoveMatterFabric(args: ArgsOf<"remove_matter_fabric">): Promise<ResponseOf<"remove_matter_fabric">> {
         const { node_id, fabric_index } = args;
         await this.#commandHandler.removeFabric(NodeId(node_id), FabricIndex(fabric_index));
-        return {};
+        return null;
     }
 
     async #handleSetAclEntry(args: ArgsOf<"set_acl_entry">): Promise<ResponseOf<"set_acl_entry">> {

--- a/packages/ws-controller/src/types/WebSocketMessageTypes.ts
+++ b/packages/ws-controller/src/types/WebSocketMessageTypes.ts
@@ -143,7 +143,7 @@ export interface APICommands {
         response: { [key: string]: string };
     };
     subscribe_attribute: {
-        requestArgs: {};
+        requestArgs: Record<string, never>;
         response: null;
     };
     read_attribute: {

--- a/packages/ws-controller/src/types/WebSocketMessageTypes.ts
+++ b/packages/ws-controller/src/types/WebSocketMessageTypes.ts
@@ -85,13 +85,13 @@ export interface APICommands {
             ssid: string;
             credentials: string;
         };
-        response: {};
+        response: null;
     };
     set_thread_dataset: {
         requestArgs: {
             dataset: string;
         };
-        response: {};
+        response: null;
     };
     open_commissioning_window: {
         requestArgs: {
@@ -144,7 +144,7 @@ export interface APICommands {
     };
     subscribe_attribute: {
         requestArgs: {};
-        response: {};
+        response: null;
     };
     read_attribute: {
         requestArgs: {
@@ -214,7 +214,7 @@ export interface APICommands {
             node_id: number | bigint;
             fabric_index: number;
         };
-        response: {};
+        response: null;
     };
     set_acl_entry: {
         requestArgs: {


### PR DESCRIPTION
## Summary
- Standardize all void command responses from `{}` / `Record<string, never>` to `null`
- Updated in both ws-controller (types + handlers) and ws-client (model types)
- Affects: set_wifi_credentials, set_thread_dataset, subscribe_attribute, remove_matter_fabric, set_default_fabric_label

**Note on wire-protocol change:** This is an intentional standardization. The `set_default_fabric_label` command already used `response: null` on the server side — only the client type needed alignment. For the other commands, the handler return values are updated to match. The Home Assistant Matter integration (the primary consumer) handles both `null` and `{}` responses for void commands.

## Test plan
- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes

Fixes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)