### PR TITLE
Hide stale phantom Thread externals in mesh visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Enhancement: Hide phantom Thread "External" routers/devices that only persist as stale neighbor-table entries (every observer offline, or single observer with other connections)
+
 ## 0.6.4 (2026-04-30)
 
 - Enhancement: Retain Thread Border Router registry entries for 24h after their last mDNS source goes off-air, so the dashboard can still show information even if stale

--- a/packages/dashboard/src/pages/network/network-utils.ts
+++ b/packages/dashboard/src/pages/network/network-utils.ts
@@ -217,6 +217,16 @@ export function getThreadExtendedAddressHex(node: MatterNode): string | undefine
 }
 
 /**
+ * Counts entries in the Thread neighbor table without normalizing each entry.
+ * Use this in hot paths where only the cardinality matters; the full parse
+ * does a base64 decode per entry that adds up across re-renders.
+ */
+export function getNeighborTableLength(node: MatterNode): number {
+    const neighborTable = node.attributes["0/53/7"];
+    return Array.isArray(neighborTable) ? neighborTable.length : 0;
+}
+
+/**
  * Parses the Thread neighbor table from a node's attributes.
  * Attribute 0/53/7 (NeighborTable) is an array of neighbor objects.
  * The data uses numeric keys matching the Matter spec field IDs.

--- a/packages/dashboard/src/pages/network/thread-graph.ts
+++ b/packages/dashboard/src/pages/network/thread-graph.ts
@@ -30,6 +30,7 @@ import {
     getNetworkType,
     getThreadExtendedAddressHex,
     getThreadRole,
+    parseNeighborTable,
 } from "./network-utils.js";
 
 declare global {
@@ -217,14 +218,27 @@ export class ThreadGraph extends BaseNetworkGraph {
         for (const device of this._unknownDevices) {
             const isSelected = device.id === this._selectedNodeId;
 
-            // Hide if hideOfflineNodes is enabled AND all nodes that see it are offline
-            let shouldHide = false;
-            if (this.hideOfflineNodes) {
-                const hasOnlineSeenBy = device.seenBy.some(nodeId => {
-                    const node = this.nodes[nodeId];
-                    return node && node.available !== false;
-                });
-                shouldHide = !hasOnlineSeenBy;
+            // Unknown externals are pure neighbor-table inference. Two stale-cache
+            // signatures we always filter, regardless of the offline-nodes toggle:
+            //   1. every observer is offline — entry can no longer be re-confirmed.
+            //   2. exactly one observer that has other neighbors — single-source
+            //      ghost from a node that's clearly otherwise reachable.
+            // BRs have independent mDNS evidence — honor only the user toggle for them.
+            const hasOnlineObserver = device.seenBy.some(nodeId => {
+                const node = this.nodes[nodeId];
+                return node !== undefined && node.available !== false;
+            });
+            let shouldHide: boolean;
+            if (device.kind === "unknown") {
+                shouldHide = !hasOnlineObserver;
+                if (!shouldHide && device.seenBy.length === 1) {
+                    const observer = this.nodes[device.seenBy[0]];
+                    if (observer !== undefined && parseNeighborTable(observer).length > 1) {
+                        shouldHide = true;
+                    }
+                }
+            } else {
+                shouldHide = this.hideOfflineNodes && !hasOnlineObserver;
             }
 
             if (shouldHide) {

--- a/packages/dashboard/src/pages/network/thread-graph.ts
+++ b/packages/dashboard/src/pages/network/thread-graph.ts
@@ -27,10 +27,10 @@ import {
     findUnknownDevices,
     getDeviceName,
     getEdgeSignalScore,
+    getNeighborTableLength,
     getNetworkType,
     getThreadExtendedAddressHex,
     getThreadRole,
-    parseNeighborTable,
 } from "./network-utils.js";
 
 declare global {
@@ -233,7 +233,7 @@ export class ThreadGraph extends BaseNetworkGraph {
                 shouldHide = !hasOnlineObserver;
                 if (!shouldHide && device.seenBy.length === 1) {
                     const observer = this.nodes[device.seenBy[0]];
-                    if (observer !== undefined && parseNeighborTable(observer).length > 1) {
+                    if (observer !== undefined && getNeighborTableLength(observer) > 1) {
                         shouldHide = true;
                     }
                 }


### PR DESCRIPTION
## Summary

Two filter rules for `kind: "unknown"` external Thread devices in the mesh viz, applied regardless of the offline-nodes toggle. Border-Router-kind externals (mDNS-evidenced) are unaffected.

1. Hide if every observing node is offline — entry can no longer be re-confirmed and is almost certainly cached from a removed/recycled device.
2. Hide if a single observer reports the entry but also has other neighbor-table entries — a lone ghost reported by an otherwise well-connected node, typically a stale row a device hasn't aged out yet.

Edges to hidden externals cascade off via the existing hidden-endpoint filter, so offline source nodes stay visible but float without their phantom routers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)