### PR TITLE
ws-controller: keep reconnect debounce armed across non-Connected states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This page shows a detailed overview of the changes between versions without the 
 - Feature: (iamadamreed) Adds TCL custom cluster
 - Feature: (burmistrzak) Adds "window open mode" attribute for Eve custom cluster
 - Fix: Ensures that also official test certificates are initialized correctly when DCL-Testnet-flag is enabled
+- Fix: Fixed some edge cases in the "Node available" logic to ensure it correctly reflects the node stats
 - Fix: Update matter.js to the latest 0.17.0-nightly
     - Fixes write encoding for some cases of nullable attributes
     - Make scanNetwork failures non-fatal for commissioning

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "packages/matter-server"
             ],
             "devDependencies": {
-                "@matter/testing": "0.17.0-alpha.0-20260512-576f5796c",
+                "@matter/testing": "0.17.0-alpha.0-20260515-6eb5f8476",
                 "@nacho-iot/js-tools": "^0.1.7",
                 "@types/mocha": "^10.0.10",
                 "glob": "^13.0.6",
@@ -2490,9 +2490,9 @@
             }
         },
         "node_modules/@lit-labs/ssr-dom-shim": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
-            "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+            "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@lit/context": {
@@ -2543,77 +2543,77 @@
             "link": true
         },
         "node_modules/@matter/general": {
-            "version": "0.17.0-alpha.0-20260512-576f5796c",
-            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.0-alpha.0-20260512-576f5796c.tgz",
-            "integrity": "sha512-SlEsq/fiC2q5oKYFmdcMHihqC868aeGe1n2Ac3v7qyFtxr3hPhCMBnVd/L3LWxwXGz+z52V90ihIbtCM0IAaYA==",
+            "version": "0.17.0-alpha.0-20260515-6eb5f8476",
+            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.0-alpha.0-20260515-6eb5f8476.tgz",
+            "integrity": "sha512-IoubohRUEOzNccPIv7DDWzBOVd2bZuYyG+AX2by5kjVT4h+QSz05Ylic8PDaTUGbsjmYXKGRHOmQ830e2nGdXA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/curves": "^2.2.0"
             }
         },
         "node_modules/@matter/main": {
-            "version": "0.17.0-alpha.0-20260512-576f5796c",
-            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.0-alpha.0-20260512-576f5796c.tgz",
-            "integrity": "sha512-54riVdjey5Eety2SG8b2GCVCAYz+LhzHoaIEIclmYBlIliFa/Afirx2/Gis7AFTShGEkHT2ZGk2yNKGOo0vUyg==",
+            "version": "0.17.0-alpha.0-20260515-6eb5f8476",
+            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.0-alpha.0-20260515-6eb5f8476.tgz",
+            "integrity": "sha512-0+M8JwR6CN77kHTkKQHGf7Rx81crXmS4a4/MWvs/hgNyaH760xzGM+s5eBC6R6E4OG/b/SZ51WPVNaeNzhPsiw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/model": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/node": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/protocol": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/types": "0.17.0-alpha.0-20260512-576f5796c"
+                "@matter/general": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/model": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/node": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/protocol": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/types": "0.17.0-alpha.0-20260515-6eb5f8476"
             },
             "optionalDependencies": {
-                "@matter/nodejs": "0.17.0-alpha.0-20260512-576f5796c"
+                "@matter/nodejs": "0.17.0-alpha.0-20260515-6eb5f8476"
             }
         },
         "node_modules/@matter/model": {
-            "version": "0.17.0-alpha.0-20260512-576f5796c",
-            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.0-alpha.0-20260512-576f5796c.tgz",
-            "integrity": "sha512-GOFlFQ+WL9nKBsrDxNhaUjLpqlmsPXQH3osDS3fqQjugS7z2868USX6KDMbChz2zsGGFWGHGIb21FvmfX7xHHw==",
+            "version": "0.17.0-alpha.0-20260515-6eb5f8476",
+            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.0-alpha.0-20260515-6eb5f8476.tgz",
+            "integrity": "sha512-QouEMdIYWOafp9p+wVkDgm2BfVXTSVBthktFwRnWgDf9rQWsMMUnLzMCw0kn9bqyscVRW1i4hGVUdEr0pubw3Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260512-576f5796c"
+                "@matter/general": "0.17.0-alpha.0-20260515-6eb5f8476"
             }
         },
         "node_modules/@matter/node": {
-            "version": "0.17.0-alpha.0-20260512-576f5796c",
-            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.0-alpha.0-20260512-576f5796c.tgz",
-            "integrity": "sha512-KH734qYYgYp2dOpflXLkaJO2FvQIPrHyIGL7QFVWJrK+15prNLZNxb2F8kAzyAoiHHeJ2OCCkbYke3hhsRPnaw==",
+            "version": "0.17.0-alpha.0-20260515-6eb5f8476",
+            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.0-alpha.0-20260515-6eb5f8476.tgz",
+            "integrity": "sha512-3pe74QkkGOVRbqSDrmLG0m/g0rtuZACdfmJmDFWIPb0gCmb+/xud8I72yrfunI14eJBeygQUOejCE27ltf3wFQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/model": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/protocol": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/types": "0.17.0-alpha.0-20260512-576f5796c"
+                "@matter/general": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/model": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/protocol": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/types": "0.17.0-alpha.0-20260515-6eb5f8476"
             }
         },
         "node_modules/@matter/nodejs": {
-            "version": "0.17.0-alpha.0-20260512-576f5796c",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.0-alpha.0-20260512-576f5796c.tgz",
-            "integrity": "sha512-3P9xDd1kOMlwL6EgFAMb/U3jgEtziuF029Xfov7v+KjEW/hlT0tgzHTu4vnsWkinOkDsfbNYeQBCvddNED1Q1w==",
+            "version": "0.17.0-alpha.0-20260515-6eb5f8476",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.0-alpha.0-20260515-6eb5f8476.tgz",
+            "integrity": "sha512-IzxWEQHk3KLHtojVfJynKQUcyk5Topnyn0MUlpefDqVYOFZ4Znn/MH6d8rEI+c5cpltbuaqH4goJ1R0QcR60dw==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/node": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/protocol": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/types": "0.17.0-alpha.0-20260512-576f5796c"
+                "@matter/general": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/node": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/protocol": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/types": "0.17.0-alpha.0-20260515-6eb5f8476"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
             }
         },
         "node_modules/@matter/nodejs-ble": {
-            "version": "0.17.0-alpha.0-20260512-576f5796c",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.0-alpha.0-20260512-576f5796c.tgz",
-            "integrity": "sha512-PBPUZu+ujDyJa92lYk5Iycsuch/eT1IcucJh0tp9/wNTmTA+/dDCdXH5AY9ZtxjCY7ExjucTb/pF8i2N83ej6w==",
+            "version": "0.17.0-alpha.0-20260515-6eb5f8476",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.0-alpha.0-20260515-6eb5f8476.tgz",
+            "integrity": "sha512-68CkJcTlbZMp8PI1DNQg50LKnbfCDl6/5ucH8nVgVI/FZ0PrSxpr0yBMF4wKrTzACYjXe6wTpC82zFXdOv+fyg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/protocol": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/types": "0.17.0-alpha.0-20260512-576f5796c"
+                "@matter/general": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/protocol": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/types": "0.17.0-alpha.0-20260515-6eb5f8476"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -2624,20 +2624,20 @@
             }
         },
         "node_modules/@matter/protocol": {
-            "version": "0.17.0-alpha.0-20260512-576f5796c",
-            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.0-alpha.0-20260512-576f5796c.tgz",
-            "integrity": "sha512-G1L8YAd0nfkVT25LjPjEPlQaGahsOZCbTR3k/U3rFRxqfJ82w5+0xOR08V2L0bFRTyBogbc12NxPMuAgT9Yoog==",
+            "version": "0.17.0-alpha.0-20260515-6eb5f8476",
+            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.0-alpha.0-20260515-6eb5f8476.tgz",
+            "integrity": "sha512-e1M6coRaSKATw+qaO7cCuHLAAp05weWYO8AwLfUekbX7Q3M/7jv8Iz3hFVkfB/83C8eiC1Mnzj2G0MPK3aLJhw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/model": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/types": "0.17.0-alpha.0-20260512-576f5796c"
+                "@matter/general": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/model": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/types": "0.17.0-alpha.0-20260515-6eb5f8476"
             }
         },
         "node_modules/@matter/testing": {
-            "version": "0.17.0-alpha.0-20260512-576f5796c",
-            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.0-alpha.0-20260512-576f5796c.tgz",
-            "integrity": "sha512-P8r9IAc56/TQgcoFw4Eo8jJ2E3QIXKqTawvaBzu7PBGUpTljmR80lilYkVobdegF9XFR91dr5CPukBartEFzHg==",
+            "version": "0.17.0-alpha.0-20260515-6eb5f8476",
+            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.0-alpha.0-20260515-6eb5f8476.tgz",
+            "integrity": "sha512-ePHNbJk2qqNoMeT72vZ1rUR5FCnDjR2lS50EZ7N6TYG6ZGqeSUMifrDqgthsCGFz38C+u9Q1XHMLvMM63ucfJA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -2662,13 +2662,13 @@
             }
         },
         "node_modules/@matter/types": {
-            "version": "0.17.0-alpha.0-20260512-576f5796c",
-            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.0-alpha.0-20260512-576f5796c.tgz",
-            "integrity": "sha512-6/M+nkdAqQwlPzFgSsaeQLnSsE/xG/4UTaTXhWvgn4KqhsbvvGVGcgmMIdHY7QsBnHZHPICzfdKkyZ1OPBF3vA==",
+            "version": "0.17.0-alpha.0-20260515-6eb5f8476",
+            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.0-alpha.0-20260515-6eb5f8476.tgz",
+            "integrity": "sha512-Sd63wxKtNnwHDXQLdzJWDq3md+ZvHdl6khxYwwoavea20wI31c8FiS/gjNEKdtiYDRAPcU2UawZ2QNEvc7IHbQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/model": "0.17.0-alpha.0-20260512-576f5796c"
+                "@matter/general": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/model": "0.17.0-alpha.0-20260515-6eb5f8476"
             }
         },
         "node_modules/@mdi/js": {
@@ -3521,16 +3521,16 @@
             }
         },
         "node_modules/@project-chip/matter.js": {
-            "version": "0.17.0-alpha.0-20260512-576f5796c",
-            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.0-alpha.0-20260512-576f5796c.tgz",
-            "integrity": "sha512-Pf+gahrgceimWRNovmQrGct/Kmf+neWxn+aKyizSMYbRI5ZcJvUCWquQAOzPzsxgXFG1liZm9nHjsIFngqjjfA==",
+            "version": "0.17.0-alpha.0-20260515-6eb5f8476",
+            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.0-alpha.0-20260515-6eb5f8476.tgz",
+            "integrity": "sha512-cfrZsGg6FdFsG6lc/lP4pBbpDIUSXwSgSCN5sndEUHXGcERSKBn8UmU2wM+mIO8vn108Sq0Lgooy+SdQPKaXNA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/model": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/node": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/protocol": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/types": "0.17.0-alpha.0-20260512-576f5796c"
+                "@matter/general": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/model": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/node": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/protocol": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/types": "0.17.0-alpha.0-20260515-6eb5f8476"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -3781,9 +3781,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
-            "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+            "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
             "cpu": [
                 "arm"
             ],
@@ -3795,9 +3795,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
-            "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+            "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
             "cpu": [
                 "arm64"
             ],
@@ -3809,9 +3809,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
-            "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+            "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
             "cpu": [
                 "arm64"
             ],
@@ -3823,9 +3823,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
-            "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+            "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
             "cpu": [
                 "x64"
             ],
@@ -3837,9 +3837,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
-            "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+            "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
             "cpu": [
                 "arm64"
             ],
@@ -3851,9 +3851,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
-            "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+            "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
             "cpu": [
                 "x64"
             ],
@@ -3865,9 +3865,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
-            "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+            "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
             "cpu": [
                 "arm"
             ],
@@ -3879,9 +3879,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
-            "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+            "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
             "cpu": [
                 "arm"
             ],
@@ -3893,9 +3893,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
-            "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+            "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
             "cpu": [
                 "arm64"
             ],
@@ -3907,9 +3907,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
-            "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+            "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
             "cpu": [
                 "arm64"
             ],
@@ -3921,9 +3921,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
-            "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+            "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
             "cpu": [
                 "loong64"
             ],
@@ -3935,9 +3935,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
-            "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+            "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
             "cpu": [
                 "loong64"
             ],
@@ -3949,9 +3949,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
-            "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+            "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
             "cpu": [
                 "ppc64"
             ],
@@ -3963,9 +3963,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
-            "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+            "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
             "cpu": [
                 "ppc64"
             ],
@@ -3977,9 +3977,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
-            "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+            "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
             "cpu": [
                 "riscv64"
             ],
@@ -3991,9 +3991,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
-            "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+            "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
             "cpu": [
                 "riscv64"
             ],
@@ -4005,9 +4005,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
-            "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+            "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
             "cpu": [
                 "s390x"
             ],
@@ -4019,9 +4019,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
-            "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+            "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
             "cpu": [
                 "x64"
             ],
@@ -4033,9 +4033,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
-            "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+            "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
             "cpu": [
                 "x64"
             ],
@@ -4047,9 +4047,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
-            "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+            "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
             "cpu": [
                 "x64"
             ],
@@ -4061,9 +4061,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
-            "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+            "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
             "cpu": [
                 "arm64"
             ],
@@ -4075,9 +4075,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
-            "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+            "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
             "cpu": [
                 "arm64"
             ],
@@ -4089,9 +4089,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
-            "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+            "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
             "cpu": [
                 "ia32"
             ],
@@ -4103,9 +4103,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
-            "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+            "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
             "cpu": [
                 "x64"
             ],
@@ -4117,9 +4117,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
-            "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+            "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
             "cpu": [
                 "x64"
             ],
@@ -4663,13 +4663,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.7.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-            "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+            "version": "25.8.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.8.0.tgz",
+            "integrity": "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.21.0"
+                "undici-types": ">=7.24.0 <7.24.7"
             }
         },
         "node_modules/@types/qs": {
@@ -6260,9 +6260,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.353",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
-            "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
+            "version": "1.5.356",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.356.tgz",
+            "integrity": "sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==",
             "dev": true,
             "license": "ISC"
         },
