### PR TITLE
Emit node_updated before queued endpoint_added events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Fix: Ensures the same event order as the Python Matter server when endpoints got added
+
 ## 0.6.3 (2026-04-29)
 
 - Feature: (AlixBa) Add a "Hide" menu on the Thread network visualization to hide offline nodes and specific connections

--- a/package-lock.json
+++ b/package-lock.json
@@ -10689,9 +10689,9 @@
             "license": "MIT"
         },
         "node_modules/uuid": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-            "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.1.tgz",
+            "integrity": "sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -373,13 +373,18 @@ export class ControllerCommandHandler {
                 attributeCache.update(node);
             }
             basicInfoChangedInBatch = false;
+            // Emit node_updated first so consumers see the new endpoint in node.endpoints,
+            // then drain any endpoint_added events queued since the previous structure change.
             this.events.nodeStructureChanged.emit(nodeId);
+            for (const endpointId of this.#nodes.drainPendingEndpointAdds(nodeId)) {
+                this.events.nodeEndpointAdded.emit(nodeId, endpointId);
+            }
         });
         node.events.decommissioned.on(() => {
             this.#cleanupNodeAfterRemoval(nodeId);
             this.events.nodeDecommissioned.emit(nodeId);
         });
-        node.events.nodeEndpointAdded.on(endpointId => this.events.nodeEndpointAdded.emit(nodeId, endpointId));
+        node.events.nodeEndpointAdded.on(endpointId => this.#nodes.queueEndpointAdded(nodeId, endpointId));
         node.events.nodeEndpointRemoved.on(endpointId => this.events.nodeEndpointRemoved.emit(nodeId, endpointId));
 
         // Store the node for direct access

--- a/packages/ws-controller/src/controller/Nodes.ts
+++ b/packages/ws-controller/src/controller/Nodes.ts
@@ -5,6 +5,7 @@
  */
 
 import { NodeId } from "@matter/main";
+import { EndpointNumber } from "@matter/main/types";
 import { NodeStates, PairedNode } from "@project-chip/matter.js/device";
 import { ServerError } from "../types/WebSocketMessageTypes.js";
 import { AttributeDataCache } from "./AttributeDataCache.js";
@@ -25,6 +26,13 @@ export class Nodes {
     #previousStates = new Map<NodeId, NodeStates>();
     /** Cached availability so serialization and event paths always agree */
     #lastAvailability = new Map<NodeId, boolean>();
+    /**
+     * Endpoint additions queued until the next nodeStructureChanged for that node.
+     * Preserves the wire contract used by python-matter-server: endpoint_added must
+     * arrive AFTER a node_updated that already carries the new endpoint, so consumers
+     * (e.g., Home Assistant) can resolve node.endpoints[endpoint_id] in their callback.
+     */
+    #pendingEndpointAdds = new Map<NodeId, EndpointNumber[]>();
 
     /**
      * Get the attribute cache instance.
@@ -74,6 +82,32 @@ export class Nodes {
         this.#attributeCache.delete(nodeId);
         this.#previousStates.delete(nodeId);
         this.#lastAvailability.delete(nodeId);
+        this.#pendingEndpointAdds.delete(nodeId);
+    }
+
+    /**
+     * Buffer an endpoint_added until the next nodeStructureChanged for that node.
+     */
+    queueEndpointAdded(nodeId: NodeId, endpointId: EndpointNumber): void {
+        let queue = this.#pendingEndpointAdds.get(nodeId);
+        if (queue === undefined) {
+            queue = [];
+            this.#pendingEndpointAdds.set(nodeId, queue);
+        }
+        queue.push(endpointId);
+    }
+
+    /**
+     * Take ownership of buffered endpoint additions for a node and clear the queue.
+     * Returned array is in insertion order; an empty array is returned if nothing is queued.
+     */
+    drainPendingEndpointAdds(nodeId: NodeId): EndpointNumber[] {
+        const queue = this.#pendingEndpointAdds.get(nodeId);
+        if (queue === undefined || queue.length === 0) {
+            return [];
+        }
+        this.#pendingEndpointAdds.delete(nodeId);
+        return queue;
     }
 
     /**

--- a/packages/ws-controller/test/NodesTest.ts
+++ b/packages/ws-controller/test/NodesTest.ts
@@ -5,10 +5,12 @@
  */
 
 import { NodeId } from "@matter/main";
+import { EndpointNumber } from "@matter/main/types";
 import { NodeStates } from "@project-chip/matter.js/device";
 import { Nodes } from "../src/controller/Nodes.js";
 
 const TEST_NODE_ID = NodeId(1);
+const OTHER_NODE_ID = NodeId(2);
 
 describe("Nodes", () => {
     describe("isNodeAvailable", () => {
@@ -193,6 +195,51 @@ describe("Nodes", () => {
 
             nodes.delete(TEST_NODE_ID);
             expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(false);
+        });
+
+        it("clears queued endpoint additions", () => {
+            const nodes = new Nodes();
+            nodes.queueEndpointAdded(TEST_NODE_ID, EndpointNumber(32));
+            nodes.delete(TEST_NODE_ID);
+            expect(nodes.drainPendingEndpointAdds(TEST_NODE_ID)).to.deep.equal([]);
+        });
+    });
+
+    describe("pending endpoint adds", () => {
+        let nodes: Nodes;
+
+        beforeEach(() => {
+            nodes = new Nodes();
+        });
+
+        it("returns an empty array when nothing is queued", () => {
+            expect(nodes.drainPendingEndpointAdds(TEST_NODE_ID)).to.deep.equal([]);
+        });
+
+        it("preserves insertion order across multiple queues", () => {
+            nodes.queueEndpointAdded(TEST_NODE_ID, EndpointNumber(32));
+            nodes.queueEndpointAdded(TEST_NODE_ID, EndpointNumber(33));
+            nodes.queueEndpointAdded(TEST_NODE_ID, EndpointNumber(34));
+
+            expect(nodes.drainPendingEndpointAdds(TEST_NODE_ID)).to.deep.equal([
+                EndpointNumber(32),
+                EndpointNumber(33),
+                EndpointNumber(34),
+            ]);
+        });
+
+        it("clears the queue after draining", () => {
+            nodes.queueEndpointAdded(TEST_NODE_ID, EndpointNumber(32));
+            nodes.drainPendingEndpointAdds(TEST_NODE_ID);
+            expect(nodes.drainPendingEndpointAdds(TEST_NODE_ID)).to.deep.equal([]);
+        });
+
+        it("isolates queues per node", () => {
+            nodes.queueEndpointAdded(TEST_NODE_ID, EndpointNumber(1));
+            nodes.queueEndpointAdded(OTHER_NODE_ID, EndpointNumber(2));
+
+            expect(nodes.drainPendingEndpointAdds(TEST_NODE_ID)).to.deep.equal([EndpointNumber(1)]);
+            expect(nodes.drainPendingEndpointAdds(OTHER_NODE_ID)).to.deep.equal([EndpointNumber(2)]);
         });
     });
 });


### PR DESCRIPTION
## Summary
- Buffers `nodeEndpointAdded` forwards on `Nodes` and drains them after `nodeStructureChanged` emits, so `node_updated` always reaches consumers before the matching `endpoint_added`.
- Restores the wire-order contract that python-matter-server (and Home Assistant's matter integration) depend on for resolving `node.endpoints[endpoint_id]` inside the `endpoint_added` callback.

## Why
`PairedNode` fires `nodeEndpointAdded` immediately, while `nodeStructureChanged` only fires after the attribute cache refresh (~240 ms later). The python client doesn't add the endpoint on `ENDPOINT_ADDED` — it relies on the next `NODE_UPDATED` to populate `node.endpoints`. With the previous immediate-passthrough, HA's `endpoint_added_callback` ran a `node.endpoints[endpoint_id]` lookup on a not-yet-populated map and raised `KeyError`, which unwound `_client_listen` and reloaded the matter integration (dropping and reopening the WebSocket — observed as `[N] WebSocket connection closed` followed ~200 ms later by `[N+1] WebSocket connection established` whenever a bridged endpoint was added, e.g. mid-OTA on a hub).

The python matter-server emitted these in the safe order (`NODE_UPDATED` first inside `_handle_endpoints_added` → `_interview_node` → then `ENDPOINT_ADDED`); this PR matches that contract on the TS side.

## Changes
- `Nodes`: `#pendingEndpointAdds` map plus `queueEndpointAdded` / `drainPendingEndpointAdds`; cleared on `delete`.
- `ControllerCommandHandler.#registerNode`: `nodeEndpointAdded` listener now queues; `structureChanged` handler emits `nodeStructureChanged` first, then drains and emits queued `nodeEndpointAdded` events in arrival order.
- Tests: 4 new cases under `pending endpoint adds`; 1 new case verifying `delete` clears the queue.

`endpoint_removed` is unchanged — the python client signals subscribers before popping from `node.endpoints`, so the existing immediate forward stays consistent with HA's `endpoint_removed_callback`.

## Test plan
- [x] `npm run format-verify`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` (full suite green; new tests pass)
- [ ] Manual: bridged endpoint addition on an Aqara M2/M3-style hub triggers `node_updated` followed by `endpoint_added` in HA logs without the `KeyError: <endpoint_id>` traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)