### PR TITLE
Use LQI for Thread mesh visualization colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Adjustment: Thread mesh visualization now uses LQI (instead of RSSI) for connection-line and neighbor-list colors.
+
 ## 0.6.5 (2026-05-04)
 
 - Enhancement: Hide phantom Thread "External" routers/devices that only persist as stale neighbor-table entries (every observer offline, or single observer with other connections)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,11 @@ npm run server
 # Start server with options
 npm run server -- --storage-path data --primary-interface en0
 
-# Run tests (uses @matter/testing with mocha)
-npm test
+# Run tests (uses @matter/testing with mocha).
+# Integration tests (Commission On Network) need an explicit network interface,
+# otherwise mDNS discovery picks up VPN/utun adapters and the test times out.
+# Set both env vars to the active LAN interface (e.g. en0):
+PRIMARY_INTERFACE=en0 MATTER_MDNS_NETWORKINTERFACE=en0 npm test
 
 # Lint (oxlint with type-aware checking)
 npm run lint
@@ -99,8 +102,11 @@ npm run lint
 # 3. Build (required)
 npm run build
 
-# 4. Run tests (required)
-npm test
+# 4. Run tests (required). See note above — integration tests need both
+#    PRIMARY_INTERFACE and MATTER_MDNS_NETWORKINTERFACE set to the active LAN
+#    interface (e.g. en0). Without them, the Commission On Network test times out
+#    when mDNS picks a VPN/utun interface.
+PRIMARY_INTERFACE=en0 MATTER_MDNS_NETWORKINTERFACE=en0 npm test
 ```
 
 All four checks must pass **in this order**. `npm run format` must be run **before** build/lint — it rewrites files in-place using oxfmt and the build/lint must validate the formatted output. Skipping format leads to formatting drift that gets caught later.

--- a/packages/dashboard/public/index.html
+++ b/packages/dashboard/public/index.html
@@ -56,6 +56,7 @@
     --signal-color-strong: #4caf50;
     --signal-color-medium: #ff9800;
     --signal-color-weak: #f44336;
+    --signal-color-none: #9e9e9e;
     --node-color-selected: #1976d2;
     --node-color-offline: #d32f2f;
     --node-color-selected-offline: #b71c1c;
@@ -114,6 +115,7 @@
     --signal-color-strong: #66bb6a;
     --signal-color-medium: #ffa726;
     --signal-color-weak: #ef5350;
+    --signal-color-none: #757575;
     --node-color-selected: #42a5f5;
     --node-color-offline: #ef5350;
     --node-color-selected-offline: #e53935;

--- a/packages/dashboard/src/pages/network/network-details.ts
+++ b/packages/dashboard/src/pages/network/network-details.ts
@@ -7,14 +7,21 @@
 import { consume } from "@lit/context";
 import "@material/web/divider/divider";
 import { isTestNodeId, type BorderRouterEntry, type MatterClient, type MatterNode } from "@matter-server/ws-client";
-import { mdiClose, mdiRefresh, mdiSignalCellular1, mdiSignalCellular2, mdiSignalCellular3 } from "@mdi/js";
+import {
+    mdiClose,
+    mdiLinkVariantOff,
+    mdiRefresh,
+    mdiSignalCellular1,
+    mdiSignalCellular2,
+    mdiSignalCellular3,
+} from "@mdi/js";
 import { LitElement, TemplateResult, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { clientContext } from "../../client/client-context.js";
 import "../../components/ha-svg-icon";
 import { formatNodeAddressFromAny, getEffectiveFabricIndex } from "../../util/format_hex.js";
-import { getCssVar, reducedMotionStyles } from "../../util/shared-styles.js";
-import type { ThreadEdgePair, ThreadExternalDevice } from "./network-types.js";
+import { reducedMotionStyles } from "../../util/shared-styles.js";
+import type { SignalLevel, ThreadEdgePair, ThreadExternalDevice } from "./network-types.js";
 import type { NodeConnection } from "./network-utils.js";
 import {
     decodeMeshcopStateBitmap,
@@ -105,12 +112,17 @@ export class NetworkDetails extends LitElement {
         }
     }
 
-    private _getSignalIconFromColor(color: string): string {
-        const strongColor = getCssVar("--signal-color-strong", "#4caf50");
-        const mediumColor = getCssVar("--signal-color-medium", "#ff9800");
-        if (color === strongColor) return mdiSignalCellular3;
-        if (color === mediumColor) return mdiSignalCellular2;
-        return mdiSignalCellular1;
+    private _getSignalIcon(level: SignalLevel): string {
+        switch (level) {
+            case "strong":
+                return mdiSignalCellular3;
+            case "medium":
+                return mdiSignalCellular2;
+            case "weak":
+                return mdiSignalCellular1;
+            case "none":
+                return mdiLinkVariantOff;
+        }
     }
 
     /**
@@ -273,7 +285,7 @@ export class NetworkDetails extends LitElement {
                                                   this._handleKeyDown(e, conn.connectedNodeId)}
                                           >
                                               <ha-svg-icon
-                                                  .path=${this._getSignalIconFromColor(conn.signalColor)}
+                                                  .path=${this._getSignalIcon(conn.signalLevel)}
                                                   style="--icon-primary-color: ${conn.signalColor}"
                                               ></ha-svg-icon>
                                               <div class="neighbor-info">
@@ -477,7 +489,7 @@ export class NetworkDetails extends LitElement {
                                     @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, conn.connectedNodeId)}
                                 >
                                     <ha-svg-icon
-                                        .path=${this._getSignalIconFromColor(conn.signalColor)}
+                                        .path=${this._getSignalIcon(conn.signalLevel)}
                                         style="--icon-primary-color: ${conn.signalColor}"
                                     ></ha-svg-icon>
                                     <div class="neighbor-info">

--- a/packages/dashboard/src/pages/network/network-types.ts
+++ b/packages/dashboard/src/pages/network/network-types.ts
@@ -12,9 +12,10 @@ import type { BorderRouterEntry } from "@matter-server/ws-client";
 export type NetworkType = "thread" | "wifi" | "ethernet" | "unknown";
 
 /**
- * Classification of a Thread mesh link based on RSSI/LQI.
+ * Classification of a Thread mesh link based on LQI.
+ * "none" means LQI=0 — neighbor entry exists but no recent valid frames (dead/stale link).
  */
-export type SignalLevel = "strong" | "medium" | "weak";
+export type SignalLevel = "strong" | "medium" | "weak" | "none";
 
 /**
  * Thread routing role from ThreadNetworkDiagnostics cluster.
@@ -45,7 +46,10 @@ export interface ThreadNeighbor {
     linkFrameCounter: number;
     /** MLE frame counter */
     mleFrameCounter: number;
-    /** Link Quality Indicator (0-255, higher is better) */
+    /**
+     * Link Quality Indicator. Spec types as uint8 (0-255), but OpenThread reports
+     * 0-3 in practice. 0 = no recent valid frames (dead/stale link).
+     */
     lqi: number;
     /** Average RSSI in dBm (nullable) */
     avgRssi: number | null;
@@ -80,9 +84,9 @@ export interface ThreadRoute {
     nextHop: number;
     /** Path cost */
     pathCost: number;
-    /** LQI in */
+    /** LQI in (0-3 on OpenThread; 0 = no link). */
     lqiIn: number;
-    /** LQI out */
+    /** LQI out (0-3 on OpenThread; 0 = no link). */
     lqiOut: number;
     /** Age of the route */
     age: number;
@@ -110,8 +114,7 @@ export interface ThreadConnection {
     fromNodeId: number | string;
     toNodeId: number | string;
     signalColor: string;
-    /** Undefined when link strength is unknown (e.g. route-table entry without LQI). */
-    signalLevel?: SignalLevel;
+    signalLevel: SignalLevel;
     lqi: number;
     rssi: number | null;
     /** Path cost from route table (1 = direct, higher = multi-hop). Only available for routers. */

--- a/packages/dashboard/src/pages/network/network-utils.ts
+++ b/packages/dashboard/src/pages/network/network-utils.ts
@@ -22,13 +22,16 @@ const WIFI_FEATURE = 1 << 0; // Bit 0: WiFi Network Interface
 const THREAD_FEATURE = 1 << 1; // Bit 1: Thread Network Interface
 const ETHERNET_FEATURE = 1 << 2; // Bit 2: Ethernet Network Interface
 
-// Signal strength thresholds (dBm)
+// WiFi RSSI thresholds (dBm). Used only for the WiFi diagnostics graph; Thread
+// neighbor/route edges are LQI-driven (see below).
 const SIGNAL_STRONG_THRESHOLD = -70;
 const SIGNAL_MEDIUM_THRESHOLD = -85;
 
-// LQI thresholds (0-255)
-const LQI_STRONG_THRESHOLD = 200;
-const LQI_MEDIUM_THRESHOLD = 100;
+// Thread LQI thresholds. Spec types LQI as uint8 (0-255), but OpenThread — the
+// dominant Thread stack — only ever reports 0-3. We classify on the 0-3 scale:
+// 3 = strong, 2 = medium, 1 = weak, 0 = no link (stale/dead neighbor entry).
+const LQI_STRONG_THRESHOLD = 2;
+const LQI_MEDIUM_THRESHOLD = 1;
 
 // Signal colors — read from CSS variables for theme awareness
 function getSignalColorStrong(): string {
@@ -39,6 +42,9 @@ function getSignalColorMedium(): string {
 }
 function getSignalColorWeak(): string {
     return getCssVar("--signal-color-weak", "#f44336");
+}
+function getSignalColorNone(): string {
+    return getCssVar("--signal-color-none", "#9e9e9e");
 }
 
 /**
@@ -615,19 +621,17 @@ export function decodeMeshcopStateBitmap(hex: string | undefined): DecodedStateB
     };
 }
 
-/** Determine signal level from a Thread neighbor's RSSI/LQI. */
+/** Determine signal level from a Thread neighbor's LQI. */
 export function getSignalLevel(neighbor: ThreadNeighbor): SignalLevel {
-    const rssi = neighbor.avgRssi ?? neighbor.lastRssi;
-    if (rssi !== null) {
-        if (rssi > SIGNAL_STRONG_THRESHOLD) return "strong";
-        if (rssi > SIGNAL_MEDIUM_THRESHOLD) return "medium";
-        return "weak";
-    }
     return getSignalLevelFromLqi(neighbor.lqi);
 }
 
-/** Determine signal level from an LQI value alone (e.g. route table entries without RSSI). */
+/**
+ * Map an LQI value (0-3 in practice on OpenThread) to a signal level.
+ * 0 = "none" (no recent valid frames — stale/dead link).
+ */
 export function getSignalLevelFromLqi(lqi: number): SignalLevel {
+    if (lqi <= 0) return "none";
     if (lqi > LQI_STRONG_THRESHOLD) return "strong";
     if (lqi > LQI_MEDIUM_THRESHOLD) return "medium";
     return "weak";
@@ -642,52 +646,22 @@ export function signalLevelToColor(level: SignalLevel): string {
             return getSignalColorMedium();
         case "weak":
             return getSignalColorWeak();
+        case "none":
+            return getSignalColorNone();
     }
 }
 
-/**
- * Gets the signal color based on RSSI or LQI values.
- * Green: Strong signal
- * Orange: Medium signal
- * Red: Weak signal
- */
+/** Gets the signal color for a Thread neighbor based on its LQI. */
 export function getSignalColor(neighbor: ThreadNeighbor): string {
-    // Prefer RSSI if available
-    const rssi = neighbor.avgRssi ?? neighbor.lastRssi;
-
-    if (rssi !== null) {
-        if (rssi > SIGNAL_STRONG_THRESHOLD) {
-            return getSignalColorStrong();
-        }
-        if (rssi > SIGNAL_MEDIUM_THRESHOLD) {
-            return getSignalColorMedium();
-        }
-        return getSignalColorWeak();
-    }
-
-    // Fallback to LQI (0-255, higher is better)
-    if (neighbor.lqi > LQI_STRONG_THRESHOLD) {
-        return getSignalColorStrong();
-    }
-    if (neighbor.lqi > LQI_MEDIUM_THRESHOLD) {
-        return getSignalColorMedium();
-    }
-    return getSignalColorWeak();
+    return getSignalColorFromLqi(neighbor.lqi);
 }
 
 /**
- * Get signal color based on LQI value alone.
- * Used for route table entries where only LQI is available.
- * @param lqi Link Quality Indicator (0-255, higher is better)
+ * Get signal color from an LQI value (0-3 in practice on OpenThread).
+ * 0 = grey (no link), 1 = red, 2 = orange, 3 = green.
  */
 export function getSignalColorFromLqi(lqi: number): string {
-    if (lqi > LQI_STRONG_THRESHOLD) {
-        return getSignalColorStrong();
-    }
-    if (lqi > LQI_MEDIUM_THRESHOLD) {
-        return getSignalColorMedium();
-    }
-    return getSignalColorWeak();
+    return signalLevelToColor(getSignalLevelFromLqi(lqi));
 }
 
 /** Strips trailing dot and `.local` suffix from an mDNS hostname. */
@@ -853,8 +827,7 @@ export interface NodeConnection {
     extAddressHex: string;
     /** Signal strength info (if available) */
     signalColor: string;
-    /** Undefined when link strength is unknown. */
-    signalLevel?: SignalLevel;
+    signalLevel: SignalLevel;
     lqi: number | null;
     rssi: number | null;
     /** Whether this connection is from THIS node's neighbor table (true) or from the OTHER node's table (false) */
@@ -989,16 +962,15 @@ export function buildThreadEdgePairs(
             if (!isFromA && pair.edgeBA) continue;
 
             const bidirectionalLqi = getRouteBidirectionalLqi(route);
-            const signalColor =
-                bidirectionalLqi !== undefined
-                    ? getSignalColorFromLqi(bidirectionalLqi)
-                    : "var(--md-sys-color-outline, grey)";
+            // No bidirectional LQI = both lqiIn and lqiOut are 0 → treat as no-link.
+            const signalLevel: SignalLevel =
+                bidirectionalLqi !== undefined ? getSignalLevelFromLqi(bidirectionalLqi) : "none";
 
             const edge: ThreadConnection = {
                 fromNodeId,
                 toNodeId,
-                signalColor,
-                signalLevel: bidirectionalLqi !== undefined ? getSignalLevelFromLqi(bidirectionalLqi) : undefined,
+                signalColor: signalLevelToColor(signalLevel),
+                signalLevel,
                 lqi: bidirectionalLqi ?? 0,
                 rssi: null,
                 pathCost: route.pathCost,
@@ -1096,15 +1068,21 @@ export function getNodeConnectionsFromPairs(
 
         if (survivors.length === 0) continue;
 
-        // Among survivors: prefer outgoing (matches graph highlight swap),
+        // Mirror graph behavior: zero-LQI edges are hidden in the mesh, so prefer a live
+        // survivor here too. Fall back to a "none" survivor only when both directions
+        // are dead — then the panel renders a single no-link entry.
+        const liveSurvivors = survivors.filter(s => s.conn.signalLevel !== "none");
+        const usable = liveSurvivors.length > 0 ? liveSurvivors : survivors;
+
+        // Among usable survivors: prefer outgoing (matches graph highlight swap),
         // fall back to worst signal (matches graph dedup)
         let winner: { conn: ThreadConnection; isOutgoing: boolean };
-        const outgoingSurvivor = survivors.find(s => s.isOutgoing);
+        const outgoingSurvivor = usable.find(s => s.isOutgoing);
         if (outgoingSurvivor) {
             winner = outgoingSurvivor;
         } else {
-            survivors.sort((a, b) => getEdgeSignalScore(a.conn) - getEdgeSignalScore(b.conn));
-            winner = survivors[0];
+            usable.sort((a, b) => getEdgeSignalScore(a.conn) - getEdgeSignalScore(b.conn));
+            winner = usable[0];
         }
 
         const remoteNode = nodes[remoteId];

--- a/packages/dashboard/src/pages/network/thread-graph.ts
+++ b/packages/dashboard/src/pages/network/thread-graph.ts
@@ -288,6 +288,11 @@ export class ThreadGraph extends BaseNetworkGraph {
         for (const pair of this._edgePairs.values()) {
             // Collect both directional edges for this pair
             const edgesInPair: { conn: ThreadConnection; visEdge: NetworkGraphEdge; filterHidden: boolean }[] = [];
+            // Track if any directional edge in this pair was a no-link (LQI=0) report.
+            // If exactly one direction reports zero while the other has a real link, the pair
+            // is asymmetric — surface the surviving edge as dashed so testers can spot it.
+            let hadZeroEdge = false;
+            let hadLiveEdge = false;
 
             for (const conn of [pair.edgeAB, pair.edgeBA]) {
                 if (!conn) continue;
@@ -305,6 +310,14 @@ export class ThreadGraph extends BaseNetworkGraph {
                 // Cascade from hidden nodes (offline filter)
                 if (hiddenNodeIds.has(fromId) || hiddenNodeIds.has(toId)) {
                     filterHidden = true;
+                }
+
+                // No-link filter: LQI=0 means stale/dead neighbor entry, never draw.
+                if (conn.signalLevel === "none") {
+                    filterHidden = true;
+                    hadZeroEdge = true;
+                } else {
+                    hadLiveEdge = true;
                 }
 
                 // Signal level filters
@@ -345,6 +358,17 @@ export class ThreadGraph extends BaseNetworkGraph {
                 // Keep the weakest (index 0), hide the better one(s)
                 for (let i = 1; i < visibleInPair.length; i++) {
                     visibleInPair[i].visEdge.hidden = true;
+                }
+            }
+
+            // Asymmetric link: one direction reported the link as dead while the other
+            // saw a live link. Mark the surviving edge dashed and annotate the tooltip.
+            if (hadZeroEdge && hadLiveEdge) {
+                for (const e of edgesInPair) {
+                    if (!e.visEdge.hidden) {
+                        e.visEdge.dashes = true;
+                        e.visEdge.title = `${e.visEdge.title ?? ""} (asymmetric: peer reports no link)`;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

Addresses #604.

Thread `NeighborTable` LQI is `uint8` 0-255 per Matter spec, but OpenThread — the dominant Thread stack — only ever reports 0-3. The previous code preferred RSSI and fell back to LQI with `> 200` / `> 100` thresholds, so almost every real Thread link bucketed into the "weak" red band.

This PR switches the Thread mesh chart edge colors and neighbor-list quality icons to LQI-driven coloring on the actual 0-3 scale:

- **3** → strong (green)
- **2** → medium (orange)
- **1** → weak (red)
- **0** → no link (grey)

Behavior in detail:
- Chart edges with LQI=0 are **hidden** (stale/dead neighbor entries).
- If only one direction reports zero (asymmetric link), the surviving direction is drawn **dashed** with an `(asymmetric: peer reports no link)` tooltip suffix.
- Neighbor/connection lists keep the entry but render a `mdiLinkVariantOff` icon for LQI=0.
- **RSSI and LQI both remain visible numerically** in node details, connection details, and edge tooltips — only the color/icon source changes.
- The side panel `getNodeConnectionsFromPairs` was tightened to prefer a live survivor over a "none" survivor in asymmetric pairs, so the panel doesn't render a no-link icon for a link the chart shows as live.
- `SignalLevel` is now non-optional on `ThreadConnection` and `NodeConnection` (all producers set it).
- WiFi RSSI coloring is **untouched** (only path is `getSignalColorFromRssi`).

Also adds a note to `CLAUDE.md` that the integration test suite needs `PRIMARY_INTERFACE` and `MATTER_MDNS_NETWORKINTERFACE` set to the active LAN interface — without them mDNS picks a VPN/utun adapter and the Commission On Network test times out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)