### PR TITLE
fix(dashboard): keep Matter NodeIds as number | bigint across camera UI

### DIFF
--- a/packages/dashboard/src/components/avsum-ptz-strip.ts
+++ b/packages/dashboard/src/components/avsum-ptz-strip.ts
@@ -32,7 +32,7 @@ export class AvsumPtzStrip extends LitElement {
     @property({ attribute: false })
     client?: MatterClient;
 
-    @property({ type: Number }) nodeId!: number;
+    @property({ attribute: false }) nodeId!: number | bigint;
     @property({ type: Number }) endpointId!: number;
     /** Active VideoStreamID for DPTZ moves; required when DPTZ is selected mode. */
     @property({ type: Number, attribute: false }) activeVideoStreamId: number | null = null;

--- a/packages/dashboard/src/components/webrtc-stream-view.ts
+++ b/packages/dashboard/src/components/webrtc-stream-view.ts
@@ -143,7 +143,7 @@ export class WebRtcStreamView extends LitElement {
     @property({ attribute: false })
     client?: MatterClient;
 
-    @property({ type: Number }) nodeId!: number;
+    @property({ attribute: false }) nodeId!: number | bigint;
     @property({ type: Number }) endpointId!: number;
     @property({ type: Object }) resolution: { width: number; height: number } | null = null;
 
@@ -544,7 +544,7 @@ export class WebRtcStreamView extends LitElement {
             mySessionId: this._webRtcSessionId,
         });
         if (this._webRtcSessionId === null) {
-            if (Number(data.node_id) === Number(this.nodeId) && data.endpoint_id === this.endpointId) {
+            if (String(data.node_id) === String(this.nodeId) && data.endpoint_id === this.endpointId) {
                 this._preSessionQueue.push(data);
                 console.log("[webrtc-stream-view] queued pre-session callback");
             } else {
@@ -556,7 +556,7 @@ export class WebRtcStreamView extends LitElement {
             console.log("[webrtc-stream-view] dropped: session id mismatch");
             return;
         }
-        if (Number(data.node_id) !== Number(this.nodeId)) {
+        if (String(data.node_id) !== String(this.nodeId)) {
             console.log("[webrtc-stream-view] dropped: node id mismatch");
             return;
         }

--- a/packages/dashboard/src/pages/camera-overlay.ts
+++ b/packages/dashboard/src/pages/camera-overlay.ts
@@ -43,7 +43,7 @@ export class CameraOverlay extends LitElement {
     @property({ attribute: false })
     client?: MatterClient;
 
-    @property({ type: Number }) nodeId!: number;
+    @property({ attribute: false }) nodeId!: number | bigint;
     @property({ type: Number }) endpointId!: number;
 
     @state() private _state: StreamState = "idle";

--- a/packages/dashboard/src/pages/components/node-details.ts
+++ b/packages/dashboard/src/pages/components/node-details.ts
@@ -221,7 +221,7 @@ export class NodeDetails extends LitElement {
 
     private _openCameraOverlay(): void {
         const overlay = document.createElement("camera-overlay");
-        overlay.nodeId = Number(this.node!.node_id);
+        overlay.nodeId = this.node!.node_id;
         overlay.endpointId = this.endpoint;
         const root = document.querySelector("matter-dashboard-app");
         if (root) {


### PR DESCRIPTION
## Summary

- Addresses post-merge review on #644 (Copilot, 4 comments + 3 suppressed): every camera-UI component declared `nodeId` as `number` and `node-details` cast via `Number(this.node.node_id)`. Matter NodeIds are 64-bit and `MatterNode.node_id` / `MatterClient.deviceCommand` are already typed `number | bigint` throughout the rest of the codebase — only the dashboard camera surfaces were narrowing.
- `camera-overlay`, `avsum-ptz-strip`, `webrtc-stream-view`: `@property({ type: Number }) nodeId!: number` → `@property({ attribute: false }) nodeId!: number | bigint`.
- `node-details._openCameraOverlay`: drop the `Number(...)` cast, pass `node.node_id` straight through.
- `webrtc-stream-view`: switch `Number(data.node_id) === Number(this.nodeId)` callback-routing comparisons to `String(a) === String(b)`, matching the bigint-safe pattern already used in `chime-commands`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)