@@ -6829,19 +6829,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/get-tsconfig": {
-            "version": "4.14.0",
-            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-            "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "resolve-pkg-maps": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
         },
         "node_modules/glob": {
@@ -7517,9 +7504,9 @@
             }
         },
         "node_modules/lit": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
-            "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.3.tgz",
+            "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@lit/reactive-element": "^2.1.0",
@@ -7539,9 +7526,9 @@
             }
         },
         "node_modules/lit-html": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
-            "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+            "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@types/trusted-types": "^2.0.2"
@@ -8882,16 +8869,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/resolve-pkg-maps": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-            }
-        },
         "node_modules/reusify": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -8974,9 +8951,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.60.3",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
-            "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
+            "version": "4.60.4",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+            "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8990,31 +8967,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.60.3",
-                "@rollup/rollup-android-arm64": "4.60.3",
-                "@rollup/rollup-darwin-arm64": "4.60.3",
-                "@rollup/rollup-darwin-x64": "4.60.3",
-                "@rollup/rollup-freebsd-arm64": "4.60.3",
-                "@rollup/rollup-freebsd-x64": "4.60.3",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
-                "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
-                "@rollup/rollup-linux-arm64-gnu": "4.60.3",
-                "@rollup/rollup-linux-arm64-musl": "4.60.3",
-                "@rollup/rollup-linux-loong64-gnu": "4.60.3",
-                "@rollup/rollup-linux-loong64-musl": "4.60.3",
-                "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
-                "@rollup/rollup-linux-ppc64-musl": "4.60.3",
-                "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
-                "@rollup/rollup-linux-riscv64-musl": "4.60.3",
-                "@rollup/rollup-linux-s390x-gnu": "4.60.3",
-                "@rollup/rollup-linux-x64-gnu": "4.60.3",
-                "@rollup/rollup-linux-x64-musl": "4.60.3",
-                "@rollup/rollup-openbsd-x64": "4.60.3",
-                "@rollup/rollup-openharmony-arm64": "4.60.3",
-                "@rollup/rollup-win32-arm64-msvc": "4.60.3",
-                "@rollup/rollup-win32-ia32-msvc": "4.60.3",
-                "@rollup/rollup-win32-x64-gnu": "4.60.3",
-                "@rollup/rollup-win32-x64-msvc": "4.60.3",
+                "@rollup/rollup-android-arm-eabi": "4.60.4",
+                "@rollup/rollup-android-arm64": "4.60.4",
+                "@rollup/rollup-darwin-arm64": "4.60.4",
+                "@rollup/rollup-darwin-x64": "4.60.4",
+                "@rollup/rollup-freebsd-arm64": "4.60.4",
+                "@rollup/rollup-freebsd-x64": "4.60.4",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+                "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+                "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+                "@rollup/rollup-linux-arm64-musl": "4.60.4",
+                "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+                "@rollup/rollup-linux-loong64-musl": "4.60.4",
+                "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+                "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+                "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+                "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+                "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+                "@rollup/rollup-linux-x64-gnu": "4.60.4",
+                "@rollup/rollup-linux-x64-musl": "4.60.4",
+                "@rollup/rollup-openbsd-x64": "4.60.4",
+                "@rollup/rollup-openharmony-arm64": "4.60.4",
+                "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+                "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+                "@rollup/rollup-win32-x64-gnu": "4.60.4",
+                "@rollup/rollup-win32-x64-msvc": "4.60.4",
                 "fsevents": "~2.3.2"
             }
         },
