### PR TITLE
Enhance write-attribute errors, BR hostnames in network view, matter.js nightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This page shows a detailed overview of the changes between versions without the 
 ## **WORK IN PROGRESS**
 
 - Enhancement: Hide phantom Thread "External" routers/devices that only persist as stale neighbor-table entries (every observer offline, or single observer with other connections)
+- Enhancement: Also use the Discovered BR hostnames in Connection- and Neighbor-Lists
+- Fix: Enhance error messages when Writes fail
+- Fix: Update matter.js to the latest 0.17.0-nightly
 
 ## 0.6.4 (2026-04-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ This page shows a detailed overview of the changes between versions without the 
 ## **WORK IN PROGRESS**
 
 - Enhancement: Hide phantom Thread "External" routers/devices that only persist as stale neighbor-table entries (every observer offline, or single observer with other connections)
-- Enhancement: Also use the Discovered BR hostnames in Connection- and Neighbor-Lists
-- Fix: Enhance error messages when Writes fail
+- Enhancement: Also use discovered BR hostnames in connection and neighbor lists
+- Fix: Enhance error messages when writes fail
 - Fix: Update matter.js to the latest 0.17.0-nightly
 
 ## 0.6.4 (2026-04-30)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This page shows a detailed overview of the changes between versions without the 
 ## **WORK IN PROGRESS**
 
 - Enhancement: Hide phantom Thread "External" routers/devices that only persist as stale neighbor-table entries (every observer offline, or single observer with other connections)
