### PR TITLE
fix(dashboard): normalize null Thread diagnostics attributes to undefined

### DIFF
--- a/packages/dashboard/src/pages/network/network-utils.ts
+++ b/packages/dashboard/src/pages/network/network-utils.ts
@@ -145,26 +145,29 @@ export function categorizeDevices(nodes: Record<string, MatterNode>): Categorize
 
 /**
  * Gets the Thread routing role for a node.
- * Uses attribute 0/53/1 (RoutingRole).
+ * Uses attribute 0/53/1 (RoutingRole, nullable per Matter spec).
  */
 export function getThreadRole(node: MatterNode): number | undefined {
-    return node.attributes["0/53/1"] as number | undefined;
+    const v = node.attributes["0/53/1"];
+    return typeof v === "number" ? v : undefined;
 }
 
 /**
  * Gets the Thread channel for a node.
- * Uses attribute 0/53/0 (Channel).
+ * Uses attribute 0/53/0 (Channel, nullable per Matter spec).
  */
 export function getThreadChannel(node: MatterNode): number | undefined {
-    return node.attributes["0/53/0"] as number | undefined;
+    const v = node.attributes["0/53/0"];
+    return typeof v === "number" ? v : undefined;
 }
 
 /**
  * Gets the Thread extended PAN ID for a node.
- * Uses attribute 0/53/4 (ExtendedPanId).
+ * Uses attribute 0/53/4 (ExtendedPanId, nullable per Matter spec).
  */
 export function getThreadExtendedPanId(node: MatterNode): bigint | undefined {
-    return node.attributes["0/53/4"] as bigint | undefined;
+    const v = node.attributes["0/53/4"];
+    return typeof v === "bigint" ? v : undefined;
 }
 
 /**

--- a/packages/dashboard/src/pages/network/network-utils.ts
+++ b/packages/dashboard/src/pages/network/network-utils.ts
@@ -170,10 +170,15 @@ export function getThreadChannel(node: MatterNode): number | undefined {
 /**
  * Gets the Thread extended PAN ID for a node.
  * Uses attribute 0/53/4 (ExtendedPanId, nullable per Matter spec).
+ *
+ * The WebSocket JSON reviver only revives integers above Number.MAX_SAFE_INTEGER
+ * as bigint; smaller uint64 values arrive as plain number, so accept both.
  */
 export function getThreadExtendedPanId(node: MatterNode): bigint | undefined {
     const v = node.attributes["0/53/4"];
-    return typeof v === "bigint" ? v : undefined;
+    if (typeof v === "bigint") return v;
+    if (typeof v === "number" && Number.isInteger(v)) return BigInt(v);
+    return undefined;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Thread Network Diagnostics attributes `0/53/0 Channel`, `0/53/1 RoutingRole`, `0/53/4 ExtendedPanId` are nullable per Matter spec.
- Existing `getThreadChannel` / `getThreadRole` / `getThreadExtendedPanId` cast the raw attribute via `as T | undefined`, which lies at runtime — a real `null` slipped past every `!== undefined` guard in callers.
- Concrete crash: `findUnknownDevices` → `observerXp.toString(16)` blew up with `Cannot read properties of null (reading 'toString')`, breaking the whole Thread network graph for users with a node reporting `null` ExtendedPanId.
- Fix: replace casts with `typeof` runtime guards so `null` (and any other unexpected runtime type) is normalized to `undefined` at the source.

Addresses #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)