### PR TITLE
Handle multi-device QR codes in commissioning (#430)

### DIFF
--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -33,7 +33,8 @@
     },
     "devDependencies": {
         "@types/node": "^25.5.2",
-        "@types/ws": "^8.18.1"
+        "@types/ws": "^8.18.1",
+        "@matter/testing": "0.17.0-alpha.0-20260410-75362b6ea"
     },
     "files": [
         "dist/**/*",

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -80,7 +80,6 @@ import {
     CommissioningResponse,
     DiscoveryRequest,
     DiscoveryResponse,
-    InvokeByIdRequest,
     InvokeRequest,
     MatterNodeData,
     OpenCommissioningWindowRequest,
@@ -91,7 +90,6 @@ import {
     SubscribeAttributeResponse,
     SubscribeEventRequest,
     SubscribeEventResponse,
-    WriteAttributeByIdRequest,
     WriteAttributeRequest,
 } from "../types/CommandHandler.js";
 import {
@@ -949,65 +947,6 @@ export class ControllerCommandHandler {
         });
     }
 
-    /** InvokeById minimalistic handler because only used for error testing */
-    async handleInvokeById(data: InvokeByIdRequest): Promise<void> {
-        const { nodeId, endpointId, clusterId, commandId, data: commandData, timedInteractionTimeoutMs } = data;
-        const client = this.#nodes.interactionClientFor(nodeId);
-        await client.invoke<Command<any, any, any>>({
-            endpointId,
-            clusterId: clusterId,
-            command: Command(commandId, TlvAny, 0x00, TlvNoResponse, {
-                timed: timedInteractionTimeoutMs !== undefined,
-            }),
-            request: commandData === undefined ? TlvVoid.encodeTlv() : TlvObject({}).encodeTlv(commandData as any),
-            asTimedRequest: timedInteractionTimeoutMs !== undefined,
-            timedRequestTimeout: Millis(timedInteractionTimeoutMs),
-            skipValidation: true,
-        });
-    }
-
-    async handleWriteAttributeById(data: WriteAttributeByIdRequest): Promise<void> {
-        const { nodeId, endpointId, clusterId, attributeId, value } = data;
-
-        const client = this.#nodes.interactionClientFor(nodeId);
-
-        logger.info("Writing attribute", attributeId, "with value", value);
-
-        let tlvValue: any;
-
-        if (value === null) {
-            tlvValue = TlvNullable(TlvBoolean).encodeTlv(value); // Boolean is just a placeholder here
-        } else if (value instanceof Uint8Array) {
-            tlvValue = TlvByteString.encodeTlv(value);
-        } else {
-            switch (typeof value) {
-                case "boolean":
-                    tlvValue = TlvBoolean.encodeTlv(value);
-                    break;
-                case "number":
-                    tlvValue = TlvInt32.encodeTlv(value);
-                    break;
-                case "bigint":
-                    tlvValue = TlvUInt64.encodeTlv(value);
-                    break;
-                case "string":
-                    tlvValue = TlvString.encodeTlv(value);
-                    break;
-                default:
-                    throw ServerError.invalidArguments(`Unsupported value type "${typeof value}" for Any encoding`);
-            }
-        }
-
-        await client.setAttribute({
-            attributeData: {
-                endpointId,
-                clusterId,
-                attribute: Attribute(attributeId, TlvAny),
-                value: tlvValue,
-            },
-        });
-    }
-
     #determineCommissionOptions(data: CommissioningRequest): NodeCommissioningOptions[] {
         return buildCommissionOptions(data, this.bleEnabled);
     }