-- Enhancement: Also use discovered BR hostnames in connection and neighbor lists
+- Enhancement: Uses discovered BR hostnames also in connection and neighbor lists
 - Fix: Enhance error messages when writes fail
 - Fix: Update matter.js to the latest 0.17.0-nightly
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "packages/matter-server"
             ],
             "devDependencies": {
-                "@matter/testing": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/testing": "0.17.0-alpha.0-20260504-e005cc190",
                 "@nacho-iot/js-tools": "0.1.3",
                 "@types/mocha": "^10.0.10",
                 "glob": "^13.0.6",
@@ -2543,77 +2543,77 @@
             "link": true
         },
         "node_modules/@matter/general": {
-            "version": "0.17.0-alpha.0-20260504-893d6ba08",
-            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.0-alpha.0-20260504-893d6ba08.tgz",
-            "integrity": "sha512-kmDJ4HwORIbH1Omg5x+TPBha7tJl0al7TZaYsdx4Y1YF9u+jFKNAoVeVZYSPppwRxUgg5MLZJFK57fPQqTaYJQ==",
+            "version": "0.17.0-alpha.0-20260504-e005cc190",
+            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.0-alpha.0-20260504-e005cc190.tgz",
+            "integrity": "sha512-rtnqGAoVVQlfxKHVh3V0KYouTyqpZwvRLUgPAxdrudQ60wycB0HixAtsUMDp6e69MR4LoJDCdCfO/vix8BQdWQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/curves": "^2.2.0"
             }
         },
         "node_modules/@matter/main": {
-            "version": "0.17.0-alpha.0-20260504-893d6ba08",
-            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.0-alpha.0-20260504-893d6ba08.tgz",
-            "integrity": "sha512-XovDrnUYNuxWKRPcpmCFtzNM+uFTnvCYFN+X9FgKr5llb+LgZfCI7ED2f+mWafHgZtRoaSno6qTRltoFjJwzLg==",
+            "version": "0.17.0-alpha.0-20260504-e005cc190",
+            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.0-alpha.0-20260504-e005cc190.tgz",
+            "integrity": "sha512-y6xHsk9bwQw/7yK5Y2U0OmTE9qLKht8kTGt55NqqVMt+OClGslwl4BtmMAx17XK3BHN6+Zr7J8EHfOXMs8/jAw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/model": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/node": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/protocol": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/types": "0.17.0-alpha.0-20260504-893d6ba08"
+                "@matter/general": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/model": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/node": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/protocol": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/types": "0.17.0-alpha.0-20260504-e005cc190"
             },
             "optionalDependencies": {
-                "@matter/nodejs": "0.17.0-alpha.0-20260504-893d6ba08"
+                "@matter/nodejs": "0.17.0-alpha.0-20260504-e005cc190"
             }
         },
         "node_modules/@matter/model": {
-            "version": "0.17.0-alpha.0-20260504-893d6ba08",
-            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.0-alpha.0-20260504-893d6ba08.tgz",
-            "integrity": "sha512-8njT2ceUOsLoSiqWTuB1Ek6yCX/H0lOPlGXm8okfZ5e0illcLud4fmhKnIQhjWVi46IogzZAx5GDOUtdW31YNw==",
+            "version": "0.17.0-alpha.0-20260504-e005cc190",
+            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.0-alpha.0-20260504-e005cc190.tgz",
+            "integrity": "sha512-RrGSCKyEWnc1HJ80UnFxgLjpcr2cqSiN8QhzHXRI/b3yn79/AvSvEEI58hgkrCQsK1mUliuYAw1VdnbF3oK2Cg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08"
+                "@matter/general": "0.17.0-alpha.0-20260504-e005cc190"
             }
         },
         "node_modules/@matter/node": {
-            "version": "0.17.0-alpha.0-20260504-893d6ba08",
-            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.0-alpha.0-20260504-893d6ba08.tgz",
-            "integrity": "sha512-wvuPGXTyrtD2e6PV3tiWmmi2KvIjPiuODuFBLUBqrrJCbBJj6iEqxM6+mquQV/EXCIzwq29TONH5zLokxt7nng==",
+            "version": "0.17.0-alpha.0-20260504-e005cc190",
+            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.0-alpha.0-20260504-e005cc190.tgz",
+            "integrity": "sha512-/qcnzS1ewIgzOLKohY5R0fYEZwG2lZqS8a43qCJ471DJQaOW0Y2630D8p8Von2sqTojRlFHuGZI8NHIBRiEA5w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/model": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/protocol": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/types": "0.17.0-alpha.0-20260504-893d6ba08"
+                "@matter/general": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/model": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/protocol": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/types": "0.17.0-alpha.0-20260504-e005cc190"
             }
         },
         "node_modules/@matter/nodejs": {
-            "version": "0.17.0-alpha.0-20260504-893d6ba08",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.0-alpha.0-20260504-893d6ba08.tgz",
-            "integrity": "sha512-y9qAMwI1KO20cmK2wTgZbx7gzYgoJgKp0Wsu0qgM9NSvF/3OaYCkPilcwO13ihj1ShoA2eIwKgSVw4rIyNn10g==",
+            "version": "0.17.0-alpha.0-20260504-e005cc190",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.0-alpha.0-20260504-e005cc190.tgz",
+            "integrity": "sha512-kWKeTu5eHe1yvNXkKYVKsTDpbEKbnD7iU1PTqplTURUVmM2BVYiBL8VdP1LiXzEpR4XjbtLoNcrTU8z91pN60Q==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/node": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/protocol": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/types": "0.17.0-alpha.0-20260504-893d6ba08"
+                "@matter/general": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/node": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/protocol": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/types": "0.17.0-alpha.0-20260504-e005cc190"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
             }
         },
         "node_modules/@matter/nodejs-ble": {
-            "version": "0.17.0-alpha.0-20260504-893d6ba08",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.0-alpha.0-20260504-893d6ba08.tgz",
-            "integrity": "sha512-atrKJzzMIU5Qk+SHW18S/x3z5mrAT9JmBl1DOSdRAfa0UfDjjO2gQ/DUYTCvvBi4TouzPBbHO79QI1zmGthzvA==",
+            "version": "0.17.0-alpha.0-20260504-e005cc190",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.0-alpha.0-20260504-e005cc190.tgz",
+            "integrity": "sha512-5sgg8gKzHpbO8jmJ90hEX1q1z0/ZpoXdu8bx51Q5GwAcQGsvPZiNbDYdJfE4f0SVRms9mcUwYgDpevNr3bSw/Q==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/protocol": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/types": "0.17.0-alpha.0-20260504-893d6ba08"
+                "@matter/general": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/protocol": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/types": "0.17.0-alpha.0-20260504-e005cc190"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -2624,20 +2624,20 @@
             }
         },
         "node_modules/@matter/protocol": {
-            "version": "0.17.0-alpha.0-20260504-893d6ba08",
-            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.0-alpha.0-20260504-893d6ba08.tgz",
-            "integrity": "sha512-YFzfl0NT71Ubsh8dE6JnbE0qT+dTfjFNaQJpGJ04yv97LbdGLEF02Vt9ol5/NRD+4EMMdt53zEbAU/ZEszCP9A==",
+            "version": "0.17.0-alpha.0-20260504-e005cc190",
+            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.0-alpha.0-20260504-e005cc190.tgz",
+            "integrity": "sha512-7oDTRKWMNPfvPL8uYc0irNq6HNyq3jU65KDC0/0mIriw9EpmBv30UfX/VbDmdXCrnEkHKC94YLKzhCYiQtwsVA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/model": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/types": "0.17.0-alpha.0-20260504-893d6ba08"
+                "@matter/general": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/model": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/types": "0.17.0-alpha.0-20260504-e005cc190"
             }
         },
         "node_modules/@matter/testing": {
-            "version": "0.17.0-alpha.0-20260504-893d6ba08",
-            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.0-alpha.0-20260504-893d6ba08.tgz",
-            "integrity": "sha512-vNkhy9ri2zMO7RkicsybH21E9wguvv0tIjsahOicQibg/pPZxBbLYKfA37tos+DpSlQlmyU/L0MH3VM3dRbqcg==",
+            "version": "0.17.0-alpha.0-20260504-e005cc190",
+            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.0-alpha.0-20260504-e005cc190.tgz",
+            "integrity": "sha512-f3NhfNXCp/UTZzsQo4vRqlnJ17/X6lZfJKpVU+Efzw3+7CCTv/AxYNtALwL757dRdJZ0EpYmmVhjq40nJx4Y2Q==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -2692,13 +2692,13 @@
             }
         },
         "node_modules/@matter/types": {
-            "version": "0.17.0-alpha.0-20260504-893d6ba08",
-            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.0-alpha.0-20260504-893d6ba08.tgz",
-            "integrity": "sha512-0wvQOptinlrpAgroEvwU1NF6XLC0acU5HYYMBOtZVY3E/SuqW3YSdI3XwKJy16HnxS1GxtlWmX/zYUlHHhc4JA==",
+            "version": "0.17.0-alpha.0-20260504-e005cc190",
+            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.0-alpha.0-20260504-e005cc190.tgz",
+            "integrity": "sha512-YCYHkIjbH2X2UhjWgiC1jzEzvAsXUFcuVWGGwQw7yhI/j6shkx5on0cAGRfdbyAOLskkBm++QXGmDPVtMNUcxw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/model": "0.17.0-alpha.0-20260504-893d6ba08"
+                "@matter/general": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/model": "0.17.0-alpha.0-20260504-e005cc190"
             }
         },
         "node_modules/@mdi/js": {
@@ -3551,16 +3551,16 @@
             }
         },
         "node_modules/@project-chip/matter.js": {
-            "version": "0.17.0-alpha.0-20260504-893d6ba08",
-            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.0-alpha.0-20260504-893d6ba08.tgz",
-            "integrity": "sha512-x378/oTxjYAJOdy3NNw+vwknvSGcq65CBiekL0CLnZ7qPA5QDkKQqWqRbAxZs8XpQnlyTqXhkb/FBREbDgz1Wg==",
+            "version": "0.17.0-alpha.0-20260504-e005cc190",
+            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.0-alpha.0-20260504-e005cc190.tgz",
+            "integrity": "sha512-+Yt2j2lM0mGqMbxbHOpfndrW/cGgp4eNgKFnIWNgPbAzjVOM5RdcSiAnmlHM/Q13bFRFZUXo/+mr5IPvzhrFTw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/model": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/node": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/protocol": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/types": "0.17.0-alpha.0-20260504-893d6ba08"
+                "@matter/general": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/model": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/node": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/protocol": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/types": "0.17.0-alpha.0-20260504-e005cc190"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -4866,9 +4866,9 @@
             }
         },
         "node_modules/@typescript/native-preview": {
-            "version": "7.0.0-dev.20260503.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260503.1.tgz",
-            "integrity": "sha512-gDro38CPFiBUGbaFGNt+ufOsEd1OrZrfrOPxsLSfBcvvoGaqAxV++ul/BHTOShoEkIYHiFsoDX2az1IPCDV2jQ==",
+            "version": "7.0.0-dev.20260504.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260504.1.tgz",
+            "integrity": "sha512-bHFGxyIU83qjj6ywn3817A+Ug2ZID0GiBA5WFdbc/T7EjcrKnUUylexq0fU81N/mTbfw3FyP6ZCEdO2Ntcl/VQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -4878,19 +4878,19 @@
                 "node": ">=16.20.0"
             },
             "optionalDependencies": {
-                "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260503.1",
-                "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260503.1",
-                "@typescript/native-preview-linux-arm": "7.0.0-dev.20260503.1",
-                "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260503.1",
-                "@typescript/native-preview-linux-x64": "7.0.0-dev.20260503.1",
-                "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260503.1",
-                "@typescript/native-preview-win32-x64": "7.0.0-dev.20260503.1"
+                "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260504.1",
+                "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260504.1",
+                "@typescript/native-preview-linux-arm": "7.0.0-dev.20260504.1",
+                "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260504.1",
+                "@typescript/native-preview-linux-x64": "7.0.0-dev.20260504.1",
+                "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260504.1",
+                "@typescript/native-preview-win32-x64": "7.0.0-dev.20260504.1"
             }
         },
         "node_modules/@typescript/native-preview-darwin-arm64": {
-            "version": "7.0.0-dev.20260503.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260503.1.tgz",
-            "integrity": "sha512-rUZQVuBcZlxADagx+pnhDHqjX2Ewh+KWave6vtilRWR5vsGyR3FaCzPFqXteiwPg6XRijEMnMaXg60t5itm8EA==",
+            "version": "7.0.0-dev.20260504.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260504.1.tgz",
+            "integrity": "sha512-+Qs1Q7Qxfp11n/hU3pweFU+EQ37FnDsdWOOxb7/vCy8QGBysrLUUYRhQ+GSW3s663oMtN6+9Kf82hk3ZT+kXlg==",
             "cpu": [
                 "arm64"
             ],
@@ -4905,9 +4905,9 @@
             }
         },
         "node_modules/@typescript/native-preview-darwin-x64": {
-            "version": "7.0.0-dev.20260503.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260503.1.tgz",
-            "integrity": "sha512-YtK8ac8RCkRh7jwoP8Wt4LaBhpGK8cOVMi3e0cvF/8Xn5XV1ewJK3/HdNBnlDhCib3j0eVRxK/Pg9GIq/hFUxQ==",
+            "version": "7.0.0-dev.20260504.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260504.1.tgz",
+            "integrity": "sha512-Wr3GWTRiMgibmhe88cjQ612ZyY7sbgsPYEaWKGPUxBaXtMHFIzgTBIoJMuaQqQx4GEJs6AUDyhnIHG1gx4rJjg==",
             "cpu": [
                 "x64"
             ],
@@ -4922,9 +4922,9 @@
             }
         },
         "node_modules/@typescript/native-preview-linux-arm": {
-            "version": "7.0.0-dev.20260503.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260503.1.tgz",
-            "integrity": "sha512-28vAomYeU8hpz1f0dDoWz6PYehz0ffEfkJhFq4tqXzUM/QY1I15u5y03EJQ5UcP4LRwrdJe22J5LdrYpM2Lr3w==",
+            "version": "7.0.0-dev.20260504.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260504.1.tgz",
+            "integrity": "sha512-s8QkhZe0M4QD2xhK1Xiy2JUQv1AOl8kUg5DLx1G8ws0f1BK/oKyqDNbxhZMGINYLFvkjpr9lOxt7qehSnpJMYQ==",
             "cpu": [
                 "arm"
             ],
@@ -4939,9 +4939,9 @@
             }
         },
         "node_modules/@typescript/native-preview-linux-arm64": {
-            "version": "7.0.0-dev.20260503.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260503.1.tgz",
-            "integrity": "sha512-c5yM3Ea2WZSLKmscMxUhEDdaR2Ugp7P9CX6osciIPgZIF9c4LDiuKQohjQAyidx9JZKCsSXnfS88QssWH/+ONQ==",
+            "version": "7.0.0-dev.20260504.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260504.1.tgz",
+            "integrity": "sha512-y1Qai5l55Sl+/3B0hyQtvynq//C22BKFH3CfU35fbLYUo4P/ISUycyAbcA+PAPazpDFO3E56I96QUQrbJL2VVA==",
             "cpu": [
                 "arm64"
             ],
@@ -4956,9 +4956,9 @@
             }
         },
         "node_modules/@typescript/native-preview-linux-x64": {
-            "version": "7.0.0-dev.20260503.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260503.1.tgz",
-            "integrity": "sha512-M64z7LwpqNfOXYCBKmD/ObwyxYOobUk4tDv0ECNLit7pDER1sswNZjJGjgRYjQsKokmydy6p3FqtJ1uUPUP/sw==",
+            "version": "7.0.0-dev.20260504.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260504.1.tgz",
+            "integrity": "sha512-ngN3Ie3Vin6pFtqeNywxm86RTxgI0Fo0GZyJ1PxokLES8J3xfMPtMYfv85c/+5uz5+7T+m4LRLyY5IoLY4gtuw==",
             "cpu": [
                 "x64"
             ],
@@ -4973,9 +4973,9 @@
             }
         },
         "node_modules/@typescript/native-preview-win32-arm64": {
-            "version": "7.0.0-dev.20260503.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260503.1.tgz",
-            "integrity": "sha512-QHy3R1VBb8MYszjpz0IyuDjKaW6JUHg8hYEqzhZIxvrydKLF3gyDeKohnmWSFTS/oII0GvUmYM3h83fbanBvcQ==",
+            "version": "7.0.0-dev.20260504.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260504.1.tgz",
+            "integrity": "sha512-/GZDJN/CsLbqIe7EdWDkXhNX9C41VjemBeUN6+9ckvEFLH8XyKTmXPYikNOn0N819M1KSeNZltplyUslfROOdw==",
             "cpu": [
                 "arm64"
             ],
@@ -4990,9 +4990,9 @@
             }
         },
         "node_modules/@typescript/native-preview-win32-x64": {
-            "version": "7.0.0-dev.20260503.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260503.1.tgz",
-            "integrity": "sha512-nrapqpVONrg0IZjKp3AzV9M+jxPwKGTQZEOxuKh6WHMhy/UElN8RnOFlfetA8ZMtKvPkmjgjqw0qoAa5QMwhPA==",
+            "version": "7.0.0-dev.20260504.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260504.1.tgz",
+            "integrity": "sha512-EYQBdVZq4xIzhTtKxw6wvee9238hEb7XrPG413AEZBD3kcR3qqvPULXsPzQyEpneCReATSaihscP/LfhMQYUmA==",
             "cpu": [
                 "x64"
             ],
@@ -11137,7 +11137,7 @@
             "name": "@matter-server/custom-clusters",
             "version": "0.0.0-git",
             "dependencies": {
-                "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08"
+                "@matter/main": "0.17.0-alpha.0-20260504-e005cc190"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -11159,7 +11159,7 @@
             },
             "devDependencies": {
                 "@babel/preset-env": "^7.29.2",
-                "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/main": "0.17.0-alpha.0-20260504-e005cc190",
                 "@rollup/plugin-babel": "^7.0.0",
                 "@rollup/plugin-commonjs": "^29.0.2",
                 "@rollup/plugin-json": "^6.1.0",
@@ -11177,14 +11177,14 @@
                 "@matter-server/custom-clusters": "*",
                 "@matter-server/dashboard": "*",
                 "@matter-server/ws-controller": "*",
-                "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/main": "0.17.0-alpha.0-20260504-e005cc190",
                 "commander": "^14.0.3",
                 "express": "^5.2.1"
             },
             "devDependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/nodejs": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@matter/testing": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/nodejs": "0.17.0-alpha.0-20260504-e005cc190",
+                "@matter/testing": "0.17.0-alpha.0-20260504-e005cc190",
                 "@types/express": "^5.0.6",
                 "@types/node": "^25.6.0"
             },
