### PR TITLE
Fix node availability not reported to Home Assistant on device offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This page shows a detailed overview of the changes between versions without the 
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+- Fix: Correctly reports Node availabilities via WS events to HA and other consumers (also consider a device offline after five mins in Reconnection state)
+- Fix: Allows binding deletion via the dashboard when the target node no longer exists and other consistency checks
+- Fix: Fixes shutdown hang when SIGINT arrives during the startup phase
+- Fix: Adds global attributes to custom cluster Python classes
+
 ## 0.5.13 (2026-04-02)
 - Fix: Ignore directories in the OTA update directory
 - Fix: (FuNK3Y) Enhances network interface name logic for Websocket binding

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
                 "@types/mocha": "^10.0.10",
                 "glob": "^13.0.6",
                 "globals": "^17.4.0",
-                "oxfmt": "^0.43.0",
-                "oxlint": "^1.58.0",
-                "oxlint-tsgolint": "^0.19.0",
+                "oxfmt": "^0.44.0",
+                "oxlint": "^1.59.0",
+                "oxlint-tsgolint": "^0.20.0",
                 "tsx": "^4.21.0",
                 "typescript": "~5.9.3"
             }
@@ -1568,12 +1568,13 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.5.tgz",
-            "integrity": "sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1584,12 +1585,13 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.5.tgz",
-            "integrity": "sha512-Cv781jd0Rfj/paoNrul1/r4G0HLvuFKYh7C9uHZ2Pl8YXstzvCyyeWENTFR9qFnRzNMCjXmsulZuvosDg10Mog==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1600,12 +1602,13 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.5.tgz",
-            "integrity": "sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1616,12 +1619,13 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.5.tgz",
-            "integrity": "sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1632,12 +1636,13 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.5.tgz",
-            "integrity": "sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1648,12 +1653,13 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.5.tgz",
-            "integrity": "sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1664,12 +1670,13 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.5.tgz",
-            "integrity": "sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1680,12 +1687,13 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.5.tgz",
-            "integrity": "sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1696,12 +1704,13 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.5.tgz",
-            "integrity": "sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1712,12 +1721,13 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.5.tgz",
-            "integrity": "sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1728,12 +1738,13 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.5.tgz",
-            "integrity": "sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1744,12 +1755,13 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.5.tgz",
-            "integrity": "sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
             "cpu": [
                 "loong64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1760,12 +1772,13 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.5.tgz",
-            "integrity": "sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
             "cpu": [
                 "mips64el"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1776,12 +1789,13 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.5.tgz",
-            "integrity": "sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
             "cpu": [
                 "ppc64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1792,12 +1806,13 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.5.tgz",
-            "integrity": "sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1808,12 +1823,13 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.5.tgz",
-            "integrity": "sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1824,9 +1840,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.5.tgz",
-            "integrity": "sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+            "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
             "cpu": [
                 "x64"
             ],
@@ -1840,12 +1856,13 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.5.tgz",
-            "integrity": "sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1856,12 +1873,13 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.5.tgz",
-            "integrity": "sha512-28t+Sj3CPN8vkMOlZotOmDgilQwVvxWZl7b8rxpn73Tt/gCnvrHxQUMng4uu3itdFvrtba/1nHejvxqz8xgEMA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1872,12 +1890,13 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.5.tgz",
-            "integrity": "sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1888,12 +1907,13 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.5.tgz",
-            "integrity": "sha512-WfGVaa1oz5A7+ZFPkERIbIhKT4olvGl1tyzTRaB5yoZRLqC0KwaO95FeZtOdQj/oKkjW57KcVF944m62/0GYtA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1904,12 +1924,13 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.5.tgz",
-            "integrity": "sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1920,12 +1941,13 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.5.tgz",
-            "integrity": "sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1936,12 +1958,13 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.5.tgz",
-            "integrity": "sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1952,12 +1975,13 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.5.tgz",
-            "integrity": "sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1968,12 +1992,13 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.5.tgz",
-            "integrity": "sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2560,6 +2585,23 @@
                 "matter-test": "bin/test.js"
             }
         },
+        "node_modules/@matter/testing/node_modules/@esbuild/linux-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@matter/testing/node_modules/@matter/tools": {
             "version": "0.17.0-alpha.0-20260402-bd064abc8",
             "resolved": "https://registry.npmjs.org/@matter/tools/-/tools-0.17.0-alpha.0-20260402-bd064abc8.tgz",
@@ -2695,9 +2737,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm-eabi": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.43.0.tgz",
-            "integrity": "sha512-CgU2s+/9hHZgo0IxVxrbMPrMj+tJ6VM3mD7Mr/4oiz4FNTISLoCvRmB5nk4wAAle045RtRjd86m673jwPyb1OQ==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.44.0.tgz",
+            "integrity": "sha512-5UvghMd9SA/yvKTWCAxMAPXS1d2i054UeOf4iFjZjfayTwCINcC3oaSXjtbZfCaEpxgJod7XiOjTtby5yEv/BQ==",
             "cpu": [
                 "arm"
             ],
@@ -2712,9 +2754,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm64": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.43.0.tgz",
-            "integrity": "sha512-T9OfRwjA/EdYxAqbvR7TtqLv5nIrwPXuCtTwOHtS7aR9uXyn74ZYgzgTo6/ZwvTq9DY4W+DsV09hB2EXgn9EbA==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.44.0.tgz",
+            "integrity": "sha512-IVudM1BWfvrYO++Khtzr8q9n5Rxu7msUvoFMqzGJVdX7HfUXUDHwaH2zHZNB58svx2J56pmCUzophyaPFkcG/A==",
             "cpu": [
                 "arm64"
             ],
@@ -2729,9 +2771,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-arm64": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.43.0.tgz",
-            "integrity": "sha512-o3i49ZUSJWANzXMAAVY1wnqb65hn4JVzwlRQ5qfcwhRzIA8lGVaud31Q3by5ALHPrksp5QEaKCQF9aAS3TXpZA==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.44.0.tgz",
+            "integrity": "sha512-eWCLAIKAHfx88EqEP1Ga2yz7qVcqDU5lemn4xck+07bH182hDdprOHjbogyk0In1Djys3T0/pO2JepFnRJ41Mg==",
             "cpu": [
                 "arm64"
             ],
@@ -2746,9 +2788,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-x64": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.43.0.tgz",
-            "integrity": "sha512-vWECzzCFkb0kK6jaHjbtC5sC3adiNWtqawFCxhpvsWlzVeKmv5bNvkB4nux+o4JKWTpHCM57NDK/MeXt44txmA==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.44.0.tgz",
+            "integrity": "sha512-eHTBznHLM49++dwz07MblQ2cOXyIgeedmE3Wgy4ptUESj38/qYZyRi1MPwC9olQJWssMeY6WI3UZ7YmU5ggvyQ==",
             "cpu": [
                 "x64"
             ],
@@ -2763,9 +2805,9 @@
             }
         },
         "node_modules/@oxfmt/binding-freebsd-x64": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.43.0.tgz",
-            "integrity": "sha512-rgz8JpkKiI/umOf7fl9gwKyQasC8bs5SYHy6g7e4SunfLBY3+8ATcD5caIg8KLGEtKFm5ujKaH8EfjcmnhzTLg==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.44.0.tgz",
+            "integrity": "sha512-jLMmbj0u0Ft43QpkUVr/0v1ZfQCGWAvU+WznEHcN3wZC/q6ox7XeSJtk9P36CCpiDSUf3sGnzbIuG1KdEMEDJQ==",
             "cpu": [
                 "x64"
             ],
@@ -2780,9 +2822,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.43.0.tgz",
-            "integrity": "sha512-nWYnF3vIFzT4OM1qL/HSf1Yuj96aBuKWSaObXHSWliwAk2rcj7AWd6Lf7jowEBQMo4wCZVnueIGw/7C4u0KTBQ==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.44.0.tgz",
+            "integrity": "sha512-n+A/u/ByK1qV8FVGOwyaSpw5NPNl0qlZfgTBqHeGIqr8Qzq1tyWZ4lAaxPoe5mZqE3w88vn3+jZtMxriHPE7tg==",
             "cpu": [
                 "arm"
             ],
@@ -2797,9 +2839,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.43.0.tgz",
-            "integrity": "sha512-sFg+NWJbLfupYTF4WELHAPSnLPOn1jiDZ33Z1jfDnTaA+cC3iB35x0FMMZTFdFOz3icRIArncwCcemJFGXu6TQ==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.44.0.tgz",
+            "integrity": "sha512-5eax+FkxyCqAi3Rw0mrZFr7+KTt/XweFsbALR+B5ljWBLBl8nHe4ADrUnb1gLEfQCJLl+Ca5FIVD4xEt95AwIw==",
             "cpu": [
                 "arm"
             ],
@@ -2814,9 +2856,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.43.0.tgz",
-            "integrity": "sha512-MelWqv68tX6wZEILDrTc9yewiGXe7im62+5x0bNXlCYFOZdA+VnYiJfAihbROsZ5fm90p9C3haFrqjj43XnlAA==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.44.0.tgz",
+            "integrity": "sha512-58l8JaHxSGOmOMOG2CIrNsnkRJAj0YcHQCmvNACniOa/vd1iRHhlPajczegzS5jwMENlqgreyiTR9iNlke8qCw==",
             "cpu": [
                 "arm64"
             ],
@@ -2831,9 +2873,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-musl": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.43.0.tgz",
-            "integrity": "sha512-ROaWfYh+6BSJ1Arwy5ujijTlwnZetxDxzBpDc1oBR4d7rfrPBqzeyjd5WOudowzQUgyavl2wEpzn1hw3jWcqLA==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.44.0.tgz",
+            "integrity": "sha512-AlObQIXyVRZ96LbtVljtFq0JqH5B92NU+BQeDFrXWBUWlCKAM0wF5GLfIhCLT5kQ3Sl+U0YjRJ7Alqj5hGQaCg==",
             "cpu": [
                 "arm64"
             ],
