### PR TITLE
Add safe BigInt-to-number conversion utility

### DIFF
--- a/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
@@ -76,16 +76,21 @@ export class NodeBindingDialog extends LitElement {
         }
     }
 
-    /** Helper to safely convert node_id (number | bigint) to number for API calls */
+    /**
+     * Safely convert node_id (number | bigint) to number for API calls.
+     * Mirrors safeNodeIdToNumber() from @matter-server/ws-controller — inlined
+     * here because the dashboard should not depend on the server-side package.
+     */
     private getNodeIdAsNumber(): number {
         const nodeId = this.node!.node_id;
         if (typeof nodeId === "bigint") {
-            if (nodeId > BigInt(Number.MAX_SAFE_INTEGER)) {
-                throw new RangeError(
-                    `Node ID ${nodeId} exceeds Number.MAX_SAFE_INTEGER and cannot be safely converted`,
-                );
+            if (nodeId < 0n || nodeId > BigInt(Number.MAX_SAFE_INTEGER)) {
+                throw new RangeError(`Node ID ${nodeId} cannot be safely converted to number`);
             }
             return Number(nodeId);
+        }
+        if (!Number.isSafeInteger(nodeId) || nodeId < 0) {
+            throw new RangeError(`Node ID ${nodeId} is not a non-negative safe integer`);
         }
         return nodeId;
     }

--- a/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
@@ -76,10 +76,16 @@ export class NodeBindingDialog extends LitElement {
         }
     }
 
-    /** Helper to convert node_id (number | bigint) to number for API calls */
+    /** Helper to safely convert node_id (number | bigint) to number for API calls */
     private getNodeIdAsNumber(): number {
         const nodeId = this.node!.node_id;
-        return typeof nodeId === "bigint" ? Number(nodeId) : nodeId;
+        if (typeof nodeId === "bigint") {
+            if (nodeId > BigInt(Number.MAX_SAFE_INTEGER)) {
+                throw new Error(`Node ID ${nodeId} exceeds Number.MAX_SAFE_INTEGER and cannot be safely converted`);
+            }
+            return Number(nodeId);
+        }
+        return nodeId;
     }
 
     private async removeNodeAtACLEntry(

--- a/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
@@ -81,7 +81,9 @@ export class NodeBindingDialog extends LitElement {
         const nodeId = this.node!.node_id;
         if (typeof nodeId === "bigint") {
             if (nodeId > BigInt(Number.MAX_SAFE_INTEGER)) {
-                throw new Error(`Node ID ${nodeId} exceeds Number.MAX_SAFE_INTEGER and cannot be safely converted`);
+                throw new RangeError(
+                    `Node ID ${nodeId} exceeds Number.MAX_SAFE_INTEGER and cannot be safely converted`,
+                );
             }
             return Number(nodeId);
         }

--- a/packages/ws-controller/src/index.ts
+++ b/packages/ws-controller/src/index.ts
@@ -29,6 +29,7 @@ export * from "./types/WebSocketMessageTypes.js";
 
 // Export utilities
 export { formatNodeId } from "./util/formatNodeId.js";
+export { safeNodeIdToNumber } from "./util/safeNodeIdToNumber.js";
 export * from "./util/matterVersion.js";
 
 // Re-Export classes from matter.js

--- a/packages/ws-controller/src/util/safeNodeIdToNumber.ts
+++ b/packages/ws-controller/src/util/safeNodeIdToNumber.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const MAX_SAFE_NODE_ID = BigInt(Number.MAX_SAFE_INTEGER);
+
+/**
+ * Safely converts a node ID (which may be a bigint) to a number.
+ * Throws if the value exceeds Number.MAX_SAFE_INTEGER.
+ */
+export function safeNodeIdToNumber(nodeId: number | bigint): number {
+    if (typeof nodeId === "number") return nodeId;
+    if (nodeId > MAX_SAFE_NODE_ID) {
+        throw new Error(`Node ID ${nodeId} exceeds Number.MAX_SAFE_INTEGER and cannot be safely converted`);
+    }
+    return Number(nodeId);
+}

--- a/packages/ws-controller/src/util/safeNodeIdToNumber.ts
+++ b/packages/ws-controller/src/util/safeNodeIdToNumber.ts
@@ -8,12 +8,21 @@ const MAX_SAFE_NODE_ID = BigInt(Number.MAX_SAFE_INTEGER);
 
 /**
  * Safely converts a node ID (which may be a bigint) to a number.
- * Throws if the value exceeds Number.MAX_SAFE_INTEGER.
+ * The node ID must be a non-negative safe integer.
+ * Throws if the value is negative or exceeds Number.MAX_SAFE_INTEGER.
  */
 export function safeNodeIdToNumber(nodeId: number | bigint): number {
-    if (typeof nodeId === "number") return nodeId;
+    if (typeof nodeId === "number") {
+        if (!Number.isSafeInteger(nodeId) || nodeId < 0) {
+            throw new RangeError(`Node ID ${nodeId} is not a non-negative safe integer and cannot be safely converted`);
+        }
+        return nodeId;
+    }
+    if (nodeId < 0n) {
+        throw new RangeError(`Node ID ${nodeId} is negative and cannot be safely converted`);
+    }
     if (nodeId > MAX_SAFE_NODE_ID) {
-        throw new Error(`Node ID ${nodeId} exceeds Number.MAX_SAFE_INTEGER and cannot be safely converted`);
+        throw new RangeError(`Node ID ${nodeId} exceeds Number.MAX_SAFE_INTEGER and cannot be safely converted`);
     }
     return Number(nodeId);
 }


### PR DESCRIPTION
## Summary
- Add `safeNodeIdToNumber()` utility that throws on precision loss instead of silently truncating
- Fix the only unsafe `Number(nodeId)` call in the dashboard binding dialog
- Export utility from `@matter-server/ws-controller` package

## Test plan
- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes

Fixes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)