### PR TITLE
Make @matter/nodejs-ble import dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This page shows a detailed overview of the changes between versions without the 
 ## **WORK IN PROGRESS**
 
 - Adjustment: Thread mesh visualization now uses LQI (instead of RSSI) for connection-line and neighbor-list colors.
+- Fix: Only import BLE module when BLE was enabled for the server
 
 ## 0.6.5 (2026-05-04)
 

--- a/packages/ws-controller/src/controller/MatterController.ts
+++ b/packages/ws-controller/src/controller/MatterController.ts
@@ -32,7 +32,7 @@ const logger = Logger.get("MatterController");
 
 let bleSupportLoaded: Promise<void> | undefined;
 
-// `@matter/nodejs-ble` is an optionalDependency; tolerate missing install at runtime.
+// Lazy-load the optional `@matter/nodejs-ble` so a missing install only fails when BLE is enabled.
 async function loadBleSupport(environment: Environment): Promise<void> {
     if (!environment.vars.get("ble.enable", false)) return;
     if (bleSupportLoaded === undefined) {
@@ -40,13 +40,10 @@ async function loadBleSupport(environment: Environment): Promise<void> {
             try {
                 await import("@matter/nodejs-ble");
             } catch (error) {
-                const code = (error as { code?: string } | undefined)?.code;
-                if (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") {
-                    logger.error(
-                        `BLE requested (ble.enable=true) but '@matter/nodejs-ble' is not installed. Install it to enable BLE commissioning.`,
-                    );
-                    return;
-                }
+                logger.error(
+                    `Failed to load '@matter/nodejs-ble'. Disable BLE or ensure the package is installed.`,
+                    error,
+                );
                 throw error;
             }
         })();

--- a/packages/ws-controller/src/controller/MatterController.ts
+++ b/packages/ws-controller/src/controller/MatterController.ts
@@ -27,10 +27,32 @@ import { BorderRouterDiscovery } from "./BorderRouterDiscovery.js";
 import { ControllerCommandHandler } from "./ControllerCommandHandler.js";
 import { LegacyDataInjector, LegacyServerData } from "./LegacyDataInjector.js";
 import { resolveServerId } from "./ServerIdResolver.js";
-// Register BLE
-import "@matter/nodejs-ble";
 
 const logger = Logger.get("MatterController");
+
+let bleSupportLoaded: Promise<void> | undefined;
+
+// `@matter/nodejs-ble` is an optionalDependency; tolerate missing install at runtime.
+async function loadBleSupport(environment: Environment): Promise<void> {
+    if (!environment.vars.get("ble.enable", false)) return;
+    if (bleSupportLoaded === undefined) {
+        bleSupportLoaded = (async () => {
+            try {
+                await import("@matter/nodejs-ble");
+            } catch (error) {
+                const code = (error as { code?: string } | undefined)?.code;
+                if (code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND") {
+                    logger.error(
+                        `BLE requested (ble.enable=true) but '@matter/nodejs-ble' is not installed. Install it to enable BLE commissioning.`,
+                    );
+                    return;
+                }
+                throw error;
+            }
+        })();
+    }
+    return bleSupportLoaded;
+}
 
 export async function computeCompressedNodeId(
     crypto: Crypto,
@@ -84,6 +106,8 @@ export class MatterController {
         options: MatterControllerOptions,
         legacyData?: LegacyServerData,
     ) {
+        await loadBleSupport(environment);
+
         // Resolve the server ID to use
         const serverId = await resolveServerId(
             environment,


### PR DESCRIPTION
## Summary
- Replace top-level `import "@matter/nodejs-ble"` side-effect import in `MatterController.ts` with a guarded dynamic `await import(...)` invoked from `MatterController.create()`.
- The package is only loaded when `ble.enable` is set (matches how `--bluetooth-adapter` enables BLE in `MatterServer.ts`); when BLE is disabled the optional dependency is never touched.
- If loading fails while BLE is enabled, log a hint ("Disable BLE or ensure the package is installed") and rethrow so the failure is loud rather than silent.

The package is an `optionalDependencies` entry, so the previous static import crashed the process with `ERR_MODULE_NOT_FOUND` in environments where optional deps are excluded.

Addresses #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)