@@ -2848,9 +2890,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.43.0.tgz",
-            "integrity": "sha512-PJRs/uNxmFipJJ8+SyKHh7Y7VZIKQicqrrBzvfyM5CtKi8D7yZKTwUOZV3ffxmiC2e7l1SDJpkBEOyue5NAFsg==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.44.0.tgz",
+            "integrity": "sha512-YcFE8/q/BbrCiIiM5piwbkA6GwJc5QqhMQp2yDrqQ2fuVkZ7CInb1aIijZ/k8EXc72qXMSwKpVlBv1w/MsGO/A==",
             "cpu": [
                 "ppc64"
             ],
@@ -2865,9 +2907,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.43.0.tgz",
-            "integrity": "sha512-j6biGAgzIhj+EtHXlbNumvwG7XqOIdiU4KgIWRXAEj/iUbHKukKW8eXa4MIwpQwW1YkxovduKtzEAPnjlnAhVQ==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.44.0.tgz",
+            "integrity": "sha512-eOdzs6RqkRzuqNHUX5C8ISN5xfGh4xDww8OEd9YAmc3OWN8oAe5bmlIqQ+rrHLpv58/0BuU48bxkhnIGjA/ATQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -2882,9 +2924,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.43.0.tgz",
-            "integrity": "sha512-RYWxAcslKxvy7yri24Xm9cmD0RiANaiEPs007EFG6l9h1ChM69Q5SOzACaCoz4Z9dEplnhhneeBaTWMEdpgIbA==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.44.0.tgz",
+            "integrity": "sha512-YBgNTxntD/QvlFUfgvh8bEdwOhXiquX8gaofZJAwYa/Xp1S1DQrFVZEeck7GFktr24DztsSp8N8WtWCBwxs0Hw==",
             "cpu": [
                 "riscv64"
             ],
@@ -2899,9 +2941,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.43.0.tgz",
-            "integrity": "sha512-DT6Q8zfQQy3jxpezAsBACEHNUUixKSYTwdXeXojNHe4DQOoxjPdjr3Szu6BRNjxLykZM/xMNmp9ElOIyDppwtw==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.44.0.tgz",
+            "integrity": "sha512-GLIh1R6WHWshl/i4QQDNgj0WtT25aRO4HNUWEoitxiywyRdhTFmFEYT2rXlcl9U6/26vhmOqG5cRlMLG3ocaIA==",
             "cpu": [
                 "s390x"
             ],
@@ -2916,9 +2958,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-gnu": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.43.0.tgz",
-            "integrity": "sha512-R8Yk7iYcuZORXmCfFZClqbDxRZgZ9/HEidUuBNdoX8Ptx07cMePnMVJ/woB84lFIDjh2ROHVaOP40Ds3rBXFqg==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.44.0.tgz",
+            "integrity": "sha512-gZOpgTlOsLcLfAF9qgpTr7FIIFSKnQN3hDf/0JvQ4CIwMY7h+eilNjxq/CorqvYcEOu+LRt1W4ZS7KccEHLOdA==",
             "cpu": [
                 "x64"
             ],
@@ -2933,9 +2975,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-musl": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.43.0.tgz",
-            "integrity": "sha512-F2YYqyvnQNvi320RWZNAvsaWEHwmW3k4OwNJ1hZxRKXupY63expbBaNp6jAgvYs7y/g546vuQnGHQuCBhslhLQ==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.44.0.tgz",
+            "integrity": "sha512-1CyS9JTB+pCUFYFI6pkQGGZaT/AY5gnhHVrQQLhFba6idP9AzVYm1xbdWfywoldTYvjxQJV6x4SuduCIfP3W+A==",
             "cpu": [
                 "x64"
             ],
@@ -2950,9 +2992,9 @@
             }
         },
         "node_modules/@oxfmt/binding-openharmony-arm64": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.43.0.tgz",
-            "integrity": "sha512-OE6TdietLXV3F6c7pNIhx/9YC1/2YFwjU9DPc/fbjxIX19hNIaP1rS0cFjCGJlGX+cVJwIKWe8Mos+LdQ1yAJw==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.44.0.tgz",
+            "integrity": "sha512-bmEv70Ak6jLr1xotCbF5TxIKjsmQaiX+jFRtnGtfA03tJPf6VG3cKh96S21boAt3JZc+Vjx8PYcDuLj39vM2Pw==",
             "cpu": [
                 "arm64"
             ],
@@ -2967,9 +3009,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.43.0.tgz",
-            "integrity": "sha512-0nWK6a7pGkbdoypfVicmV9k/N1FwjPZENoqhlTU+5HhZnAhpIO3za30nEE33u6l6tuy9OVfpdXUqxUgZ+4lbZw==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.44.0.tgz",
+            "integrity": "sha512-yWzB+oCpSnP/dmw85eFLAT5o35Ve5pkGS2uF/UCISpIwDqf1xa7OpmtomiqY/Vzg8VyvMbuf6vroF2khF/+1Vg==",
             "cpu": [
                 "arm64"
             ],
@@ -2984,9 +3026,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.43.0.tgz",
-            "integrity": "sha512-9aokTR4Ft+tRdvgN/pKzSkVy2ksc4/dCpDm9L/xFrbIw0yhLtASLbvoG/5WOTUh/BRPPnfGTsWznEqv0dlOmhA==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.44.0.tgz",
+            "integrity": "sha512-TcWpo18xEIE3AmIG2kpr3kz5IEhQgnx0lazl2+8L+3eTopOAUevQcmlr4nhguImNWz0OMeOZrYZOhJNCf16nlQ==",
             "cpu": [
                 "ia32"
             ],
@@ -3001,9 +3043,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-x64-msvc": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.43.0.tgz",
-            "integrity": "sha512-4bPgdQux2ZLWn3bf2TTXXMHcJB4lenmuxrLqygPmvCJ104Yqzj1UctxSRzR31TiJ4MLaG22RK8dUsVpJtrCz5g==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.44.0.tgz",
+            "integrity": "sha512-oj8aLkPJZppIM4CMQNsyir9ybM1Xw/CfGPTSsTnzpVGyljgfbdP0EVUlURiGM0BDrmw5psQ6ArmGCcUY/yABaQ==",
             "cpu": [
                 "x64"
             ],
@@ -3018,9 +3060,9 @@
             }
         },
         "node_modules/@oxlint-tsgolint/darwin-arm64": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.19.0.tgz",
-            "integrity": "sha512-FVOIp5Njte8Z6PpINz7sL5blqSro0pAL8VAHYQ+K5Xm4cOrPQ6DGIhH14oXnbRjzn8Kl69qjz8TPteyn8EqwsQ==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.20.0.tgz",
+            "integrity": "sha512-KKQcIHZHMxqpHUA1VXIbOG6chNCFkUWbQy6M+AFVtPKkA/3xAeJkJ3njoV66bfzwPHRcWQO+kcj5XqtbkjakoA==",
             "cpu": [
                 "arm64"
             ],
@@ -3032,9 +3074,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/darwin-x64": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.19.0.tgz",
-            "integrity": "sha512-GakDTDACePvqOFq3N4oQCl8SyMMa7VBnqV0gDcXPuK50jdWCUqlxM9tgRJarjyIVvmDEJRGYOen+4uBtVwg4Aw==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.20.0.tgz",
+            "integrity": "sha512-7HeVMuclGfG+NLZi2ybY0T4fMI7/XxO/208rJk+zEIloKkVnlh11Wd241JMGwgNFXn+MLJbOqOfojDb2Dt4L1g==",
             "cpu": [
                 "x64"
             ],
@@ -3046,9 +3088,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/linux-arm64": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.19.0.tgz",
-            "integrity": "sha512-Ya0R7somo+KDhhkPtENJ9Q28Fost+aqA3MPe86pEqgmukHFc/KO65PgShOSbIFjZNptELEQvsWL8gDxYZWhH3w==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.20.0.tgz",
+            "integrity": "sha512-zxhUwz+WSxE6oWlZLK2z2ps9yC6ebmgoYmjAl0Oa48+GqkZ56NVgo+wb8DURNv6xrggzHStQxqQxe3mK51HZag==",
             "cpu": [
                 "arm64"
             ],
@@ -3060,9 +3102,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/linux-x64": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.19.0.tgz",
-            "integrity": "sha512-yFH378jWc1k/oJmpk+TKpWbKvFieJJvsOHxVMSNFc+ukqs44ZSHVt4HFfAhXAt/bzVK2f7EIDTGp8Hm1OjoJ6Q==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/linux-x64/-/linux-x64-0.20.0.tgz",
+            "integrity": "sha512-/1l6FnahC9im8PK+Ekkx/V3yetO/PzZnJegE2FXcv/iXEhbeVxP/ouiTYcUQu9shT1FWJCSNti1VJHH+21Y1dg==",
             "cpu": [
                 "x64"
             ],
@@ -3074,9 +3116,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/win32-arm64": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.19.0.tgz",
-            "integrity": "sha512-R6NyAtha7OWxh7NGBeFxqDTGAVl1Xj4xLa8Qj39PKbIDqBeVW8BIb+1nEnRp+Mo/VpRoeoFAcqlBsuMcUMd26Q==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.20.0.tgz",
+            "integrity": "sha512-oPZ5Yz8sVdo7P/5q+i3IKeix31eFZ55JAPa1+RGPoe9PoaYVsdMvR6Jvib6YtrqoJnFPlg3fjEjlEPL8VBKYJA==",
             "cpu": [
                 "arm64"
             ],
@@ -3088,9 +3130,9 @@
             ]
         },
         "node_modules/@oxlint-tsgolint/win32-x64": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.19.0.tgz",