@@ -11197,7 +11197,7 @@
             "version": "0.0.0-git",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@matter/testing": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/testing": "0.17.0-alpha.0-20260504-e005cc190",
                 "@types/node": "^25.6.0",
                 "@types/ws": "^8.18.1",
                 "ws": "^8.20.0"
@@ -11211,8 +11211,8 @@
             "version": "0.0.0-git",
             "dependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08",
-                "@project-chip/matter.js": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/main": "0.17.0-alpha.0-20260504-e005cc190",
+                "@project-chip/matter.js": "0.17.0-alpha.0-20260504-e005cc190",
                 "ws": "^8.20.0"
             },
             "devDependencies": {
@@ -11223,7 +11223,7 @@
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.0-alpha.0-20260504-893d6ba08"
+                "@matter/nodejs-ble": "0.17.0-alpha.0-20260504-e005cc190"
             }
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,8 @@
                 "packages/matter-server"
             ],
             "devDependencies": {
-                "@matter/testing": "0.17.0-alpha.0-20260430-11b356f65",
-                "@nacho-iot/js-tools": "^0.1.3",
+                "@matter/testing": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@nacho-iot/js-tools": "0.1.3",
                 "@types/mocha": "^10.0.10",
                 "glob": "^13.0.6",
                 "globals": "^17.5.0",
@@ -41,9 +41,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+            "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -161,9 +161,9 @@
             }
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
-            "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.3.tgz",
+            "integrity": "sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -172,7 +172,7 @@
                 "@babel/helper-optimise-call-expression": "^7.27.1",
                 "@babel/helper-replace-supers": "^7.28.6",
                 "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-                "@babel/traverse": "^7.28.6",
