### PR TITLE
Fix node_removed event sent before BasicInformation Leave event

### DIFF
--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -361,7 +361,23 @@ export class ControllerCommandHandler {
             basicInfoChangedInBatch = false;
             this.events.nodeStructureChanged.emit(nodeId);
         });
-        node.events.decommissioned.on(() => this.events.nodeDecommissioned.emit(nodeId));
+        node.events.decommissioned.on(() => {
+            // Defer so that any events emitted synchronously in the same call stack
+            // (e.g. the BasicInformation Leave event that triggers decommissioning) are
+            // relayed to clients before node_removed.  See matter-js/matterjs-server#75.
+            queueMicrotask(() => {
+                try {
+                    // Clean up internal state — mirrors the cleanup in decommissionNode() so
+                    // that nodes removed by an external controller are handled identically.
+                    this.#nodes.delete(nodeId);
+                    this.#customClusterPoller.unregisterNode(nodeId);
+
+                    this.events.nodeDecommissioned.emit(nodeId);
+                } catch (error) {
+                    logger.error(`Error during decommission cleanup for node ${this.formatNode(nodeId)}`, error);
+                }
+            });
+        });
         node.events.nodeEndpointAdded.on(endpointId => this.events.nodeEndpointAdded.emit(nodeId, endpointId));
         node.events.nodeEndpointRemoved.on(endpointId => this.events.nodeEndpointRemoved.emit(nodeId, endpointId));
 

--- a/packages/ws-controller/test/DecommissionEventOrderTest.ts
+++ b/packages/ws-controller/test/DecommissionEventOrderTest.ts
@@ -1,0 +1,161 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NodeId, Observable } from "@matter/main";
+import type { DecodedEventReportValue } from "@matter/main/protocol";
+import type { EventId, EventPriority } from "@matter/main/types";
+
+/**
+ * Tests for the decommission event ordering fix (matter-js/matterjs-server#75).
+ *
+ * When another controller removes a node from the fabric, matter.js's PairedNode
+ * processes the BasicInformation Leave event and emits events in this synchronous
+ * order:
+ *   1. decommissioned (via _triggerEventUpdate → Peers.#onLeave → lifecycle.decommissioned)
+ *   2. eventTriggered  (the Leave event itself, emitted after _triggerEventUpdate)
+ *
+ * ControllerCommandHandler must relay these so that WebSocket clients receive
+ * the Leave node_event BEFORE node_removed.  It achieves this by deferring the
+ * nodeDecommissioned emission via queueMicrotask().
+ *
+ * These tests exercise that deferral pattern in isolation, without requiring a
+ * full CommissioningController / PairedNode stack.
+ */
+describe("Decommission event ordering", () => {
+    /**
+     * Simulates the ControllerCommandHandler event wiring and the PairedNode
+     * firing pattern for a decommission triggered by an external controller.
+     */
+    it("should emit eventChanged before nodeDecommissioned when both fire synchronously", async () => {
+        // --- Simulated PairedNode events (source) ---
+        const nodeEvents = {
+            decommissioned: new Observable<[void]>(),
+            eventTriggered: new Observable<[DecodedEventReportValue<any>]>(),
+        };
+
+        // --- Simulated ControllerCommandHandler events (sink) ---
+        const handlerEvents = {
+            eventChanged: new Observable<[nodeId: NodeId, data: DecodedEventReportValue<any>]>(),
+            nodeDecommissioned: new Observable<[nodeId: NodeId]>(),
+        };
+
+        const nodeId = NodeId(1);
+
+        // Wire up listeners the same way ControllerCommandHandler does:
+        // eventTriggered → eventChanged (synchronous relay)
+        nodeEvents.eventTriggered.on(data => handlerEvents.eventChanged.emit(nodeId, data));
+
+        // decommissioned → nodeDecommissioned (deferred via microtask)
+        nodeEvents.decommissioned.on(() => {
+            queueMicrotask(() => handlerEvents.nodeDecommissioned.emit(nodeId));
+        });
+
+        // Track the order in which a WebSocket client would receive events
+        const received: string[] = [];
+        handlerEvents.eventChanged.on(() => {
+            received.push("node_event");
+        });
+        handlerEvents.nodeDecommissioned.on(() => {
+            received.push("node_removed");
+        });
+
+        // --- Simulate PairedNode's processing of a Leave event ---
+        // In PairedNode, _triggerEventUpdate fires first (leading to decommissioned),
+        // then eventTriggered fires synchronously after.
+        nodeEvents.decommissioned.emit();
+        nodeEvents.eventTriggered.emit({
+            path: {
+                endpointId: 0,
+                clusterId: 0x28, // BasicInformation
+                eventId: 3 as EventId, // Leave
+                eventName: "leave",
+            },
+            events: [
+                {
+                    eventNumber: 1,
+                    epochTimestamp: Date.now(),
+                    priority: 2 as EventPriority,
+                    data: { fabricIndex: 1 },
+                },
+            ],
+        } as unknown as DecodedEventReportValue<any>);
+
+        // At this point, eventChanged has fired synchronously but nodeDecommissioned
+        // is still pending in the microtask queue.
+        expect(received).to.deep.equal(["node_event"]);
+
+        // Flush the microtask queue
+        await new Promise<void>(resolve => queueMicrotask(resolve));
+
+        // Now nodeDecommissioned should have fired, AFTER eventChanged
+        expect(received).to.deep.equal(["node_event", "node_removed"]);
+    });
+
+    it("should emit nodeDecommissioned even when no Leave event fires (offline removal)", async () => {
+        const nodeEvents = {
+            decommissioned: new Observable<[void]>(),
+            eventTriggered: new Observable<[DecodedEventReportValue<any>]>(),
+        };
+
+        const handlerEvents = {
+            eventChanged: new Observable<[nodeId: NodeId, data: DecodedEventReportValue<any>]>(),
+            nodeDecommissioned: new Observable<[nodeId: NodeId]>(),
+        };
+
+        const nodeId = NodeId(1);
+
+        nodeEvents.eventTriggered.on(data => handlerEvents.eventChanged.emit(nodeId, data));
+        nodeEvents.decommissioned.on(() => {
+            queueMicrotask(() => handlerEvents.nodeDecommissioned.emit(nodeId));
+        });
+
+        const received: string[] = [];
+        handlerEvents.eventChanged.on(() => {
+            received.push("node_event");
+        });
+        handlerEvents.nodeDecommissioned.on(() => {
+            received.push("node_removed");
+        });
+
+        // Only decommissioned fires — no Leave event (device is offline)
+        nodeEvents.decommissioned.emit();
+
+        expect(received).to.deep.equal([]);
+
+        await new Promise<void>(resolve => queueMicrotask(resolve));
+
+        // Only node_removed should be received
+        expect(received).to.deep.equal(["node_removed"]);
+    });
+
+    it("should not crash when nodeDecommissioned listener throws", async () => {
+        const decommissioned = new Observable<[void]>();
+        const nodeDecommissioned = new Observable<[nodeId: NodeId]>();
+
+        const nodeId = NodeId(1);
+        let errorCaught = false;
+
+        decommissioned.on(() => {
+            queueMicrotask(() => {
+                try {
+                    nodeDecommissioned.emit(nodeId);
+                } catch {
+                    errorCaught = true;
+                }
+            });
+        });
+
+        // Register a listener that throws
+        nodeDecommissioned.on(() => {
+            throw new Error("listener error");
+        });
+
+        decommissioned.emit();
+        await new Promise<void>(resolve => queueMicrotask(resolve));
+
+        expect(errorCaught).to.equal(true);
+    });
+});

