### PR TITLE
Retain Thread Border Router entries 24h after last source goes off-air

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
+- Enhancement: Retain Thread Border Router registry entries for 24h after their last mDNS source goes off-air, so the dashboard's xa→name join keeps working for BRs that announce sparsely. Last-known fields are preserved across single- and full-source loss; LRU eviction prefers stale entries before live ones.
 - Fix: Ensures the same event order as the Python Matter server when endpoints got added
+- Fix: Update matter.js to the latest 0.17.0-nightly
+    - Fixes validation issues when writing values guarded by constraint checks
 
 ## 0.6.3 (2026-04-29)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "packages/matter-server"
             ],
             "devDependencies": {
-                "@matter/testing": "0.17.0-alpha.0-20260429-8fd498888",
+                "@matter/testing": "0.17.0-alpha.0-20260430-11b356f65",
                 "@nacho-iot/js-tools": "^0.1.3",
                 "@types/mocha": "^10.0.10",
                 "glob": "^13.0.6",
@@ -2525,77 +2525,77 @@
             "link": true
         },
         "node_modules/@matter/general": {
-            "version": "0.17.0-alpha.0-20260429-8fd498888",
-            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.0-alpha.0-20260429-8fd498888.tgz",
-            "integrity": "sha512-aXUlIzCLjEcb34xXvDedStiVR9eYYj//v2NzEoE2l/aWOnGgQbItF31rx8ZD/jiabpFZcE6VIImg9LAjKFhxzw==",
+            "version": "0.17.0-alpha.0-20260430-11b356f65",
+            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.0-alpha.0-20260430-11b356f65.tgz",
+            "integrity": "sha512-YcZpeNP8LU9y4z1wrW4FOaXQrMdW+KiHfVNTn0eQk4L4+ybM1kHpTspmr26OS8NVNG0hla1aKNNW6KaLCNr5kQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/curves": "^2.2.0"
             }
         },
         "node_modules/@matter/main": {
-            "version": "0.17.0-alpha.0-20260429-8fd498888",
-            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.0-alpha.0-20260429-8fd498888.tgz",
-            "integrity": "sha512-IQ9bgj4Glab5dujttmF+ZIEzYhcgS6XV/vbSaaOJsgxm/mcR9UTy8S1XYfL36eICIFELi35v/lbDh3n8Dh5rPg==",
+            "version": "0.17.0-alpha.0-20260430-11b356f65",
+            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.0-alpha.0-20260430-11b356f65.tgz",
+            "integrity": "sha512-zqjIp5K9OLsoBudZZ2j9shCU67OTqbqgZv+hCEPD/9aNtVb9R3IvYAl+Bwvxqk2v9dh7AykgqoQaECRzurGasg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/model": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/node": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/protocol": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/types": "0.17.0-alpha.0-20260429-8fd498888"
+                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/model": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/node": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/protocol": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/types": "0.17.0-alpha.0-20260430-11b356f65"
             },
             "optionalDependencies": {
-                "@matter/nodejs": "0.17.0-alpha.0-20260429-8fd498888"
+                "@matter/nodejs": "0.17.0-alpha.0-20260430-11b356f65"
             }
         },
         "node_modules/@matter/model": {
-            "version": "0.17.0-alpha.0-20260429-8fd498888",
-            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.0-alpha.0-20260429-8fd498888.tgz",
-            "integrity": "sha512-TY8GD9BA+AbY28ygrQ0dsmC04LUQixbFSQmqCN2pVekLXhSXiiyde4QSuRxh34te+UEDiZcvl4cXPCcjM+GJZg==",
+            "version": "0.17.0-alpha.0-20260430-11b356f65",
+            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.0-alpha.0-20260430-11b356f65.tgz",
+            "integrity": "sha512-unBhD9Plh4cXKnAOB3qZ2URrqtkb5FxbfAgFtt4sc0RLyXnSAYwywctlC/DedpSp/mErsIS8nAy25xguCMsKPg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260429-8fd498888"
+                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65"
             }
         },
         "node_modules/@matter/node": {
-            "version": "0.17.0-alpha.0-20260429-8fd498888",
-            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.0-alpha.0-20260429-8fd498888.tgz",
-            "integrity": "sha512-cPvpyyh7vilRYW1BbzwOqdWM7rSOgVbI7E6lkGLHx/3sU6uM4NgPOZ24ml5+smOhvsYa9oPT/ePHi6pzmB8iEQ==",
+            "version": "0.17.0-alpha.0-20260430-11b356f65",
+            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.0-alpha.0-20260430-11b356f65.tgz",
+            "integrity": "sha512-wkbuFoGknAa97NAliifN506Bdqrt2HoRvW6diOS8ckTpDeC9KAXwOTONnIVvR9VbFJ0Ix6QsXs0sLLjtj3rt+w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/model": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/protocol": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/types": "0.17.0-alpha.0-20260429-8fd498888"
+                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/model": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/protocol": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/types": "0.17.0-alpha.0-20260430-11b356f65"
             }
         },
         "node_modules/@matter/nodejs": {
-            "version": "0.17.0-alpha.0-20260429-8fd498888",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.0-alpha.0-20260429-8fd498888.tgz",
-            "integrity": "sha512-jnylv7LauiAeEOQjvMx11L0pXjqnAq159jEe3/rImb3EXenRH1B8fnN+1HioFJ3QzyTJUC7FGstoY6sKLSRu4g==",
+            "version": "0.17.0-alpha.0-20260430-11b356f65",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.0-alpha.0-20260430-11b356f65.tgz",
+            "integrity": "sha512-wUDXN3yijTHYEEMkBCz3FfAuGyUe7uwIgMxvsKpbbakiEfyYXmFha9UaTsdWEHCrou1eU/T1814AkrTshzkBSw==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/node": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/protocol": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/types": "0.17.0-alpha.0-20260429-8fd498888"
+                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/node": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/protocol": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/types": "0.17.0-alpha.0-20260430-11b356f65"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
             }
         },
         "node_modules/@matter/nodejs-ble": {
-            "version": "0.17.0-alpha.0-20260429-8fd498888",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.0-alpha.0-20260429-8fd498888.tgz",
-            "integrity": "sha512-xoW+hT0JbvqEV7cY5rZOs31y7CA0F+2LP6qofcfm2jKJzCCrPNIKyjTGXeuswW0Popibe6uGTvhefP5uxVZ0jg==",
+            "version": "0.17.0-alpha.0-20260430-11b356f65",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.0-alpha.0-20260430-11b356f65.tgz",
+            "integrity": "sha512-qAgJLbtCE+hfP/sEbZtOMRUxyuKsGMTurazyPpote0MiHjoTYQnkHe9Q8fK8HVRYsZPEEAC8dyOpu560sGeFNQ==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/protocol": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/types": "0.17.0-alpha.0-20260429-8fd498888"
+                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/protocol": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/types": "0.17.0-alpha.0-20260430-11b356f65"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -2606,20 +2606,20 @@
             }
         },
         "node_modules/@matter/protocol": {
-            "version": "0.17.0-alpha.0-20260429-8fd498888",
-            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.0-alpha.0-20260429-8fd498888.tgz",
-            "integrity": "sha512-cYRgGfLOSFJmnsSxu/rKv1ooreFF2Vn2SljbfDy3yFeQdCLpP7UrRha0GqvHOkadTa2KxmPnC+XMks2qUyO0CA==",
+            "version": "0.17.0-alpha.0-20260430-11b356f65",
+            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.0-alpha.0-20260430-11b356f65.tgz",
+            "integrity": "sha512-ROVn+zR21sdD55RhfnYp5vaGWBD5uBjfIKsle1Klkm2bHPNoTMJCqgD6J1k5UDzdEogjz/4p0YRqnveG0gTbNA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/model": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/types": "0.17.0-alpha.0-20260429-8fd498888"
+                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/model": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/types": "0.17.0-alpha.0-20260430-11b356f65"
             }
         },
         "node_modules/@matter/testing": {
-            "version": "0.17.0-alpha.0-20260429-8fd498888",
-            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.0-alpha.0-20260429-8fd498888.tgz",
-            "integrity": "sha512-6gwHeFC4YfL0LkokcNWPnWUB7i2nnNzfkWK3Ukja//zprqUhNp7IUNvCOkbWJmu8FcSskgrPtzumYWIYVArdFg==",
+            "version": "0.17.0-alpha.0-20260430-11b356f65",
+            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.0-alpha.0-20260430-11b356f65.tgz",
+            "integrity": "sha512-Bctdb0fL9Xu5IRgmJ//2c15hOakkJJ8hjsu3jSgd8aJEcMbf2tbghn+5tQZqoRs2lq3cacUlH9wo1vVufuLnuw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -2644,13 +2644,13 @@
             }
         },
         "node_modules/@matter/types": {
-            "version": "0.17.0-alpha.0-20260429-8fd498888",
-            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.0-alpha.0-20260429-8fd498888.tgz",
-            "integrity": "sha512-bc2H+N7H8y/8eXYe2BAcJYn0cxUzQZCT/SrjSfQMMTMCgPVnI/p/FWOxdaL7imJTeAQJrqLowwXaRHJk3DsgeA==",
+            "version": "0.17.0-alpha.0-20260430-11b356f65",
+            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.0-alpha.0-20260430-11b356f65.tgz",
+            "integrity": "sha512-9y3xs7eqbjYqNKjVbGxNOCOSUxy15t96DBuaYKrfJgh6XpWJGd2y13W/diEqzqxXv04GZiJhSImQy+0geFTMbQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/model": "0.17.0-alpha.0-20260429-8fd498888"
+                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/model": "0.17.0-alpha.0-20260430-11b356f65"
             }
         },
         "node_modules/@mdi/js": {
@@ -3503,16 +3503,16 @@
             }
         },
         "node_modules/@project-chip/matter.js": {
-            "version": "0.17.0-alpha.0-20260429-8fd498888",
-            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.0-alpha.0-20260429-8fd498888.tgz",
-            "integrity": "sha512-goYD6J4oS8tPX/sfgBW33CK7CC/xFwnzZyS9BHY97e+YnbGRgndrRVz9GjuS1Zh3PdhFSX+soaLWWagiE6tF7A==",
+            "version": "0.17.0-alpha.0-20260430-11b356f65",
+            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.0-alpha.0-20260430-11b356f65.tgz",
+            "integrity": "sha512-xnhMqLtA+owYMk7B9W4VpwKn4DzBLdhAfxGIxiNt1bwq+egY4VuNVgdHkq9NQi0rx1aVVS3jbqMqT8rlF0uG3Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/model": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/node": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/protocol": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/types": "0.17.0-alpha.0-20260429-8fd498888"
+                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/model": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/node": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/protocol": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/types": "0.17.0-alpha.0-20260430-11b356f65"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -4818,9 +4818,9 @@
             }
         },
         "node_modules/@typescript/native-preview": {
-            "version": "7.0.0-dev.20260429.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260429.1.tgz",
-            "integrity": "sha512-SGKnvs5EA+V1spnraYJqum/lEajE0IQ2bVVPC72hFfWjoCfQ6N7iVYxLUGreiE3VFyQWWQBPgXZrRUFnawVvpQ==",
+            "version": "7.0.0-dev.20260430.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260430.1.tgz",
+            "integrity": "sha512-HHk3tPpzPKqHY4AHMxGK6i960Dd1kIvnSnT3mzD1hNO/sUVG2YdWvWBIActGkRnKS94AZBpekOr1bQP7O2OwIg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -4830,19 +4830,19 @@
                 "node": ">=16.20.0"
             },
             "optionalDependencies": {
-                "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260429.1",
-                "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260429.1",
-                "@typescript/native-preview-linux-arm": "7.0.0-dev.20260429.1",
-                "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260429.1",
-                "@typescript/native-preview-linux-x64": "7.0.0-dev.20260429.1",
-                "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260429.1",
-                "@typescript/native-preview-win32-x64": "7.0.0-dev.20260429.1"
+                "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260430.1",
+                "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260430.1",
+                "@typescript/native-preview-linux-arm": "7.0.0-dev.20260430.1",
+                "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260430.1",
+                "@typescript/native-preview-linux-x64": "7.0.0-dev.20260430.1",
+                "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260430.1",
+                "@typescript/native-preview-win32-x64": "7.0.0-dev.20260430.1"
             }
         },
         "node_modules/@typescript/native-preview-darwin-arm64": {
-            "version": "7.0.0-dev.20260429.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260429.1.tgz",
-            "integrity": "sha512-+Rl8iPf+vYKq0fnb8euEOJxxvE/abEOWmhdllQIe+Shd8xhS7UVi+2WunsP1GyH2Ofc+N8rGYz0/dMnhrRYEZA==",
+            "version": "7.0.0-dev.20260430.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260430.1.tgz",
+            "integrity": "sha512-1Rk5JoMlmlF4GzeNxQmpaZSSPFa056DCrGLjhXwVIqRf8+pGNKKxyD2ugGSyOeLShqYb1XUoE9LhsAhdh1xgSA==",
             "cpu": [
                 "arm64"
             ],
@@ -4857,9 +4857,9 @@
             }
         },
         "node_modules/@typescript/native-preview-darwin-x64": {
-            "version": "7.0.0-dev.20260429.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260429.1.tgz",
-            "integrity": "sha512-be6Y7VVJz+usdI1ifCHy5mcldpxf8KXGYoyIp8w5Rd54zUtvtkYEJJWKzV5/bJt4bsQLLcp1i0vD4KJSr06Tmg==",
+            "version": "7.0.0-dev.20260430.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260430.1.tgz",
+            "integrity": "sha512-wjXJtELfI0QIYxGCqqKMR3DonPUlMP4aWOYRPiN5ylDtdV+OqCC16zvH7C+No7xvlf8dDxlV1ZTyuRCWL6CQmw==",
             "cpu": [
                 "x64"
             ],
@@ -4874,9 +4874,9 @@
             }
         },
         "node_modules/@typescript/native-preview-linux-arm": {
-            "version": "7.0.0-dev.20260429.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260429.1.tgz",
-            "integrity": "sha512-ngN6+qt5bPdp2zzasShoT4UONGXr+tvzHdz4NjuitwhiAF/d70CseXunb4syaudl1a+lJyTHro/ALTC0hRf6vA==",
+            "version": "7.0.0-dev.20260430.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260430.1.tgz",
+            "integrity": "sha512-3eqYkqy1XpbIJC1XkGbkwAvTtSCw6dSjYzJaw9bvow4fS1totTFZP/2K9ecXQ3gIZaPS4Ome/SpkZHl1cy9eZA==",
             "cpu": [
                 "arm"
             ],
@@ -4891,9 +4891,9 @@
             }
         },
         "node_modules/@typescript/native-preview-linux-arm64": {
-            "version": "7.0.0-dev.20260429.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260429.1.tgz",
-            "integrity": "sha512-44amAEH/VxG6K/hrAmhiyOTnwoTzm7bj0ja7d8sV8Iuocv37oUiSB/8OgJLytLqfIh+Q6kipfTwY6Do3jh6THQ==",
+            "version": "7.0.0-dev.20260430.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260430.1.tgz",
+            "integrity": "sha512-PeCFDB1glivpkqqKsQJ1RrM4f5B1yXzXFF+eKwgEZ+evcQ3N+BgeR7BpuRhOpHU9ixJchKjU1bXgcHOAaM+Rkw==",
             "cpu": [
                 "arm64"
             ],
@@ -4908,9 +4908,9 @@
             }
         },
         "node_modules/@typescript/native-preview-linux-x64": {
-            "version": "7.0.0-dev.20260429.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260429.1.tgz",
-            "integrity": "sha512-haAOqc0fJCZkt4RDi0/ZQGBdDfpDzr2N+mEcR+FbiYQD3Y00kOK34hXSrjZafO2kq56ZDWunvCaUTCev0fJDbA==",
+            "version": "7.0.0-dev.20260430.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260430.1.tgz",
+            "integrity": "sha512-Eg7nbRV57ayq0Pjuott/36UbQlVlpz2YRVLM5h8RyXx6SwvgrdYxNv/1zULLB0UlWdyKkK3bXILmR8YmNvbl+g==",
             "cpu": [
                 "x64"
             ],
@@ -4925,9 +4925,9 @@
             }
         },
         "node_modules/@typescript/native-preview-win32-arm64": {
-            "version": "7.0.0-dev.20260429.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260429.1.tgz",
-            "integrity": "sha512-J5O0tGVGqOZHbqm9ijRnZ5ADfPqYTjFIwZtYKpQL1yj1dZnUzMszO8P3bnOSfYD//DJhZINQyJzpPJxu29uiwQ==",
+            "version": "7.0.0-dev.20260430.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260430.1.tgz",
+            "integrity": "sha512-0LAjufJKUZnHmp0bxlndjphDQlIeUXA0czZCrKENtKySeGMXrM9PAFtSx94ldWVXDTZ9ZP1r+FxbIvP9pRORzA==",
             "cpu": [
                 "arm64"
             ],
@@ -4942,9 +4942,9 @@
             }
         },
         "node_modules/@typescript/native-preview-win32-x64": {
-            "version": "7.0.0-dev.20260429.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260429.1.tgz",
-            "integrity": "sha512-/OZ99Hi/32huvZQ5fdqTwqLvZtKC3QrCXmLuKfMyVuBisV/TSd6LhlFQLolvIpr7/E530mnFZ4sXjgDEzVFqAw==",
+            "version": "7.0.0-dev.20260430.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260430.1.tgz",
+            "integrity": "sha512-FvLWX7d3b/IhL0656tnjep7dOMnI7CPrg+5oI1MKIY74qgvR+8VRo6aGj0IRCwtAJeklpxBpljEcIGuS5Yc/pQ==",
             "cpu": [
                 "x64"
             ],
@@ -6234,9 +6234,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.344",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
-            "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+            "version": "1.5.345",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz",
+            "integrity": "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==",
             "dev": true,
             "license": "ISC"
         },