@@ -9559,9 +9536,9 @@
             }
         },
         "node_modules/smob": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.1.tgz",
-            "integrity": "sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.2.tgz",
+            "integrity": "sha512-RQsvleCbF8cVHEv+xuDGaA4pOizFqJ0GgjtMSRo6oP8pnN7WsigHgVGey6aILRBKv4W2YOMHLqbKdnB6hpB9fw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9971,14 +9948,13 @@
             "license": "0BSD"
         },
         "node_modules/tsx": {
-            "version": "4.21.0",
-            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-            "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+            "version": "4.22.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
+            "integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "esbuild": "~0.27.0",
-                "get-tsconfig": "^4.7.5"
+                "esbuild": "~0.28.0"
             },
             "bin": {
                 "tsx": "dist/cli.mjs"
@@ -9988,490 +9964,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.3"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/android-arm": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/android-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openharmony"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/esbuild": {
-            "version": "0.27.7",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.7",
-                "@esbuild/android-arm": "0.27.7",
-                "@esbuild/android-arm64": "0.27.7",
-                "@esbuild/android-x64": "0.27.7",
-                "@esbuild/darwin-arm64": "0.27.7",
-                "@esbuild/darwin-x64": "0.27.7",
-                "@esbuild/freebsd-arm64": "0.27.7",
-                "@esbuild/freebsd-x64": "0.27.7",
-                "@esbuild/linux-arm": "0.27.7",
-                "@esbuild/linux-arm64": "0.27.7",
-                "@esbuild/linux-ia32": "0.27.7",
-                "@esbuild/linux-loong64": "0.27.7",
-                "@esbuild/linux-mips64el": "0.27.7",
-                "@esbuild/linux-ppc64": "0.27.7",
-                "@esbuild/linux-riscv64": "0.27.7",
-                "@esbuild/linux-s390x": "0.27.7",
-                "@esbuild/linux-x64": "0.27.7",
-                "@esbuild/netbsd-arm64": "0.27.7",
-                "@esbuild/netbsd-x64": "0.27.7",
-                "@esbuild/openbsd-arm64": "0.27.7",
-                "@esbuild/openbsd-x64": "0.27.7",
-                "@esbuild/openharmony-arm64": "0.27.7",
-                "@esbuild/sunos-x64": "0.27.7",
-                "@esbuild/win32-arm64": "0.27.7",
-                "@esbuild/win32-ia32": "0.27.7",
-                "@esbuild/win32-x64": "0.27.7"
             }
         },
         "node_modules/tsx/node_modules/fsevents": {
@@ -10523,17 +10015,34 @@
             }
         },
         "node_modules/type-is": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-            "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+            "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
             "license": "MIT",
             "dependencies": {
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "media-typer": "^1.1.0",
                 "mime-types": "^3.0.0"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/type-is/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/typedoc": {
@@ -10595,9 +10104,9 @@
             "license": "MIT"
         },
         "node_modules/undici-types": {
-            "version": "7.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-            "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+            "version": "7.24.6",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+            "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
             "dev": true,
             "license": "MIT"
         },
