### PR TITLE
Fix shutdown hang when SIGINT arrives during startup

### DIFF
--- a/packages/matter-server/src/MatterServer.ts
+++ b/packages/matter-server/src/MatterServer.ts
@@ -78,6 +78,8 @@ let config: ConfigStorage;
 let legacyData: LegacyData;
 let legacyDataWriter: LegacyDataWriter | undefined;
 let fileLoggerClose: (() => Promise<void>) | undefined;
+let stopping = false;
+let startCompleted: Promise<void> = Promise.resolve();
 
 async function start() {
     // Set up file logging additionally to the console if configured
@@ -190,6 +192,19 @@ async function start() {
 }
 
 async function stop() {
+    if (stopping) {
+        return;
+    }
+    stopping = true;
+
+    // Wait for start() to finish (or fail) before tearing down, so we don't
+    // race against in-flight initialization that could re-create resources.
+    try {
+        await startCompleted;
+    } catch {
+        // start() failed - that's fine, we still need to clean up
+    }
+
     try {
         await server?.stop();
     } catch (err) {
@@ -229,8 +244,10 @@ async function stop() {
     }
 }
 
-start().catch(async err => {
-    console.error(err);
+startCompleted = start().catch(async err => {
+    if (!stopping) {
+        console.error(err);
+    }
     await config?.close();
 });
 

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -273,10 +273,10 @@ export class ControllerCommandHandler {
     }
 
     async close() {
+        await this.#customClusterPoller.stop();
         if (!this.#started) {
             return;
         }
-        await this.#customClusterPoller.stop();
         return this.#controller.close();
     }
 


### PR DESCRIPTION
## Summary

- Fix race condition between `start()` and `stop()` when SIGINT/SIGTERM arrives during server initialization
- `stop()` now awaits `start()` completion before tearing down resources, preventing dangling timers/sockets
- Guard against re-entrant `stop()` calls from repeated signals
- Always stop `CustomClusterPoller` timer in `close()`, even if the controller hadn't fully started yet

## Context

When the Docker container is stopped while the server is still initializing (e.g. during DCL certificate/vendor fetching or BLE setup), `stop()` runs concurrently with `start()`. The `ControllerCommandHandler.close()` returns early because `#started` is still `false`, but then `start()` continues and sets `#started = true` — leaving the poller timer and controller resources alive. This keeps the Node.js process from exiting, requiring multiple SIGINT/SIGKILL to terminate.

Addresses #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)