--- a/packages/ws-controller/test/tsconfig.json
+++ b/packages/ws-controller/test/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "extends": "../../tools/tsc/tsconfig.test.json",
+    "compilerOptions": {
+        "types": [
+            "node",
+            "mocha",
+            "@matter/testing"
+        ]
+    },
+    "references": [
+        {
+            "path": "../../tools/src"
+        },
+        {
+            "path": "../src"
+        }
+    ]
+}

--- a/packages/ws-controller/tsconfig.json
+++ b/packages/ws-controller/tsconfig.json
@@ -1,5 +1,5 @@
 {
     "compilerOptions": { "composite": true },
     "files": [],
-    "references": [{ "path": "src" }]
+    "references": [{ "path": "src" }, { "path": "test" }]
 }


### PR DESCRIPTION
## Summary

- Defers `nodeDecommissioned` emission via `queueMicrotask()` so that events emitted synchronously in the same call stack (e.g. the BasicInformation Leave event that triggers decommissioning from another controller) are relayed to WebSocket clients **before** `node_removed`
- Cleans up internal state (`#nodes`, `#customClusterPoller`) in the `decommissioned` handler so that nodes removed by an external controller are cleaned up identically to the WebSocket `remove_node` command path
- Wraps the deferred microtask body in try/catch to prevent uncaught exceptions from crashing the process
- Adds unit tests for the decommission event ordering pattern

Fixes #75

## Details

When another controller (e.g. Apple Home) removes a node from the fabric, matter.js's `PairedNode` processes the Leave event in this order within a single call stack:

1. `_triggerEventUpdate()` fires the cluster-level Leave event → `Peers.#onLeave()` → `decommissioned.emit()` (synchronous)
2. `eventTriggered.emit()` fires the PairedNode-level event

Since `ControllerCommandHandler` relayed both synchronously, `node_removed` reached WebSocket clients before the Leave `node_event`. By deferring `nodeDecommissioned` to a microtask, the synchronous `eventTriggered` completes first.

### Internal state cleanup

Previously, the `decommissioned` event handler only emitted `nodeDecommissioned` to notify WebSocket clients but did not clean up `#nodes` or `#customClusterPoller`. This meant nodes removed by an external controller left stale entries in server state. The handler now mirrors the cleanup performed by `decommissionNode()`.

### Offline removal via WebSocket command

When a node is removed via the WebSocket `remove_node` command while the device is offline, no Leave event is emitted — only `node_removed`. This is correct behaviour because `events.decommissioned` is always emitted regardless of the removal path:

1. **External controller**: Leave event → `Peers.#onLeave()` → `decommissioned.emit()`
2. **WebSocket command (online)**: `PairedNode.decommission()` → `decommissioned.emit()`
3. **WebSocket command (offline)**: `PairedNode.close(true)` → `decommissioned.emit()`

The Leave event is purely informational for clients — the server performs no special processing on it. `node_removed` is the authoritative signal that cleanup is complete.

## Test plan

- [x] `npm run format` passes
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] `npm test` — ws-controller (3/3 new + existing), ws-client (43/43) pass; integration test failures are pre-existing on main
- [x] New tests verify:
  - Event ordering: `node_event` (Leave) arrives before `node_removed` when both fire synchronously
  - Offline removal: `node_removed` is emitted even when no Leave event fires
  - Error resilience: listener exceptions are caught and don't crash the process

🤖 Generated with [Claude Code](https://claude.com/claude-code)