-            "integrity": "sha512-2ePvxcbS5tPOmrQvxR8Kc+IqzdTtlrGeMDv+jjTYfkTFPmh2rF9yxVchi/4WM6js3gt2UauQeMV/tfnZNemENQ==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@oxlint-tsgolint/win32-x64/-/win32-x64-0.20.0.tgz",
+            "integrity": "sha512-4stx8RHj3SP9vQyRF/yZbz5igtPvYMEUR8CUoha4BVNZihi39DpCR8qkU7lpjB5Ga1DRMo2pHaA4bdTOMaY4mw==",
             "cpu": [
                 "x64"
             ],
@@ -3102,9 +3144,9 @@
             ]
         },
         "node_modules/@oxlint/binding-android-arm-eabi": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.58.0.tgz",
-            "integrity": "sha512-1T7UN3SsWWxpWyWGn1cT3ASNJOo+pI3eUkmEl7HgtowapcV8kslYpFQcYn431VuxghXakPNlbjRwhqmR37PFOg==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.59.0.tgz",
+            "integrity": "sha512-etYDw/UaEv936AQUd/CRMBVd+e+XuuU6wC+VzOv1STvsTyZenLChepLWqLtnyTTp4YMlM22ypzogDDwqYxv5cg==",
             "cpu": [
                 "arm"
             ],
@@ -3119,9 +3161,9 @@
             }
         },
         "node_modules/@oxlint/binding-android-arm64": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.58.0.tgz",
-            "integrity": "sha512-GryzujxuiRv2YFF7bRy8mKcxlbuAN+euVUtGJt9KKbLT8JBUIosamVhcthLh+VEr6KE6cjeVMAQxKAzJcoN7dg==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.59.0.tgz",
+            "integrity": "sha512-TgLc7XVLKH2a4h8j3vn1MDjfK33i9MY60f/bKhRGWyVzbk5LCZ4X01VZG7iHrMmi5vYbAp8//Ponigx03CLsdw==",
             "cpu": [
                 "arm64"
             ],
@@ -3136,9 +3178,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-arm64": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.58.0.tgz",
-            "integrity": "sha512-7/bRSJIwl4GxeZL9rPZ11anNTyUO9epZrfEJH/ZMla3+/gbQ6xZixh9nOhsZ0QwsTW7/5J2A/fHbD1udC5DQQA==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.59.0.tgz",
+            "integrity": "sha512-DXyFPf5ZKldMLloRHx/B9fsxsiTQomaw7cmEW3YIJko2HgCh+GUhp9gGYwHrqlLJPsEe3dYj9JebjX92D3j3AA==",
             "cpu": [
                 "arm64"
             ],
@@ -3153,9 +3195,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-x64": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.58.0.tgz",
-            "integrity": "sha512-EqdtJSiHweS2vfILNrpyJ6HUwpEq2g7+4Zx1FPi4hu3Hu7tC3znF6ufbXO8Ub2LD4mGgznjI7kSdku9NDD1Mkg==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.59.0.tgz",
+            "integrity": "sha512-LgvrsdgVLX1qWqIEmNsSmMXJhpAWdtUQ0M+oR0CySwi+9IHWyOGuIL8w8+u/kbZNMyZr4WUyYB5i0+D+AKgkLg==",
             "cpu": [
                 "x64"
             ],
@@ -3170,9 +3212,9 @@
             }
         },
         "node_modules/@oxlint/binding-freebsd-x64": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.58.0.tgz",
-            "integrity": "sha512-VQt5TH4M42mY20F545G637RKxV/yjwVtKk2vfXuazfReSIiuvWBnv+FVSvIV5fKVTJNjt3GSJibh6JecbhGdBw==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.59.0.tgz",
+            "integrity": "sha512-bOJhqX/ny4hrFuTPlyk8foSRx/vLRpxJh0jOOKN2NWW6FScXHPAA5rQbrwdQPcgGB5V8Ua51RS03fke8ssBcug==",
             "cpu": [
                 "x64"
             ],
@@ -3187,9 +3229,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.58.0.tgz",
-            "integrity": "sha512-fBYcj4ucwpAtjJT3oeBdFBYKvNyjRSK+cyuvBOTQjh0jvKp4yeA4S/D0IsCHus/VPaNG5L48qQkh+Vjy3HL2/Q==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.59.0.tgz",
+            "integrity": "sha512-vVUXxYMF9trXCsz4m9H6U0IjehosVHxBzVgJUxly1uz4W1PdDyicaBnpC0KRXsHYretLVe+uS9pJy8iM57Kujw==",
             "cpu": [
                 "arm"
             ],
@@ -3204,9 +3246,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.58.0.tgz",
-            "integrity": "sha512-0BeuFfwlUHlJ1xpEdSD1YO3vByEFGPg36uLjK1JgFaxFb4W6w17F8ET8sz5cheZ4+x5f2xzdnRrrWv83E3Yd8g==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.59.0.tgz",
+            "integrity": "sha512-TULQW8YBPGRWg5yZpFPL54HLOnJ3/HiX6VenDPi6YfxB/jlItwSMFh3/hCeSNbh+DAMaE1Py0j5MOaivHkI/9Q==",
             "cpu": [
                 "arm"
             ],
@@ -3221,9 +3263,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-gnu": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.58.0.tgz",
-            "integrity": "sha512-TXlZgnPTlxrQzxG9ZXU7BNwx1Ilrr17P3GwZY0If2EzrinqRH3zXPc3HrRcBJgcsoZNMuNL5YivtkJYgp467UQ==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.59.0.tgz",
+            "integrity": "sha512-Gt54Y4eqSgYJ90xipm24xeyaPV854706o/kiT8oZvUt3VDY7qqxdqyGqchMaujd87ib+/MXvnl9WkK8Cc1BExg==",
             "cpu": [
                 "arm64"
             ],
@@ -3238,9 +3280,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-musl": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.58.0.tgz",
-            "integrity": "sha512-zSoYRo5dxHLcUx93Stl2hW3hSNjPt99O70eRVWt5A1zwJ+FPjeCCANCD2a9R4JbHsdcl11TIQOjyigcRVOH2mw==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.59.0.tgz",
+            "integrity": "sha512-3CtsKp7NFB3OfqQzbuAecrY7GIZeiv7AD+xutU4tefVQzlfmTI7/ygWLrvkzsDEjTlMq41rYHxgsn6Yh8tybmA==",
             "cpu": [
                 "arm64"
             ],
@@ -3255,9 +3297,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.58.0.tgz",
-            "integrity": "sha512-NQ0U/lqxH2/VxBYeAIvMNUK1y0a1bJ3ZicqkF2c6wfakbEciP9jvIE4yNzCFpZaqeIeRYaV7AVGqEO1yrfVPjA==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.59.0.tgz",
+            "integrity": "sha512-K0diOpT3ncDmOfl9I1HuvpEsAuTxkts0VYwIv/w6Xiy9CdwyPBVX88Ga9l8VlGgMrwBMnSY4xIvVlVY/fkQk7Q==",
             "cpu": [
                 "ppc64"
             ],
@@ -3272,9 +3314,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.58.0.tgz",
-            "integrity": "sha512-X9J+kr3gIC9FT8GuZt0ekzpNUtkBVzMVU4KiKDSlocyQuEgi3gBbXYN8UkQiV77FTusLDPsovjo95YedHr+3yg==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.59.0.tgz",
+            "integrity": "sha512-xAU7+QDU6kTJJ7mJLOGgo7oOjtAtkKyFZ0Yjdb5cEo3DiCCPFLvyr08rWiQh6evZ7RiUTf+o65NY/bqttzJiQQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -3289,9 +3331,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-musl": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.58.0.tgz",
-            "integrity": "sha512-CDze3pi1OO3Wvb/QsXjmLEY4XPKGM6kIo82ssNOgmcl1IdndF9VSGAE38YLhADWmOac7fjqhBw82LozuUVxD0Q==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.59.0.tgz",
+            "integrity": "sha512-KUmZmKlTTyauOnvUNVxK7G40sSSx0+w5l1UhaGsC6KPpOYHenx2oqJTnabmpLJicok7IC+3Y6fXAUOMyexaeJQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -3306,9 +3348,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-s390x-gnu": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.58.0.tgz",
-            "integrity": "sha512-b/89glbxFaEAcA6Uf1FvCNecBJEgcUTsV1quzrqXM/o4R1M4u+2KCVuyGCayN2UpsRWtGGLb+Ver0tBBpxaPog==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.59.0.tgz",
+            "integrity": "sha512-4usRxC8gS0PGdkHnRmwJt/4zrQNZyk6vL0trCxwZSsAKM+OxhB8nKiR+mhjdBbl8lbMh2gc3bZpNN/ik8c4c2A==",
             "cpu": [
                 "s390x"
             ],
@@ -3323,9 +3365,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-gnu": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.58.0.tgz",
-            "integrity": "sha512-0/yYpkq9VJFCEcuRlrViGj8pJUFFvNS4EkEREaN7CB1EcLXJIaVSSa5eCihwBGXtOZxhnblWgxks9juRdNQI7w==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.59.0.tgz",
+            "integrity": "sha512-s/rNE2gDmbwAOOP493xk2X7M8LZfI1LJFSSW1+yanz3vuQCFPiHkx4GY+O1HuLUDtkzGlhtMrIcxxzyYLv308w==",
             "cpu": [
                 "x64"
             ],
@@ -3340,9 +3382,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-musl": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.58.0.tgz",
-            "integrity": "sha512-hr6FNvmcAXiH+JxSvaJ4SJ1HofkdqEElXICW9sm3/Rd5eC3t7kzvmLyRAB3NngKO2wzXRCAm4Z/mGWfrsS4X8w==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.59.0.tgz",
+            "integrity": "sha512-+yYj1udJa2UvvIUmEm0IcKgc0UlPMgz0nsSTvkPL2y6n0uU5LgIHSwVu4AHhrve6j9BpVSoRksnz8c9QcvITJA==",
             "cpu": [
                 "x64"
             ],