+                "@babel/traverse": "^7.29.0",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -427,9 +427,9 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -483,6 +483,23 @@
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": {
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-rest-destructuring-rhs-array/-/plugin-bugfix-safari-rest-destructuring-rhs-array-7.29.3.tgz",
+            "integrity": "sha512-SRS46DFR4HqzUzCVgi90/xMoL+zeBDBvWdKYXSEzh79kXswNFEglUpMKxR04//dPqwYXWUBJ3mpUd933ru9Kmg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1445,19 +1462,20 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
-            "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.3.tgz",
+            "integrity": "sha512-ySZypNLAIH1ClygLDQzVMoGQRViATnkHkYYV6TcNDz+8+jwZCdsguGvsb3EY5d9wyWyhmF1iSuFM0Yh5XPnqSA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.29.0",
+                "@babel/compat-data": "^7.29.3",
                 "@babel/helper-compilation-targets": "^7.28.6",
                 "@babel/helper-plugin-utils": "^7.28.6",
                 "@babel/helper-validator-option": "^7.27.1",
                 "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
                 "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
                 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+                "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "^7.29.3",
                 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
                 "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
                 "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
@@ -2525,77 +2543,77 @@
             "link": true
         },
         "node_modules/@matter/general": {
-            "version": "0.17.0-alpha.0-20260430-11b356f65",
-            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.0-alpha.0-20260430-11b356f65.tgz",
-            "integrity": "sha512-YcZpeNP8LU9y4z1wrW4FOaXQrMdW+KiHfVNTn0eQk4L4+ybM1kHpTspmr26OS8NVNG0hla1aKNNW6KaLCNr5kQ==",
+            "version": "0.17.0-alpha.0-20260504-893d6ba08",
+            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.0-alpha.0-20260504-893d6ba08.tgz",
+            "integrity": "sha512-kmDJ4HwORIbH1Omg5x+TPBha7tJl0al7TZaYsdx4Y1YF9u+jFKNAoVeVZYSPppwRxUgg5MLZJFK57fPQqTaYJQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/curves": "^2.2.0"
             }
         },
         "node_modules/@matter/main": {
-            "version": "0.17.0-alpha.0-20260430-11b356f65",
-            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.0-alpha.0-20260430-11b356f65.tgz",
-            "integrity": "sha512-zqjIp5K9OLsoBudZZ2j9shCU67OTqbqgZv+hCEPD/9aNtVb9R3IvYAl+Bwvxqk2v9dh7AykgqoQaECRzurGasg==",
+            "version": "0.17.0-alpha.0-20260504-893d6ba08",
+            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.0-alpha.0-20260504-893d6ba08.tgz",
+            "integrity": "sha512-XovDrnUYNuxWKRPcpmCFtzNM+uFTnvCYFN+X9FgKr5llb+LgZfCI7ED2f+mWafHgZtRoaSno6qTRltoFjJwzLg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/model": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/node": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/protocol": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/types": "0.17.0-alpha.0-20260430-11b356f65"
+                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/model": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/node": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/protocol": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/types": "0.17.0-alpha.0-20260504-893d6ba08"
             },
             "optionalDependencies": {
-                "@matter/nodejs": "0.17.0-alpha.0-20260430-11b356f65"
+                "@matter/nodejs": "0.17.0-alpha.0-20260504-893d6ba08"
             }
         },
         "node_modules/@matter/model": {
-            "version": "0.17.0-alpha.0-20260430-11b356f65",
-            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.0-alpha.0-20260430-11b356f65.tgz",
-            "integrity": "sha512-unBhD9Plh4cXKnAOB3qZ2URrqtkb5FxbfAgFtt4sc0RLyXnSAYwywctlC/DedpSp/mErsIS8nAy25xguCMsKPg==",
+            "version": "0.17.0-alpha.0-20260504-893d6ba08",
+            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.0-alpha.0-20260504-893d6ba08.tgz",
+            "integrity": "sha512-8njT2ceUOsLoSiqWTuB1Ek6yCX/H0lOPlGXm8okfZ5e0illcLud4fmhKnIQhjWVi46IogzZAx5GDOUtdW31YNw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65"
+                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08"
             }
         },
         "node_modules/@matter/node": {
-            "version": "0.17.0-alpha.0-20260430-11b356f65",
-            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.0-alpha.0-20260430-11b356f65.tgz",
-            "integrity": "sha512-wkbuFoGknAa97NAliifN506Bdqrt2HoRvW6diOS8ckTpDeC9KAXwOTONnIVvR9VbFJ0Ix6QsXs0sLLjtj3rt+w==",
+            "version": "0.17.0-alpha.0-20260504-893d6ba08",
+            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.0-alpha.0-20260504-893d6ba08.tgz",
+            "integrity": "sha512-wvuPGXTyrtD2e6PV3tiWmmi2KvIjPiuODuFBLUBqrrJCbBJj6iEqxM6+mquQV/EXCIzwq29TONH5zLokxt7nng==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/model": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/protocol": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/types": "0.17.0-alpha.0-20260430-11b356f65"
+                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/model": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/protocol": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/types": "0.17.0-alpha.0-20260504-893d6ba08"
             }
         },
         "node_modules/@matter/nodejs": {
-            "version": "0.17.0-alpha.0-20260430-11b356f65",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.0-alpha.0-20260430-11b356f65.tgz",
-            "integrity": "sha512-wUDXN3yijTHYEEMkBCz3FfAuGyUe7uwIgMxvsKpbbakiEfyYXmFha9UaTsdWEHCrou1eU/T1814AkrTshzkBSw==",
+            "version": "0.17.0-alpha.0-20260504-893d6ba08",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.0-alpha.0-20260504-893d6ba08.tgz",
+            "integrity": "sha512-y9qAMwI1KO20cmK2wTgZbx7gzYgoJgKp0Wsu0qgM9NSvF/3OaYCkPilcwO13ihj1ShoA2eIwKgSVw4rIyNn10g==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/node": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/protocol": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/types": "0.17.0-alpha.0-20260430-11b356f65"
+                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/node": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/protocol": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/types": "0.17.0-alpha.0-20260504-893d6ba08"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
             }
         },
         "node_modules/@matter/nodejs-ble": {
-            "version": "0.17.0-alpha.0-20260430-11b356f65",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.0-alpha.0-20260430-11b356f65.tgz",
-            "integrity": "sha512-qAgJLbtCE+hfP/sEbZtOMRUxyuKsGMTurazyPpote0MiHjoTYQnkHe9Q8fK8HVRYsZPEEAC8dyOpu560sGeFNQ==",
+            "version": "0.17.0-alpha.0-20260504-893d6ba08",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.0-alpha.0-20260504-893d6ba08.tgz",
+            "integrity": "sha512-atrKJzzMIU5Qk+SHW18S/x3z5mrAT9JmBl1DOSdRAfa0UfDjjO2gQ/DUYTCvvBi4TouzPBbHO79QI1zmGthzvA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/protocol": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/types": "0.17.0-alpha.0-20260430-11b356f65"
+                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/protocol": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/types": "0.17.0-alpha.0-20260504-893d6ba08"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -2606,24 +2624,24 @@
             }
         },
         "node_modules/@matter/protocol": {
-            "version": "0.17.0-alpha.0-20260430-11b356f65",
-            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.0-alpha.0-20260430-11b356f65.tgz",
-            "integrity": "sha512-ROVn+zR21sdD55RhfnYp5vaGWBD5uBjfIKsle1Klkm2bHPNoTMJCqgD6J1k5UDzdEogjz/4p0YRqnveG0gTbNA==",
+            "version": "0.17.0-alpha.0-20260504-893d6ba08",
+            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.0-alpha.0-20260504-893d6ba08.tgz",
+            "integrity": "sha512-YFzfl0NT71Ubsh8dE6JnbE0qT+dTfjFNaQJpGJ04yv97LbdGLEF02Vt9ol5/NRD+4EMMdt53zEbAU/ZEszCP9A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/model": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/types": "0.17.0-alpha.0-20260430-11b356f65"
+                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/model": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/types": "0.17.0-alpha.0-20260504-893d6ba08"
             }
         },
         "node_modules/@matter/testing": {
-            "version": "0.17.0-alpha.0-20260430-11b356f65",
-            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.0-alpha.0-20260430-11b356f65.tgz",
-            "integrity": "sha512-Bctdb0fL9Xu5IRgmJ//2c15hOakkJJ8hjsu3jSgd8aJEcMbf2tbghn+5tQZqoRs2lq3cacUlH9wo1vVufuLnuw==",
+            "version": "0.17.0-alpha.0-20260504-893d6ba08",
+            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.0-alpha.0-20260504-893d6ba08.tgz",
+            "integrity": "sha512-vNkhy9ri2zMO7RkicsybH21E9wguvv0tIjsahOicQibg/pPZxBbLYKfA37tos+DpSlQlmyU/L0MH3VM3dRbqcg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@nacho-iot/js-tools": "*",
+                "@nacho-iot/js-tools": "^0.1.4",
                 "@types/express": "^5.0.6",
                 "ansi-colors": "^4.1.3",
                 "chai": "^4.5.0",
@@ -2643,14 +2661,44 @@
                 "matter-test": "bin/test.js"
             }
         },