@@ -11130,7 +10639,7 @@
             "name": "@matter-server/custom-clusters",
             "version": "0.0.0-git",
             "dependencies": {
-                "@matter/main": "0.17.0-alpha.0-20260512-576f5796c"
+                "@matter/main": "0.17.0-alpha.0-20260515-6eb5f8476"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -11152,7 +10661,7 @@
             },
             "devDependencies": {
                 "@babel/preset-env": "^7.29.5",
-                "@matter/main": "0.17.0-alpha.0-20260512-576f5796c",
+                "@matter/main": "0.17.0-alpha.0-20260515-6eb5f8476",
                 "@rollup/plugin-babel": "^7.0.0",
                 "@rollup/plugin-commonjs": "^29.0.2",
                 "@rollup/plugin-json": "^6.1.0",
@@ -11170,14 +10679,14 @@
                 "@matter-server/custom-clusters": "*",
                 "@matter-server/dashboard": "*",
                 "@matter-server/ws-controller": "*",
-                "@matter/main": "0.17.0-alpha.0-20260512-576f5796c",
+                "@matter/main": "0.17.0-alpha.0-20260515-6eb5f8476",
                 "commander": "^14.0.3",
                 "express": "^5.2.1"
             },
             "devDependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/nodejs": "0.17.0-alpha.0-20260512-576f5796c",
-                "@matter/testing": "0.17.0-alpha.0-20260512-576f5796c",
+                "@matter/nodejs": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@matter/testing": "0.17.0-alpha.0-20260515-6eb5f8476",
                 "@types/express": "^5.0.6",
                 "@types/node": "^25.6.0"
             },
@@ -11190,7 +10699,7 @@
             "version": "0.0.0-git",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@matter/testing": "0.17.0-alpha.0-20260512-576f5796c",
+                "@matter/testing": "0.17.0-alpha.0-20260515-6eb5f8476",
                 "@types/node": "^25.6.0",
                 "@types/ws": "^8.18.1",
                 "ws": "^8.20.0"
@@ -11204,8 +10713,8 @@
             "version": "0.0.0-git",
             "dependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/main": "0.17.0-alpha.0-20260512-576f5796c",
