### PR TITLE
Fix shutdown flow to properly close all storage and await runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This page shows a detailed overview of the changes between versions without the 
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+- Fix: Ensures correct shutdown flow including releasing all locks
+
 ## 0.5.9 (2026-03-26)
 - Fix: Always return response data for device commands (ignore "response_type")
 

--- a/packages/matter-server/src/MatterServer.ts
+++ b/packages/matter-server/src/MatterServer.ts
@@ -190,23 +190,49 @@ async function start() {
 }
 
 async function stop() {
-    await server?.stop();
-    await controller?.stop();
-    // Flush any pending legacy data writes before closing
-    if (legacyDataWriter?.hasPendingWork()) {
-        logger.info("Flushing pending legacy data writes...");
-        await legacyDataWriter.flush();
+    try {
+        await server?.stop();
+    } catch (err) {
+        console.error(`Failed to stop server: ${err}`);
     }
-    await config?.close();
+    try {
+        await controller?.stop();
+    } catch (err) {
+        console.error(`Failed to stop controller: ${err}`);
+    }
+    // Flush any pending legacy data writes before closing
+    try {
+        if (legacyDataWriter?.hasPendingWork()) {
+            logger.info("Flushing pending legacy data writes...");
+            await legacyDataWriter.flush();
+        }
+    } catch (err) {
+        console.error(`Failed to flush legacy data: ${err}`);
+    }
+    try {
+        await config?.close();
+    } catch (err) {
+        console.error(`Failed to close config storage: ${err}`);
+    }
+    // Wait for the Environment runtime to fully shut down (flushes all storage,
+    // completes async worker cleanup). Without this, controller storage like
+    // "server-1-fff1" may not be flushed before the process exits.
+    try {
+        await env.runtime.close();
+    } catch (err) {
+        console.error(`Failed to close runtime: ${err}`);
+    }
     try {
         await fileLoggerClose?.();
     } catch (err) {
         console.error(`Failed to flush log file on shutdown: ${err}`);
     }
-    process.exit(0);
 }
 
-start().catch(err => console.error(err));
+start().catch(async err => {
+    console.error(err);
+    await config?.close();
+});
 
 process.on("SIGINT", () => void stop().catch(err => console.error(err)));
 process.on("SIGTERM", () => void stop().catch(err => console.error(err)));

--- a/packages/ws-controller/src/controller/MatterController.ts
+++ b/packages/ws-controller/src/controller/MatterController.ts
@@ -97,43 +97,45 @@ export class MatterController {
         if (legacyData !== undefined) {
             const crypto = environment.get(Crypto);
             const baseStorage = await config.service.open(serverId);
-            if (legacyData.credentials && legacyData.fabricId) {
-                await LegacyDataInjector.injectCredentials(
-                    baseStorage.createContext("credentials"),
-                    baseStorage.createContext("fabrics"),
-                    crypto,
-                    legacyData.credentials,
-                    legacyData.fabric,
-                );
-            }
-            if (
-                (await LegacyDataInjector.injectNodeData(
-                    baseStorage,
-                    legacyData.nodeData,
-                    legacyData.fabric?.fabricIndex,
-                )) &&
-                legacyData.nodeData !== undefined
-            ) {
-                for (const [nodeIdStr, data] of Object.entries(legacyData.nodeData.nodes)) {
-                    const { date_commissioned: commissionedAt } = data;
-                    commissionedDates.set(nodeIdStr, Timestamp(new Date(commissionedAt).getTime()));
-                }
-            }
-
-            // Check if the nextNodeId needs to be updated based on legacy data
-            const lastNodeId = legacyData.nodeData?.last_node_id;
-            if (typeof lastNodeId === "number" || typeof lastNodeId === "bigint") {
-                // Compare as BigInt to safely handle both number and bigint types
-                if (BigInt(config.nextNodeId) <= BigInt(lastNodeId)) {
-                    const newNextNodeId = BigInt(lastNodeId) + 10n;
-                    logger.info(
-                        `Updating nextNodeId from ${config.nextNodeId} to ${newNextNodeId} (legacy last_node_id: ${lastNodeId})`,
+            try {
+                if (legacyData.credentials && legacyData.fabricId) {
+                    await LegacyDataInjector.injectCredentials(
+                        baseStorage.createContext("credentials"),
+                        baseStorage.createContext("fabrics"),
+                        crypto,
+                        legacyData.credentials,
+                        legacyData.fabric,
                     );
-                    await config.set({ nextNodeId: newNextNodeId });
                 }
-            }
+                if (
+                    (await LegacyDataInjector.injectNodeData(
+                        baseStorage,
+                        legacyData.nodeData,
+                        legacyData.fabric?.fabricIndex,
+                    )) &&
+                    legacyData.nodeData !== undefined
+                ) {
+                    for (const [nodeIdStr, data] of Object.entries(legacyData.nodeData.nodes)) {
+                        const { date_commissioned: commissionedAt } = data;
+                        commissionedDates.set(nodeIdStr, Timestamp(new Date(commissionedAt).getTime()));
+                    }
+                }
 
-            await baseStorage.close();
+                // Check if the nextNodeId needs to be updated based on legacy data
+                const lastNodeId = legacyData.nodeData?.last_node_id;
+                if (typeof lastNodeId === "number" || typeof lastNodeId === "bigint") {
+                    // Compare as BigInt to safely handle both number and bigint types
+                    if (BigInt(config.nextNodeId) <= BigInt(lastNodeId)) {
+                        const newNextNodeId = BigInt(lastNodeId) + 10n;
+                        logger.info(
+                            `Updating nextNodeId from ${config.nextNodeId} to ${newNextNodeId} (legacy last_node_id: ${lastNodeId})`,
+                        );
+                        await config.set({ nextNodeId: newNextNodeId });
+                    }
+                }
+            } finally {
+                await baseStorage.close();
+            }
         }
 
         await instance.initialize(legacyData?.vendorId, legacyData?.fabricId, commissionedDates);

--- a/packages/ws-controller/src/controller/ServerIdResolver.ts
+++ b/packages/ws-controller/src/controller/ServerIdResolver.ts
@@ -104,39 +104,49 @@ export async function resolveServerId(
         // Open and verify the fabric configuration matches
         try {
             const baseStorage = await config.service.open(DEFAULT_SERVER_ID);
-            const fabricsContext = baseStorage.createContext("fabrics");
+            let closed = false;
+            try {
+                const fabricsContext = baseStorage.createContext("fabrics");
 
-            // Read fabric entries
-            const fabrics = await fabricsContext.get<{ fabricId: FabricId; rootVendorId: VendorId }[]>("fabrics", []);
-            if (fabrics.length === 1) {
-                // Single fabric - check if it matches
-                const fabricData = fabrics[0];
-                const storedFabricId = fabricData.fabricId;
-                const storedVendorId = fabricData.rootVendorId;
-                if (storedFabricId === FabricId(fabricId) && storedVendorId === vendorId) {
-                    // Matching fabric - rename it to the new format to avoid future checks
-                    await baseStorage.close();
-                    if (storagePath !== undefined) {
-                        const oldPath = join(storagePath, DEFAULT_SERVER_ID);
-                        const newPath = join(storagePath, candidateId);
-                        try {
-                            await rename(oldPath, newPath);
-                            logger.info(`Renamed storage "${DEFAULT_SERVER_ID}" to "${candidateId}"`);
-                            return candidateId;
-                        } catch (renameErr) {
-                            logger.error(
-                                `Failed to rename storage from "${DEFAULT_SERVER_ID}" to "${candidateId}"`,
-                                renameErr,
-                            );
-                            return DEFAULT_SERVER_ID;
+                // Read fabric entries
+                const fabrics = await fabricsContext.get<{ fabricId: FabricId; rootVendorId: VendorId }[]>(
+                    "fabrics",
+                    [],
+                );
+                if (fabrics.length === 1) {
+                    // Single fabric - check if it matches
+                    const fabricData = fabrics[0];
+                    const storedFabricId = fabricData.fabricId;
+                    const storedVendorId = fabricData.rootVendorId;
+                    if (storedFabricId === FabricId(fabricId) && storedVendorId === vendorId) {
+                        // Matching fabric - close before rename to release file handles
+                        await baseStorage.close();
+                        closed = true;
+                        if (storagePath !== undefined) {
+                            const oldPath = join(storagePath, DEFAULT_SERVER_ID);
+                            const newPath = join(storagePath, candidateId);
+                            try {
+                                await rename(oldPath, newPath);
+                                logger.info(`Renamed storage "${DEFAULT_SERVER_ID}" to "${candidateId}"`);
+                                return candidateId;
+                            } catch (renameErr) {
+                                logger.error(
+                                    `Failed to rename storage from "${DEFAULT_SERVER_ID}" to "${candidateId}"`,
+                                    renameErr,
+                                );
+                                return DEFAULT_SERVER_ID;
+                            }
                         }
+                        return DEFAULT_SERVER_ID;
                     }
-                    return DEFAULT_SERVER_ID;
+                } else {
+                    logger.error(`Multiple fabrics found, using new storage`, fabrics);
                 }
-            } else {
-                logger.error(`Multiple fabrics found, using new storage`, fabrics);
+            } finally {
+                if (!closed) {
+                    await baseStorage.close();
+                }
             }
-            await baseStorage.close();
             logger.info(`Existing "server" storage does not match fabric config, using new ID: ${candidateId}`);
         } catch (err) {
             logger.debug(`Could not verify "server" storage: ${err}`);


### PR DESCRIPTION
## Summary
- Remove `process.exit(0)` from shutdown — it killed the process before async cleanup completed
- Add `await env.runtime.close()` to wait for the matter.js Runtime to fully shut down (flush all storage, complete worker cleanup)
- Isolate each shutdown step with try/catch so a failure in one doesn't skip subsequent cleanup
- Add `try/finally` guards around `storageService.open()` calls in `ServerIdResolver` and `MatterController` to prevent storage leaks on exceptions

adreses #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)