@@ -11089,7 +11089,7 @@
             "name": "@matter-server/custom-clusters",
             "version": "0.0.0-git",
             "dependencies": {
-                "@matter/main": "0.17.0-alpha.0-20260429-8fd498888"
+                "@matter/main": "0.17.0-alpha.0-20260430-11b356f65"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -11111,7 +11111,7 @@
             },
             "devDependencies": {
                 "@babel/preset-env": "^7.29.2",
-                "@matter/main": "0.17.0-alpha.0-20260429-8fd498888",
+                "@matter/main": "0.17.0-alpha.0-20260430-11b356f65",
                 "@rollup/plugin-babel": "^7.0.0",
                 "@rollup/plugin-commonjs": "^29.0.2",
                 "@rollup/plugin-json": "^6.1.0",
@@ -11129,14 +11129,14 @@
                 "@matter-server/custom-clusters": "*",
                 "@matter-server/dashboard": "*",
                 "@matter-server/ws-controller": "*",
-                "@matter/main": "0.17.0-alpha.0-20260429-8fd498888",
+                "@matter/main": "0.17.0-alpha.0-20260430-11b356f65",
                 "commander": "^14.0.3",
                 "express": "^5.2.1"
             },
             "devDependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/nodejs": "0.17.0-alpha.0-20260429-8fd498888",