@@ -1024,10 +963,13 @@ export class ControllerCommandHandler {
                 });
             } catch (error) {
                 const originalMessage = error instanceof Error ? error.message : String(error);
-                throw ServerError.nodeCommissionFailed(
+                const err = ServerError.nodeCommissionFailed(
                     `Commission failed: ${originalMessage}`,
                     error instanceof Error ? error : undefined,
                 );
+                // Attach partially-commissioned nodeIds so callers can reconcile state
+                (err as any).commissionedNodeIds = nodeIds;
+                throw err;
             }
 
             await this.#registerNode(nodeId);

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -80,6 +80,7 @@ import {
     CommissioningResponse,
     DiscoveryRequest,
     DiscoveryResponse,
+    InvokeByIdRequest,
     InvokeRequest,
     MatterNodeData,
     OpenCommissioningWindowRequest,
@@ -90,6 +91,7 @@ import {
     SubscribeAttributeResponse,
     SubscribeEventRequest,
     SubscribeEventResponse,
+    WriteAttributeByIdRequest,
     WriteAttributeRequest,
 } from "../types/CommandHandler.js";
 import {
@@ -152,6 +154,96 @@ function determineMatterVersion(attributes: AttributesData): string | undefined 
     }
 
     return undefined;
+}
+
+/**
+ * Build commission options from a commissioning request. Handles single and multi-device
+ * QR codes per Matter spec Section 5.1.3 (*-separated payloads), manual pairing codes,
+ * and passcode-based commissioning.
+ *
+ * Returns one NodeCommissioningOptions per device to commission.
+ */
+export function buildCommissionOptions(data: CommissioningRequest, bleEnabled: boolean): NodeCommissioningOptions[] {
+    const devices: { passcode: number; longDiscriminator?: number; shortDiscriminator?: number }[] = [];
+    let productId: number | undefined = undefined;
+    let vendorId: VendorId | undefined = undefined;
+    let knownAddress: ServerAddress | undefined = undefined;
+
+    if ("manualCode" in data && data.manualCode.length > 0) {
+        const pairingCodeCodec = ManualPairingCodeCodec.decode(data.manualCode);
+        devices.push({
+            passcode: pairingCodeCodec.passcode,
+            shortDiscriminator: pairingCodeCodec.shortDiscriminator,
+        });
+    } else if ("qrCode" in data && data.qrCode.length > 0) {
+        const pairingCodeCodec = QrPairingCodeCodec.decode(data.qrCode);
+        if (pairingCodeCodec.length === 0) {
+            throw ServerError.invalidArguments("QR code does not contain any device information");
+        }
+        for (const entry of pairingCodeCodec) {
+            devices.push({
+                passcode: entry.passcode,
+                longDiscriminator: entry.discriminator,
+            });
+        }
+    } else if ("passcode" in data) {
+        const device: { passcode: number; longDiscriminator?: number; shortDiscriminator?: number } = {
+            passcode: data.passcode,
+        };
+        // Check for discriminator-based discovery
+        if ("shortDiscriminator" in data) {
+            device.shortDiscriminator = data.shortDiscriminator;
+        } else if ("longDiscriminator" in data) {
+            device.longDiscriminator = data.longDiscriminator;
+        } else if ("vendorId" in data && "productId" in data) {
+            vendorId = VendorId(data.vendorId);
+            productId = data.productId;
+        }
+        devices.push(device);
+    } else {
+        throw ServerError.invalidArguments("No pairing code provided");
+    }
+
+    if (data.knownAddress !== undefined) {
+        const { ip, port } = data.knownAddress;
+        knownAddress = {
+            type: "udp",
+            ip,
+            port,
+        };
+    }
+
+    const { onNetworkOnly, wifiCredentials: wifiNetwork, threadCredentials: threadNetwork } = data;
+    const baseNodeId = data.nodeId !== undefined ? BigInt(data.nodeId) : undefined;
+
+    return devices.map((device, index) => {
+        const { passcode, longDiscriminator, shortDiscriminator } = device;
+        return {
+            commissioning: {
+                nodeId: baseNodeId !== undefined ? NodeId(baseNodeId + BigInt(index)) : undefined,
+                regulatoryLocation: GeneralCommissioning.RegulatoryLocationType.IndoorOutdoor,
+                regulatoryCountryCode: "XX",
+                wifiNetwork,
+                threadNetwork,
+            },
+            discovery: {
+                knownAddress,
+                identifierData:
+                    longDiscriminator !== undefined
+                        ? { longDiscriminator }
+                        : shortDiscriminator !== undefined
+                          ? { shortDiscriminator }
+                          : vendorId !== undefined
+                            ? { vendorId, productId }
+                            : {},
+                discoveryCapabilities: {
+                    ble: bleEnabled && !onNetworkOnly,
+                    onIpNetwork: true,
+                },
+            },
+            passcode,
+        };
+    });
 }
 
 export class ControllerCommandHandler {
@@ -857,102 +949,93 @@ export class ControllerCommandHandler {
         });
     }
 
