### PR TITLE
Fix OTA import failing with EISDIR on directory entries

### DIFF
--- a/packages/matter-server/src/ota.ts
+++ b/packages/matter-server/src/ota.ts
@@ -31,7 +31,8 @@ export async function initializeOta(controller: MatterController, cliOptions: Cl
  */
 async function loadOtaFiles(controller: MatterController, directory: string) {
     try {
-        const files = await readdir(directory);
+        const entries = await readdir(directory, { withFileTypes: true });
+        const files = entries.filter(e => e.isFile()).map(e => e.name);
         for (const file of files) {
             // Skip JSON files (metadata files)
             if (file.toLowerCase().endsWith(".json")) {


### PR DESCRIPTION
## Summary
- `readdir()` returns all entries including subdirectories, but the OTA loader attempted to read them as files, causing `EISDIR` errors on every startup
- Use `readdir` with `{ withFileTypes: true }` and filter to files only before processing

Addresses #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)