### PR TITLE
Fix node availability events not emitted on `Disconnected` state

### DIFF
--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -16,7 +16,8 @@
     "scripts": {
         "clean": "matter-build clean",
         "build": "matter-build",
-        "build-clean": "matter-build --clean"
+        "build-clean": "matter-build --clean",
+        "test": "matter-test --force-exit"
     },
     "engines": {
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -307,10 +307,6 @@ export class ControllerCommandHandler {
         });
         node.events.eventTriggered.on(data => this.events.eventChanged.emit(nodeId, data));
         node.events.stateChanged.on(state => {
-            if (state === NodeStates.Disconnected) {
-                return;
-            }
-
             // Calculate availability before and after state change
             const previousState = this.#nodes.getPreviousState(nodeId);
             const wasAvailable = this.#lastAvailability.get(nodeId) ?? false;

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -160,8 +160,6 @@ export class ControllerCommandHandler {
     #availableUpdates = new Map<NodeId, SoftwareUpdateInfo>();
     /** Poller for custom cluster attributes (Eve energy, etc.) */
     #customClusterPoller: CustomClusterPoller;
-    /** Track the last known availability for each node to detect changes */
-    #lastAvailability = new Map<NodeId, boolean>();
     /** Track in-flight invoke-commands for deduplication across all WebSocket connections */
     readonly #inFlightInvokes = new Map<string, Promise<unknown>>();
     events = {
@@ -307,11 +305,6 @@ export class ControllerCommandHandler {
         });
         node.events.eventTriggered.on(data => this.events.eventChanged.emit(nodeId, data));
         node.events.stateChanged.on(state => {
-            // Calculate availability before and after state change
-            const previousState = this.#nodes.getPreviousState(nodeId);
-            const wasAvailable = this.#lastAvailability.get(nodeId) ?? false;
-            const isAvailable = this.#nodes.isNodeAvailable(state, previousState);
-
             // Only refresh cache on Connected state (not Reconnecting, WaitingForDiscovery, etc.)
             if (state === NodeStates.Connected) {
                 attributeCache.update(node);
@@ -322,19 +315,18 @@ export class ControllerCommandHandler {
                 }
             }
 
-            // Update state tracking for the next transition
-            this.#nodes.setPreviousState(nodeId, state);
-            this.#lastAvailability.set(nodeId, isAvailable);
+            // Process state change and check if availability changed
+            const result = this.#nodes.processStateChange(nodeId, state);
 
             // Emit state changed event
             this.events.nodeStateChanged.emit(nodeId, state);
 
             // Emit availability changed if it actually changed
-            if (wasAvailable !== isAvailable) {
+            if (result.availabilityChanged) {
                 logger.info(
-                    `Node ${this.formatNode(nodeId)} availability changed: ${wasAvailable} -> ${isAvailable} (state: ${NodeStates[previousState ?? -1]} -> ${NodeStates[state]})`,
+                    `Node ${this.formatNode(nodeId)} availability changed to ${result.available} (state: ${NodeStates[state]})`,
                 );
-                this.events.nodeAvailabilityChanged.emit(nodeId, isAvailable);
+                this.events.nodeAvailabilityChanged.emit(nodeId, result.available);
             }
         });
         node.events.structureChanged.on(() => {
@@ -354,12 +346,7 @@ export class ControllerCommandHandler {
 
         // Seed state tracking from the node's current connection state so the first
         // stateChanged event shows a real previous state instead of "undefined".
-        const initialState = node.connectionState;
-        this.#nodes.setPreviousState(nodeId, initialState);
-        // Only mark as available when actually connected; all other states default to false (unavailable).
-        if (initialState === NodeStates.Connected) {
-            this.#lastAvailability.set(nodeId, true);
-        }
+        this.#nodes.seedState(nodeId, node.connectionState);
 
         // Initialize attribute cache if node is already initialized
         if (node.initialized) {

--- a/packages/ws-controller/src/controller/Nodes.ts
+++ b/packages/ws-controller/src/controller/Nodes.ts
@@ -27,6 +27,8 @@ export class Nodes {
     #attributeCache = new AttributeDataCache();
     /** Track previous connection state for availability debouncing */
     #previousStates = new Map<NodeId, NodeStates>();
+    /** Track the last known availability for each node to detect changes */
+    #lastAvailability = new Map<NodeId, boolean>();
 
     /**
      * Get the attribute cache instance.
@@ -75,6 +77,7 @@ export class Nodes {
         this.#nodes.delete(nodeId);
         this.#attributeCache.delete(nodeId);
         this.#previousStates.delete(nodeId);
+        this.#lastAvailability.delete(nodeId);
     }
 
     /**
@@ -127,6 +130,42 @@ export class Nodes {
         const currentState = node.connectionState;
         const previousState = this.#previousStates.get(nodeId);
         return this.isNodeAvailable(currentState, previousState);
+    }
+
+    /**
+     * Seed initial state tracking for a newly registered node.
+     * Only marks as available when actually connected; all other states default to unavailable.
+     */
+    seedState(nodeId: NodeId, initialState: NodeStates): void {
+        this.#previousStates.set(nodeId, initialState);
+        if (initialState === NodeStates.Connected) {
+            this.#lastAvailability.set(nodeId, true);
+        }
+    }
+
+    /**
+     * Process a node state change and return whether availability changed.
+     * Updates internal state tracking and returns the availability transition if one occurred.
+     *
+     * @returns Object with `availabilityChanged: true` and `available` value if availability changed,
+     *          or `availabilityChanged: false` if it did not.
+     */
+    processStateChange(
+        nodeId: NodeId,
+        newState: NodeStates,
+    ): { availabilityChanged: true; available: boolean } | { availabilityChanged: false } {
+        const previousState = this.#previousStates.get(nodeId);
+        const wasAvailable = this.#lastAvailability.get(nodeId) ?? false;
+        const isAvailable = this.isNodeAvailable(newState, previousState);
+
+        // Update state tracking for the next transition
+        this.#previousStates.set(nodeId, newState);
+        this.#lastAvailability.set(nodeId, isAvailable);
+
+        if (wasAvailable !== isAvailable) {
+            return { availabilityChanged: true, available: isAvailable };
+        }
+        return { availabilityChanged: false };
     }
 
     /**

--- a/packages/ws-controller/test/NodesTest.ts
+++ b/packages/ws-controller/test/NodesTest.ts
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NodeId } from "@matter/main";
+import { NodeStates } from "@project-chip/matter.js/device";
+import { Nodes } from "../src/controller/Nodes.js";
+
+const TEST_NODE_ID = NodeId(1);
+
+describe("Nodes", () => {
+    describe("isNodeAvailable", () => {
+        let nodes: Nodes;
+
+        beforeEach(() => {
+            nodes = new Nodes();
+        });
+
+        it("should return true when Connected", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Connected)).to.equal(true);
+        });
+
+        it("should return true when Reconnecting from Connected (debounce)", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Reconnecting, NodeStates.Connected)).to.equal(true);
+        });
+
+        it("should return false when Reconnecting from non-Connected state", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Reconnecting, NodeStates.WaitingForDeviceDiscovery)).to.equal(
+                false,
+            );
+        });
+
+        it("should return false when Reconnecting with no previous state", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Reconnecting)).to.equal(false);
+        });
+
+        it("should return false when Disconnected", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Disconnected)).to.equal(false);
+        });
+
+        it("should return false when Disconnected even if previously Connected", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Disconnected, NodeStates.Connected)).to.equal(false);
+        });
+
+        it("should return false when WaitingForDeviceDiscovery", () => {
+            expect(nodes.isNodeAvailable(NodeStates.WaitingForDeviceDiscovery)).to.equal(false);
+        });
+    });
+
+    describe("processStateChange", () => {
+        let nodes: Nodes;
+
+        beforeEach(() => {
+            nodes = new Nodes();
+        });
+
+        it("should emit availability changed when Connected node transitions to Disconnected", () => {
+            // Seed as Connected (available)
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+
+            // Transition to Disconnected
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Disconnected);
+
+            expect(result.availabilityChanged).to.equal(true);
+            if (result.availabilityChanged) {
+                expect(result.available).to.equal(false);
+            }
+        });
+
+        it("should emit availability changed when Connected node transitions to WaitingForDeviceDiscovery", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.WaitingForDeviceDiscovery);
+
+            expect(result.availabilityChanged).to.equal(true);
+            if (result.availabilityChanged) {
+                expect(result.available).to.equal(false);
+            }
+        });
+
+        it("should emit availability changed when Disconnected node transitions to Connected", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Disconnected);
+
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Connected);
+
+            expect(result.availabilityChanged).to.equal(true);
+            if (result.availabilityChanged) {
+                expect(result.available).to.equal(true);
+            }
+        });
+
+        it("should not emit availability changed when Connected node transitions to Reconnecting (debounce)", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting);
+
+            expect(result.availabilityChanged).to.equal(false);
+        });
+
+        it("should not emit availability changed when already unavailable node transitions between unavailable states", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Disconnected);
+
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.WaitingForDeviceDiscovery);
+
+            expect(result.availabilityChanged).to.equal(false);
+        });
+
+        it("should track state across multiple transitions (Connected -> Reconnecting -> Disconnected)", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+
+            // Connected -> Reconnecting: still available (debounce)
+            const result1 = nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting);
+            expect(result1.availabilityChanged).to.equal(false);
+
+            // Reconnecting -> Disconnected: now unavailable
+            const result2 = nodes.processStateChange(TEST_NODE_ID, NodeStates.Disconnected);
+            expect(result2.availabilityChanged).to.equal(true);
+            if (result2.availabilityChanged) {
+                expect(result2.available).to.equal(false);
+            }
+        });
+
+        it("should handle full lifecycle: Connected -> Reconnecting -> Disconnected -> Connected", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+
+            // Connected -> Reconnecting (debounce, still available)
+            expect(nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting).availabilityChanged).to.equal(false);
+
+            // Reconnecting -> Disconnected (becomes unavailable)
+            const goOffline = nodes.processStateChange(TEST_NODE_ID, NodeStates.Disconnected);
+            expect(goOffline.availabilityChanged).to.equal(true);
+            if (goOffline.availabilityChanged) {
+                expect(goOffline.available).to.equal(false);
+            }
+
+            // Disconnected -> Connected (becomes available again)
+            const goOnline = nodes.processStateChange(TEST_NODE_ID, NodeStates.Connected);
+            expect(goOnline.availabilityChanged).to.equal(true);
+            if (goOnline.availabilityChanged) {
+                expect(goOnline.available).to.equal(true);
+            }
+        });
+    });
+});

--- a/packages/ws-controller/test/tsconfig.json
+++ b/packages/ws-controller/test/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "extends": "../../tools/tsc/tsconfig.test.json",
+    "compilerOptions": {
+        "types": [
+            "node",
+            "mocha",
+            "@matter/testing"
+        ]
+    },
+    "references": [
+        {
+            "path": "../../tools/src"
+        },
+        {
+            "path": "../../ws-client/src"
+        },
+        {
+            "path": "../src"
+        }
+    ]
+}

--- a/packages/ws-controller/tsconfig.json
+++ b/packages/ws-controller/tsconfig.json
@@ -1,5 +1,5 @@
 {
     "compilerOptions": { "composite": true },
     "files": [],
-    "references": [{ "path": "src" }]
+    "references": [{ "path": "src" }, { "path": "test" }]
 }


### PR DESCRIPTION
Like this PR, the description below is AI-generated but still worth a read.
Feel free to push changes directly, or close this PR and open another one that attempts a similar (or different) fix.

Fixes https://github.com/matter-js/matterjs-server/issues/494

### Problem

When a Matter device is unplugged or becomes unreachable, the Matter.js server dashboard correctly shows it as offline, but Home Assistant never marks the device as unavailable. The device remains shown as available indefinitely in HA until the server is restarted.

### Root cause

This is a regression introduced in #162 (82068d1), which added the availability tracking and debouncing system. That commit introduced both the `nodeAvailabilityChanged` event (the new mechanism for pushing availability updates to WebSocket clients) and an early return guard in the `stateChanged` handler that skips all processing when a node enters the `Disconnected` state:

```typescript
node.events.stateChanged.on(state => {
    if (state === NodeStates.Disconnected) {
        return; // Blocks ALL processing below
    }
    // ... availability calculation, state tracking, event emission
});
```

Before #162, availability worked because:
1. `nodeStateChanged` was emitted for all states including `Disconnected`
2. `available` was computed live as `node.isConnected` each time node data was serialized

After #162, the approach changed to a push-based model using `nodeAvailabilityChanged`, and `nodeStateChanged` was deliberately changed to no longer trigger `node_updated` events (the comment reads: *"Availability changes are handled by nodeAvailabilityChanged"*). However, the `Disconnected` guard prevents the new `nodeAvailabilityChanged` event from ever firing for that state — breaking both the new path and the old one simultaneously.

The guard also caused a secondary bug: `previousState` was never updated for `Disconnected` transitions. This meant the debounce logic could produce incorrect results. For example, in a Connected → Disconnected → Reconnecting sequence, the debounce would see `previousState = Connected` (stale) and incorrectly report the node as still available.

The availability tracking system introduced in #162 shipped with no test coverage, which is why this regression went undetected. The `ws-controller` package had no tests at all. Broader test coverage for ws-controller would be worth addressing in future PRs.

### Fix

Remove the `Disconnected` guard so all state transitions are processed uniformly. The availability tracking logic already handles `Disconnected` correctly — `isNodeAvailable()` returns `false` for it — it was just never being called.

Additionally, move the availability tracking state (`#lastAvailability` map) and the state-change processing logic from `ControllerCommandHandler` into `Nodes`, where the related state (`#previousStates`) and availability logic (`isNodeAvailable`) already live. This consolidates the availability concern into a single class via a new `processStateChange()` method that:
1. Computes availability from the new state and previous state
2. Updates internal tracking maps
3. Returns whether availability actually changed (and the new value)

`ControllerCommandHandler` now calls `processStateChange()` and reacts to the result, rather than managing the tracking maps directly.

### Commits (reviewable individually)

1. **Fix node availability not updating on Disconnected state** — the bugfix: removes the `Disconnected` early return (4 lines deleted)
2. **Move availability tracking logic from ControllerCommandHandler into Nodes** — refactor, also fixes `#lastAvailability` entries not being cleaned up when a node is removed
3. **Add unit tests for Nodes availability logic** — 14 tests + test infrastructure

Each commit is independent — commits 2 and/or 3 can be dropped if the refactor or tests are unwanted. Note that dropping commit 2 leaves the `#lastAvailability` cleanup missing from node removal — a minor memory leak that existed before this PR.

### Known pre-existing issue: debounce inconsistency between event and serialization paths

There are two paths that determine node availability, and they can disagree during the `Reconnecting` debounce window:

1. **Event path** (`processStateChange`): Reads `previousState` *before* updating it. For a Connected → Reconnecting transition, it sees `(Reconnecting, Connected)` → available (debounce). No `nodeAvailabilityChanged` event is emitted.
2. **Serialization path** (`isAvailable`, called by `getNodeDetails`): Reads `node.connectionState` live from the `PairedNode` and `previousState` from `#previousStates` — which has *already been updated* to `Reconnecting`. It sees `(Reconnecting, Reconnecting)` → unavailable.

This means that during the debounce window, if a `node_updated` event is triggered for an unrelated reason (e.g., a structure change or attribute update), the serialized node data will include `available: false` even though no `nodeAvailabilityChanged` event was emitted.

This inconsistency predates this PR — the same read-then-update vs read-after-update ordering existed in the original inline code in `ControllerCommandHandler`. The proper fix would be to have `isAvailable()` return the cached `#lastAvailability` value instead of recomputing from the state pair, but that is a separate change.

### Further AI summary on changes

<details><summary>Furhther AI summary (click to open)</summary>
<p>

### Changes

- **`Nodes.ts`**: Add `#lastAvailability` map, `seedState()` method for initial state setup, and `processStateChange()` method that encapsulates the full state transition logic. Clean up `#lastAvailability` in `delete()`.
- **`ControllerCommandHandler.ts`**: Remove `#lastAvailability` map (moved to `Nodes`). Replace inline state tracking logic in the `stateChanged` handler with a call to `nodes.processStateChange()`. Replace manual state seeding with `nodes.seedState()`.
- **`test/NodesTest.ts`** (new): 14 unit tests covering `isNodeAvailable()` and `processStateChange()`. The `processStateChange` tests cover the exact scenario that was broken (Connected → Disconnected must report `availabilityChanged: true`) and the full device lifecycle (Connected → Reconnecting → Disconnected → Connected). Re-adding the original `Disconnected` guard causes 3 test failures.
- **`ws-controller/package.json`**, **`ws-controller/tsconfig.json`**, **`ws-controller/test/tsconfig.json`** (new): Test infrastructure for ws-controller, which previously had no tests.

### How it was verified

- Confirmed that Matter.js `PairedNode.#setConnectionState()` already deduplicates state transitions (returns early if state is unchanged), so there is no risk of event floods
- Verified the two non-device-offline sources of `Disconnected` are harmless:
  - **Decommissioning**: `Disconnected` fires before `decommissioned` — HA gets a `node_updated(available: false)` followed by `node_removed`, which is correct
  - **Controller shutdown**: WebSocket connection is tearing down, events have no effect
- Verified that nodes starting in `Disconnected` state (the Matter.js default) don't produce spurious availability events: `seedState` defaults `lastAvailability` to `false`, matching the `Disconnected` → unavailable calculation
- All existing tests pass (299 tests across ws-controller, ws-client, and matter-server)

</p>
</details> 