-    #determineCommissionOptions(data: CommissioningRequest): NodeCommissioningOptions {
-        let passcode: number | undefined = undefined;
-        let shortDiscriminator: number | undefined = undefined;
-        let longDiscriminator: number | undefined = undefined;
-        let productId: number | undefined = undefined;
-        let vendorId: VendorId | undefined = undefined;
-        let knownAddress: ServerAddress | undefined = undefined;
+    /** InvokeById minimalistic handler because only used for error testing */
+    async handleInvokeById(data: InvokeByIdRequest): Promise<void> {
+        const { nodeId, endpointId, clusterId, commandId, data: commandData, timedInteractionTimeoutMs } = data;
+        const client = this.#nodes.interactionClientFor(nodeId);
+        await client.invoke<Command<any, any, any>>({
+            endpointId,
+            clusterId: clusterId,
+            command: Command(commandId, TlvAny, 0x00, TlvNoResponse, {
+                timed: timedInteractionTimeoutMs !== undefined,
+            }),
+            request: commandData === undefined ? TlvVoid.encodeTlv() : TlvObject({}).encodeTlv(commandData as any),
+            asTimedRequest: timedInteractionTimeoutMs !== undefined,
+            timedRequestTimeout: Millis(timedInteractionTimeoutMs),
+            skipValidation: true,
+        });
+    }
 
-        if ("manualCode" in data && data.manualCode.length > 0) {
-            const pairingCodeCodec = ManualPairingCodeCodec.decode(data.manualCode);
-            shortDiscriminator = pairingCodeCodec.shortDiscriminator;
-            longDiscriminator = undefined;
-            passcode = pairingCodeCodec.passcode;
-        } else if ("qrCode" in data && data.qrCode.length > 0) {
-            const pairingCodeCodec = QrPairingCodeCodec.decode(data.qrCode);
-            // TODO handle the case where multiple devices are included
-            longDiscriminator = pairingCodeCodec[0].discriminator;
-            shortDiscriminator = undefined;
-            passcode = pairingCodeCodec[0].passcode;
-        } else if ("passcode" in data) {
-            passcode = data.passcode;
-            // Check for discriminator-based discovery
-            if ("shortDiscriminator" in data) {
-                shortDiscriminator = data.shortDiscriminator;
-            } else if ("longDiscriminator" in data) {
-                longDiscriminator = data.longDiscriminator;
-            } else if ("vendorId" in data && "productId" in data) {
-                vendorId = VendorId(data.vendorId);
-                productId = data.productId;
-            }
-            // If none of the above, discovers any commissionable device
+    async handleWriteAttributeById(data: WriteAttributeByIdRequest): Promise<void> {
+        const { nodeId, endpointId, clusterId, attributeId, value } = data;
+
+        const client = this.#nodes.interactionClientFor(nodeId);
+
+        logger.info("Writing attribute", attributeId, "with value", value);
+
+        let tlvValue: any;
+
+        if (value === null) {
+            tlvValue = TlvNullable(TlvBoolean).encodeTlv(value); // Boolean is just a placeholder here
+        } else if (value instanceof Uint8Array) {
+            tlvValue = TlvByteString.encodeTlv(value);
         } else {
-            throw ServerError.invalidArguments("No pairing code provided");
+            switch (typeof value) {
+                case "boolean":
+                    tlvValue = TlvBoolean.encodeTlv(value);
+                    break;
+                case "number":
+                    tlvValue = TlvInt32.encodeTlv(value);
+                    break;
+                case "bigint":
+                    tlvValue = TlvUInt64.encodeTlv(value);
+                    break;
+                case "string":
+                    tlvValue = TlvString.encodeTlv(value);
+                    break;
+                default:
+                    throw ServerError.invalidArguments(`Unsupported value type "${typeof value}" for Any encoding`);
+            }
         }
 
-        if (data.knownAddress !== undefined) {
-            const { ip, port } = data.knownAddress;
-            knownAddress = {
-                type: "udp",
-                ip,
-                port,
-            };
-        }
-
-        if (passcode == undefined) {
-            throw ServerError.invalidArguments("No passcode provided");
-        }
-
-        const { onNetworkOnly, wifiCredentials: wifiNetwork, threadCredentials: threadNetwork } = data;
-        const options = {
-            commissioning: {
-                nodeId: data.nodeId,
-                regulatoryLocation: GeneralCommissioning.RegulatoryLocationType.IndoorOutdoor,
-                regulatoryCountryCode: "XX",
-                wifiNetwork,
-                threadNetwork,
+        await client.setAttribute({
+            attributeData: {
+                endpointId,
+                clusterId,
+                attribute: Attribute(attributeId, TlvAny),
+                value: tlvValue,
             },
-            discovery: {
-                knownAddress,
-                identifierData:
-                    longDiscriminator !== undefined
-                        ? { longDiscriminator }
-                        : shortDiscriminator !== undefined
-                          ? { shortDiscriminator }
-                          : vendorId !== undefined
-                            ? { vendorId, productId }
-                            : {},
-                discoveryCapabilities: {
-                    ble: this.bleEnabled && !onNetworkOnly,
-                    onIpNetwork: true,
-                },
-            },
-            passcode,
-        };
-        return options;
+        });
+    }
+
+    #determineCommissionOptions(data: CommissioningRequest): NodeCommissioningOptions[] {
+        return buildCommissionOptions(data, this.bleEnabled);
     }
 
     async commissionNode(data: CommissioningRequest): Promise<CommissioningResponse> {
-        let nodeId: NodeId;
-        try {
-            nodeId = await this.#controller.commissionNode(this.#determineCommissionOptions(data), {
-                connectNodeAfterCommissioning: true,
-            });
-        } catch (error) {
-            // Preserve the original error message with context
-            const originalMessage = error instanceof Error ? error.message : String(error);
-            throw ServerError.nodeCommissionFailed(
-                `Commission failed: ${originalMessage}`,
-                error instanceof Error ? error : undefined,
-            );
+        const optionsList = this.#determineCommissionOptions(data);
+        const nodeIds: NodeId[] = [];
+
+        for (const options of optionsList) {
+            let nodeId: NodeId;
+            try {
+                nodeId = await this.#controller.commissionNode(options, {
+                    connectNodeAfterCommissioning: true,
+                });
+            } catch (error) {
+                const originalMessage = error instanceof Error ? error.message : String(error);
+                throw ServerError.nodeCommissionFailed(
+                    `Commission failed: ${originalMessage}`,
+                    error instanceof Error ? error : undefined,
+                );
+            }
+
+            await this.#registerNode(nodeId);
+            this.events.nodeAdded.emit(nodeId);
+            nodeIds.push(nodeId);
         }
 