-        "node_modules/@matter/types": {
-            "version": "0.17.0-alpha.0-20260430-11b356f65",
-            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.0-alpha.0-20260430-11b356f65.tgz",
-            "integrity": "sha512-9y3xs7eqbjYqNKjVbGxNOCOSUxy15t96DBuaYKrfJgh6XpWJGd2y13W/diEqzqxXv04GZiJhSImQy+0geFTMbQ==",
+        "node_modules/@matter/testing/node_modules/@nacho-iot/js-tools": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/@nacho-iot/js-tools/-/js-tools-0.1.4.tgz",
+            "integrity": "sha512-mMFSXKL69ydc0iayDpz6smNvfC7H26VGXXpil/Kiew89KPfAd2h7tNfJXfEuy741P2wXXgUL6n/uZTGq60vGaw==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/model": "0.17.0-alpha.0-20260430-11b356f65"
+                "@microsoft/tsdoc": "^0.16.0",
+                "@typescript/native-preview": "^7.0.0-dev.20260413.1",
+                "ansi-colors": "^4.1.3",
+                "commander": "^14.0.3",
+                "detective-typescript": "^14.1.2",
+                "esbuild": "^0.28.0",
+                "minimatch": "^10.2.5",
+                "type-fest": "^5.6.0",
+                "typedoc": "^0.28.19",
+                "typedoc-github-theme": "^0.4.0",
+                "typescript": "~6.0.2"
+            },
+            "bin": {
+                "nacho-build": "bin/build.js",
+                "nacho-run": "bin/run.js"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "optionalDependencies": {
+                "@esbuild/linux-x64": "^0.28.0"
+            }
+        },
+        "node_modules/@matter/types": {
+            "version": "0.17.0-alpha.0-20260504-893d6ba08",
+            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.0-alpha.0-20260504-893d6ba08.tgz",
+            "integrity": "sha512-0wvQOptinlrpAgroEvwU1NF6XLC0acU5HYYMBOtZVY3E/SuqW3YSdI3XwKJy16HnxS1GxtlWmX/zYUlHHhc4JA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/model": "0.17.0-alpha.0-20260504-893d6ba08"
             }
         },
         "node_modules/@mdi/js": {
@@ -3503,16 +3551,16 @@
             }
         },
         "node_modules/@project-chip/matter.js": {
-            "version": "0.17.0-alpha.0-20260430-11b356f65",
-            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.0-alpha.0-20260430-11b356f65.tgz",
-            "integrity": "sha512-xnhMqLtA+owYMk7B9W4VpwKn4DzBLdhAfxGIxiNt1bwq+egY4VuNVgdHkq9NQi0rx1aVVS3jbqMqT8rlF0uG3Q==",
+            "version": "0.17.0-alpha.0-20260504-893d6ba08",
+            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.0-alpha.0-20260504-893d6ba08.tgz",
+            "integrity": "sha512-x378/oTxjYAJOdy3NNw+vwknvSGcq65CBiekL0CLnZ7qPA5QDkKQqWqRbAxZs8XpQnlyTqXhkb/FBREbDgz1Wg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/model": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/node": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/protocol": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/types": "0.17.0-alpha.0-20260430-11b356f65"
+                "@matter/general": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/model": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/node": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/protocol": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/types": "0.17.0-alpha.0-20260504-893d6ba08"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -4818,9 +4866,9 @@
             }
         },
         "node_modules/@typescript/native-preview": {
-            "version": "7.0.0-dev.20260430.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260430.1.tgz",
-            "integrity": "sha512-HHk3tPpzPKqHY4AHMxGK6i960Dd1kIvnSnT3mzD1hNO/sUVG2YdWvWBIActGkRnKS94AZBpekOr1bQP7O2OwIg==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-gDro38CPFiBUGbaFGNt+ufOsEd1OrZrfrOPxsLSfBcvvoGaqAxV++ul/BHTOShoEkIYHiFsoDX2az1IPCDV2jQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -4830,19 +4878,19 @@
                 "node": ">=16.20.0"
             },
             "optionalDependencies": {
-                "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260430.1",
-                "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260430.1",
-                "@typescript/native-preview-linux-arm": "7.0.0-dev.20260430.1",
-                "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260430.1",
-                "@typescript/native-preview-linux-x64": "7.0.0-dev.20260430.1",
-                "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260430.1",
-                "@typescript/native-preview-win32-x64": "7.0.0-dev.20260430.1"
+                "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260503.1",
+                "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260503.1",
+                "@typescript/native-preview-linux-arm": "7.0.0-dev.20260503.1",
+                "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260503.1",
+                "@typescript/native-preview-linux-x64": "7.0.0-dev.20260503.1",
+                "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260503.1",
+                "@typescript/native-preview-win32-x64": "7.0.0-dev.20260503.1"
             }
         },
         "node_modules/@typescript/native-preview-darwin-arm64": {
-            "version": "7.0.0-dev.20260430.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260430.1.tgz",
-            "integrity": "sha512-1Rk5JoMlmlF4GzeNxQmpaZSSPFa056DCrGLjhXwVIqRf8+pGNKKxyD2ugGSyOeLShqYb1XUoE9LhsAhdh1xgSA==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-rUZQVuBcZlxADagx+pnhDHqjX2Ewh+KWave6vtilRWR5vsGyR3FaCzPFqXteiwPg6XRijEMnMaXg60t5itm8EA==",
             "cpu": [
                 "arm64"
             ],
@@ -4857,9 +4905,9 @@
             }
         },
         "node_modules/@typescript/native-preview-darwin-x64": {
-            "version": "7.0.0-dev.20260430.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260430.1.tgz",
-            "integrity": "sha512-wjXJtELfI0QIYxGCqqKMR3DonPUlMP4aWOYRPiN5ylDtdV+OqCC16zvH7C+No7xvlf8dDxlV1ZTyuRCWL6CQmw==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-YtK8ac8RCkRh7jwoP8Wt4LaBhpGK8cOVMi3e0cvF/8Xn5XV1ewJK3/HdNBnlDhCib3j0eVRxK/Pg9GIq/hFUxQ==",
             "cpu": [
                 "x64"
             ],
@@ -4874,9 +4922,9 @@
             }
         },
         "node_modules/@typescript/native-preview-linux-arm": {
-            "version": "7.0.0-dev.20260430.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260430.1.tgz",
-            "integrity": "sha512-3eqYkqy1XpbIJC1XkGbkwAvTtSCw6dSjYzJaw9bvow4fS1totTFZP/2K9ecXQ3gIZaPS4Ome/SpkZHl1cy9eZA==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-28vAomYeU8hpz1f0dDoWz6PYehz0ffEfkJhFq4tqXzUM/QY1I15u5y03EJQ5UcP4LRwrdJe22J5LdrYpM2Lr3w==",
             "cpu": [
                 "arm"
             ],
@@ -4891,9 +4939,9 @@
             }
         },
         "node_modules/@typescript/native-preview-linux-arm64": {
-            "version": "7.0.0-dev.20260430.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260430.1.tgz",
-            "integrity": "sha512-PeCFDB1glivpkqqKsQJ1RrM4f5B1yXzXFF+eKwgEZ+evcQ3N+BgeR7BpuRhOpHU9ixJchKjU1bXgcHOAaM+Rkw==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-c5yM3Ea2WZSLKmscMxUhEDdaR2Ugp7P9CX6osciIPgZIF9c4LDiuKQohjQAyidx9JZKCsSXnfS88QssWH/+ONQ==",
             "cpu": [
                 "arm64"
             ],
@@ -4908,9 +4956,9 @@
             }
         },
         "node_modules/@typescript/native-preview-linux-x64": {
-            "version": "7.0.0-dev.20260430.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260430.1.tgz",
-            "integrity": "sha512-Eg7nbRV57ayq0Pjuott/36UbQlVlpz2YRVLM5h8RyXx6SwvgrdYxNv/1zULLB0UlWdyKkK3bXILmR8YmNvbl+g==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-M64z7LwpqNfOXYCBKmD/ObwyxYOobUk4tDv0ECNLit7pDER1sswNZjJGjgRYjQsKokmydy6p3FqtJ1uUPUP/sw==",
             "cpu": [
                 "x64"
             ],
@@ -4925,9 +4973,9 @@
             }
         },
         "node_modules/@typescript/native-preview-win32-arm64": {
-            "version": "7.0.0-dev.20260430.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260430.1.tgz",
-            "integrity": "sha512-0LAjufJKUZnHmp0bxlndjphDQlIeUXA0czZCrKENtKySeGMXrM9PAFtSx94ldWVXDTZ9ZP1r+FxbIvP9pRORzA==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-QHy3R1VBb8MYszjpz0IyuDjKaW6JUHg8hYEqzhZIxvrydKLF3gyDeKohnmWSFTS/oII0GvUmYM3h83fbanBvcQ==",
             "cpu": [
                 "arm64"
             ],
@@ -4942,9 +4990,9 @@
             }
         },
         "node_modules/@typescript/native-preview-win32-x64": {
-            "version": "7.0.0-dev.20260430.1",
-            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260430.1.tgz",
-            "integrity": "sha512-FvLWX7d3b/IhL0656tnjep7dOMnI7CPrg+5oI1MKIY74qgvR+8VRo6aGj0IRCwtAJeklpxBpljEcIGuS5Yc/pQ==",
+            "version": "7.0.0-dev.20260503.1",
+            "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20260503.1.tgz",
+            "integrity": "sha512-nrapqpVONrg0IZjKp3AzV9M+jxPwKGTQZEOxuKh6WHMhy/UElN8RnOFlfetA8ZMtKvPkmjgjqw0qoAa5QMwhPA==",
             "cpu": [
                 "x64"
             ],
@@ -5275,9 +5323,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.24",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
-            "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
+            "version": "2.10.27",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
+            "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -6234,9 +6282,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.345",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz",
-            "integrity": "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==",
+            "version": "1.5.349",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+            "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
             "dev": true,
             "license": "ISC"
         },