-                "@project-chip/matter.js": "0.17.0-alpha.0-20260512-576f5796c",
+                "@matter/main": "0.17.0-alpha.0-20260515-6eb5f8476",
+                "@project-chip/matter.js": "0.17.0-alpha.0-20260515-6eb5f8476",
                 "ws": "^8.20.0"
             },
             "devDependencies": {
@@ -11216,7 +10725,7 @@
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.0-alpha.0-20260512-576f5796c"
+                "@matter/nodejs-ble": "0.17.0-alpha.0-20260515-6eb5f8476"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "python:build": "cd python_client && .venv/bin/pip install build && .venv/bin/python -m build"
     },
     "devDependencies": {
-        "@matter/testing": "0.17.0-alpha.0-20260512-576f5796c",
+        "@matter/testing": "0.17.0-alpha.0-20260515-6eb5f8476",
         "@nacho-iot/js-tools": "^0.1.7",
         "@types/mocha": "^10.0.10",
         "glob": "^13.0.6",

--- a/packages/custom-clusters/package.json
+++ b/packages/custom-clusters/package.json
@@ -33,7 +33,7 @@
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
     },
     "dependencies": {
-        "@matter/main": "0.17.0-alpha.0-20260512-576f5796c"
+        "@matter/main": "0.17.0-alpha.0-20260515-6eb5f8476"
     },
     "files": [
         "dist/**/*",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -42,7 +42,7 @@
     },
     "devDependencies": {
         "@babel/preset-env": "^7.29.5",
-        "@matter/main": "0.17.0-alpha.0-20260512-576f5796c",
+        "@matter/main": "0.17.0-alpha.0-20260515-6eb5f8476",
         "@rollup/plugin-babel": "^7.0.0",
         "@rollup/plugin-commonjs": "^29.0.2",
         "@rollup/plugin-json": "^6.1.0",

--- a/packages/dashboard/src/client/models/descriptions.ts
+++ b/packages/dashboard/src/client/models/descriptions.ts
@@ -16474,63 +16474,63 @@ export const clusters: Record<number, ClusterDescription> = {
                 "cluster_id": 2820,
                 "label": "RmsVoltage",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "1288": {
                 "id": 1288,
                 "cluster_id": 2820,
                 "label": "RmsCurrent",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "1291": {
                 "id": 1291,
                 "cluster_id": 2820,
                 "label": "ActivePower",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "1536": {
                 "id": 1536,
                 "cluster_id": 2820,
                 "label": "AcVoltageMultiplier",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "1537": {
                 "id": 1537,
                 "cluster_id": 2820,
                 "label": "AcVoltageDivisor",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "1538": {
                 "id": 1538,
                 "cluster_id": 2820,
                 "label": "AcCurrentMultiplier",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "1539": {
                 "id": 1539,
                 "cluster_id": 2820,
                 "label": "AcCurrentDivisor",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "1540": {
                 "id": 1540,
                 "cluster_id": 2820,
                 "label": "AcPowerMultiplier",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "1541": {
                 "id": 1541,
                 "cluster_id": 2820,
                 "label": "AcPowerDivisor",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "65528": {
                 "id": 65528,
@@ -16747,28 +16747,28 @@ export const clusters: Record<number, ClusterDescription> = {
                 "cluster_id": 302775297,
                 "label": "TamperAlarm",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "17": {
                 "id": 17,
                 "cluster_id": 302775297,
                 "label": "PreheatingState",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "18": {
                 "id": 18,
                 "cluster_id": 302775297,
                 "label": "NoDisturbingState",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "19": {
                 "id": 19,
                 "cluster_id": 302775297,
                 "label": "SensorType",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "20": {
                 "id": 20,
@@ -16964,28 +16964,28 @@ export const clusters: Record<number, ClusterDescription> = {
                 "cluster_id": 308149265,
                 "label": "WattAccumulated",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "308084770": {
                 "id": 308084770,
                 "cluster_id": 308149265,
                 "label": "Current",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "308084771": {
                 "id": 308084771,
                 "cluster_id": 308149265,
                 "label": "Watt",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "308084772": {
                 "id": 308084772,
                 "cluster_id": 308149265,
                 "label": "Voltage",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             }
         },
         "commands": {}
@@ -17041,7 +17041,7 @@ export const clusters: Record<number, ClusterDescription> = {
                 "cluster_id": 319486977,
                 "label": "GetConfig",
                 "type": "Optional[bytes]",
-                "writable": true
+                "writable": false
             },
             "319422465": {
                 "id": 319422465,
@@ -17055,84 +17055,84 @@ export const clusters: Record<number, ClusterDescription> = {
                 "cluster_id": 319486977,
                 "label": "LoggingMetadata",
                 "type": "Optional[bytes]",
-                "writable": true
+                "writable": false
             },
             "319422467": {
                 "id": 319422467,
                 "cluster_id": 319486977,
                 "label": "LoggingData",
                 "type": "Optional[bytes]",
-                "writable": true
+                "writable": false
             },
             "319422470": {
                 "id": 319422470,
                 "cluster_id": 319486977,
                 "label": "TimesOpened",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "319422471": {
                 "id": 319422471,
                 "cluster_id": 319486977,
                 "label": "LastEventTime",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "319422472": {
                 "id": 319422472,
                 "cluster_id": 319486977,
                 "label": "Voltage",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "319422473": {
                 "id": 319422473,
                 "cluster_id": 319486977,
                 "label": "Current",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "319422474": {
                 "id": 319422474,
                 "cluster_id": 319486977,
                 "label": "Watt",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "319422475": {
                 "id": 319422475,
                 "cluster_id": 319486977,
                 "label": "WattAccumulated",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "319422476": {
                 "id": 319422476,
                 "cluster_id": 319486977,
                 "label": "StatusFault",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "319422477": {
                 "id": 319422477,
                 "cluster_id": 319486977,
                 "label": "MotionSensitivity",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "319422478": {
                 "id": 319422478,
                 "cluster_id": 319486977,
                 "label": "WattAccumulatedControlPoint",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "319422480": {
                 "id": 319422480,
                 "cluster_id": 319486977,
                 "label": "ObstructionDetected",
                 "type": "Optional[bool]",
-                "writable": true
+                "writable": false
             },
             "319422481": {
                 "id": 319422481,
@@ -17146,42 +17146,42 @@ export const clusters: Record<number, ClusterDescription> = {
                 "cluster_id": 319486977,
                 "label": "Rloc16",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "319422483": {
                 "id": 319422483,
                 "cluster_id": 319486977,
                 "label": "Altitude",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "319422484": {
                 "id": 319422484,
                 "cluster_id": 319486977,
                 "label": "Pressure",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "319422485": {
                 "id": 319422485,
                 "cluster_id": 319486977,
                 "label": "WeatherTrend",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "319422487": {
                 "id": 319422487,
                 "cluster_id": 319486977,
                 "label": "WindowOpenMode",
                 "type": "Optional[bool]",
-                "writable": true
+                "writable": false
             },
             "319422488": {
                 "id": 319422488,
                 "cluster_id": 319486977,
                 "label": "ValvePosition",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             }
         },
         "commands": {}
@@ -17195,28 +17195,28 @@ export const clusters: Record<number, ClusterDescription> = {
                 "cluster_id": 319683586,
                 "label": "CurrentSummationDelivered",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "769": {
                 "id": 769,
                 "cluster_id": 319683586,
                 "label": "Multiplier",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "770": {
                 "id": 770,
                 "cluster_id": 319683586,
                 "label": "Divisor",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "1024": {
                 "id": 1024,
                 "cluster_id": 319683586,
                 "label": "InstantaneousDemand",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "65528": {
                 "id": 65528,
@@ -17286,35 +17286,35 @@ export const clusters: Record<number, ClusterDescription> = {
                 "cluster_id": 322239491,
                 "label": "CurrentHumidity",
                 "type": "Optional[unknown]",
-                "writable": true
+                "writable": false
             },
             "3": {
                 "id": 3,
                 "cluster_id": 322239491,
                 "label": "WaterBucketFull",
                 "type": "Optional[bool]",
-                "writable": true
+                "writable": false
             },
             "4": {
                 "id": 4,
                 "cluster_id": 322239491,
                 "label": "FilterAlert",
                 "type": "Optional[bool]",
-                "writable": true
+                "writable": false
             },
             "5": {
                 "id": 5,
                 "cluster_id": 322239491,
                 "label": "ErrorCodes",
                 "type": "Optional[string]",
-                "writable": true
+                "writable": false
             },
             "6": {
                 "id": 6,
                 "cluster_id": 322239491,
                 "label": "FeatureSet",
                 "type": "Optional[string]",
-                "writable": true
+                "writable": false
             },
             "65528": {
                 "id": 65528,

--- a/packages/matter-server/package.json
+++ b/packages/matter-server/package.json
@@ -34,7 +34,7 @@
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
     },
     "dependencies": {
-        "@matter/main": "0.17.0-alpha.0-20260512-576f5796c",
+        "@matter/main": "0.17.0-alpha.0-20260515-6eb5f8476",
         "@matter-server/ws-controller": "*",
         "@matter-server/dashboard": "*",
         "@matter-server/custom-clusters": "*",
@@ -44,8 +44,8 @@
     "devDependencies": {
         "@types/express": "^5.0.6",
         "@types/node": "^25.6.0",
-        "@matter/nodejs": "0.17.0-alpha.0-20260512-576f5796c",
-        "@matter/testing": "0.17.0-alpha.0-20260512-576f5796c",
+        "@matter/nodejs": "0.17.0-alpha.0-20260515-6eb5f8476",
+        "@matter/testing": "0.17.0-alpha.0-20260515-6eb5f8476",
         "@matter-server/ws-client": "*"
     },
     "files": [

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -37,7 +37,7 @@
     "devDependencies": {
         "@types/node": "^25.6.0",
         "@types/ws": "^8.18.1",
-        "@matter/testing": "0.17.0-alpha.0-20260512-576f5796c",
+        "@matter/testing": "0.17.0-alpha.0-20260515-6eb5f8476",
         "ws": "^8.20.0"
     },
     "files": [

--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -34,12 +34,12 @@
         "node": ">=20.19.0 <22.0.0 || >=22.13.0"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.0-alpha.0-20260512-576f5796c"
+        "@matter/nodejs-ble": "0.17.0-alpha.0-20260515-6eb5f8476"
     },
     "dependencies": {
-        "@matter/main": "0.17.0-alpha.0-20260512-576f5796c",
+        "@matter/main": "0.17.0-alpha.0-20260515-6eb5f8476",
         "@matter-server/ws-client": "*",
-        "@project-chip/matter.js": "0.17.0-alpha.0-20260512-576f5796c",
+        "@project-chip/matter.js": "0.17.0-alpha.0-20260515-6eb5f8476",
         "ws": "^8.20.0"
     },
     "devDependencies": {

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -101,7 +101,7 @@ import { Nodes } from "./Nodes.js";
 
 const logger = Logger.get("ControllerCommandHandler");
 
-/** After this duration in Reconnecting state, declare the node unavailable */
+/** Grace period after leaving Connected before a node is declared unavailable. */
 const RECONNECT_TIMEOUT = Minutes(3);
 
 /**
@@ -298,16 +298,12 @@ export class ControllerCommandHandler {
         const node = await this.#controller.getNode(nodeId);
         const attributeCache = this.#nodes.attributeCache;
 
-        // Wire all Events to the Event emitters
-        // Track if a BasicInformation or BridgedDeviceBasicInformation attribute changed during
-        // a subscription batch. When the batch ends (connectionAlive), emit a full node_updated.
+        // Defer the full node_updated until the subscription batch ends (connectionAlive)
+        // so consumers see one update per batch rather than one per attribute.
         let basicInfoChangedInBatch = false;
         node.events.attributeChanged.on(data => {
-            // Update the attribute cache with the new value in WebSocket format
             attributeCache.updateAttribute(nodeId, data);
-            // Then emit the event for listeners
             this.events.attributeChanged.emit(nodeId, data);
-            // Mark for full node_updated if any BasicInformation cluster attribute changed
             if (FULL_UPDATE_CLUSTER_IDS.has(data.path.clusterId)) {
                 basicInfoChangedInBatch = true;
             }
@@ -321,7 +317,6 @@ export class ControllerCommandHandler {
         });
         node.events.eventTriggered.on(data => this.events.eventChanged.emit(nodeId, data));
         node.events.stateChanged.on(state => {
-            // Only refresh cache on Connected state
             if (state === NodeStates.Connected) {
                 attributeCache.update(node);
                 const attributes = attributeCache.get(nodeId);
@@ -330,35 +325,35 @@ export class ControllerCommandHandler {
                 }
             }
 
-            // Manage reconnect timer
-            if (state === NodeStates.Reconnecting) {
-                if (!this.#reconnectTimers.has(nodeId)) {
-                    const timer = Time.getTimer(`reconnect-timeout-${nodeId}`, RECONNECT_TIMEOUT, () => {
-                        this.#reconnectTimers.delete(nodeId);
-                        if (this.#nodes.forceUnavailable(nodeId)) {
-                            logger.info(
-                                `Node ${this.formatNode(nodeId)} still reconnecting after timeout, marking unavailable`,
-                            );
-                            this.events.nodeAvailabilityChanged.emit(nodeId, false);
-                        }
-                    });
-                    timer.utility = true;
-                    timer.start();
-                    this.#reconnectTimers.set(nodeId, timer);
-                }
-            } else {
-                // Any non-Reconnecting state clears the timer
+            // Arm on Connected->Reconnecting only; keep running across later
+            // non-Connected states; cancel on return to Connected.
+            if (state === NodeStates.Connected) {
                 this.#reconnectTimers.get(nodeId)?.stop();
                 this.#reconnectTimers.delete(nodeId);
+            } else if (
+                state === NodeStates.Reconnecting &&
+                !this.#reconnectTimers.has(nodeId) &&
+                this.#nodes.isAvailable(nodeId)
+            ) {
+                const timer = Time.getTimer(`reconnect-timeout-${nodeId}`, RECONNECT_TIMEOUT, () => {
+                    this.#reconnectTimers.delete(nodeId);
+                    if (this.#nodes.forceUnavailable(nodeId)) {
+                        logger.info(
+                            `Node ${this.formatNode(nodeId)} still reconnecting after timeout, marking unavailable`,
+                        );
+                        this.events.nodeAvailabilityChanged.emit(nodeId, false);
+                    }
+                });
+                timer.utility = true;
+                timer.start();
+                this.#reconnectTimers.set(nodeId, timer);
             }
 
-            // Process state change and check if availability changed
-            const result = this.#nodes.processStateChange(nodeId, state);
+            const debouncePending = this.#reconnectTimers.has(nodeId);
+            const result = this.#nodes.processStateChange(nodeId, state, debouncePending);
 
-            // Emit state changed event
             this.events.nodeStateChanged.emit(nodeId, state);
 
-            // Emit availability changed if it actually changed
             if (result.availabilityChanged) {
                 logger.info(
                     `Node ${this.formatNode(nodeId)} availability changed to ${result.available} (state: ${NodeStates[state]})`,
@@ -367,13 +362,10 @@ export class ControllerCommandHandler {
             }
         });
         node.events.structureChanged.on(() => {
-            // Structure changed means endpoints may have been added/removed, refresh cache
             if (node.isConnected) {
                 attributeCache.update(node);
             }
             basicInfoChangedInBatch = false;
-            // Emit node_updated first so consumers see the new endpoint in node.endpoints,
-            // then drain any endpoint_added events queued since the previous structure change.
             this.events.nodeStructureChanged.emit(nodeId);
             for (const endpointId of this.#nodes.drainPendingEndpointAdds(nodeId)) {
                 this.events.nodeEndpointAdded.emit(nodeId, endpointId);
@@ -386,15 +378,12 @@ export class ControllerCommandHandler {
         node.events.nodeEndpointAdded.on(endpointId => this.#nodes.queueEndpointAdded(nodeId, endpointId));
         node.events.nodeEndpointRemoved.on(endpointId => this.events.nodeEndpointRemoved.emit(nodeId, endpointId));
 
-        // Store the node for direct access
         this.#nodes.set(nodeId, node);
 
         this.#nodes.seedState(nodeId, node.connectionState);
 
-        // Initialize attribute cache if node is already initialized
         if (node.initialized) {
             attributeCache.add(node);
-            // Register for custom cluster polling (e.g., Eve energy)
             const attributes = attributeCache.get(nodeId);
             if (attributes) {
                 this.#customClusterPoller.registerNode(this.#peerOf(nodeId), attributes);

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -339,7 +339,7 @@ export class ControllerCommandHandler {
                     this.#reconnectTimers.delete(nodeId);
                     if (this.#nodes.forceUnavailable(nodeId)) {
                         logger.info(
-                            `Node ${this.formatNode(nodeId)} still reconnecting after timeout, marking unavailable`,
+                            `Node ${this.formatNode(nodeId)} offline grace period expired, marking unavailable`,
                         );
                         this.events.nodeAvailabilityChanged.emit(nodeId, false);
                     }

--- a/packages/ws-controller/src/controller/Nodes.ts
+++ b/packages/ws-controller/src/controller/Nodes.ts
@@ -22,36 +22,24 @@ import { AttributeDataCache } from "./AttributeDataCache.js";
 export class Nodes {
     #nodes = new Map<NodeId, PairedNode>();
     #attributeCache = new AttributeDataCache();
-    /** Track previous connection state for availability debouncing */
-    #previousStates = new Map<NodeId, NodeStates>();
-    /** Cached availability so serialization and event paths always agree */
+    /** Cached so serialization and event paths always agree on availability. */
     #lastAvailability = new Map<NodeId, boolean>();
     /**
-     * Endpoint additions queued until the next nodeStructureChanged for that node.
-     * Preserves the wire contract used by python-matter-server: endpoint_added must
-     * arrive AFTER a node_updated that already carries the new endpoint, so consumers
-     * (e.g., Home Assistant) can resolve node.endpoints[endpoint_id] in their callback.
+     * Buffered endpoint_added events. python-matter-server wire contract requires
+     * node_updated (carrying the new endpoint) to arrive before endpoint_added,
+     * so HA can resolve node.endpoints[endpoint_id] in its callback.
      */
     #pendingEndpointAdds = new Map<NodeId, EndpointNumber[]>();
 
-    /**
-     * Get the attribute cache instance.
-     */
     get attributeCache(): AttributeDataCache {
         return this.#attributeCache;
     }
 
-    /**
-     * Get all node IDs.
-     */
     getIds(): NodeId[] {
         return Array.from(this.#nodes.keys());
     }
 
-    /**
-     * Get a node by ID.
-     * @throws ServerError if node not found
-     */
+    /** @throws ServerError if node not found */
     get(nodeId: NodeId): PairedNode {
         const node = this.#nodes.get(nodeId);
         if (node === undefined) {
@@ -60,34 +48,21 @@ export class Nodes {
         return node;
     }
 
-    /**
-     * Check if a node exists.
-     */
     has(nodeId: NodeId): boolean {
         return this.#nodes.has(nodeId);
     }
 
-    /**
-     * Add or update a node in storage.
-     */
     set(nodeId: NodeId, node: PairedNode): void {
         this.#nodes.set(nodeId, node);
     }
 
-    /**
-     * Remove a node from storage and clear its attribute cache and state tracking.
-     */
     delete(nodeId: NodeId): void {
         this.#nodes.delete(nodeId);
         this.#attributeCache.delete(nodeId);
-        this.#previousStates.delete(nodeId);
         this.#lastAvailability.delete(nodeId);
         this.#pendingEndpointAdds.delete(nodeId);
     }
 
-    /**
-     * Buffer an endpoint_added until the next nodeStructureChanged for that node.
-     */
     queueEndpointAdded(nodeId: NodeId, endpointId: EndpointNumber): void {
         let queue = this.#pendingEndpointAdds.get(nodeId);
         if (queue === undefined) {
@@ -97,10 +72,7 @@ export class Nodes {
         queue.push(endpointId);
     }
 
-    /**
-     * Take ownership of buffered endpoint additions for a node and clear the queue.
-     * Returned array is in insertion order; an empty array is returned if nothing is queued.
-     */
+    /** Returns insertion-ordered queue; empty if nothing pending. */
     drainPendingEndpointAdds(nodeId: NodeId): EndpointNumber[] {
         const queue = this.#pendingEndpointAdds.get(nodeId);
         if (queue === undefined || queue.length === 0) {
@@ -110,30 +82,19 @@ export class Nodes {
         return queue;
     }
 
-    /**
-     * Initialize state tracking for a newly paired/discovered node.
-     * Sets previous state and initial availability so the first stateChanged event
-     * has a real previous state instead of undefined.
-     */
     seedState(nodeId: NodeId, initialState: NodeStates): void {
-        this.#previousStates.set(nodeId, initialState);
         this.#lastAvailability.set(nodeId, initialState === NodeStates.Connected);
     }
 
-    /**
-     * Process a state change for a node. Reads previous state BEFORE updating,
-     * computes new availability, and updates both tracking maps atomically.
-     * Returns whether availability changed and the new value.
-     */
+    /** `debouncePending` = reconnect timer armed by caller; keeps non-Connected states available. */
     processStateChange(
         nodeId: NodeId,
         newState: NodeStates,
+        debouncePending: boolean,
     ): { availabilityChanged: true; available: boolean } | { availabilityChanged: false } {
-        const previousState = this.#previousStates.get(nodeId);
         const wasAvailable = this.#lastAvailability.get(nodeId) ?? false;
-        const available = this.isNodeAvailable(newState, previousState);
+        const available = this.isNodeAvailable(newState, debouncePending);
 
-        this.#previousStates.set(nodeId, newState);
         this.#lastAvailability.set(nodeId, available);
 
         if (wasAvailable !== available) {
@@ -142,47 +103,21 @@ export class Nodes {
         return { availabilityChanged: false };
     }
 
-    /**
-     * Force a node to unavailable state. Used by reconnect timeout
-     * when debounce period expires without reconnection.
-     * Only updates #lastAvailability — #previousStates is left as-is because
-     * processStateChange() will overwrite it on the next real state transition.
-     * Returns true if the node was previously considered available.
-     */
+    /** Returns true if the node was previously considered available. */
     forceUnavailable(nodeId: NodeId): boolean {
         const wasAvailable = this.#lastAvailability.get(nodeId) ?? false;
         this.#lastAvailability.set(nodeId, false);
         return wasAvailable;
     }
 
-    /**
-     * Determine if a node should be considered available based on its connection state.
-     * Uses debouncing logic similar to Python Matter Server:
-     * - Connected: available
-     * - Reconnecting when previously Connected: still available (debouncing)
-     * - WaitingForDeviceDiscovery or Disconnected: unavailable
-     *
-     * @param currentState Current connection state
-     * @param previousState Previous connection state (undefined if first state change)
-     * @returns true if node should be considered available
-     */
-    isNodeAvailable(currentState: NodeStates, previousState?: NodeStates): boolean {
+    isNodeAvailable(currentState: NodeStates, debouncePending = false): boolean {
         if (currentState === NodeStates.Connected) {
             return true;
         }
-        // Debounce: if transitioning from Connected to Reconnecting, still consider available
-        if (currentState === NodeStates.Reconnecting && previousState === NodeStates.Connected) {
-            return true;
-        }
-        // WaitingForDeviceDiscovery, Disconnected, or Reconnecting from non-connected state
-        return false;
+        return debouncePending;
     }
 
-    /**
-     * Check if a node is available. Returns the cached availability value set by
-     * seedState/processStateChange/forceUnavailable, avoiding the race where
-     * recomputing from live state disagrees with the event path's determination.
-     */
+    /** Returns the cached value, not a recomputation — avoids disagreement with the event path. */
     isAvailable(nodeId: NodeId): boolean {
         return this.#lastAvailability.get(nodeId) ?? false;
     }

--- a/packages/ws-controller/test/NodesTest.ts
+++ b/packages/ws-controller/test/NodesTest.ts
@@ -20,33 +20,35 @@ describe("Nodes", () => {
             nodes = new Nodes();
         });
 
-        it("returns true when Connected", () => {
+        it("returns true when Connected (no debounce)", () => {
             expect(nodes.isNodeAvailable(NodeStates.Connected)).to.equal(true);
         });
 
-        it("returns true when Reconnecting from Connected (debounce)", () => {
-            expect(nodes.isNodeAvailable(NodeStates.Reconnecting, NodeStates.Connected)).to.equal(true);
+        it("returns true when Connected even if debounce pending", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Connected, true)).to.equal(true);
         });
 
-        it("returns false when Reconnecting from WaitingForDeviceDiscovery", () => {
-            expect(nodes.isNodeAvailable(NodeStates.Reconnecting, NodeStates.WaitingForDeviceDiscovery)).to.equal(
-                false,
-            );
+        it("returns true when Reconnecting with debounce pending", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Reconnecting, true)).to.equal(true);
         });
 
-        it("returns false when Reconnecting with no previous state", () => {
+        it("returns true when WaitingForDeviceDiscovery with debounce pending", () => {
+            expect(nodes.isNodeAvailable(NodeStates.WaitingForDeviceDiscovery, true)).to.equal(true);
+        });
+
+        it("returns true when Disconnected with debounce pending", () => {
+            expect(nodes.isNodeAvailable(NodeStates.Disconnected, true)).to.equal(true);
+        });
+
+        it("returns false when Reconnecting without debounce", () => {
             expect(nodes.isNodeAvailable(NodeStates.Reconnecting)).to.equal(false);
         });
 
-        it("returns false when Disconnected", () => {
+        it("returns false when Disconnected without debounce", () => {
             expect(nodes.isNodeAvailable(NodeStates.Disconnected)).to.equal(false);
         });
 
-        it("returns false when Disconnected even if previously Connected", () => {
-            expect(nodes.isNodeAvailable(NodeStates.Disconnected, NodeStates.Connected)).to.equal(false);
-        });
-
-        it("returns false when WaitingForDeviceDiscovery", () => {
+        it("returns false when WaitingForDeviceDiscovery without debounce", () => {
             expect(nodes.isNodeAvailable(NodeStates.WaitingForDeviceDiscovery)).to.equal(false);
         });
     });
@@ -58,18 +60,18 @@ describe("Nodes", () => {
             nodes = new Nodes();
         });
 
-        it("reports unavailable when Connected -> Disconnected", () => {
+        it("reports unavailable when Connected -> Disconnected (no debounce)", () => {
             nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
-            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Disconnected);
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Disconnected, false);
             expect(result.availabilityChanged).to.equal(true);
             if (result.availabilityChanged) {
                 expect(result.available).to.equal(false);
             }
         });
 
-        it("reports unavailable when Connected -> WaitingForDeviceDiscovery", () => {
+        it("reports unavailable when Connected -> WaitingForDeviceDiscovery (no debounce)", () => {
             nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
-            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.WaitingForDeviceDiscovery);
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.WaitingForDeviceDiscovery, false);
             expect(result.availabilityChanged).to.equal(true);
             if (result.availabilityChanged) {
                 expect(result.available).to.equal(false);
@@ -78,54 +80,90 @@ describe("Nodes", () => {
 
         it("reports available when Disconnected -> Connected", () => {
             nodes.seedState(TEST_NODE_ID, NodeStates.Disconnected);
-            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Connected);
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Connected, false);
             expect(result.availabilityChanged).to.equal(true);
             if (result.availabilityChanged) {
                 expect(result.available).to.equal(true);
             }
         });
 
-        it("does NOT report change when Connected -> Reconnecting (debounce)", () => {
+        it("does NOT report change when Connected -> Reconnecting with debounce pending", () => {
             nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
-            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting);
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting, true);
             expect(result.availabilityChanged).to.equal(false);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
+        });
+
+        it("does NOT report change when Reconnecting -> WaitingForDeviceDiscovery with debounce pending", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+            nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting, true);
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.WaitingForDeviceDiscovery, true);
+            expect(result.availabilityChanged).to.equal(false);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
         });
 
         it("does NOT report change when unavailable -> another unavailable", () => {
             nodes.seedState(TEST_NODE_ID, NodeStates.Disconnected);
-            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.WaitingForDeviceDiscovery);
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.WaitingForDeviceDiscovery, false);
             expect(result.availabilityChanged).to.equal(false);
         });
 
         it("reports available on Connected for unseeded node", () => {
-            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Connected);
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Connected, false);
             expect(result.availabilityChanged).to.equal(true);
             if (result.availabilityChanged) {
                 expect(result.available).to.equal(true);
             }
         });
 
-        it("handles full lifecycle: Connected -> Reconnecting -> Disconnected -> Connected", () => {
+        it("Connected -> Reconnecting -> WaitingForDeviceDiscovery stays available while timer armed", () => {
             nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
 
-            // Connected -> Reconnecting: debounced, still available, no change
-            const r1 = nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting);
+            // Connected -> Reconnecting: timer armed, debounced, still available
+            const r1 = nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting, true);
             expect(r1.availabilityChanged).to.equal(false);
             expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
 
-            // Reconnecting -> Disconnected: now unavailable
-            const r2 = nodes.processStateChange(TEST_NODE_ID, NodeStates.Disconnected);
-            expect(r2.availabilityChanged).to.equal(true);
-            if (r2.availabilityChanged) {
-                expect(r2.available).to.equal(false);
-            }
+            // Reconnecting -> WaitingForDeviceDiscovery (timer still armed): still available
+            const r2 = nodes.processStateChange(TEST_NODE_ID, NodeStates.WaitingForDeviceDiscovery, true);
+            expect(r2.availabilityChanged).to.equal(false);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
 
-            // Disconnected -> Connected: available again
-            const r3 = nodes.processStateChange(TEST_NODE_ID, NodeStates.Connected);
-            expect(r3.availabilityChanged).to.equal(true);
-            if (r3.availabilityChanged) {
-                expect(r3.available).to.equal(true);
-            }
+            // WaitingForDeviceDiscovery -> Connected: timer cleared, stays available
+            const r3 = nodes.processStateChange(TEST_NODE_ID, NodeStates.Connected, false);
+            expect(r3.availabilityChanged).to.equal(false);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
+        });
+
+        it("emits offline when debounce drops while still non-Connected", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+            nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting, true);
+
+            // Timer expiry simulated by forceUnavailable, then next state change has debouncePending=false
+            nodes.forceUnavailable(TEST_NODE_ID);
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.WaitingForDeviceDiscovery, false);
+            // wasAvailable already false (forceUnavailable) -> no further change
+            expect(result.availabilityChanged).to.equal(false);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(false);
+        });
+
+        it("full lifecycle: Connected -> Reconnecting -> Disconnected -> Connected", () => {
+            nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
+
+            // Connected -> Reconnecting: timer armed, no change
+            const r1 = nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting, true);
+            expect(r1.availabilityChanged).to.equal(false);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
+
+            // Reconnecting -> Disconnected with debounce still pending: no change
+            const r2 = nodes.processStateChange(TEST_NODE_ID, NodeStates.Disconnected, true);
+            expect(r2.availabilityChanged).to.equal(false);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
+
+            // Disconnected -> Connected: timer cleared, stays available
+            const r3 = nodes.processStateChange(TEST_NODE_ID, NodeStates.Connected, false);
+            expect(r3.availabilityChanged).to.equal(false);
+            expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
         });
     });
 
@@ -172,13 +210,12 @@ describe("Nodes", () => {
             nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
             expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
 
-            // Transition to Reconnecting - debounced, still available
-            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting);
+            // Transition to Reconnecting with debounce armed: still available
+            const result = nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting, true);
             expect(result.availabilityChanged).to.equal(false);
 
-            // The core bug fix: isAvailable returns the CACHED value (true)
-            // rather than recomputing from live state (Reconnecting without
-            // previous-state context would give false)
+            // isAvailable returns the CACHED debounced value without needing
+            // to know the live debounce state.
             expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
         });
 

--- a/packages/ws-controller/test/NodesTest.ts
+++ b/packages/ws-controller/test/NodesTest.ts
@@ -135,7 +135,7 @@ describe("Nodes", () => {
             expect(nodes.isAvailable(TEST_NODE_ID)).to.equal(true);
         });
 
-        it("emits offline when debounce drops while still non-Connected", () => {
+        it("stays unavailable across non-Connected state changes after forceUnavailable", () => {
             nodes.seedState(TEST_NODE_ID, NodeStates.Connected);
             nodes.processStateChange(TEST_NODE_ID, NodeStates.Reconnecting, true);
 


### PR DESCRIPTION
## Summary
- Reconnect-offline debounce timer was tied to `NodeStates.Reconnecting` only. matter.js transitions `Connected -> Reconnecting -> WaitingForDeviceDiscovery` rapidly on subscription timeout, clearing the timer and emitting `availability=false` within ~1s instead of after the 3-minute grace.
- Arm timer on `Connected -> Reconnecting` only (gated by current availability), keep it running across any subsequent non-Connected state, cancel only on return to `Connected`.
- `processStateChange` / `isNodeAvailable` now take an explicit `debouncePending` flag owned by the timer; removed `#previousStates` map.
- Also pulls in `@matter/*` bump to `20260515-6eb5f8476` and regenerated dashboard cluster descriptions.

Addresses #646.

🤖 Generated with [Claude Code](https://claude.com/claude-code)