-                "@matter/testing": "0.17.0-alpha.0-20260429-8fd498888",
+                "@matter/nodejs": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/testing": "0.17.0-alpha.0-20260430-11b356f65",
                 "@types/express": "^5.0.6",
                 "@types/node": "^25.6.0"
             },
@@ -11149,7 +11149,7 @@
             "version": "0.0.0-git",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@matter/testing": "0.17.0-alpha.0-20260429-8fd498888",
+                "@matter/testing": "0.17.0-alpha.0-20260430-11b356f65",
                 "@types/node": "^25.6.0",
                 "@types/ws": "^8.18.1",
                 "ws": "^8.20.0"
@@ -11163,8 +11163,8 @@
             "version": "0.0.0-git",
             "dependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/main": "0.17.0-alpha.0-20260429-8fd498888",
-                "@project-chip/matter.js": "0.17.0-alpha.0-20260429-8fd498888",
+                "@matter/main": "0.17.0-alpha.0-20260430-11b356f65",
+                "@project-chip/matter.js": "0.17.0-alpha.0-20260430-11b356f65",
                 "ws": "^8.20.0"
             },
             "devDependencies": {
@@ -11175,7 +11175,7 @@
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.0-alpha.0-20260429-8fd498888"
+                "@matter/nodejs-ble": "0.17.0-alpha.0-20260430-11b356f65"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "python:build": "cd python_client && .venv/bin/pip install build && .venv/bin/python -m build"
     },
     "devDependencies": {
-        "@matter/testing": "0.17.0-alpha.0-20260429-8fd498888",
+        "@matter/testing": "0.17.0-alpha.0-20260430-11b356f65",
         "@nacho-iot/js-tools": "^0.1.3",
         "@types/mocha": "^10.0.10",
         "glob": "^13.0.6",

--- a/packages/custom-clusters/package.json
+++ b/packages/custom-clusters/package.json
@@ -33,7 +33,7 @@
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
     },
     "dependencies": {
-        "@matter/main": "0.17.0-alpha.0-20260429-8fd498888"
+        "@matter/main": "0.17.0-alpha.0-20260430-11b356f65"
     },
     "files": [
         "dist/**/*",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -42,7 +42,7 @@
     },
     "devDependencies": {
         "@babel/preset-env": "^7.29.2",
-        "@matter/main": "0.17.0-alpha.0-20260429-8fd498888",
+        "@matter/main": "0.17.0-alpha.0-20260430-11b356f65",
         "@rollup/plugin-babel": "^7.0.0",
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-json": "^6.1.0",

--- a/packages/dashboard/src/pages/matter-network-view.ts
+++ b/packages/dashboard/src/pages/matter-network-view.ts
@@ -106,12 +106,6 @@ class MatterNetworkView extends LitElement {
         }
     }
 