@@ -6850,9 +6898,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "17.5.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-            "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+            "version": "17.6.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+            "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -11003,9 +11051,9 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+            "version": "2.8.4",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+            "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
             "devOptional": true,
             "license": "ISC",
             "bin": {
@@ -11089,7 +11137,7 @@
             "name": "@matter-server/custom-clusters",
             "version": "0.0.0-git",
             "dependencies": {
-                "@matter/main": "0.17.0-alpha.0-20260430-11b356f65"
+                "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -11111,7 +11159,7 @@
             },
             "devDependencies": {
                 "@babel/preset-env": "^7.29.2",
-                "@matter/main": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08",
                 "@rollup/plugin-babel": "^7.0.0",
                 "@rollup/plugin-commonjs": "^29.0.2",
                 "@rollup/plugin-json": "^6.1.0",
@@ -11129,14 +11177,14 @@
                 "@matter-server/custom-clusters": "*",
                 "@matter-server/dashboard": "*",
                 "@matter-server/ws-controller": "*",
-                "@matter/main": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08",
                 "commander": "^14.0.3",
                 "express": "^5.2.1"
             },
             "devDependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/nodejs": "0.17.0-alpha.0-20260430-11b356f65",
-                "@matter/testing": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/nodejs": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@matter/testing": "0.17.0-alpha.0-20260504-893d6ba08",
                 "@types/express": "^5.0.6",
                 "@types/node": "^25.6.0"
             },
