### PR TITLE
chore(ws-controller): use @matter/main version export

### DIFF
--- a/packages/ws-controller/src/util/matterVersion.ts
+++ b/packages/ws-controller/src/util/matterVersion.ts
@@ -4,42 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * Utility to get the Matter.js SDK version from @matter/main package.
- */
-
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-
-interface PackageJson {
-    version: string;
-}
-
-/**
- * Get the version of the @matter/main package.
- */
-export function getMatterVersion(): string {
-    // Use import.meta.resolve for ESM-native module resolution
-    const matterMainUrl = import.meta.resolve("@matter/main");
-    const matterMainPath = fileURLToPath(matterMainUrl);
-    // Navigate up from the resolved module to find package.json
-    let dir = dirname(matterMainPath);
-    while (dir !== "/") {
-        try {
-            const packageJsonPath = join(dir, "package.json");
-            const content = readFileSync(packageJsonPath, "utf-8");
-            const pkg = JSON.parse(content) as PackageJson & { name?: string };
-            if (pkg.name === "@matter/main") {
-                return pkg.version;
-            }
-        } catch {
-            // Continue searching
-        }
-        dir = dirname(dir);
-    }
-    throw new Error("Could not find @matter/main package.json");
-}
+import { version } from "@matter/main";
 
 /** Cached Matter.js SDK version */
-export const MATTER_VERSION = getMatterVersion();
+export const MATTER_VERSION = version;


### PR DESCRIPTION
## Summary
- Replace custom package.json walk in `getMatterVersion()` with the `version` export now provided by `@matter/main`.
- Drops `readFileSync` / `import.meta.resolve` / `fileURLToPath` plumbing — `matterVersion.ts` is now two lines.
- `MATTER_VERSION` export preserved; all 7 callsites untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)