-        await this.#registerNode(nodeId);
-
-        this.events.nodeAdded.emit(nodeId);
-        return { nodeId };
+        return { nodeId: nodeIds[0], nodeIds };
     }
 
     getCommissionerNodeId() {

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -616,17 +616,28 @@ export class WebSocketControllerHandler implements WebServerHandler {
             }
         }
 
+        // Reserve a single ID upfront; will adjust after commissioning if multiple devices were involved
         await this.#config.set({
             nextNodeId: typeof nextNodeId === "bigint" ? nextNodeId + 1n : nextNodeId + 1,
         });
 
-        const { nodeId } = await this.#commandHandler.commissionNode({
+        const { nodeId, nodeIds } = await this.#commandHandler.commissionNode({
             nodeId: NodeId(nextNodeId),
             onNetworkOnly: network_only,
             ...(isQrCode ? { qrCode: code } : { manualCode: code }),
             wifiCredentials,
             threadCredentials,
         });
+
+        // If multiple devices were commissioned, advance the counter for the additional nodes
+        if (nodeIds.length > 1) {
+            await this.#config.set({
+                nextNodeId:
+                    typeof nextNodeId === "bigint"
+                        ? nextNodeId + BigInt(nodeIds.length)
+                        : nextNodeId + nodeIds.length,
+            });
+        }
 
         return this.#collectNodeDetails(nodeId);
     }
@@ -921,6 +932,9 @@ export class WebSocketControllerHandler implements WebServerHandler {
             timeout,
         });
         const pairingCodeCodec = QrPairingCodeCodec.decode(qrCode);
+        if (pairingCodeCodec.length === 0) {
+            throw new Error("Generated QR code does not contain any device information");
+        }
         return { setup_pin_code: pairingCodeCodec[0].passcode, setup_manual_code: manualCode, setup_qr_code: qrCode };
     }
 

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -621,21 +621,39 @@ export class WebSocketControllerHandler implements WebServerHandler {
             nextNodeId: typeof nextNodeId === "bigint" ? nextNodeId + 1n : nextNodeId + 1,
         });
 