@@ -3357,9 +3399,9 @@
             }
         },
         "node_modules/@oxlint/binding-openharmony-arm64": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.58.0.tgz",
-            "integrity": "sha512-R+O368VXgRql1K6Xar+FEo7NEwfo13EibPMoTv3sesYQedRXd6m30Dh/7lZMxnrQVFfeo4EOfYIP4FpcgWQNHg==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.59.0.tgz",
+            "integrity": "sha512-bUplUb48LYsB3hHlQXP2ZMOenpieWoOyppLAnnAhuPag3MGPnt+7caxE3w/Vl9wpQsTA3gzLntQi9rxWrs7Xqg==",
             "cpu": [
                 "arm64"
             ],
@@ -3374,9 +3416,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-arm64-msvc": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.58.0.tgz",
-            "integrity": "sha512-Q0FZiAY/3c4YRj4z3h9K1PgaByrifrfbBoODSeX7gy97UtB7pySPUQfC2B/GbxWU6k7CzQrRy5gME10PltLAFQ==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.59.0.tgz",
+            "integrity": "sha512-/HLsLuz42rWl7h7ePdmMTpHm2HIDmPtcEMYgm5BBEHiEiuNOrzMaUpd2z7UnNni5LGN9obJy2YoAYBLXQwazrA==",
             "cpu": [
                 "arm64"
             ],
@@ -3391,9 +3433,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-ia32-msvc": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.58.0.tgz",
-            "integrity": "sha512-Y8FKBABrSPp9H0QkRLHDHOSUgM/309a3IvOVgPcVxYcX70wxJrk608CuTg7w+C6vEd724X5wJoNkBcGYfH7nNQ==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.59.0.tgz",
+            "integrity": "sha512-rUPy+JnanpPwV/aJCPnxAD1fW50+XPI0VkWr7f0vEbqcdsS8NpB24Rw6RsS7SdpFv8Dw+8ugCwao5nCFbqOUSg==",
             "cpu": [
                 "ia32"
             ],
@@ -3408,9 +3450,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-x64-msvc": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.58.0.tgz",
-            "integrity": "sha512-bCn5rbiz5My+Bj7M09sDcnqW0QJyINRVxdZ65x1/Y2tGrMwherwK/lpk+HRQCKvXa8pcaQdF5KY5j54VGZLwNg==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.59.0.tgz",
+            "integrity": "sha512-xkE7puteDS/vUyRngLXW0t8WgdWoS/tfxXjhP/P7SMqPDx+hs44SpssO3h3qmTqECYEuXBUPzcAw5257Ka+ofA==",
             "cpu": [
                 "x64"
             ],
