### PR TITLE
chore(dashboard): tighten context publish order + replace as-any cast

### DIFF
--- a/packages/dashboard/src/pages/components/header.ts
+++ b/packages/dashboard/src/pages/components/header.ts
@@ -72,9 +72,7 @@ export class DashboardHeader extends LitElement {
     }
 
     private _openSettings() {
-        if (this.client) {
-            showSettingsDialog();
-        }
+        showSettingsDialog();
     }
 
     private _getThemeIcon(): string {

--- a/packages/dashboard/src/pages/matter-cluster-view.ts
+++ b/packages/dashboard/src/pages/matter-cluster-view.ts
@@ -27,7 +27,7 @@ import "../pages/components/node-details";
 import { DevModeService } from "../util/dev-mode-service.js";
 import { formatHex, formatNodeAddress, getEffectiveFabricIndex } from "../util/format_hex.js";
 import { notFoundStyles } from "../util/shared-styles.js";
-import { getClusterCommandsTag } from "./cluster-commands/index.js";
+import { BaseClusterCommands, getClusterCommandsTag } from "./cluster-commands/index.js";
 import { bindingContext } from "./components/context.js";
 
 declare global {
@@ -377,9 +377,9 @@ class MatterClusterView extends LitElement {
 
         // After render, find and configure the cluster commands component
         const container = this.shadowRoot?.getElementById("cluster-commands-container");
-        if (container) {
-            const commandsElement = container.firstElementChild as any;
-            if (commandsElement && this.node) {
+        if (container && this.node && this.endpoint !== undefined && this.cluster !== undefined) {
+            const commandsElement = container.firstElementChild;
+            if (commandsElement instanceof BaseClusterCommands) {
                 commandsElement.node = this.node;
                 commandsElement.endpoint = this.endpoint;
                 commandsElement.cluster = this.cluster;

--- a/packages/dashboard/src/pages/matter-dashboard-app.ts
+++ b/packages/dashboard/src/pages/matter-dashboard-app.ts
@@ -109,9 +109,10 @@ class MatterDashboardApp extends LitElement {
     private _connect() {
         this.client.startListening().then(
             () => {
-                this._state = "connected";
+                // Publish context before flipping state so the connected render sees a defined client.
                 this.clientProvider.setValue(this.client);
                 this.tickProvider.setValue(++this._tick);
+                this._state = "connected";
                 this._setupEventListeners();
             },
             (_err: MatterError) => {

--- a/packages/dashboard/src/pages/matter-network-view.ts
+++ b/packages/dashboard/src/pages/matter-network-view.ts
@@ -9,7 +9,7 @@ import type { MatterClient, MatterNode } from "@matter-server/ws-client";
 import { mdiEyeOff, mdiFitToScreen, mdiMagnifyMinus, mdiMagnifyPlus, mdiPause, mdiPlay } from "@mdi/js";
 import { css, html, LitElement } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
-import { clientContext, tickContext } from "../client/client-context.js";
+import { clientContext } from "../client/client-context.js";
 import "../components/ha-svg-icon";
 import { reducedMotionStyles } from "../util/shared-styles.js";
 import "./components/footer";
@@ -42,9 +42,6 @@ const HIDE_OPTIONS: readonly { key: HideOptionKey; label: string }[] = [
 class MatterNetworkView extends LitElement {
     @consume({ context: clientContext })
     public client!: MatterClient;
-
-    @consume({ context: tickContext, subscribe: true })
-    protected _tick = 0;
 
     @property({ type: Object })
     public nodes: Record<string, MatterNode> = {};


### PR DESCRIPTION
## Summary

Follow-up cleanups after PR #599 (Lit-context-based `MatterClient` access).

- **matter-dashboard-app**: publish `clientContext` / `tickContext` before flipping `_state = "connected"`. Today the synchronous order doesn't matter (Lit batches state-driven re-render into a microtask, so both `setValue` calls land first), but a future refactor that introduces an `await` between the state flip and the publish would leave consumers with `client === undefined` on first render. One-line WHY comment captures the invariant.
- **matter-network-view**: drop the redundant `tickContext` subscription. The file's only `this.client` access is `BorderRouterStore.refresh(this.client)` (one-shot, non-reactive); reactive UI data flows in via the parent-passed `.nodes` prop, and the parent already calls `requestUpdate()` on `nodes_changed`. Subscription was pure noise.
- **header**: drop the duplicative `if (this.client)` guard in `_openSettings`. Both click sites (dev badge, settings icon) are render-gated by `${this.client ? … : nothing}`, so the runtime guard never fires meaningfully. `showSettingsDialog()` takes no args.
- **matter-cluster-view**: replace `as any` cast on the dynamically-created cluster-commands element with `instanceof BaseClusterCommands` narrowing. CLAUDE.md flags `as any` as a red. The guard is widened to also assert `node` / `endpoint` / `cluster` are defined, matching the render-time precondition (the container is only rendered when all three are known).

## Follow-up (tracked, not in this PR)

- Surface dashboard cluster command failures in the UI (`base-cluster-commands.ts` `sendCommand` currently catches errors and only `console.error`s). Needs UX design + Matter IM status-code mapping.
- Audit dashboard for remaining `as any` casts and replace with typed narrowing.