-        const { nodeId, nodeIds } = await this.#commandHandler.commissionNode({
-            nodeId: NodeId(nextNodeId),
-            onNetworkOnly: network_only,
-            ...(isQrCode ? { qrCode: code } : { manualCode: code }),
-            wifiCredentials,
-            threadCredentials,
-        });
+        let nodeId: NodeId;
+        let commissionedCount: number;
+        try {
+            const result = await this.#commandHandler.commissionNode({
+                nodeId: NodeId(nextNodeId),
+                onNetworkOnly: network_only,
+                ...(isQrCode ? { qrCode: code } : { manualCode: code }),
+                wifiCredentials,
+                threadCredentials,
+            });
+            nodeId = result.nodeId;
+            commissionedCount = result.nodeIds.length;
+        } catch (error) {
+            // On partial failure, reconcile nextNodeId for any nodes that were successfully commissioned
+            const partialIds = (error as any)?.commissionedNodeIds as NodeId[] | undefined;
+            if (partialIds && partialIds.length > 1) {
+                await this.#config.set({
+                    nextNodeId:
+                        typeof nextNodeId === "bigint"
+                            ? nextNodeId + BigInt(partialIds.length)
+                            : nextNodeId + partialIds.length,
+                });
+            }
+            throw error;
+        }
 
-        // If multiple devices were commissioned, advance the counter for the additional nodes
-        if (nodeIds.length > 1) {
+        // Advance the counter past all commissioned nodes
+        if (commissionedCount > 1) {
             await this.#config.set({
                 nextNodeId:
                     typeof nextNodeId === "bigint"
-                        ? nextNodeId + BigInt(nodeIds.length)
-                        : nextNodeId + nodeIds.length,
+                        ? nextNodeId + BigInt(commissionedCount)
+                        : nextNodeId + commissionedCount,
             });
         }
 
@@ -933,7 +951,7 @@ export class WebSocketControllerHandler implements WebServerHandler {
         });
         const pairingCodeCodec = QrPairingCodeCodec.decode(qrCode);
         if (pairingCodeCodec.length === 0) {
-            throw new Error("Generated QR code does not contain any device information");
+            throw ServerError.sdkStackError("Generated QR code does not contain any device information");
         }
         return { setup_pin_code: pairingCodeCodec[0].passcode, setup_manual_code: manualCode, setup_qr_code: qrCode };
     }