@@ -4574,9 +4616,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.5.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
-            "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+            "version": "25.5.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+            "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4655,13 +4697,13 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.58.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
-            "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+            "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.58.0",
-                "@typescript-eslint/types": "^8.58.0",
+                "@typescript-eslint/tsconfig-utils": "^8.58.1",
+                "@typescript-eslint/types": "^8.58.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -4676,9 +4718,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.58.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
-            "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+            "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4692,9 +4734,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.58.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
-            "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+            "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4705,15 +4747,15 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.58.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
-            "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+            "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.58.0",
-                "@typescript-eslint/tsconfig-utils": "8.58.0",
-                "@typescript-eslint/types": "8.58.0",
-                "@typescript-eslint/visitor-keys": "8.58.0",
+                "@typescript-eslint/project-service": "8.58.1",
+                "@typescript-eslint/tsconfig-utils": "8.58.1",
+                "@typescript-eslint/types": "8.58.1",
+                "@typescript-eslint/visitor-keys": "8.58.1",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -4744,12 +4786,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.58.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
-            "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+            "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.58.0",
+                "@typescript-eslint/types": "8.58.1",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -4761,27 +4803,27 @@
             }
         },
         "node_modules/@typescript/native-preview": {
-            "version": "7.0.0-dev.20260401.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260401.1.tgz",
-            "integrity": "sha512-xJcN9WlY/P6xKjCMH4+DTzZSj/EKR6H9avuqUKs4eKyPEvaQ4bX+9Ys3Vl2qhlUaD7IRWY7HN7db0LHAGlWRSA==",
+            "version": "7.0.0-dev.20260409.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260409.1.tgz",
+            "integrity": "sha512-CV1HEMGo1xCySwUJbCQOF+mmrTue8KTJ1Od2kKWhcbOpu8fPBfaqIpbAM6tGLcNEykEjMMTYHc/VTLbMgxdScQ==",
             "license": "Apache-2.0",
             "bin": {
                 "tsgo": "bin/tsgo.js"
             },
             "optionalDependencies": {
-                "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260401.1",
-                "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260401.1",
-                "@typescript/native-preview-linux-arm": "7.0.0-dev.20260401.1",
-                "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260401.1",
-                "@typescript/native-preview-linux-x64": "7.0.0-dev.20260401.1",
-                "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260401.1",
-                "@typescript/native-preview-win32-x64": "7.0.0-dev.20260401.1"
+                "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260409.1",
+                "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260409.1",
+                "@typescript/native-preview-linux-arm": "7.0.0-dev.20260409.1",
+                "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260409.1",
+                "@typescript/native-preview-linux-x64": "7.0.0-dev.20260409.1",
+                "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260409.1",
+                "@typescript/native-preview-win32-x64": "7.0.0-dev.20260409.1"
             }
         },
         "node_modules/@typescript/native-preview-darwin-arm64": {
-            "version": "7.0.0-dev.20260401.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260401.1.tgz",
-            "integrity": "sha512-9PCc1D4/zLic30g1upOw6ZmUl98fnrXYRv5wIZ6fxm1zZAObieRKUX3Jbr8M9N8iQQFxPIZPniIScsxAbmbJvw==",
+            "version": "7.0.0-dev.20260409.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260409.1.tgz",
+            "integrity": "sha512-GcRRnaoeZVrbC47woQ/2t3vPoQcTSjsWPEAQGtwNSdw7Z9TKxG4ES22ghJIQXd3ncTRCMJ+XELnnuqxVutkJ9w==",
             "cpu": [
                 "arm64"
             ],
@@ -4792,9 +4834,9 @@
             ]
         },
         "node_modules/@typescript/native-preview-darwin-x64": {
-            "version": "7.0.0-dev.20260401.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260401.1.tgz",
-            "integrity": "sha512-wwzca1KrjSVC6ApXfITsg/wF4GGbhVYebc7zChpuyi+phrHfw6ThTPB5XFUH4nA32vqw0Hn/6KACipMgzg8GPA==",
+            "version": "7.0.0-dev.20260409.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260409.1.tgz",
+            "integrity": "sha512-7s8DXAa0Xpu/8PEjYIc4I36Ju7eVpoz9k3E+3WQdOF8pIPWYohiOj+zi68m9XYQck+rnkjUFo26ThVKqVetoMA==",
             "cpu": [
                 "x64"
             ],
@@ -4805,9 +4847,9 @@
             ]
         },
         "node_modules/@typescript/native-preview-linux-arm": {
-            "version": "7.0.0-dev.20260401.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260401.1.tgz",
-            "integrity": "sha512-bbIkRZYjtyoyCJ3wFES7qn3EwYO5Go1hxArL5X5oWiBmUHq5gMIxTZDv5mpWxopVf9Eyh4ErHefXjf1s4J+6Ag==",
+            "version": "7.0.0-dev.20260409.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260409.1.tgz",
+            "integrity": "sha512-fOa07JBUXQpEPq+024g346inYZ2xp63ELuoRq6J0jwDWQ/ftCCuvdQNMncwFhsm1qlMdKT3S68NrnSxX16hiaw==",
             "cpu": [
                 "arm"
             ],
@@ -4818,9 +4860,9 @@
             ]
         },
         "node_modules/@typescript/native-preview-linux-arm64": {
-            "version": "7.0.0-dev.20260401.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260401.1.tgz",
-            "integrity": "sha512-1hgKibGi4QZF1J0hKltgY4nj4yKDmI4Ang5ar80I+YeUdGxV/fP2kU3bJang7QtHuSso6W+a52SF62zgqbzdow==",
+            "version": "7.0.0-dev.20260409.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260409.1.tgz",
+            "integrity": "sha512-cGTzTUqRGlIDwdtkDy6qTrvrqpe27W4CdgnFn0FpxpiWnaIi3wqjlzQ1grtqrqainw/yuPy5hn/I86sQgN6nvA==",
             "cpu": [
                 "arm64"
             ],
@@ -4831,9 +4873,9 @@
             ]
         },
         "node_modules/@typescript/native-preview-linux-x64": {
-            "version": "7.0.0-dev.20260401.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260401.1.tgz",
-            "integrity": "sha512-1ysZ4c/Wa3RYIlrwVceYlhb1m1hxQ4P2x92valZXH0bNWEPb+oiQ4Yf35O/vi5h8zDdX/ZQ59vivYl27cF1VVA==",
+            "version": "7.0.0-dev.20260409.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260409.1.tgz",
+            "integrity": "sha512-lQrbc/BJKBxQrR1ttBDU5sYY1Hb2moFQgHL20T6nbapNqGpK4pzy64p+NK39O93D4omiCSk04pkchBCVrMPSAg==",
             "cpu": [
                 "x64"
             ],
@@ -4844,9 +4886,9 @@
             ]
         },
         "node_modules/@typescript/native-preview-win32-arm64": {
-            "version": "7.0.0-dev.20260401.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260401.1.tgz",
-            "integrity": "sha512-fZYLCRe36y1BuzRFFpU2/RQ212l6Y1dccRMh8oTB8HlAVAAwtbkb6cjEn0Ablj4Dy16+Ih8R9uHsxPLNhtKw1Q==",
+            "version": "7.0.0-dev.20260409.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260409.1.tgz",
+            "integrity": "sha512-kmCafMo1xZlYx+9WnfpeZJ2tnB/CcJdR8QPX7j9vqcpe51D7b7Intmr921dD48KGpVh5YgjQ1MEFE5mjGqGMaA==",
             "cpu": [
                 "arm64"
             ],
@@ -4857,9 +4899,9 @@
             ]
         },
         "node_modules/@typescript/native-preview-win32-x64": {
-            "version": "7.0.0-dev.20260401.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260401.1.tgz",
-            "integrity": "sha512-I6ses4SjWvpbvSpm1BPFRrDeqrzu7JTchJG/a26iwwmTLv4fAGLc5/o6Kv9Naygozop1W3KOcVM5i3A9oxiIjQ==",
+            "version": "7.0.0-dev.20260409.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260409.1.tgz",
+            "integrity": "sha512-WRd+JpQipTsE15QgYr3w7J0f1NKvGcq2QEgmcq8hB0WZA1X2WhQopNu+MpPQ3tdDD42VjMhm8ZoB8HpuOoXK5w==",
             "cpu": [
                 "x64"
             ],
@@ -5172,9 +5214,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.13",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
-            "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+            "version": "2.10.16",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.16.tgz",
+            "integrity": "sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -5527,9 +5569,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001784",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001784.tgz",
-            "integrity": "sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==",
+            "version": "1.0.30001787",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
+            "integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
             "dev": true,
             "funding": [
                 {
@@ -5846,9 +5888,9 @@
             "license": "MIT"
         },
         "node_modules/content-disposition": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-            "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+            "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -6130,9 +6172,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.331",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
-            "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
+            "version": "1.5.334",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz",
+            "integrity": "sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==",
             "dev": true,
             "license": "ISC"
         },
@@ -6205,9 +6247,10 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.27.5",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.5.tgz",
-            "integrity": "sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
@@ -6217,32 +6260,49 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.5",
-                "@esbuild/android-arm": "0.27.5",
-                "@esbuild/android-arm64": "0.27.5",
-                "@esbuild/android-x64": "0.27.5",
-                "@esbuild/darwin-arm64": "0.27.5",
-                "@esbuild/darwin-x64": "0.27.5",
-                "@esbuild/freebsd-arm64": "0.27.5",
-                "@esbuild/freebsd-x64": "0.27.5",
-                "@esbuild/linux-arm": "0.27.5",
-                "@esbuild/linux-arm64": "0.27.5",
-                "@esbuild/linux-ia32": "0.27.5",
-                "@esbuild/linux-loong64": "0.27.5",
-                "@esbuild/linux-mips64el": "0.27.5",
-                "@esbuild/linux-ppc64": "0.27.5",
-                "@esbuild/linux-riscv64": "0.27.5",
-                "@esbuild/linux-s390x": "0.27.5",
-                "@esbuild/linux-x64": "0.27.5",
-                "@esbuild/netbsd-arm64": "0.27.5",
-                "@esbuild/netbsd-x64": "0.27.5",
-                "@esbuild/openbsd-arm64": "0.27.5",
-                "@esbuild/openbsd-x64": "0.27.5",
-                "@esbuild/openharmony-arm64": "0.27.5",
-                "@esbuild/sunos-x64": "0.27.5",
-                "@esbuild/win32-arm64": "0.27.5",
-                "@esbuild/win32-ia32": "0.27.5",
-                "@esbuild/win32-x64": "0.27.5"
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
+            }
+        },
+        "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/escalade": {
@@ -7477,9 +7537,9 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "11.2.7",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-            "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+            "version": "11.3.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+            "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -8103,9 +8163,9 @@
             }
         },
         "node_modules/oxfmt": {
-            "version": "0.43.0",
-            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.43.0.tgz",
-            "integrity": "sha512-KTYNG5ISfHSdmeZ25Xzb3qgz9EmQvkaGAxgBY/p38+ZiAet3uZeu7FnMwcSQJg152Qwl0wnYAxDc+Z/H6cvrwA==",
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.44.0.tgz",
+            "integrity": "sha512-lnncqvHewyRvaqdrnntVIrZV2tEddz8lbvPsQzG/zlkfvgZkwy0HP1p/2u1aCDToeg1jb9zBpbJdfkV73Itw+w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8121,31 +8181,31 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxfmt/binding-android-arm-eabi": "0.43.0",
-                "@oxfmt/binding-android-arm64": "0.43.0",
-                "@oxfmt/binding-darwin-arm64": "0.43.0",
-                "@oxfmt/binding-darwin-x64": "0.43.0",
-                "@oxfmt/binding-freebsd-x64": "0.43.0",
-                "@oxfmt/binding-linux-arm-gnueabihf": "0.43.0",
-                "@oxfmt/binding-linux-arm-musleabihf": "0.43.0",
-                "@oxfmt/binding-linux-arm64-gnu": "0.43.0",
-                "@oxfmt/binding-linux-arm64-musl": "0.43.0",
-                "@oxfmt/binding-linux-ppc64-gnu": "0.43.0",
-                "@oxfmt/binding-linux-riscv64-gnu": "0.43.0",
-                "@oxfmt/binding-linux-riscv64-musl": "0.43.0",
-                "@oxfmt/binding-linux-s390x-gnu": "0.43.0",
-                "@oxfmt/binding-linux-x64-gnu": "0.43.0",
-                "@oxfmt/binding-linux-x64-musl": "0.43.0",
-                "@oxfmt/binding-openharmony-arm64": "0.43.0",
-                "@oxfmt/binding-win32-arm64-msvc": "0.43.0",
-                "@oxfmt/binding-win32-ia32-msvc": "0.43.0",
-                "@oxfmt/binding-win32-x64-msvc": "0.43.0"
+                "@oxfmt/binding-android-arm-eabi": "0.44.0",
+                "@oxfmt/binding-android-arm64": "0.44.0",
+                "@oxfmt/binding-darwin-arm64": "0.44.0",
+                "@oxfmt/binding-darwin-x64": "0.44.0",
+                "@oxfmt/binding-freebsd-x64": "0.44.0",
+                "@oxfmt/binding-linux-arm-gnueabihf": "0.44.0",
+                "@oxfmt/binding-linux-arm-musleabihf": "0.44.0",
+                "@oxfmt/binding-linux-arm64-gnu": "0.44.0",
+                "@oxfmt/binding-linux-arm64-musl": "0.44.0",
+                "@oxfmt/binding-linux-ppc64-gnu": "0.44.0",
+                "@oxfmt/binding-linux-riscv64-gnu": "0.44.0",
+                "@oxfmt/binding-linux-riscv64-musl": "0.44.0",
+                "@oxfmt/binding-linux-s390x-gnu": "0.44.0",
+                "@oxfmt/binding-linux-x64-gnu": "0.44.0",
+                "@oxfmt/binding-linux-x64-musl": "0.44.0",
+                "@oxfmt/binding-openharmony-arm64": "0.44.0",
+                "@oxfmt/binding-win32-arm64-msvc": "0.44.0",
+                "@oxfmt/binding-win32-ia32-msvc": "0.44.0",
+                "@oxfmt/binding-win32-x64-msvc": "0.44.0"
             }
         },
         "node_modules/oxlint": {
-            "version": "1.58.0",
-            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.58.0.tgz",
-            "integrity": "sha512-t4s9leczDMqlvOSjnbCQe7gtoLkWgBGZ7sBdCJ9EOj5IXFSG/X7OAzK4yuH4iW+4cAYe8kLFbC8tuYMwWZm+Cg==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.59.0.tgz",
+            "integrity": "sha512-0xBLeGGjP4vD9pygRo8iuOkOzEU1MqOnfiOl7KYezL/QvWL8NUg6n03zXc7ZVqltiOpUxBk2zgHI3PnRIEdAvw==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -8158,25 +8218,25 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxlint/binding-android-arm-eabi": "1.58.0",
-                "@oxlint/binding-android-arm64": "1.58.0",
-                "@oxlint/binding-darwin-arm64": "1.58.0",
-                "@oxlint/binding-darwin-x64": "1.58.0",
-                "@oxlint/binding-freebsd-x64": "1.58.0",
-                "@oxlint/binding-linux-arm-gnueabihf": "1.58.0",
-                "@oxlint/binding-linux-arm-musleabihf": "1.58.0",
-                "@oxlint/binding-linux-arm64-gnu": "1.58.0",
-                "@oxlint/binding-linux-arm64-musl": "1.58.0",
-                "@oxlint/binding-linux-ppc64-gnu": "1.58.0",
-                "@oxlint/binding-linux-riscv64-gnu": "1.58.0",
-                "@oxlint/binding-linux-riscv64-musl": "1.58.0",
-                "@oxlint/binding-linux-s390x-gnu": "1.58.0",
-                "@oxlint/binding-linux-x64-gnu": "1.58.0",
-                "@oxlint/binding-linux-x64-musl": "1.58.0",
-                "@oxlint/binding-openharmony-arm64": "1.58.0",
-                "@oxlint/binding-win32-arm64-msvc": "1.58.0",
-                "@oxlint/binding-win32-ia32-msvc": "1.58.0",
-                "@oxlint/binding-win32-x64-msvc": "1.58.0"
+                "@oxlint/binding-android-arm-eabi": "1.59.0",
+                "@oxlint/binding-android-arm64": "1.59.0",
+                "@oxlint/binding-darwin-arm64": "1.59.0",
+                "@oxlint/binding-darwin-x64": "1.59.0",
+                "@oxlint/binding-freebsd-x64": "1.59.0",
+                "@oxlint/binding-linux-arm-gnueabihf": "1.59.0",
+                "@oxlint/binding-linux-arm-musleabihf": "1.59.0",
+                "@oxlint/binding-linux-arm64-gnu": "1.59.0",
+                "@oxlint/binding-linux-arm64-musl": "1.59.0",
+                "@oxlint/binding-linux-ppc64-gnu": "1.59.0",
+                "@oxlint/binding-linux-riscv64-gnu": "1.59.0",
+                "@oxlint/binding-linux-riscv64-musl": "1.59.0",
+                "@oxlint/binding-linux-s390x-gnu": "1.59.0",
+                "@oxlint/binding-linux-x64-gnu": "1.59.0",
+                "@oxlint/binding-linux-x64-musl": "1.59.0",
+                "@oxlint/binding-openharmony-arm64": "1.59.0",
+                "@oxlint/binding-win32-arm64-msvc": "1.59.0",
+                "@oxlint/binding-win32-ia32-msvc": "1.59.0",
+                "@oxlint/binding-win32-x64-msvc": "1.59.0"
             },
             "peerDependencies": {
                 "oxlint-tsgolint": ">=0.18.0"
@@ -8188,21 +8248,21 @@
             }
         },
         "node_modules/oxlint-tsgolint": {
-            "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.19.0.tgz",
-            "integrity": "sha512-pSzUmDjMyjC8iUUZ7fCLo0D1iUaYIfodd/WIQ6Zra11YkjkUQk3BOFoW4I5ec6uZ/0s2FEmxtiZ7hiTXFRp1cg==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/oxlint-tsgolint/-/oxlint-tsgolint-0.20.0.tgz",
+            "integrity": "sha512-/Uc9TQyN1l8w9QNvXtVHYtz+SzDJHKpb5X0UnHodl0BVzijUPk0LPlDOHAvogd1UI+iy9ZSF6gQxEqfzUxCULQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "tsgolint": "bin/tsgolint.js"
             },
             "optionalDependencies": {
-                "@oxlint-tsgolint/darwin-arm64": "0.19.0",
-                "@oxlint-tsgolint/darwin-x64": "0.19.0",
-                "@oxlint-tsgolint/linux-arm64": "0.19.0",
-                "@oxlint-tsgolint/linux-x64": "0.19.0",
-                "@oxlint-tsgolint/win32-arm64": "0.19.0",
-                "@oxlint-tsgolint/win32-x64": "0.19.0"
+                "@oxlint-tsgolint/darwin-arm64": "0.20.0",
+                "@oxlint-tsgolint/darwin-x64": "0.20.0",
+                "@oxlint-tsgolint/linux-arm64": "0.20.0",
+                "@oxlint-tsgolint/linux-x64": "0.20.0",
+                "@oxlint-tsgolint/win32-arm64": "0.20.0",
+                "@oxlint-tsgolint/win32-x64": "0.20.0"
             }
         },
         "node_modules/p-limit": {
@@ -8497,9 +8557,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-            "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+            "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
@@ -8681,9 +8741,9 @@
             "license": "MIT"
         },
         "node_modules/regjsparser": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-            "integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+            "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -9331,13 +9391,13 @@
             }
         },
         "node_modules/side-channel-list": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-            "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3"
