### PR TITLE
feat(dashboard): refine dev-mode command UX and cluster header

### DIFF
--- a/packages/dashboard/public/index.html
+++ b/packages/dashboard/public/index.html
@@ -18,6 +18,7 @@
     --roboto-font: Roboto, system-ui;
     --text-color: rgba(0, 0, 0, 0.6);
     --danger-color: #db4437;
+    --success-color: #2e7d32;
 
     --md-sys-color-primary: #03a9f4;
     --md-sys-color-on-primary: #fff;
@@ -123,6 +124,7 @@
     --graph-node-fallback: #999999;
     --text-color: rgba(255, 255, 255, 0.6);
     --danger-color: #ff7961;
+    --success-color: #66bb6a;
     --primary-color: #4fc3f7;
     color-scheme: dark;
   }

--- a/packages/dashboard/src/components/dialogs/dev/command-invoke-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/dev/command-invoke-dialog.ts
@@ -23,12 +23,13 @@ export class CommandInvokeDialog extends LitElement {
     @property({ type: Number }) public nodeId!: number | bigint;
     @property({ type: Number }) public endpointId!: number;
     @property({ type: Number }) public clusterId!: number;
+    @property({ type: Number }) public commandId!: number;
     @property({ type: String }) public commandName!: string;
-    @property({ type: String }) public commandLabel!: string;
 
     @state() private _busy = false;
     @state() private _error: string | null = null;
     @state() private _response: string | null = null;
+    @state() private _success = false;
 
     @query("textarea") private _textarea!: HTMLTextAreaElement;
 
@@ -50,6 +51,7 @@ export class CommandInvokeDialog extends LitElement {
 
     private async _invoke() {
         this._error = null;
+        this._success = false;
         const parsed = parseJsonPayload(this._textarea.value);
         if (!parsed.ok) {
             this._error = `Invalid JSON: ${parsed.error}`;
@@ -71,11 +73,18 @@ export class CommandInvokeDialog extends LitElement {
                 this.commandName,
                 payload,
             );
-            this._response = toBigIntAwareJson(result ?? null, 2);
+            if (result === null || result === undefined) {
+                this._success = true;
+                this._response = null;
+            } else {
+                this._response = toBigIntAwareJson(result, 2);
+                this._success = false;
+            }
             this._error = null;
         } catch (err) {
             this._error = err instanceof Error ? err.message : String(err);
             this._response = null;
+            this._success = false;
         } finally {
             this._busy = false;
         }
@@ -84,11 +93,14 @@ export class CommandInvokeDialog extends LitElement {
     protected override render() {
         return html`
             <md-dialog open @cancel=${preventDefault} @closed=${this._handleClosed}>
-                <div slot="headline">Invoke ${this.commandLabel}</div>
+                <div slot="headline">Invoke ${this.commandName}</div>
                 <div slot="content">
                     <p class="path" id="invoke-path">
                         Cluster <code>${this.clusterId}</code> (${formatHex(this.clusterId)}) · Endpoint
-                        <code>${this.endpointId}</code> · Command <code>${this.commandName}</code>
+                        <code>${this.endpointId}</code> · Command <code>${this.commandId}</code> (${formatHex(
+                            this.commandId,
+                        )})
+                        · <code>${this.commandName}</code>
                     </p>
                     <label class="textarea-label" for="payload">Payload (JSON)</label>
                     <textarea
@@ -103,6 +115,7 @@ export class CommandInvokeDialog extends LitElement {
                     ${this._error
                         ? html`<div id="invoke-error" class="error" role="alert">${this._error}</div>`
                         : nothing}
+                    ${this._success ? html`<div class="success" role="status">Success</div>` : nothing}
                     ${this._response !== null
                         ? html`
                               <label class="textarea-label">Response</label>
@@ -175,6 +188,17 @@ export class CommandInvokeDialog extends LitElement {
             font-size: 0.875rem;
             white-space: pre-wrap;
             word-break: break-word;
+        }
+
+        .success {
+            margin-top: 10px;
+            padding: 10px 12px;
+            background: color-mix(in srgb, var(--success-color) 18%, transparent);
+            color: var(--success-color);
+            border: 1px solid color-mix(in srgb, var(--success-color) 40%, transparent);
+            border-radius: 6px;
+            font-size: 0.9rem;
+            font-weight: 500;
         }
 
         .response {

--- a/packages/dashboard/src/components/dialogs/dev/show-command-invoke-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/dev/show-command-invoke-dialog.ts
@@ -11,8 +11,8 @@ export interface ShowCommandInvokeDialogOptions {
     nodeId: number | bigint;
     endpointId: number;
     clusterId: number;
+    commandId: number;
     commandName: string;
-    commandLabel: string;
 }
 
 export const showCommandInvokeDialog = async (options: ShowCommandInvokeDialogOptions) => {
@@ -22,7 +22,7 @@ export const showCommandInvokeDialog = async (options: ShowCommandInvokeDialogOp
     dialog.nodeId = options.nodeId;
     dialog.endpointId = options.endpointId;
     dialog.clusterId = options.clusterId;
+    dialog.commandId = options.commandId;
     dialog.commandName = options.commandName;
-    dialog.commandLabel = options.commandLabel;
     document.querySelector("matter-dashboard-app")?.renderRoot.appendChild(dialog);
 };

--- a/packages/dashboard/src/pages/matter-cluster-view.ts
+++ b/packages/dashboard/src/pages/matter-cluster-view.ts
@@ -124,9 +124,11 @@ class MatterClusterView extends LitElement {
         );
         const nodeHex = formatNodeAddress(fabricIndex, this.node.node_id);
 
+        const clusterName = clusters[this.cluster]?.label ?? "Custom/Unknown Cluster";
+
         return html`
             <dashboard-header
-                .title=${`Node ${this.node.node_id} ${nodeHex}  |  Endpoint ${this.endpoint}  |  Cluster ${this.cluster}`}
+                .title=${`Node ${this.node.node_id} ${nodeHex}  |  Endpoint ${this.endpoint}  |  Cluster ${this.cluster} (${clusterName})`}
                 .backButton=${`#node/${this.node.node_id}/${this.endpoint}`}
                 .client=${this.client}
             ></dashboard-header>
@@ -277,7 +279,8 @@ class MatterClusterView extends LitElement {
 
         const commands = acceptedList
             .map(id => clusterMeta?.commands[id])
-            .filter((cmd): cmd is NonNullable<typeof cmd> => cmd !== undefined);
+            .filter((cmd): cmd is NonNullable<typeof cmd> => cmd !== undefined)
+            .sort((a, b) => a.id - b.id);
 
         const online = this.node?.available === true;
 
@@ -306,7 +309,7 @@ class MatterClusterView extends LitElement {
                                                   <md-outlined-button
                                                       class="dev-invoke-button"
                                                       ?disabled=${!online}
-                                                      @click=${() => this._openCommandInvokeDialog(cmd.name, cmd.label)}
+                                                      @click=${() => this._openCommandInvokeDialog(cmd.id, cmd.name)}
                                                   >
                                                       <ha-svg-icon slot="icon" .path=${mdiPlay}></ha-svg-icon>
                                                       Invoke
@@ -322,15 +325,15 @@ class MatterClusterView extends LitElement {
         `;
     }
 
-    private _openCommandInvokeDialog(commandName: string, commandLabel: string) {
+    private _openCommandInvokeDialog(commandId: number, commandName: string) {
         if (!this.node || this.cluster === undefined) return;
         showCommandInvokeDialog({
             client: this.client,
             nodeId: this.node.node_id,
             endpointId: this.endpoint,
             clusterId: this.cluster,
+            commandId,
             commandName,
-            commandLabel,
         });
     }
 
@@ -564,6 +567,11 @@ class MatterClusterView extends LitElement {
                 padding: 8px 12px;
                 background: var(--md-sys-color-surface-container-low);
                 border-radius: 8px;
+                transition: background 120ms ease-out;
+            }
+
+            .command-row:hover {
+                background: color-mix(in srgb, var(--dev-color) 12%, var(--md-sys-color-surface-container-low));
             }
 
             .dev-invoke-button {


### PR DESCRIPTION
## Summary
- Command invoke dialog shows the command id with hex next to the cluster id, matching the existing cluster/id/hex pattern, and uses the command name as the headline.
- Null/undefined invoke responses now render a green Success banner (via a new semantic `--success-color` variable, mirroring `--danger-color`).
- Dev commands list sorts by command id and highlights the row on hover so the label on the left visually connects to the Invoke button on the right.
- Cluster page header appends the cluster name in brackets after the id, on both node and group cluster views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)