### PR TITLE
Fix dashboard build under TypeScript 6

### DIFF
--- a/packages/dashboard/src/pages/network/base-network-graph.ts
+++ b/packages/dashboard/src/pages/network/base-network-graph.ts
@@ -7,7 +7,6 @@
 import type { MatterNode } from "@matter-server/ws-client";
 import { LitElement, css } from "lit";
 import { property, state } from "lit/decorators.js";
-// @ts-expect-error vis-network doesn't have proper type declarations for standalone export
 import { DataSet, Network } from "vis-network/standalone";
 import { getCssVar } from "../../util/shared-styles.js";
 import { ThemeService } from "../../util/theme-service.js";
@@ -217,6 +216,7 @@ export abstract class BaseNetworkGraph extends LitElement {
             edges: {
                 width: 2,
                 smooth: {
+                    enabled: true,
                     type: "continuous",
                     roundness: 0.5,
                 },

--- a/packages/dashboard/src/tsconfig.json
+++ b/packages/dashboard/src/tsconfig.json
@@ -3,6 +3,8 @@
 {
     "extends": "../../../tsc/tsconfig.lib.json",
     "compilerOptions": {
+        "module": "esnext",
+        "moduleResolution": "bundler",
         "lib": [
             "es2023",
             "dom"


### PR DESCRIPTION
## Summary
- The latest matter.js alpha bump transitively pulled TypeScript `5.9.3 → 6.0.3`. TS 6's stricter `moduleResolution: node16` now demands explicit `.js` extensions on every relative and side-effect import. The dashboard's many bare `@material/web/*` and `./foo` side-effect imports tripped on this (~220 errors).
- Fixed by switching `packages/dashboard/src/tsconfig.json` to `module: esnext` / `moduleResolution: bundler`. The dashboard is a bundled web app (Rollup + esbuild), not a published library, so letting the bundler own extension resolution is semantically correct and avoids touching ~100 import sites.
- While resolving the remaining errors this surfaced two real issues in `base-network-graph.ts`:
  - `vis-network/standalone` now has working types, so the vestigial `@ts-expect-error` must go (TS2578 unused directive).
  - vis-network's `EdgeOptions.smooth` shape requires `enabled` — added `enabled: true` (TS2345).

Not related to matter.js PR #3633 — that PR prunes `dev-types` entries from matter.js's own packages for unrelated reasons. Our dashboard breakage is purely the TS 6 upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)