### PR TITLE
custom-clusters: Add `windowOpenMode` attribute to `EveCluster`

### DIFF
--- a/packages/custom-clusters/src/clusters/eve.ts
+++ b/packages/custom-clusters/src/clusters/eve.ts
@@ -62,6 +62,9 @@ export class EveCluster {
     @attribute(0x130a0015, uint32)
     weatherTrend?: number;
 
+    @attribute(0x130a0017, bool)
+    windowOpenMode?: boolean;
+
     @attribute(0x130a0018, uint32)
     valvePosition?: number;
 

--- a/packages/dashboard/src/client/models/descriptions.ts
+++ b/packages/dashboard/src/client/models/descriptions.ts
@@ -15204,6 +15204,13 @@ export const clusters: Record<number, ClusterDescription> = {
                 "type": "Optional[unknown]",
                 "writable": true
             },
+            "319422487": {
+                "id": 319422487,
+                "cluster_id": 319486977,
+                "label": "WindowOpenMode",
+                "type": "Optional[bool]",
+                "writable": false
+            },
             "319422488": {
                 "id": 319422488,
                 "cluster_id": 319486977,


### PR DESCRIPTION
Based on my current understanding of Eve's implementation, this seems to be a read-only boolean attribute.

It's `true` when a TRV is switched to "window open mode" via _magic_ setpoint value as described in https://github.com/matter-js/matterjs-server/issues/640.