### PR TITLE
Add global attributes to custom cluster Python classes

### DIFF
--- a/python_client/matter_server/common/custom_clusters.py
+++ b/python_client/matter_server/common/custom_clusters.py
@@ -593,80 +593,105 @@ class EveCluster(Cluster, CustomClusterMixin):
 
         @dataclass
         class GeneratedCommandList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """GeneratedCommandList Attribute within the Eve Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130AFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFF8
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class AcceptedCommandList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AcceptedCommandList Attribute within the Eve Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130AFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFF9
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class AttributeList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AttributeList Attribute within the Eve Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130AFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFB
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class FeatureMap(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """FeatureMap Attribute within the Eve Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130AFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFC
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=uint)
 
             value: uint = 0
 
         @dataclass
         class ClusterRevision(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """ClusterRevision Attribute within the Eve Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130AFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFD
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=uint)
 
             value: uint = 0
@@ -795,80 +820,105 @@ class InovelliCluster(Cluster, CustomClusterMixin):
 
         @dataclass
         class GeneratedCommandList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """GeneratedCommandList Attribute within the Inovelli Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x122FFC31
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFF8
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class AcceptedCommandList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AcceptedCommandList Attribute within the Inovelli Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x122FFC31
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFF9
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class AttributeList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AttributeList Attribute within the Inovelli Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x122FFC31
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFB
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class FeatureMap(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """FeatureMap Attribute within the Inovelli Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x122FFC31
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFC
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=uint)
 
             value: uint = 0
 
         @dataclass
         class ClusterRevision(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """ClusterRevision Attribute within the Inovelli Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x122FFC31
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFD
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=uint)
 
             value: uint = 0
@@ -1014,80 +1064,105 @@ class NeoCluster(Cluster, CustomClusterMixin):
 
         @dataclass
         class GeneratedCommandList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """GeneratedCommandList Attribute within the Neo Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x00125DFC11
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFF8
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class AcceptedCommandList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AcceptedCommandList Attribute within the Neo Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x00125DFC11
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFF9
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class AttributeList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AttributeList Attribute within the Neo Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x00125DFC11
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFB
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class FeatureMap(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """FeatureMap Attribute within the Neo Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x00125DFC11
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFC
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=uint)
 
             value: uint = 0
 
         @dataclass
         class ClusterRevision(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """ClusterRevision Attribute within the Neo Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x00125DFC11
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFD
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=uint)
 
             value: uint = 0
@@ -1310,80 +1385,105 @@ class HeimanCluster(Cluster, CustomClusterMixin):
 
         @dataclass
         class GeneratedCommandList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """GeneratedCommandList Attribute within the Heiman Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x120BFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFF8
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class AcceptedCommandList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AcceptedCommandList Attribute within the Heiman Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x120BFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFF9
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class AttributeList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AttributeList Attribute within the Heiman Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x120BFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFB
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class FeatureMap(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """FeatureMap Attribute within the Heiman Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x120BFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFC
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=uint)
 
             value: uint = 0
 
         @dataclass
         class ClusterRevision(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """ClusterRevision Attribute within the Heiman Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x120BFC01
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFD
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=uint)
 
             value: uint = 0
@@ -1569,80 +1669,105 @@ class ThirdRealityMeteringCluster(Cluster, CustomClusterMixin):
 
         @dataclass
         class GeneratedCommandList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """GeneratedCommandList Attribute within the ThirdRealityMetering Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130DFC02
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFF8
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class AcceptedCommandList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AcceptedCommandList Attribute within the ThirdRealityMetering Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130DFC02
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFF9
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class AttributeList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AttributeList Attribute within the ThirdRealityMetering Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130DFC02
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFB
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class FeatureMap(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """FeatureMap Attribute within the ThirdRealityMetering Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130DFC02
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFC
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=uint)
 
             value: uint = 0
 
         @dataclass
         class ClusterRevision(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """ClusterRevision Attribute within the ThirdRealityMetering Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x130DFC02
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFD
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=uint)
 
             value: uint = 0
@@ -1919,80 +2044,105 @@ class DraftElectricalMeasurementCluster(Cluster, CustomClusterMixin):
 
         @dataclass
         class GeneratedCommandList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """GeneratedCommandList Attribute within the DraftElectricalMeasurement Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x00000B04
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFF8
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class AcceptedCommandList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AcceptedCommandList Attribute within the DraftElectricalMeasurement Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x00000B04
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFF9
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class AttributeList(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """AttributeList Attribute within the DraftElectricalMeasurement Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x00000B04
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFB
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
             value: typing.List[uint] = field(default_factory=lambda: [])
 
         @dataclass
         class FeatureMap(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """FeatureMap Attribute within the DraftElectricalMeasurement Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x00000B04
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFC
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=uint)
 
             value: uint = 0
 
         @dataclass
         class ClusterRevision(ClusterAttributeDescriptor, CustomClusterAttributeMixin):
+            """ClusterRevision Attribute within the DraftElectricalMeasurement Cluster."""
+
             @ChipUtility.classproperty
             def cluster_id(cls) -> int:
+                """Return cluster id."""
                 return 0x00000B04
 
             @ChipUtility.classproperty
             def attribute_id(cls) -> int:
+                """Return attribute id."""
                 return 0x0000FFFD
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                """Return attribute type."""
                 return ClusterObjectFieldDescriptor(Type=uint)
 
             value: uint = 0


### PR DESCRIPTION
## Summary

- Add the 5 mandatory global Matter attributes (`GeneratedCommandList`, `AcceptedCommandList`, `AttributeList`, `FeatureMap`, `ClusterRevision`) to all 6 custom cluster Python classes, matching the pattern used by standard clusters in the chip wheels `Objects.py`
- Fix 5 type mismatches in `EveCluster` where the Python types diverged from the TypeScript model definitions (`timesOpened`, `pressure`, `weatherTrend`, `valvePosition`, `motionSensitivity`)

## Details

The custom cluster Python classes in `custom_clusters.py` were missing the global attributes that every standard Matter cluster includes. The chip wheels' `Objects.py` defines these for every cluster in three places:

1. `ClusterObjectFieldDescriptor` entries in the `descriptor` Fields list
2. Dataclass fields on the cluster class itself
3. Inner `Attributes` classes (each a full `ClusterAttributeDescriptor`)

This was done for all 6 custom clusters:
- `EveCluster` (0x130AFC01)
- `InovelliCluster` (0x122FFC31)
- `NeoCluster` (0x00125DFC11)
- `HeimanCluster` (0x120BFC01)
- `ThirdRealityMeteringCluster` (0x130DFC02)
- `DraftElectricalMeasurementCluster` (0x00000B04)

### Type fixes (EveCluster)

| Attribute | Was | Now | TS source type |
|---|---|---|---|
| `timesOpened` | `int` | `uint` | `uint32` |
| `pressure` | `uint` | `float32` | `single` |
| `weatherTrend` | `int` | `uint` | `uint32` |
| `valvePosition` | `int` | `uint` | `uint32` |
| `motionSensitivity` | `int` | `uint` | `uint32` |

## Test plan

- [x] Python syntax verification passes
- [x] `npm run build` passes
- [x] `npm test` passes (43/43 + 242/242)
- [x] `npm run lint` passes
- [x] Verified all 30 new inner Attribute classes have correct `cluster_id` and `attribute_id` values
- [x] Verified consistency with chip wheels `Objects.py` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)