+                "object-inspect": "^1.13.4"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -9718,13 +9778,13 @@
             "license": "MIT"
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
             "license": "MIT",
             "dependencies": {
                 "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -10527,7 +10587,7 @@
                 "@matter/nodejs": "0.17.0-alpha.0-20260402-bd064abc8",
                 "@matter/testing": "0.17.0-alpha.0-20260402-bd064abc8",
                 "@types/express": "^5.0.6",
-                "@types/node": "^25.5.0"
+                "@types/node": "^25.5.2"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -10539,11 +10599,11 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@microsoft/tsdoc": "^0.16.0",
-                "@typescript/native-preview": "^7.0.0-dev.20260331.1",
+                "@typescript/native-preview": "^7.0.0-dev.20260407.1",
                 "ansi-colors": "^4.1.3",
                 "commander": "^14.0.3",
                 "detective-typescript": "^14.0.0",
-                "esbuild": "^0.27.4",
+                "esbuild": "^0.28.0",
                 "minimatch": "^10.2.5",
                 "type-fest": "^5.5.0",
                 "typedoc": "^0.28.18",
@@ -10558,10 +10618,451 @@
             },
             "devDependencies": {
                 "@types/madge": "^5.0.3",
-                "@types/node": "^25.5.0"
+                "@types/node": "^25.5.2"
             },
             "optionalDependencies": {
-                "@esbuild/linux-x64": "^0.27.4"
+                "@esbuild/linux-x64": "^0.28.0"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+            "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/android-arm": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+            "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/android-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+            "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/android-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+            "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+            "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/darwin-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+            "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+            "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/linux-arm": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+            "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/linux-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+            "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/linux-ia32": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+            "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/linux-loong64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+            "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+            "cpu": [
+                "loong64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+            "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+            "cpu": [
+                "mips64el"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+            "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+            "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/linux-s390x": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+            "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+            "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/sunos-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+            "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/win32-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+            "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/win32-ia32": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+            "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/@esbuild/win32-x64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+            "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "packages/tools/node_modules/esbuild": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+            "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.28.0",
+                "@esbuild/android-arm": "0.28.0",
+                "@esbuild/android-arm64": "0.28.0",
+                "@esbuild/android-x64": "0.28.0",
+                "@esbuild/darwin-arm64": "0.28.0",
+                "@esbuild/darwin-x64": "0.28.0",
+                "@esbuild/freebsd-arm64": "0.28.0",
+                "@esbuild/freebsd-x64": "0.28.0",
+                "@esbuild/linux-arm": "0.28.0",
+                "@esbuild/linux-arm64": "0.28.0",
+                "@esbuild/linux-ia32": "0.28.0",
+                "@esbuild/linux-loong64": "0.28.0",
+                "@esbuild/linux-mips64el": "0.28.0",
+                "@esbuild/linux-ppc64": "0.28.0",
+                "@esbuild/linux-riscv64": "0.28.0",
+                "@esbuild/linux-s390x": "0.28.0",
+                "@esbuild/linux-x64": "0.28.0",
+                "@esbuild/netbsd-arm64": "0.28.0",
+                "@esbuild/netbsd-x64": "0.28.0",
+                "@esbuild/openbsd-arm64": "0.28.0",
+                "@esbuild/openbsd-x64": "0.28.0",
+                "@esbuild/openharmony-arm64": "0.28.0",
+                "@esbuild/sunos-x64": "0.28.0",
+                "@esbuild/win32-arm64": "0.28.0",
+                "@esbuild/win32-ia32": "0.28.0",
+                "@esbuild/win32-x64": "0.28.0"
             }
         },
         "packages/ws-client": {
@@ -10570,7 +11071,7 @@
             "license": "Apache-2.0",
             "devDependencies": {
                 "@matter/testing": "0.17.0-alpha.0-20260402-bd064abc8",
-                "@types/node": "^25.5.0",
+                "@types/node": "^25.5.2",
                 "@types/ws": "^8.18.1",
                 "ws": "^8.20.0"
             },
@@ -10588,7 +11089,7 @@
                 "ws": "^8.20.0"
             },
             "devDependencies": {
-                "@types/node": "^25.5.0",
+                "@types/node": "^25.5.2",
                 "@types/ws": "^8.18.1"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
         "@types/mocha": "^10.0.10",
         "glob": "^13.0.6",
         "globals": "^17.4.0",
-        "oxfmt": "^0.43.0",
-        "oxlint": "^1.58.0",
-        "oxlint-tsgolint": "^0.19.0",
+        "oxfmt": "^0.44.0",
+        "oxlint": "^1.59.0",
+        "oxlint-tsgolint": "^0.20.0",
         "tsx": "^4.21.0",
         "typescript": "~5.9.3"
     }

--- a/packages/matter-server/package.json
+++ b/packages/matter-server/package.json
@@ -32,7 +32,7 @@
     },
     "devDependencies": {
         "@types/express": "^5.0.6",
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.5.2",
         "@matter/nodejs": "0.17.0-alpha.0-20260402-bd064abc8",
         "@matter/testing": "0.17.0-alpha.0-20260402-bd064abc8",
         "@matter-server/ws-client": "*"

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -61,11 +61,11 @@
     "homepage": "https://github.com/matter-js/matter.js#readme",
     "dependencies": {
         "@microsoft/tsdoc": "^0.16.0",
-        "@typescript/native-preview": "^7.0.0-dev.20260331.1",
+        "@typescript/native-preview": "^7.0.0-dev.20260407.1",
         "ansi-colors": "^4.1.3",
         "commander": "^14.0.3",
         "detective-typescript": "^14.0.0",
-        "esbuild": "^0.27.4",
+        "esbuild": "^0.28.0",
         "minimatch": "^10.2.5",
         "type-fest": "^5.5.0",
         "typedoc": "^0.28.18",
@@ -73,11 +73,11 @@
         "typescript": "~5.9.3"
     },
     "optionalDependencies": {
-        "@esbuild/linux-x64": "^0.27.4"
+        "@esbuild/linux-x64": "^0.28.0"
     },
     "devDependencies": {
         "@types/madge": "^5.0.3",
-        "@types/node": "^25.5.0"
+        "@types/node": "^25.5.2"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -24,7 +24,7 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.5.2",
         "@types/ws": "^8.18.1",
         "@matter/testing": "0.17.0-alpha.0-20260402-bd064abc8",
         "ws": "^8.20.0"

--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -16,7 +16,8 @@
     "scripts": {
         "clean": "matter-build clean",
         "build": "matter-build",
-        "build-clean": "matter-build --clean"
+        "build-clean": "matter-build --clean",
+        "test": "matter-test --force-exit"
     },
     "engines": {
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -31,7 +32,7 @@
         "ws": "^8.20.0"
     },
     "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^25.5.2",
         "@types/ws": "^8.18.1"
     },
     "files": [

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -16,6 +16,7 @@ import {
     isObject,
     Logger,
     Millis,
+    Minutes,
     NodeId,
     Observable,
     Seconds,
@@ -23,6 +24,8 @@ import {
     ServerAddressUdp,
     SoftwareUpdateInfo,
     SoftwareUpdateManager,
+    Time,
+    Timer,
     DnsRecordType,
 } from "@matter/main";
 import { OperationalCredentialsClient } from "@matter/main/behaviors";
@@ -106,6 +109,9 @@ import { Nodes } from "./Nodes.js";
 
 const logger = Logger.get("ControllerCommandHandler");
 
+/** After this duration in Reconnecting state, declare the node unavailable */
+const RECONNECT_TIMEOUT = Minutes(5);
+
 /**
  * Cluster IDs whose attribute changes should trigger a full node_updated broadcast.
  * BasicInformation (0x28) covers firmware version, product name, etc.
@@ -160,8 +166,8 @@ export class ControllerCommandHandler {
     #availableUpdates = new Map<NodeId, SoftwareUpdateInfo>();
     /** Poller for custom cluster attributes (Eve energy, etc.) */
     #customClusterPoller: CustomClusterPoller;
-    /** Track the last known availability for each node to detect changes */
-    #lastAvailability = new Map<NodeId, boolean>();
+    /** Per-node timers that fire when Reconnecting state exceeds the timeout */
+    #reconnectTimers = new Map<NodeId, Timer>();
     /** Track in-flight invoke-commands for deduplication across all WebSocket connections */
     readonly #inFlightInvokes = new Map<string, Promise<unknown>>();
     events = {
@@ -273,6 +279,10 @@ export class ControllerCommandHandler {
     }
 
     async close() {
+        for (const timer of this.#reconnectTimers.values()) {
+            timer.stop();
+        }
+        this.#reconnectTimers.clear();
         await this.#customClusterPoller.stop();
         if (!this.#started) {
             return;
@@ -307,38 +317,49 @@ export class ControllerCommandHandler {
         });
         node.events.eventTriggered.on(data => this.events.eventChanged.emit(nodeId, data));
         node.events.stateChanged.on(state => {
-            if (state === NodeStates.Disconnected) {
-                return;
-            }
-
-            // Calculate availability before and after state change
-            const previousState = this.#nodes.getPreviousState(nodeId);
-            const wasAvailable = this.#lastAvailability.get(nodeId) ?? false;
-            const isAvailable = this.#nodes.isNodeAvailable(state, previousState);
-
-            // Only refresh cache on Connected state (not Reconnecting, WaitingForDiscovery, etc.)
+            // Only refresh cache on Connected state
             if (state === NodeStates.Connected) {
                 attributeCache.update(node);
-                // Register for custom cluster polling (e.g., Eve energy) after cache is updated
                 const attributes = attributeCache.get(nodeId);
                 if (attributes) {
                     this.#customClusterPoller.registerNode(nodeId, attributes);
                 }
             }
 
-            // Update state tracking for the next transition
-            this.#nodes.setPreviousState(nodeId, state);
-            this.#lastAvailability.set(nodeId, isAvailable);
+            // Manage reconnect timer
+            if (state === NodeStates.Reconnecting) {
+                if (!this.#reconnectTimers.has(nodeId)) {
+                    const timer = Time.getTimer(`reconnect-timeout-${nodeId}`, RECONNECT_TIMEOUT, () => {
+                        this.#reconnectTimers.delete(nodeId);
+                        if (this.#nodes.forceUnavailable(nodeId)) {
+                            logger.info(
+                                `Node ${this.formatNode(nodeId)} still reconnecting after timeout, marking unavailable`,
+                            );
+                            this.events.nodeAvailabilityChanged.emit(nodeId, false);
+                        }
+                    });
+                    timer.utility = true;
+                    timer.start();
+                    this.#reconnectTimers.set(nodeId, timer);
+                }
+            } else {
+                // Any non-Reconnecting state clears the timer
+                this.#reconnectTimers.get(nodeId)?.stop();
+                this.#reconnectTimers.delete(nodeId);
+            }
+
+            // Process state change and check if availability changed
+            const result = this.#nodes.processStateChange(nodeId, state);
 
             // Emit state changed event
             this.events.nodeStateChanged.emit(nodeId, state);
 
             // Emit availability changed if it actually changed
-            if (wasAvailable !== isAvailable) {
+            if (result.availabilityChanged) {
                 logger.info(
-                    `Node ${this.formatNode(nodeId)} availability changed: ${wasAvailable} -> ${isAvailable} (state: ${NodeStates[previousState ?? -1]} -> ${NodeStates[state]})`,
+                    `Node ${this.formatNode(nodeId)} availability changed to ${result.available} (state: ${NodeStates[state]})`,
                 );
-                this.events.nodeAvailabilityChanged.emit(nodeId, isAvailable);
+                this.events.nodeAvailabilityChanged.emit(nodeId, result.available);
             }
         });
         node.events.structureChanged.on(() => {
@@ -356,14 +377,7 @@ export class ControllerCommandHandler {
         // Store the node for direct access
         this.#nodes.set(nodeId, node);
 
-        // Seed state tracking from the node's current connection state so the first
-        // stateChanged event shows a real previous state instead of "undefined".
-        const initialState = node.connectionState;
-        this.#nodes.setPreviousState(nodeId, initialState);
-        // Only mark as available when actually connected; all other states default to false (unavailable).
-        if (initialState === NodeStates.Connected) {
-            this.#lastAvailability.set(nodeId, true);
-        }
+        this.#nodes.seedState(nodeId, node.connectionState);
 
         // Initialize attribute cache if node is already initialized
         if (node.initialized) {
@@ -1127,6 +1141,8 @@ export class ControllerCommandHandler {
             throw ServerError.nodeNotExists(nodeId);
         }
         await this.#controller.removeNode(nodeId, !!node?.isConnected);
+        this.#reconnectTimers.get(nodeId)?.stop();
+        this.#reconnectTimers.delete(nodeId);
         // Remove node from storage (also clears attribute cache)
         this.#nodes.delete(nodeId);
         // Unregister from custom cluster polling

--- a/packages/ws-controller/src/controller/Nodes.ts
+++ b/packages/ws-controller/src/controller/Nodes.ts
@@ -27,6 +27,8 @@ export class Nodes {
     #attributeCache = new AttributeDataCache();
     /** Track previous connection state for availability debouncing */
     #previousStates = new Map<NodeId, NodeStates>();
+    /** Cached availability so serialization and event paths always agree */
+    #lastAvailability = new Map<NodeId, boolean>();
 
     /**
      * Get the attribute cache instance.
@@ -75,21 +77,52 @@ export class Nodes {
         this.#nodes.delete(nodeId);
         this.#attributeCache.delete(nodeId);
         this.#previousStates.delete(nodeId);
+        this.#lastAvailability.delete(nodeId);
     }
 
     /**
-     * Get the previous connection state for a node.
+     * Initialize state tracking for a newly paired/discovered node.
+     * Sets previous state and initial availability so the first stateChanged event
+     * has a real previous state instead of undefined.
      */
-    getPreviousState(nodeId: NodeId): NodeStates | undefined {
-        return this.#previousStates.get(nodeId);
+    seedState(nodeId: NodeId, initialState: NodeStates): void {
+        this.#previousStates.set(nodeId, initialState);
+        this.#lastAvailability.set(nodeId, initialState === NodeStates.Connected);
     }
 
     /**
-     * Update the previous connection state for a node.
-     * Call this after processing a state change to track state transitions.
+     * Process a state change for a node. Reads previous state BEFORE updating,
+     * computes new availability, and updates both tracking maps atomically.
+     * Returns whether availability changed and the new value.
      */
-    setPreviousState(nodeId: NodeId, state: NodeStates): void {
-        this.#previousStates.set(nodeId, state);
+    processStateChange(
+        nodeId: NodeId,
+        newState: NodeStates,
+    ): { availabilityChanged: true; available: boolean } | { availabilityChanged: false } {
+        const previousState = this.#previousStates.get(nodeId);
+        const wasAvailable = this.#lastAvailability.get(nodeId) ?? false;
+        const available = this.isNodeAvailable(newState, previousState);
+
+        this.#previousStates.set(nodeId, newState);
+        this.#lastAvailability.set(nodeId, available);
+
+        if (wasAvailable !== available) {
+            return { availabilityChanged: true, available };
+        }
+        return { availabilityChanged: false };
+    }
+
+    /**
+     * Force a node to unavailable state. Used by reconnect timeout
+     * when debounce period expires without reconnection.
+     * Only updates #lastAvailability — #previousStates is left as-is because
+     * processStateChange() will overwrite it on the next real state transition.
+     * Returns true if the node was previously considered available.
+     */
+    forceUnavailable(nodeId: NodeId): boolean {
+        const wasAvailable = this.#lastAvailability.get(nodeId) ?? false;
+        this.#lastAvailability.set(nodeId, false);
+        return wasAvailable;
     }
 
     /**
@@ -116,17 +149,12 @@ export class Nodes {
     }
 
     /**
-     * Check if a node is available based on its current and previous connection state.
-     * Uses debouncing: Reconnecting from Connected is still considered available.
+     * Check if a node is available. Returns the cached availability value set by
+     * seedState/processStateChange/forceUnavailable, avoiding the race where
+     * recomputing from live state disagrees with the event path's determination.
      */
     isAvailable(nodeId: NodeId): boolean {
-        const node = this.#nodes.get(nodeId);
-        if (node === undefined) {
-            return false;
-        }
-        const currentState = node.connectionState;
-        const previousState = this.#previousStates.get(nodeId);
-        return this.isNodeAvailable(currentState, previousState);
+        return this.#lastAvailability.get(nodeId) ?? false;
     }
 
     /**

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -392,11 +392,13 @@ export class WebSocketControllerHandler implements WebServerHandler {
         data: string,
     ): Promise<{ response: ErrorResultMessage | SuccessResultMessage; enableListeners?: boolean }> {
         let messageId: string | undefined;
+        let command: string | undefined;
         try {
             logger.debug(`[${connId}] WebSocket request`, () => data);
             const request = parseBigIntAwareJson(data) as { message_id: string; command: string; args: any };
-            const { command, args } = request;
+            const { args } = request;
             messageId = request.message_id;
+            command = request.command;
             let result: ResponseOf<any>;
             let enableListeners: boolean | undefined = undefined;
             switch (command) {
@@ -514,7 +516,7 @@ export class WebSocketControllerHandler implements WebServerHandler {
                 enableListeners,
             };
         } catch (err) {
-            logger.error(`[${connId}] Failed to handle websocket request`, err);
+            logger.error(`[${connId}] WebSocket error response (${command})`, messageId, err);
             const errorCode = err instanceof ServerError ? err.code : ServerErrorCode.UnknownError;
             return {
                 response: {

--- a/packages/ws-controller/test/NodesTest.ts
+++ b/packages/ws-controller/test/NodesTest.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NodeId } from "@matter/main";
+import { NodeStates } from "@project-chip/matter.js/device";
+import { Nodes } from "../src/controller/Nodes.js";
+
+const TEST_NODE_ID = NodeId(1);
+
+describe("Nodes", () => {
+    describe("isNodeAvailable", () => {
+        let nodes: Nodes;
+
+        beforeEach(() => {
+            nodes = new Nodes();
+        });
+
+        it("returns true when Connected", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Connected)).to.equal(true);
+        });
+
+        it("returns true when Reconnecting from Connected (debounce)", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Reconnecting, NodeStates.Connected)).to.equal(true);
+        });
+
+        it("returns false when Reconnecting from WaitingForDeviceDiscovery", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Reconnecting, NodeStates.WaitingForDeviceDiscovery)).to.equal(
+                false,
+            );
+        });
+
+        it("returns false when Reconnecting with no previous state", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Reconnecting)).to.equal(false);
+        });
+
+        it("returns false when Disconnected", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Disconnected)).to.equal(false);
+        });
+
+        it("returns false when Disconnected even if previously Connected", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Disconnected, NodeStates.Connected)).to.equal(false);
+        });
+
+        it("returns false when WaitingForDeviceDiscovery", () => {
+            expect(nodes.isNodeAvailable(NodeStates.WaitingForDeviceDiscovery)).to.equal(false);
+        });
+    });
+
+    describe("processStateChange", () => {
+        let nodes: Nodes;
+
+        beforeEach(() => {
+            nodes = new Nodes();
+        });
+
+        it("reports unavailable when Connected -> Disconnected", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Disconnected);
+            expect(result.availabilityChanged).to.equal(true);
+            if (result.availabilityChanged) {
+                expect(result.available).to.equal(false);
+            }
+        });
+
+        it("reports unavailable when Connected -> WaitingForDeviceDiscovery", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.WaitingForDeviceDiscovery);
+            expect(result.availabilityChanged).to.equal(true);
+            if (result.availabilityChanged) {
+                expect(result.available).to.equal(false);
+            }
+        });
+
+        it("reports available when Disconnected -> Connected", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Disconnected);
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Connected);
+            expect(result.availabilityChanged).to.equal(true);
+            if (result.availabilityChanged) {
+                expect(result.available).to.equal(true);
+            }
+        });
+
+        it("does NOT report change when Connected -> Reconnecting (debounce)", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting);
+            expect(result.availabilityChanged).to.equal(false);
+        });
+
+        it("does NOT report change when unavailable -> another unavailable", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Disconnected);
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.WaitingForDeviceDiscovery);
+            expect(result.availabilityChanged).to.equal(false);
+        });
+
+        it("reports available on Connected for unseeded node", () => {
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Connected);
+            expect(result.availabilityChanged).to.equal(true);
+            if (result.availabilityChanged) {
+                expect(result.available).to.equal(true);
+            }
+        });
+
+        it("handles full lifecycle: Connected -> Reconnecting -> Disconnected -> Connected", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+
+            // Connected -> Reconnecting: debounced, still available, no change
+            const r1 = nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting);
+            expect(r1.availabilityChanged).to.equal(false);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
+
+            // Reconnecting -> Disconnected: now unavailable
+            const r2 = nodes.processStateChange(TEST_NODE_ID, NodeStates.Disconnected);
+            expect(r2.availabilityChanged).to.equal(true);
+            if (r2.availabilityChanged) {
+                expect(r2.available).to.equal(false);
+            }
+
+            // Disconnected -> Connected: available again
+            const r3 = nodes.processStateChange(TEST_NODE_ID, NodeStates.Connected);
+            expect(r3.availabilityChanged).to.equal(true);
+            if (r3.availabilityChanged) {
+                expect(r3.available).to.equal(true);
+            }
+        });
+    });
+
+    describe("forceUnavailable", () => {
+        let nodes: Nodes;
+
+        beforeEach(() => {
+            nodes = new Nodes();
+        });
+
+        it("returns true and sets unavailable when node was available", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
+
+            const wasAvailable = nodes.forceUnavailable(TEST_NODE_ID);
+            expect(wasAvailable).to.equal(true);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(false);
+        });
+
+        it("returns false when already unavailable", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Disconnected);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(false);
+
+            const wasAvailable = nodes.forceUnavailable(TEST_NODE_ID);
+            expect(wasAvailable).to.equal(false);
+        });
+
+        it("isAvailable returns false after forceUnavailable", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+            nodes.forceUnavailable(TEST_NODE_ID);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(false);
+        });
+    });
+
+    describe("isAvailable caching (core bug fix)", () => {
+        let nodes: Nodes;
+
+        beforeEach(() => {
+            nodes = new Nodes();
+        });
+
+        it("returns cached debounced value, not recomputed from live state", () => {
+            // Seed as Connected (available)
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
+
+            // Transition to Reconnecting - debounced, still available
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting);
+            expect(result.availabilityChanged).to.equal(false);
+
+            // The core bug fix: isAvailable returns the CACHED value (true)
+            // rather than recomputing from live state (Reconnecting without
+            // previous-state context would give false)
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
+        });
+
+        it("returns false for unknown node", () => {
+            expect(nodes.isAvailable(NodeId(999))).to.equal(false);
+        });
+    });
+
+    describe("delete", () => {
+        it("clears availability tracking", () => {
+            const nodes = new Nodes();
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
+
+            nodes.delete(TEST_NODE_ID);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(false);
+        });
+    });
+});

--- a/packages/ws-controller/test/tsconfig.json
+++ b/packages/ws-controller/test/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "extends": "../../tools/tsc/tsconfig.test.json",
+    "compilerOptions": {
+        "types": [
+            "node",
+            "mocha",
+            "@matter/testing"
+        ]
+    },
+    "references": [
+        {
+            "path": "../../tools/src"
+        },
+        {
+            "path": "../../ws-client/src"
+        },
+        {
+            "path": "../src"
+        }
+    ]
+}

--- a/packages/ws-controller/tsconfig.json
+++ b/packages/ws-controller/tsconfig.json
@@ -1,5 +1,5 @@
 {
     "compilerOptions": { "composite": true },
     "files": [],
-    "references": [{ "path": "src" }]
+    "references": [{ "path": "src" }, { "path": "test" }]
 }


### PR DESCRIPTION
## Summary

Fixes #494 — Home Assistant never marks Matter devices as unavailable when they go offline.

Two root-cause bugs were identified by analyzing the debug logs from the issue:

- **Event/serialization path split-brain:** The `stateChanged` handler computed availability using `previousState` *before* updating it (debounced `Reconnecting` from `Connected` as "available"), but `isAvailable()` — called by `getNodeDetails()` for WebSocket serialization — read `previousState` *after* the update (saw `Reconnecting` from `Reconnecting` = "unavailable"). HA relies on `node_updated` events and never got one. The dashboard reconnected WS and fetched fresh state via `start_listening`, which is why it correctly showed "OFFLINE".
- **Unbounded Reconnecting debounce:** When a device goes offline but MDNS retains its cached address, the node stays in `Reconnecting` indefinitely without transitioning to `WaitingForDeviceDiscovery`. The debounce logic considered it "still available" forever.

### Changes

- **`Nodes.ts`**: `isAvailable()` now returns a cached availability value instead of recomputing from live state. Added `processStateChange()` (atomic read-compute-update), `seedState()`, and `forceUnavailable()`. Removed `getPreviousState()`/`setPreviousState()`.
- **`ControllerCommandHandler.ts`**: Removed `Disconnected` early-return guard and inline availability tracking. Added per-node 5-minute reconnect timer — if a node stays in `Reconnecting` for 5 minutes, it is forced unavailable. Timers are cleaned up on state change, decommission, and controller close.
- **`test/NodesTest.ts`** (new): 20 unit tests covering `isNodeAvailable`, `processStateChange`, `forceUnavailable`, cached `isAvailable`, and cleanup.
- Also updates dependencies.

### Why #513 doesn't fix this

See [detailed analysis on #513](https://github.com/matter-js/matterjs-server/pull/513#issuecomment-4212783050). The `Disconnected` state is never reached when a device goes offline — `PairedNode` only sets it on decommission/close. The real issue is the split-brain between event and serialization paths, plus the unbounded debounce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)