--- a/packages/ws-controller/src/types/CommandHandler.ts
+++ b/packages/ws-controller/src/types/CommandHandler.ts
@@ -156,6 +156,7 @@ export type CommissioningRequest = {
 
 export type CommissioningResponse = {
     nodeId: NodeId;
+    nodeIds: NodeId[];
 };
 
 export type DiscoveryRequest = {

--- a/packages/ws-controller/test/CommissionOptionsTest.ts
+++ b/packages/ws-controller/test/CommissionOptionsTest.ts
@@ -1,0 +1,224 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { buildCommissionOptions } from "@matter-server/ws-controller";
+import { NodeId } from "@matter/main";
+import { CommissioningFlowType, ManualPairingCodeCodec, QrPairingCodeCodec, VendorId } from "@matter/main/types";
+import { CommissioningRequest } from "../src/types/CommandHandler.js";
+
+/** Helper to extract identifierData from a discovery options union type. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getIdentifierData(discovery: any): unknown {
+    return discovery.identifierData;
+}
+
+/** Encode a single-device QR code for testing. */
+function encodeQrCode(discriminator: number, passcode: number): string {
+    return QrPairingCodeCodec.encode([
+        {
+            version: 0,
+            vendorId: VendorId(0xfff1),
+            productId: 0x8000,
+            flowType: CommissioningFlowType.Standard,
+            discoveryCapabilities: 2, // On IP network
+            discriminator,
+            passcode,
+        },
+    ]);
+}
+
+/** Encode a multi-device QR code with *-separated payloads per Matter spec Section 5.1.3. */
+function encodeMultiDeviceQrCode(devices: { discriminator: number; passcode: number }[]): string {
+    return QrPairingCodeCodec.encode(
+        devices.map(d => ({
+            version: 0,
+            vendorId: VendorId(0xfff1),
+            productId: 0x8000,
+            flowType: CommissioningFlowType.Standard,
+            discoveryCapabilities: 2,
+            discriminator: d.discriminator,
+            passcode: d.passcode,
+        })),
+    );
+}
+
+describe("buildCommissionOptions", () => {
+    describe("QR code commissioning", () => {
+        it("should return a single option for a single-device QR code", () => {
+            const qrCode = encodeQrCode(3840, 20202021);
+            const result = buildCommissionOptions({ qrCode }, false);
+
+            expect(result).to.have.lengthOf(1);
+            expect(result[0].passcode).to.equal(20202021);
+            expect(getIdentifierData(result[0].discovery)).to.deep.equal({ longDiscriminator: 3840 });
+        });
+
+        it("should return multiple options for a multi-device QR code", () => {
+            const qrCode = encodeMultiDeviceQrCode([
+                { discriminator: 3840, passcode: 20202021 },
+                { discriminator: 1234, passcode: 99999999 },
+                { discriminator: 500, passcode: 12345678 },
+            ]);
+            const result = buildCommissionOptions({ qrCode }, false);
+
+            expect(result).to.have.lengthOf(3);
+
+            expect(result[0].passcode).to.equal(20202021);
+            expect(getIdentifierData(result[0].discovery)).to.deep.equal({ longDiscriminator: 3840 });
+
+            expect(result[1].passcode).to.equal(99999999);
+            expect(getIdentifierData(result[1].discovery)).to.deep.equal({ longDiscriminator: 1234 });
+
+            expect(result[2].passcode).to.equal(12345678);
+            expect(getIdentifierData(result[2].discovery)).to.deep.equal({ longDiscriminator: 500 });
+        });
+
+        it("should assign sequential node IDs for multi-device QR codes", () => {
+            const qrCode = encodeMultiDeviceQrCode([
+                { discriminator: 3840, passcode: 20202021 },
+                { discriminator: 1234, passcode: 99999999 },
+            ]);
+            const result = buildCommissionOptions({ qrCode, nodeId: NodeId(10) }, false);
+
+            expect(result).to.have.lengthOf(2);
+            expect(result[0].commissioning.nodeId).to.equal(NodeId(10));
+            expect(result[1].commissioning.nodeId).to.equal(NodeId(11));
+        });
+
+        it("should leave nodeId undefined for all devices when not provided", () => {
+            const qrCode = encodeMultiDeviceQrCode([
+                { discriminator: 3840, passcode: 20202021 },
+                { discriminator: 1234, passcode: 99999999 },
+            ]);
+            const result = buildCommissionOptions({ qrCode }, false);
+
+            expect(result[0].commissioning.nodeId).to.be.undefined;
+            expect(result[1].commissioning.nodeId).to.be.undefined;
+        });
+
+        it("should throw for an empty QR code string", () => {
+            expect(() => buildCommissionOptions({ qrCode: "" } as CommissioningRequest, false)).to.throw(
+                "No pairing code provided",
+            );
+        });
+    });
+
+    describe("manual pairing code commissioning", () => {
+        it("should return a single option with short discriminator", () => {
+            const manualCode = "34970112332";
+            const decoded = ManualPairingCodeCodec.decode(manualCode);
+            const result = buildCommissionOptions({ manualCode }, false);
+
+            expect(result).to.have.lengthOf(1);
+            expect(result[0].passcode).to.equal(decoded.passcode);
+            expect(getIdentifierData(result[0].discovery)).to.deep.equal({
+                shortDiscriminator: decoded.shortDiscriminator,
+            });
+        });
+    });
+
+    describe("passcode-based commissioning", () => {
+        it("should handle passcode with short discriminator", () => {
+            const result = buildCommissionOptions({ passcode: 20202021, shortDiscriminator: 15 }, false);
+
+            expect(result).to.have.lengthOf(1);
+            expect(result[0].passcode).to.equal(20202021);
+            expect(getIdentifierData(result[0].discovery)).to.deep.equal({ shortDiscriminator: 15 });
+        });
+
+        it("should handle passcode with long discriminator", () => {
+            const result = buildCommissionOptions({ passcode: 20202021, longDiscriminator: 3840 }, false);
+
+            expect(result).to.have.lengthOf(1);
+            expect(result[0].passcode).to.equal(20202021);
+            expect(getIdentifierData(result[0].discovery)).to.deep.equal({ longDiscriminator: 3840 });
+        });
+
+        it("should handle passcode with vendor/product ID", () => {
+            const result = buildCommissionOptions({ passcode: 20202021, vendorId: 0xfff1, productId: 0x8000 }, false);
+
+            expect(result).to.have.lengthOf(1);
+            expect(result[0].passcode).to.equal(20202021);
+            expect(getIdentifierData(result[0].discovery)).to.deep.equal({
+                vendorId: VendorId(0xfff1),
+                productId: 0x8000,
+            });
+        });
+
+        it("should handle passcode-only (discover any)", () => {
+            const result = buildCommissionOptions({ passcode: 20202021 }, false);
+
+            expect(result).to.have.lengthOf(1);
+            expect(result[0].passcode).to.equal(20202021);
+            expect(getIdentifierData(result[0].discovery)).to.deep.equal({});
+        });
+    });
+
+    describe("discovery capabilities", () => {
+        it("should enable BLE when bleEnabled is true and not network-only", () => {
+            const qrCode = encodeQrCode(3840, 20202021);
+            const result = buildCommissionOptions({ qrCode }, true);
+            const caps = result[0].discovery.discoveryCapabilities!;
+
+            expect(caps.ble).to.be.true;
+            expect(caps.onIpNetwork).to.be.true;
+        });
+
+        it("should disable BLE when bleEnabled is false", () => {
+            const qrCode = encodeQrCode(3840, 20202021);
+            const result = buildCommissionOptions({ qrCode }, false);
+
+            expect(result[0].discovery.discoveryCapabilities!.ble).to.be.false;
+        });
+
+        it("should disable BLE when network-only is set even if BLE is enabled", () => {
+            const qrCode = encodeQrCode(3840, 20202021);
+            const result = buildCommissionOptions({ qrCode, onNetworkOnly: true }, true);
+
+            expect(result[0].discovery.discoveryCapabilities!.ble).to.be.false;
+        });
+    });
+
+    describe("known address", () => {
+        it("should include known address when provided", () => {
+            const qrCode = encodeQrCode(3840, 20202021);
+            const result = buildCommissionOptions({ qrCode, knownAddress: { ip: "192.168.1.100", port: 5540 } }, false);
+
+            expect(result[0].discovery.knownAddress).to.deep.equal({
+                type: "udp",
+                ip: "192.168.1.100",
+                port: 5540,
+            });
+        });
+
+        it("should apply known address to all devices in multi-device QR code", () => {
+            const qrCode = encodeMultiDeviceQrCode([
+                { discriminator: 3840, passcode: 20202021 },
+                { discriminator: 1234, passcode: 99999999 },
+            ]);
+            const result = buildCommissionOptions({ qrCode, knownAddress: { ip: "192.168.1.100", port: 5540 } }, false);
+
+            expect(result[0].discovery.knownAddress).to.deep.equal({
+                type: "udp",
+                ip: "192.168.1.100",
+                port: 5540,
+            });
+            expect(result[1].discovery.knownAddress).to.deep.equal({
+                type: "udp",
+                ip: "192.168.1.100",
+                port: 5540,
+            });
+        });
+    });
+
+    describe("error cases", () => {
+        it("should throw when no pairing code is provided", () => {
+            expect(() => buildCommissionOptions({} as CommissioningRequest, false)).to.throw(
+                "No pairing code provided",
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Commission all devices encoded in a multi-device QR code per Matter spec Section 5.1.3 (`*`-separated payloads), instead of only the first
- Extract commission options logic into a testable `buildCommissionOptions` function
- Add 16 unit tests covering single/multi-device QR codes, manual pairing codes, passcode variants, BLE/network discovery, and known addresses
- Add defensive empty-array guard in `#handleOpenCommissioningWindow`

## Known limitation

The WS protocol (`commission_with_code`) still returns a single `MatterNode` in its response — this matches the current Python Matter Server protocol contract. Additional commissioned nodes are delivered only via `node_added` WebSocket events.

This works with Home Assistant today because HA ignores the `commission_with_code` response value and discovers nodes through events. However, it is non-intuitive: the response implies one node was commissioned when multiple may have been. A protocol-level change is needed to make the response honest.

Change requests filed upstream:
- matter-js/python-matter-server#1366 — update response type to support multiple nodes
- home-assistant/core#168174 — verify HA handles multi-node commissioning events correctly

## Test plan

- [x] `npm run format` — passes
- [x] `npm run lint` — passes
- [x] `npm run build` — passes
- [x] `npm test` — passes (pre-existing ping test failure only, unrelated)
- [x] 16 new unit tests for `buildCommissionOptions` all pass
- [ ] Integration test with physical multi-device QR code (requires hardware)

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)