@@ -11149,7 +11197,7 @@
             "version": "0.0.0-git",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@matter/testing": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/testing": "0.17.0-alpha.0-20260504-893d6ba08",
                 "@types/node": "^25.6.0",
                 "@types/ws": "^8.18.1",
                 "ws": "^8.20.0"
@@ -11163,8 +11211,8 @@
             "version": "0.0.0-git",
             "dependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/main": "0.17.0-alpha.0-20260430-11b356f65",
-                "@project-chip/matter.js": "0.17.0-alpha.0-20260430-11b356f65",
+                "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08",
+                "@project-chip/matter.js": "0.17.0-alpha.0-20260504-893d6ba08",
                 "ws": "^8.20.0"
             },
             "devDependencies": {
@@ -11175,7 +11223,7 @@
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.0-alpha.0-20260430-11b356f65"
+                "@matter/nodejs-ble": "0.17.0-alpha.0-20260504-893d6ba08"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "python:build": "cd python_client && .venv/bin/pip install build && .venv/bin/python -m build"
     },
     "devDependencies": {
-        "@matter/testing": "0.17.0-alpha.0-20260504-893d6ba08",
+        "@matter/testing": "0.17.0-alpha.0-20260504-e005cc190",
         "@nacho-iot/js-tools": "0.1.3",
         "@types/mocha": "^10.0.10",
         "glob": "^13.0.6",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
         "python:build": "cd python_client && .venv/bin/pip install build && .venv/bin/python -m build"
     },
     "devDependencies": {
-        "@matter/testing": "0.17.0-alpha.0-20260430-11b356f65",
-        "@nacho-iot/js-tools": "^0.1.3",
+        "@matter/testing": "0.17.0-alpha.0-20260504-893d6ba08",
+        "@nacho-iot/js-tools": "0.1.3",
         "@types/mocha": "^10.0.10",
         "glob": "^13.0.6",
         "globals": "^17.5.0",

--- a/packages/custom-clusters/package.json
+++ b/packages/custom-clusters/package.json
@@ -33,7 +33,7 @@
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
     },
     "dependencies": {
-        "@matter/main": "0.17.0-alpha.0-20260430-11b356f65"
+        "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08"
     },
     "files": [
         "dist/**/*",

--- a/packages/custom-clusters/package.json
+++ b/packages/custom-clusters/package.json
@@ -33,7 +33,7 @@
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
     },
     "dependencies": {
-        "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08"
+        "@matter/main": "0.17.0-alpha.0-20260504-e005cc190"
     },
     "files": [
         "dist/**/*",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -42,7 +42,7 @@
     },
     "devDependencies": {
         "@babel/preset-env": "^7.29.2",
-        "@matter/main": "0.17.0-alpha.0-20260430-11b356f65",
+        "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08",
         "@rollup/plugin-babel": "^7.0.0",
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-json": "^6.1.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -42,7 +42,7 @@
     },
     "devDependencies": {
         "@babel/preset-env": "^7.29.2",
-        "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08",
+        "@matter/main": "0.17.0-alpha.0-20260504-e005cc190",
         "@rollup/plugin-babel": "^7.0.0",
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-json": "^6.1.0",

--- a/packages/dashboard/src/pages/network/network-details.ts
+++ b/packages/dashboard/src/pages/network/network-details.ts
@@ -30,6 +30,7 @@ import {
     getWiFiDiagnostics,
     getWiFiSecurityTypeName,
     getWiFiVersionName,
+    stripMdnsHostname,
 } from "./network-utils.js";
 import "./update-connections-dialog.js";
 
@@ -123,6 +124,14 @@ export class NetworkDetails extends LitElement {
         const isTestNode = node ? isTestNodeId(node.node_id) : false;
         const fabricIndex = getEffectiveFabricIndex(this.client?.serverInfo?.fabric_index, isTestNode);
         return formatNodeAddressFromAny(fabricIndex, nodeId);
+    }
+
+    private _getExternalDeviceLabel(conn: NodeConnection): TemplateResult {
+        const device = this.unknownDevices.get(String(conn.connectedNodeId));
+        if (device?.kind === "br" && device.hostname) {
+            return html`${stripMdnsHostname(device.hostname)}`;
+        }
+        return html`External: <span class="mono">${conn.extAddressHex}</span>`;
     }
 
     private _renderWiFiInfo(node: MatterNode): TemplateResult | typeof nothing {
@@ -276,8 +285,7 @@ export class NetworkDetails extends LitElement {
                                                                         conn.connectedNodeId,
                                                                     )}</span
                                                                 >: ${getDeviceName(conn.connectedNode)}`
-                                                          : html`External:
-                                                                <span class="mono">${conn.extAddressHex}</span>`}
+                                                          : this._getExternalDeviceLabel(conn)}
                                                   </div>
                                                   <div class="neighbor-signal">
                                                       ${conn.rssi !== null

--- a/packages/dashboard/src/pages/network/network-utils.ts
+++ b/packages/dashboard/src/pages/network/network-utils.ts
@@ -690,6 +690,11 @@ export function getSignalColorFromLqi(lqi: number): string {
     return getSignalColorWeak();
 }
 
+/** Strips trailing dot and `.local` suffix from an mDNS hostname. */
+export function stripMdnsHostname(hostname: string): string {
+    return hostname.replace(/\.$/, "").replace(/\.local$/i, "");
+}
+
 /**
  * Gets a human-readable display name for a node.
  * Format: nodeLabel || productName (serialNumber)

--- a/packages/dashboard/src/pages/network/thread-graph.ts
+++ b/packages/dashboard/src/pages/network/thread-graph.ts
@@ -31,6 +31,7 @@ import {
     getNetworkType,
     getThreadExtendedAddressHex,
     getThreadRole,
+    stripMdnsHostname,
 } from "./network-utils.js";
 
 declare global {
@@ -246,7 +247,7 @@ export class ThreadGraph extends BaseNetworkGraph {
             }
 
             if (device.kind === "br") {
-                const hostname = device.hostname?.replace(/\.$/, "").replace(/\.local$/i, "");
+                const hostname = device.hostname !== undefined ? stripMdnsHostname(device.hostname) : undefined;
                 // Only show network name on a second line when the first line came from a
                 // distinct hostname; otherwise `top` would already be the (possibly truncated)
                 // network name and the second line would just repeat it.

--- a/packages/matter-server/package.json
+++ b/packages/matter-server/package.json
@@ -34,7 +34,7 @@
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
     },
     "dependencies": {
-        "@matter/main": "0.17.0-alpha.0-20260430-11b356f65",
+        "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08",
         "@matter-server/ws-controller": "*",
         "@matter-server/dashboard": "*",
         "@matter-server/custom-clusters": "*",
@@ -44,8 +44,8 @@
     "devDependencies": {
         "@types/express": "^5.0.6",
         "@types/node": "^25.6.0",
-        "@matter/nodejs": "0.17.0-alpha.0-20260430-11b356f65",
-        "@matter/testing": "0.17.0-alpha.0-20260430-11b356f65",
+        "@matter/nodejs": "0.17.0-alpha.0-20260504-893d6ba08",
+        "@matter/testing": "0.17.0-alpha.0-20260504-893d6ba08",
         "@matter-server/ws-client": "*"
     },
     "files": [

--- a/packages/matter-server/package.json
+++ b/packages/matter-server/package.json
@@ -34,7 +34,7 @@
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
     },
     "dependencies": {
-        "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08",
+        "@matter/main": "0.17.0-alpha.0-20260504-e005cc190",
         "@matter-server/ws-controller": "*",
         "@matter-server/dashboard": "*",
         "@matter-server/custom-clusters": "*",
@@ -44,8 +44,8 @@
     "devDependencies": {
         "@types/express": "^5.0.6",
         "@types/node": "^25.6.0",
-        "@matter/nodejs": "0.17.0-alpha.0-20260504-893d6ba08",
-        "@matter/testing": "0.17.0-alpha.0-20260504-893d6ba08",
+        "@matter/nodejs": "0.17.0-alpha.0-20260504-e005cc190",
+        "@matter/testing": "0.17.0-alpha.0-20260504-e005cc190",
         "@matter-server/ws-client": "*"
     },
     "files": [

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -37,7 +37,7 @@
     "devDependencies": {
         "@types/node": "^25.6.0",
         "@types/ws": "^8.18.1",
-        "@matter/testing": "0.17.0-alpha.0-20260504-893d6ba08",
+        "@matter/testing": "0.17.0-alpha.0-20260504-e005cc190",
         "ws": "^8.20.0"
     },
     "files": [

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -37,7 +37,7 @@
     "devDependencies": {
         "@types/node": "^25.6.0",
         "@types/ws": "^8.18.1",
-        "@matter/testing": "0.17.0-alpha.0-20260430-11b356f65",
+        "@matter/testing": "0.17.0-alpha.0-20260504-893d6ba08",
         "ws": "^8.20.0"
     },
     "files": [

--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -34,12 +34,12 @@
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.0-alpha.0-20260504-893d6ba08"
+        "@matter/nodejs-ble": "0.17.0-alpha.0-20260504-e005cc190"
     },
     "dependencies": {
-        "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08",
+        "@matter/main": "0.17.0-alpha.0-20260504-e005cc190",
         "@matter-server/ws-client": "*",
-        "@project-chip/matter.js": "0.17.0-alpha.0-20260504-893d6ba08",
+        "@project-chip/matter.js": "0.17.0-alpha.0-20260504-e005cc190",
         "ws": "^8.20.0"
     },
     "devDependencies": {

--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -34,12 +34,12 @@
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.0-alpha.0-20260430-11b356f65"
+        "@matter/nodejs-ble": "0.17.0-alpha.0-20260504-893d6ba08"
     },
     "dependencies": {
-        "@matter/main": "0.17.0-alpha.0-20260430-11b356f65",
+        "@matter/main": "0.17.0-alpha.0-20260504-893d6ba08",
         "@matter-server/ws-client": "*",
-        "@project-chip/matter.js": "0.17.0-alpha.0-20260430-11b356f65",
+        "@project-chip/matter.js": "0.17.0-alpha.0-20260504-893d6ba08",
         "ws": "^8.20.0"
     },
     "devDependencies": {

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -14,6 +14,7 @@ import {
     FabricIndex,
     isObject,
     Logger,
+    MatterAggregateError,
     Millis,
     Minutes,
     NodeId,
@@ -619,6 +620,20 @@ export class ControllerCommandHandler {
             await node.node.endpoints.for(endpointId).setStateOf(clusterProperty, { [attributeName]: value });
             return { status: 0 };
         } catch (error) {
+            if (error instanceof MatterAggregateError) {
+                const first = error.errors.find((e): e is StatusResponseError => e instanceof StatusResponseError);
+                if (first !== undefined) {
+                    const dropped = error.errors.filter(e => e !== first);
+                    if (dropped.length > 0) {
+                        logger.info(
+                            `Write aggregate: reporting first error, dropping ${dropped.length} additional`,
+                            dropped,
+                        );
+                    }
+                    return { status: first.code, clusterStatus: first.clusterCode };
+                }
+                throw error;
+            }
             StatusResponseError.accept(error);
             return { status: error.code, clusterStatus: error.clusterCode };
         }


### PR DESCRIPTION
## Summary

- **Fix**: Surface `MatterAggregateError` from `setStateOf` as a proper `[{Path, Status}]` response on the WebSocket instead of a generic `UnknownError` error envelope — WS clients now see the actual Matter status code when a write is declined
- **Enhancement**: Show discovered Thread Border Router hostnames in connection and neighbor lists; refactored hostname stripping into a shared `stripMdnsHostname` utility
- **Dependency**: Update matter.js to `0.17.0-alpha.0-20260504-893d6ba08`

Addresses #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)