### PR TITLE
Migrate commissioning methods to new Node API (#428)

### DIFF
--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -27,7 +27,6 @@ import {
     Timer,
     DnsRecordType,
 } from "@matter/main";
-import { OperationalCredentialsClient } from "@matter/main/behaviors";
 import {
     AccessControl,
     BasicInformation,
@@ -142,6 +141,33 @@ function determineMatterVersion(attributes: AttributesData): string | undefined 
     }
 
     return undefined;
+}
+
+/** Convert WebSocket ACL entries (snake_case) to Matter.js format (camelCase). */
+export function convertAclEntries(entries: AccessControlEntry[]): AccessControl.AccessControlEntry[] {
+    return entries.map(entry => ({
+        privilege: entry.privilege as AccessControl.AccessControlEntryPrivilege,
+        authMode: entry.auth_mode as AccessControl.AccessControlEntryAuthMode,
+        subjects: entry.subjects?.map(s => NodeId(BigInt(s))) ?? null,
+        targets:
+            entry.targets?.map((t: AccessControlTarget) => ({
+                cluster: t.cluster !== null ? ClusterId(t.cluster) : null,
+                endpoint: t.endpoint !== null ? EndpointNumber(t.endpoint) : null,
+                deviceType: t.device_type !== null ? DeviceTypeId(t.device_type) : null,
+            })) ?? null,
+        fabricIndex: FabricIndex.OMIT_FABRIC,
+    }));
+}
+
+/** Convert WebSocket binding targets to Matter.js format. */
+export function convertBindingTargets(bindings: BindingTarget[]): Binding.Target[] {
+    return bindings.map(binding => ({
+        node: binding.node !== null ? NodeId(binding.node) : undefined,
+        group: binding.group !== null ? GroupId(binding.group) : undefined,
+        endpoint: binding.endpoint !== null ? EndpointNumber(binding.endpoint) : undefined,
+        cluster: binding.cluster !== null ? ClusterId(binding.cluster) : undefined,
+        fabricIndex: FabricIndex.OMIT_FABRIC,
+    }));
 }
 
 export class ControllerCommandHandler {
@@ -1099,7 +1125,12 @@ export class ControllerCommandHandler {
     }
 
     removeFabric(nodeId: NodeId, fabricIndex: FabricIndex) {
-        return this.#nodes.get(nodeId).node.commandsOf(OperationalCredentialsClient).removeFabric({ fabricIndex });
+        return this.#invokeCommand(this.#nodes.get(nodeId).node, {
+            endpoint: EndpointNumber(0),
+            cluster: OperationalCredentials.Cluster,
+            command: "removeFabric",
+            fields: { fabricIndex },
+        });
     }
 
     /**
@@ -1107,28 +1138,12 @@ export class ControllerCommandHandler {
      * Writes to the ACL attribute on the AccessControl cluster (endpoint 0).
      */
     async setAclEntry(nodeId: NodeId, entries: AccessControlEntry[]): Promise<AttributeWriteResult[] | null> {
-        const aclEntries: AccessControl.AccessControlEntry[] = entries.map(entry => ({
-            privilege: entry.privilege as AccessControl.AccessControlEntryPrivilege,
-            authMode: entry.auth_mode as AccessControl.AccessControlEntryAuthMode,
-            subjects: entry.subjects?.map(s => NodeId(BigInt(s))) ?? null,
-            targets:
-                entry.targets?.map((t: AccessControlTarget) => ({
-                    cluster: t.cluster !== null ? ClusterId(t.cluster) : null,
-                    endpoint: t.endpoint !== null ? EndpointNumber(t.endpoint) : null,
-                    deviceType: t.device_type !== null ? DeviceTypeId(t.device_type) : null,
-                })) ?? null,
-            fabricIndex: FabricIndex.OMIT_FABRIC,
-        }));
+        const aclEntries = convertAclEntries(entries);
 
         logger.info("Setting ACL entries", aclEntries);
 
         const { status } = await this.#writeAttribute(nodeId, EndpointNumber(0), AccessControl.id, "acl", aclEntries);
-        return [
-            {
-                path: { endpoint_id: 0, cluster_id: AccessControl.id, attribute_id: 0 },
-                status,
-            },
-        ];
+        return [{ path: { endpoint_id: 0, cluster_id: AccessControl.id, attribute_id: 0 }, status }];
     }
 
     /**
@@ -1140,23 +1155,12 @@ export class ControllerCommandHandler {
         endpointId: EndpointNumber,
         bindings: BindingTarget[],
     ): Promise<AttributeWriteResult[] | null> {
-        const bindingEntries: Binding.Target[] = bindings.map(binding => ({
-            node: binding.node !== null ? NodeId(binding.node) : undefined,
-            group: binding.group !== null ? GroupId(binding.group) : undefined,
-            endpoint: binding.endpoint !== null ? EndpointNumber(binding.endpoint) : undefined,
-            cluster: binding.cluster !== null ? ClusterId(binding.cluster) : undefined,
-            fabricIndex: FabricIndex.OMIT_FABRIC,
-        }));
+        const bindingEntries = convertBindingTargets(bindings);
 
         logger.info("Setting bindings on endpoint", endpointId, bindingEntries);
 
         const { status } = await this.#writeAttribute(nodeId, endpointId, Binding.id, "binding", bindingEntries);
-        return [
-            {
-                path: { endpoint_id: endpointId, cluster_id: Binding.id, attribute_id: 0 },
-                status,
-            },
-        ];
+        return [{ path: { endpoint_id: endpointId, cluster_id: Binding.id, attribute_id: 0 }, status }];
     }
 
     /**

--- a/packages/ws-controller/test/ControllerCommandHandlerTest.ts
+++ b/packages/ws-controller/test/ControllerCommandHandlerTest.ts
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { EndpointNumber, FabricIndex, GroupId, NodeId } from "@matter/main/types";
+import { ClusterId } from "@matter/main/types";
+import { convertAclEntries, convertBindingTargets } from "../src/controller/ControllerCommandHandler.js";
+
+describe("ControllerCommandHandler helpers", () => {
+    // =========================================================================
+    // convertAclEntries
+    // =========================================================================
+
+    describe("convertAclEntries", () => {
+        it("converts privilege, auth_mode, and fabricIndex", () => {
+            const result = convertAclEntries([{ privilege: 5, auth_mode: 2, subjects: null, targets: null }]);
+
+            expect(result).to.have.length(1);
+            expect(result[0].privilege).to.equal(5);
+            expect(result[0].authMode).to.equal(2);
+            expect(result[0].fabricIndex).to.equal(FabricIndex.OMIT_FABRIC);
+        });
+
+        it("converts subjects from number array to NodeId array", () => {
+            const result = convertAclEntries([{ privilege: 5, auth_mode: 2, subjects: [1, 2], targets: null }]);
+
+            expect(result[0].subjects).to.deep.equal([NodeId(1n), NodeId(2n)]);
+        });
+
+        it("converts bigint subjects to NodeId", () => {
+            const result = convertAclEntries([
+                { privilege: 5, auth_mode: 2, subjects: [BigInt("123456789012345")], targets: null },
+            ]);
+
+            expect(result[0].subjects).to.deep.equal([NodeId(123456789012345n)]);
+        });
+
+        it("sets subjects to null when input subjects is null", () => {
+            const result = convertAclEntries([{ privilege: 5, auth_mode: 2, subjects: null, targets: null }]);
+            expect(result[0].subjects).to.be.null;
+        });
+
+        it("converts targets with all fields set", () => {
+            const result = convertAclEntries([
+                {
+                    privilege: 5,
+                    auth_mode: 2,
+                    subjects: null,
+                    targets: [{ cluster: 6, endpoint: 1, device_type: 256 }],
+                },
+            ]);
+
+            expect(result[0].targets).to.have.length(1);
+            expect(result[0].targets![0].cluster).to.equal(ClusterId(6));
+            expect(result[0].targets![0].endpoint).to.equal(EndpointNumber(1));
+            expect(result[0].targets![0].deviceType).to.equal(256);
+        });
+
+        it("sets target cluster/endpoint/deviceType to null when input fields are null", () => {
+            const result = convertAclEntries([
+                {
+                    privilege: 5,
+                    auth_mode: 2,
+                    subjects: null,
+                    targets: [{ cluster: null, endpoint: null, device_type: null }],
+                },
+            ]);
+
+            expect(result[0].targets![0].cluster).to.be.null;
+            expect(result[0].targets![0].endpoint).to.be.null;
+            expect(result[0].targets![0].deviceType).to.be.null;
+        });
+
+        it("sets targets to null when input targets is null", () => {
+            const result = convertAclEntries([{ privilege: 5, auth_mode: 2, subjects: null, targets: null }]);
+            expect(result[0].targets).to.be.null;
+        });
+
+        it("converts multiple entries", () => {
+            const result = convertAclEntries([
+                { privilege: 3, auth_mode: 2, subjects: [1], targets: null },
+                { privilege: 5, auth_mode: 2, subjects: [2], targets: null },
+            ]);
+
+            expect(result).to.have.length(2);
+            expect(result[0].privilege).to.equal(3);
+            expect(result[1].privilege).to.equal(5);
+        });
+
+        it("returns empty array for empty input", () => {
+            expect(convertAclEntries([])).to.deep.equal([]);
+        });
+    });
+
+    // =========================================================================
+    // convertBindingTargets
+    // =========================================================================
+
+    describe("convertBindingTargets", () => {
+        it("converts all fields when set", () => {
+            const result = convertBindingTargets([{ node: 1, group: 2, endpoint: 3, cluster: 6 }]);
+
+            expect(result).to.have.length(1);
+            expect(result[0].node).to.equal(NodeId(1n));
+            expect(result[0].group).to.equal(GroupId(2));
+            expect(result[0].endpoint).to.equal(EndpointNumber(3));
+            expect(result[0].cluster).to.equal(ClusterId(6));
+            expect(result[0].fabricIndex).to.equal(FabricIndex.OMIT_FABRIC);
+        });
+
+        it("sets node/group/endpoint/cluster to undefined when input fields are null", () => {
+            const result = convertBindingTargets([{ node: null, group: null, endpoint: null, cluster: null }]);
+
+            expect(result[0].node).to.be.undefined;
+            expect(result[0].group).to.be.undefined;
+            expect(result[0].endpoint).to.be.undefined;
+            expect(result[0].cluster).to.be.undefined;
+        });
+
+        it("converts bigint node to NodeId", () => {
+            const result = convertBindingTargets([
+                { node: BigInt("12345678901234"), group: null, endpoint: null, cluster: null },
+            ]);
+            expect(result[0].node).to.equal(NodeId(12345678901234n));
+        });
+
+        it("sets fabricIndex to OMIT_FABRIC on every entry", () => {
+            const result = convertBindingTargets([
+                { node: 1, group: null, endpoint: null, cluster: null },
+                { node: null, group: 2, endpoint: null, cluster: null },
+            ]);
+
+            for (const entry of result) {
+                expect(entry.fabricIndex).to.equal(FabricIndex.OMIT_FABRIC);
+            }
+        });
+
+        it("converts multiple bindings", () => {
+            const result = convertBindingTargets([
+                { node: 1, group: null, endpoint: 1, cluster: 6 },
+                { node: 2, group: null, endpoint: 1, cluster: 6 },
+            ]);
+            expect(result).to.have.length(2);
+        });
+
+        it("returns empty array for empty input", () => {
+            expect(convertBindingTargets([])).to.deep.equal([]);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Replaces `commandsOf(OperationalCredentialsClient)` in `removeFabric` with `#invokeCommand` using `OperationalCredentials.Cluster` — removes the last use of the legacy behavior-client pattern in this file
- Extracts ACL and binding conversion logic from `setAclEntry` and `setNodeBinding` into exported pure functions (`convertAclEntries`, `convertBindingTargets`) so they are independently testable
- Adds `ControllerCommandHandlerTest.ts` with 15 unit tests covering both helpers: field mapping, null/undefined propagation, bigint handling, `FabricIndex.OMIT_FABRIC`, and multiple-entry cases

Closes #428

## Test plan

- [ ] `npm test` — all unit tests pass (71/71 in ws-controller, pre-existing integration ping failure unchanged)
- [ ] `npm run build` — clean build
- [ ] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)