-    override firstUpdated(): void {
-        if (this.networkType === "thread") {
-            void this._refreshBorderRouters();
-        }
-    }
-
     private async _refreshBorderRouters(): Promise<void> {
         try {
             await this._borderRouterStore.refresh(this.client);
@@ -131,8 +125,6 @@ class MatterNetworkView extends LitElement {
     override updated(changedProperties: Map<string, unknown>): void {
         super.updated(changedProperties);
 
-        // Lazily refresh the BR snapshot the first time the user switches into the Thread
-        // view, in case firstUpdated() fired while the WiFi view was active.
         if (changedProperties.has("networkType") && this.networkType === "thread") {
             void this._refreshBorderRouters();
         }

--- a/packages/matter-server/package.json
+++ b/packages/matter-server/package.json
@@ -34,7 +34,7 @@
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
     },
     "dependencies": {
-        "@matter/main": "0.17.0-alpha.0-20260429-8fd498888",
+        "@matter/main": "0.17.0-alpha.0-20260430-11b356f65",
         "@matter-server/ws-controller": "*",
         "@matter-server/dashboard": "*",
         "@matter-server/custom-clusters": "*",
@@ -44,8 +44,8 @@
     "devDependencies": {
         "@types/express": "^5.0.6",
         "@types/node": "^25.6.0",
-        "@matter/nodejs": "0.17.0-alpha.0-20260429-8fd498888",
-        "@matter/testing": "0.17.0-alpha.0-20260429-8fd498888",
+        "@matter/nodejs": "0.17.0-alpha.0-20260430-11b356f65",
+        "@matter/testing": "0.17.0-alpha.0-20260430-11b356f65",
         "@matter-server/ws-client": "*"
     },
     "files": [

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -37,7 +37,7 @@
     "devDependencies": {
         "@types/node": "^25.6.0",
         "@types/ws": "^8.18.1",
-        "@matter/testing": "0.17.0-alpha.0-20260429-8fd498888",
+        "@matter/testing": "0.17.0-alpha.0-20260430-11b356f65",
         "ws": "^8.20.0"
     },
     "files": [

--- a/packages/ws-client/src/models/model.ts
+++ b/packages/ws-client/src/models/model.ts
@@ -55,9 +55,11 @@ export interface BorderRouterEntry {
     /**
      * Epoch milliseconds of the most recent successful mDNS discovery for this entry.
      * Frozen when `sources` becomes empty (the entry is "stale"); updated on every
-     * re-discovery. Stale entries are retained server-side for 24h after `lastSeen`
-     * and then pruned. Consumers can derive stale state via `sources.length === 0`
-     * and stale age via `Date.now() - lastSeen`.
+     * re-discovery. Stale entries are retained server-side for at least 24h after
+     * `lastSeen`; the actual prune is lazy and happens on the next `get`, `list`,
+     * or mDNS discovery event after the window elapses, so an entry may linger
+     * longer than 24h if there is no activity. Consumers can derive stale state
+     * via `sources.length === 0` and stale age via `Date.now() - lastSeen`.
      */
     lastSeen: number;
 }

--- a/packages/ws-client/src/models/model.ts
+++ b/packages/ws-client/src/models/model.ts
@@ -52,7 +52,13 @@ export interface BorderRouterEntry {
     domainName?: string;
     /** Which mDNS source(s) contributed to this entry. */
     sources: ("meshcop" | "trel")[];
-    /** Epoch milliseconds of the most recent record install or update. */
+    /**
+     * Epoch milliseconds of the most recent successful mDNS discovery for this entry.
+     * Frozen when `sources` becomes empty (the entry is "stale"); updated on every
+     * re-discovery. Stale entries are retained server-side for 24h after `lastSeen`
+     * and then pruned. Consumers can derive stale state via `sources.length === 0`
+     * and stale age via `Date.now() - lastSeen`.
+     */
     lastSeen: number;
 }
 

--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -34,12 +34,12 @@
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.0-alpha.0-20260429-8fd498888"
+        "@matter/nodejs-ble": "0.17.0-alpha.0-20260430-11b356f65"
     },
     "dependencies": {
-        "@matter/main": "0.17.0-alpha.0-20260429-8fd498888",
+        "@matter/main": "0.17.0-alpha.0-20260430-11b356f65",
         "@matter-server/ws-client": "*",
-        "@project-chip/matter.js": "0.17.0-alpha.0-20260429-8fd498888",
+        "@project-chip/matter.js": "0.17.0-alpha.0-20260430-11b356f65",
         "ws": "^8.20.0"
     },
     "devDependencies": {

--- a/packages/ws-controller/src/controller/BorderRouterDiscovery.ts
+++ b/packages/ws-controller/src/controller/BorderRouterDiscovery.ts
@@ -15,9 +15,11 @@ const REGISTRY_MAX_ENTRIES = 256;
  *  yet emitted a valid xa, but bounded so a noisy LAN can't grow `#instanceObservers`
  *  without limit. Eviction targets the oldest xa-less observer first. */
 const INSTANCE_OBSERVER_CAP = 512;
-/** Stale entries (sources.length === 0) are pruned 24h after their last successful
- *  mDNS discovery (entry.lastSeen). Long enough that BRs announcing once per
- *  ~half-day stay resolvable; short enough that vanished BRs eventually drop. */
+/** Stale entries (sources.length === 0) become eligible for pruning 24h after their
+ *  last successful mDNS discovery (entry.lastSeen). Pruning is lazy — `#pruneExpired`
+ *  runs on `list` / `get` / `#onDiscovered`, so without activity an eligible entry
+ *  may linger past the window. Long enough that BRs announcing once per ~half-day
+ *  stay resolvable; short enough that vanished BRs eventually drop. */
 const STALE_RETENTION_MS = 24 * 60 * 60 * 1000;
 const MESHCOP_TYPE_QNAME = "_meshcop._udp.local";
 const TREL_TYPE_QNAME = "_trel._udp.local";

--- a/packages/ws-controller/src/controller/BorderRouterDiscovery.ts
+++ b/packages/ws-controller/src/controller/BorderRouterDiscovery.ts
@@ -281,13 +281,12 @@ export class BorderRouterDiscovery {
 
     #onInstanceChanged(name: DnssdNameLike, source: Source): void {
         if (!this.#started) return;
-        try {
-            this.#parseAndUpsert(name, source);
-        } catch (e) {
-            logger.debug("Error processing border router instance change:", e);
-        }
-
         if (name.isDiscovered) {
+            try {
+                this.#parseAndUpsert(name, source);
+            } catch (e) {
+                logger.debug("Error processing border router instance change:", e);
+            }
             return;
         }
 

--- a/packages/ws-controller/src/controller/BorderRouterDiscovery.ts
+++ b/packages/ws-controller/src/controller/BorderRouterDiscovery.ts
@@ -540,21 +540,29 @@ export class BorderRouterDiscovery {
     }
 
     #evictOldest(): boolean {
-        let oldestKey: string | undefined;
-        let oldestSeen = Number.POSITIVE_INFINITY;
+        let oldestStaleKey: string | undefined;
+        let oldestStaleSeen = Number.POSITIVE_INFINITY;
+        let oldestLiveKey: string | undefined;
+        let oldestLiveSeen = Number.POSITIVE_INFINITY;
         for (const [xa, entry] of this.#registry) {
-            if (entry.lastSeen < oldestSeen) {
-                oldestSeen = entry.lastSeen;
-                oldestKey = xa;
+            if (entry.sources.length === 0) {
+                if (entry.lastSeen < oldestStaleSeen) {
+                    oldestStaleSeen = entry.lastSeen;
+                    oldestStaleKey = xa;
+                }
+            } else if (entry.lastSeen < oldestLiveSeen) {
+                oldestLiveSeen = entry.lastSeen;
+                oldestLiveKey = xa;
             }
         }
-        if (oldestKey === undefined) return false;
+        const evictKey = oldestStaleKey ?? oldestLiveKey;
+        if (evictKey === undefined) return false;
 
-        this.#registry.delete(oldestKey);
+        this.#registry.delete(evictKey);
 
         let releasedObservers = 0;
         for (const [instanceKey, tracking] of [...this.#instanceObservers]) {
-            if (tracking.xaKey !== oldestKey) continue;
+            if (tracking.xaKey !== evictKey) continue;
             tracking.name.off(tracking.observer);
             if (tracking.targetKey !== undefined) {
                 this.#releaseTarget(tracking.targetKey);
@@ -569,7 +577,7 @@ export class BorderRouterDiscovery {
                 `Border router registry exceeded ${REGISTRY_MAX_ENTRIES} entries; evicting oldest (released ${releasedObservers} instance observer${releasedObservers === 1 ? "" : "s"})`,
             );
         } else {
-            logger.debug(`Evicted border router xa=${oldestKey}; released ${releasedObservers} instance observers`);
+            logger.debug(`Evicted border router xa=${evictKey}; released ${releasedObservers} instance observers`);
         }
         return true;
     }

--- a/packages/ws-controller/src/controller/BorderRouterDiscovery.ts
+++ b/packages/ws-controller/src/controller/BorderRouterDiscovery.ts
@@ -15,6 +15,10 @@ const REGISTRY_MAX_ENTRIES = 256;
  *  yet emitted a valid xa, but bounded so a noisy LAN can't grow `#instanceObservers`
  *  without limit. Eviction targets the oldest xa-less observer first. */
 const INSTANCE_OBSERVER_CAP = 512;
+/** Stale entries (sources.length === 0) are pruned 24h after their last successful
+ *  mDNS discovery (entry.lastSeen). Long enough that BRs announcing once per
+ *  ~half-day stay resolvable; short enough that vanished BRs eventually drop. */
+const STALE_RETENTION_MS = 24 * 60 * 60 * 1000;
 const MESHCOP_TYPE_QNAME = "_meshcop._udp.local";
 const TREL_TYPE_QNAME = "_trel._udp.local";
 const MESHCOP_SUFFIX = "._meshcop._udp.local";
@@ -182,12 +186,23 @@ export class BorderRouterDiscovery {
     }
 
     list(): BorderRouterEntry[] {
+        this.#pruneExpired();
         return Array.from(this.#registry.values(), entry => this.#snapshotEntry(entry));
     }
 
     get(extAddressHex: string): BorderRouterEntry | undefined {
+        this.#pruneExpired();
         const entry = this.#registry.get(extAddressHex.toUpperCase());
         return entry === undefined ? undefined : this.#snapshotEntry(entry);
+    }
+
+    #pruneExpired(): void {
+        const cutoff = Date.now() - STALE_RETENTION_MS;
+        for (const [xaKey, entry] of this.#registry) {
+            if (entry.sources.length === 0 && entry.lastSeen < cutoff) {
+                this.#registry.delete(xaKey);
+            }
+        }
     }
 
     /** Shallow copy so callers cannot mutate registry state through the returned reference. */
@@ -201,6 +216,7 @@ export class BorderRouterDiscovery {
 
     #onDiscovered(name: DnssdNameLike): void {
         if (!this.#started) return;
+        this.#pruneExpired();
         const lower = name.qname.toLowerCase();
         if (lower === MESHCOP_TYPE_QNAME || lower === TREL_TYPE_QNAME) {
             return;

--- a/packages/ws-controller/src/controller/BorderRouterDiscovery.ts
+++ b/packages/ws-controller/src/controller/BorderRouterDiscovery.ts
@@ -299,36 +299,6 @@ export class BorderRouterDiscovery {
         if (idx !== -1) {
             entry.sources.splice(idx, 1);
         }
-        // Clear fields exclusively contributed by the disappearing source so the registry
-        // doesn't expose stale meshcop naming / state when only trel remains (or vice versa).
-        if (source === "meshcop") {
-            entry.meshcopPort = undefined;
-            entry.networkName = undefined;
-            entry.vendorName = undefined;
-            entry.modelName = undefined;
-            entry.threadVersion = undefined;
-            entry.borderAgentIdHex = undefined;
-            entry.stateBitmapHex = undefined;
-            entry.activeTimestampHex = undefined;
-            entry.partitionIdHex = undefined;
-            entry.domainName = undefined;
-        } else {
-            entry.trelPort = undefined;
-        }
-        if (entry.sources.length === 0) {
-            this.#registry.delete(xaKey);
-            return;
-        }
-        // Hostname / addresses can come from either source (meshcop wins on conflict). With
-        // the dropped source gone, re-parse the still-discovered companion instance so those
-        // shared fields reflect the surviving advertisement instead of lingering on the
-        // value the disappearing source last set.
-        for (const otherTracking of this.#instanceObservers.values()) {
-            if (otherTracking.xaKey === xaKey && otherTracking.source !== source) {
-                this.#parseAndUpsert(otherTracking.name, otherTracking.source);
-                break;
-            }
-        }
     }
 
     #onTargetChanged(target: DnssdNameLike): void {

--- a/packages/ws-controller/test/BorderRouterDiscoveryTest.ts
+++ b/packages/ws-controller/test/BorderRouterDiscoveryTest.ts
@@ -512,6 +512,69 @@ describe("BorderRouterDiscovery", () => {
             expect(stub.filterCount()).to.equal(0);
             expect(stub.discoveredObserverCount()).to.equal(0);
         });
+
+        it("prunes a stale entry once 24h elapses since lastSeen", async () => {
+            const originalDateNow = Date.now;
+            let now = 1000;
+            Date.now = () => now;
+            try {
+                await disc.start();
+                stub.makeTarget("Kuche.local.", ["192.168.1.10"]);
+                const inst = stub.makeInstance("Kuche._meshcop._udp.local", {
+                    txt: { xa: "aabbccddeeff0011", nn: "MyNet" },
+                    srvTarget: "Kuche.local.",
+                    srvPort: 49154,
+                });
+                stub.discover(inst);
+
+                inst.setDiscovered(false);
+                inst.emit({ name: inst });
+                expect(disc.get("AABBCCDDEEFF0011")!.sources).to.deep.equal([]);
+
+                now += 24 * 60 * 60 * 1000 - 1;
+                expect(disc.get("AABBCCDDEEFF0011")).to.not.equal(undefined);
+
+                now += 2;
+                expect(disc.get("AABBCCDDEEFF0011")).to.equal(undefined);
+                expect(disc.list()).to.deep.equal([]);
+            } finally {
+                Date.now = originalDateNow;
+            }
+        });
+
+        it("resets the retention clock when a stale entry is re-discovered", async () => {
+            const originalDateNow = Date.now;
+            let now = 1000;
+            Date.now = () => now;
+            try {
+                await disc.start();
+                stub.makeTarget("Kuche.local.", ["192.168.1.10"]);
+                const inst = stub.makeInstance("Kuche._meshcop._udp.local", {
+                    txt: { xa: "aabbccddeeff0011", nn: "MyNet" },
+                    srvTarget: "Kuche.local.",
+                    srvPort: 49154,
+                });
+                stub.discover(inst);
+
+                inst.setDiscovered(false);
+                inst.emit({ name: inst });
+                const staleAt = now;
+
+                now += 12 * 60 * 60 * 1000;
+                inst.setDiscovered(true);
+                stub.discover(inst);
+
+                const live = disc.get("AABBCCDDEEFF0011");
+                expect(live).to.not.equal(undefined);
+                expect(live!.sources).to.deep.equal(["meshcop"]);
+                expect(live!.lastSeen).to.equal(now);
+
+                now = staleAt + 24 * 60 * 60 * 1000 + 1;
+                expect(disc.get("AABBCCDDEEFF0011")).to.not.equal(undefined);
+            } finally {
+                Date.now = originalDateNow;
+            }
+        });
     });
 });
 

--- a/packages/ws-controller/test/BorderRouterDiscoveryTest.ts
+++ b/packages/ws-controller/test/BorderRouterDiscoveryTest.ts
@@ -184,7 +184,7 @@ describe("BorderRouterDiscovery", () => {
             expect(e!.extendedPanIdHex).to.equal("AAAAAAAAAAAAAAAA");
         });
 
-        it("removes a source when an instance becomes undiscovered, deletes entry when last source", async () => {
+        it("retains entry across single-source loss and full-source loss with last-known fields preserved", async () => {
             await disc.start();
             stub.makeTarget("Kuche.local.", ["192.168.1.10"]);
             stub.makeTarget("br.local.", ["10.0.0.5"]);
@@ -206,15 +206,22 @@ describe("BorderRouterDiscovery", () => {
             trelInst.setDiscovered(false);
             trelInst.emit({ name: trelInst });
 
-            const after = disc.get("AABBCCDDEEFF0011");
-            expect(after).to.not.equal(undefined);
-            expect(after!.sources).to.deep.equal(["meshcop"]);
-            expect(after!.trelPort).to.equal(undefined);
+            const afterTrelLoss = disc.get("AABBCCDDEEFF0011");
+            expect(afterTrelLoss).to.not.equal(undefined);
+            expect(afterTrelLoss!.sources).to.deep.equal(["meshcop"]);
+            expect(afterTrelLoss!.trelPort).to.equal(12345);
+            expect(afterTrelLoss!.networkName).to.equal("MyNet");
             expect(stub.targetByKey("br.local.")!.observerCount()).to.equal(0);
 
             meshcopInst.setDiscovered(false);
             meshcopInst.emit({ name: meshcopInst });
-            expect(disc.get("AABBCCDDEEFF0011")).to.equal(undefined);
+
+            const stale = disc.get("AABBCCDDEEFF0011");
+            expect(stale).to.not.equal(undefined);
+            expect(stale!.sources).to.deep.equal([]);
+            expect(stale!.networkName).to.equal("MyNet");
+            expect(stale!.meshcopPort).to.equal(49154);
+            expect(stale!.trelPort).to.equal(12345);
             expect(stub.targetByKey("kuche.local.")!.observerCount()).to.equal(0);
         });
 

--- a/packages/ws-controller/test/BorderRouterDiscoveryTest.ts
+++ b/packages/ws-controller/test/BorderRouterDiscoveryTest.ts
@@ -629,6 +629,153 @@ describe("BorderRouterDiscovery", () => {
                 Date.now = originalDateNow;
             }
         });
+
+        it("freezes lastSeen when an entry transitions to stale", async () => {
+            const originalDateNow = Date.now;
+            let now = 1000;
+            Date.now = () => now;
+            try {
+                await disc.start();
+                stub.makeTarget("Kuche.local.", ["192.168.1.10"]);
+                const inst = stub.makeInstance("Kuche._meshcop._udp.local", {
+                    txt: { xa: "aabbccddeeff0011", nn: "MyNet" },
+                    srvTarget: "Kuche.local.",
+                    srvPort: 49154,
+                });
+                stub.discover(inst);
+                const discoveredAt = now;
+
+                now += 60 * 1000;
+
+                inst.setDiscovered(false);
+                inst.emit({ name: inst });
+
+                const stale = disc.get("AABBCCDDEEFF0011");
+                expect(stale).to.not.equal(undefined);
+                expect(stale!.sources).to.deep.equal([]);
+                expect(stale!.lastSeen).to.equal(discoveredAt);
+            } finally {
+                Date.now = originalDateNow;
+            }
+        });
+
+        it("eviction picks stale entry even when newer than several live entries", async () => {
+            const originalDateNow = Date.now;
+            let now = 1000;
+            Date.now = () => now;
+            try {
+                await disc.start();
+
+                for (let i = 1; i <= 2; i++) {
+                    const xa = makeXa(i);
+                    const host = `liveOld${i}.local.`;
+                    stub.makeTarget(host, [`10.0.0.${i}`]);
+                    const inst = stub.makeInstance(`${xa.toLowerCase()}._meshcop._udp.local`, {
+                        txt: { xa: xa.toLowerCase(), nn: `OldLive${i}` },
+                        srvTarget: host,
+                        srvPort: 49000 + i,
+                    });
+                    stub.discover(inst);
+                    now++;
+                }
+                const oldLive1 = makeXa(1);
+                const oldLive2 = makeXa(2);
+
+                now = 5000;
+                const staleXa = makeXa(100);
+                stub.makeTarget("staleHost.local.", ["10.5.0.0"]);
+                const staleInst = stub.makeInstance(`${staleXa.toLowerCase()}._meshcop._udp.local`, {
+                    txt: { xa: staleXa.toLowerCase(), nn: "Stale" },
+                    srvTarget: "staleHost.local.",
+                    srvPort: 49500,
+                });
+                stub.discover(staleInst);
+                staleInst.setDiscovered(false);
+                staleInst.emit({ name: staleInst });
+                expect(disc.get(staleXa)!.sources).to.deep.equal([]);
+                expect(disc.get(staleXa)!.lastSeen).to.equal(5000);
+                now = 10000;
+
+                for (let i = 200; i < 200 + 253; i++) {
+                    const xa = makeXa(i);
+                    const host = `host${i}.local.`;
+                    stub.makeTarget(host, [`10.1.${(i >> 8) & 0xff}.${i & 0xff}`]);
+                    const inst = stub.makeInstance(`${xa.toLowerCase()}._meshcop._udp.local`, {
+                        txt: { xa: xa.toLowerCase(), nn: `Net${i}` },
+                        srvTarget: host,
+                        srvPort: 49154 + i,
+                    });
+                    stub.discover(inst);
+                    now++;
+                }
+                expect(disc.list().length).to.equal(256);
+
+                const newXa = makeXa(900);
+                stub.makeTarget("newHost.local.", ["10.2.0.0"]);
+                const newInst = stub.makeInstance(`${newXa.toLowerCase()}._meshcop._udp.local`, {
+                    txt: { xa: newXa.toLowerCase(), nn: "New" },
+                    srvTarget: "newHost.local.",
+                    srvPort: 50000,
+                });
+                stub.discover(newInst);
+
+                expect(disc.list().length).to.equal(256);
+                expect(disc.get(staleXa)).to.equal(undefined);
+                expect(disc.get(oldLive1)).to.not.equal(undefined);
+                expect(disc.get(oldLive2)).to.not.equal(undefined);
+                expect(disc.get(newXa)).to.not.equal(undefined);
+            } finally {
+                Date.now = originalDateNow;
+            }
+        });
+
+        it("re-discovers a stale entry from the other source", async () => {
+            await disc.start();
+            stub.makeTarget("Kuche.local.", ["192.168.1.10"]);
+            const meshcopInst = stub.makeInstance("Kuche._meshcop._udp.local", {
+                txt: { xa: "aabbccddeeff0011", nn: "MyNet" },
+                srvTarget: "Kuche.local.",
+                srvPort: 49154,
+            });
+            stub.discover(meshcopInst);
+            meshcopInst.setDiscovered(false);
+            meshcopInst.emit({ name: meshcopInst });
+            expect(disc.get("AABBCCDDEEFF0011")!.sources).to.deep.equal([]);
+
+            stub.makeTarget("br.local.", ["10.0.0.5"]);
+            const trelInst = stub.makeInstance("aabbccddeeff0011._trel._udp.local", {
+                txt: { xa: "aabbccddeeff0011" },
+                srvTarget: "br.local.",
+                srvPort: 12345,
+            });
+            stub.discover(trelInst);
+
+            const live = disc.get("AABBCCDDEEFF0011");
+            expect(live).to.not.equal(undefined);
+            expect(live!.sources).to.deep.equal(["trel"]);
+            expect(live!.trelPort).to.equal(12345);
+            expect(live!.networkName).to.equal("MyNet");
+            expect(live!.meshcopPort).to.equal(49154);
+        });
+
+        it("stop() clears stale entries from the registry", async () => {
+            await disc.start();
+            stub.makeTarget("Kuche.local.", ["192.168.1.10"]);
+            const inst = stub.makeInstance("Kuche._meshcop._udp.local", {
+                txt: { xa: "aabbccddeeff0011", nn: "MyNet" },
+                srvTarget: "Kuche.local.",
+                srvPort: 49154,
+            });
+            stub.discover(inst);
+            inst.setDiscovered(false);
+            inst.emit({ name: inst });
+            expect(disc.get("AABBCCDDEEFF0011")!.sources).to.deep.equal([]);
+
+            await disc.stop();
+
+            expect(disc.list()).to.deep.equal([]);
+            expect(disc.get("AABBCCDDEEFF0011")).to.equal(undefined);
+        });
     });
 });
 

--- a/packages/ws-controller/test/BorderRouterDiscoveryTest.ts
+++ b/packages/ws-controller/test/BorderRouterDiscoveryTest.ts
@@ -575,6 +575,60 @@ describe("BorderRouterDiscovery", () => {
                 Date.now = originalDateNow;
             }
         });
+
+        it("eviction prefers stale entries before live ones when the cap is hit", async () => {
+            const originalDateNow = Date.now;
+            let now = 1000;
+            Date.now = () => now;
+            try {
+                await disc.start();
+
+                const staleXa = makeXa(0);
+                stub.makeTarget("staleHost.local.", ["10.0.0.1"]);
+                const staleInst = stub.makeInstance(`${staleXa.toLowerCase()}._meshcop._udp.local`, {
+                    txt: { xa: staleXa.toLowerCase(), nn: "Stale" },
+                    srvTarget: "staleHost.local.",
+                    srvPort: 49000,
+                });
+                stub.discover(staleInst);
+                staleInst.setDiscovered(false);
+                staleInst.emit({ name: staleInst });
+                expect(disc.get(staleXa)!.sources).to.deep.equal([]);
+                now++;
+
+                for (let i = 1; i < 256; i++) {
+                    const xa = makeXa(i);
+                    const host = `host${i}.local.`;
+                    stub.makeTarget(host, [`10.1.${(i >> 8) & 0xff}.${i & 0xff}`]);
+                    const inst = stub.makeInstance(`${xa.toLowerCase()}._meshcop._udp.local`, {
+                        txt: { xa: xa.toLowerCase(), nn: `Net${i}` },
+                        srvTarget: host,
+                        srvPort: 49154 + i,
+                    });
+                    stub.discover(inst);
+                    now++;
+                }
+                expect(disc.list().length).to.equal(256);
+
+                const newXa = makeXa(500);
+                stub.makeTarget("newHost.local.", ["10.2.0.0"]);
+                const newInst = stub.makeInstance(`${newXa.toLowerCase()}._meshcop._udp.local`, {
+                    txt: { xa: newXa.toLowerCase(), nn: "New" },
+                    srvTarget: "newHost.local.",
+                    srvPort: 50000,
+                });
+                stub.discover(newInst);
+
+                expect(disc.list().length).to.equal(256);
+                expect(disc.get(staleXa)).to.equal(undefined);
+                expect(disc.get(newXa)).to.not.equal(undefined);
+                for (let i = 1; i < 256; i++) {
+                    expect(disc.get(makeXa(i))).to.not.equal(undefined);
+                }
+            } finally {
+                Date.now = originalDateNow;
+            }
+        });
     });
 });
 


### PR DESCRIPTION
## Summary

- Retain mDNS-discovered Thread Border Router registry entries for 24h after their last `_meshcop`/`_trel` source goes off-air, so the dashboard's xa→name join keeps working when BRs announce sparsely.
- Last-known fields (network name, vendor, ports, state bitmap, …) are preserved across single- and full-source loss instead of being wiped immediately.
- LRU eviction (cap 256) now prefers stale entries over live ones; live BRs survive cap pressure as long as any stale entry is around to sacrifice.
- Pickup matter.js bump to `0.17.0-alpha.0-20260430-11b356f65`.
- Drop redundant `firstUpdated` BR refresh in the dashboard so the Thread panel only sends one `get_thread_border_routers` per mount.

Stale state is **derived** (`sources.length === 0`) rather than stored, so the wire format is unchanged. `BorderRouterEntry.lastSeen` JSDoc is tightened to document the new "frozen on stale, bumped on re-discovery" contract.

Spec: `docs/superpowers/specs/2026-04-30-thread-br-stale-retention-design.md` (uncommitted).
Plan: `docs/superpowers/plans/2026-04-30-thread-br-stale-retention.md` (uncommitted).

Refs matter-js/matterjs-server#406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)