### PR TITLE
fix(docker): healthcheck honours LISTEN_ADDRESS / PORT

### DIFF
--- a/docker/matterjs-server/Dockerfile
+++ b/docker/matterjs-server/Dockerfile
@@ -77,9 +77,13 @@ VOLUME ["/data"]
 # WebSocket API port
 EXPOSE 5580
 
+# Healthcheck script honours LISTEN_ADDRESS / PORT so it still works when the
+# server is bound to a non-localhost address. See script for limitations.
+COPY --chmod=0755 healthcheck.sh /usr/local/bin/healthcheck.sh
+
 # Health check - verify the server is responding
 HEALTHCHECK --interval=60s --timeout=10s --start-period=30s --start-interval=5s --retries=3 \
-    CMD curl -f http://localhost:5580/health || exit 1
+    CMD ["/usr/local/bin/healthcheck.sh"]
 
 # Run the matter server directly (all config via environment variables)
 USER 1000:1000

--- a/docker/matterjs-server/Dockerfile.dev
+++ b/docker/matterjs-server/Dockerfile.dev
@@ -45,9 +45,13 @@ VOLUME ["/data"]
 # WebSocket API port
 EXPOSE 5580
 
+# Healthcheck script honours LISTEN_ADDRESS / PORT so it still works when the
+# server is bound to a non-localhost address. See script for limitations.
+COPY --chmod=0755 docker/matterjs-server/healthcheck.sh /usr/local/bin/healthcheck.sh
+
 # Health check - verify the server is responding
 HEALTHCHECK --interval=60s --timeout=10s --start-period=30s --start-interval=5s --retries=3 \
-    CMD curl -f http://localhost:5580/ || exit 1
+    CMD ["/usr/local/bin/healthcheck.sh"]
 
 # Run the matter server with data stored in /data
 # --enable-source-maps provides better stack traces in error logs

--- a/docker/matterjs-server/healthcheck.sh
+++ b/docker/matterjs-server/healthcheck.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Resolves LISTEN_ADDRESS (first value if comma-separated) into a healthcheck
+# URL, falling back to localhost. IPv6 literals are bracketed for the URL.
+# Limitation: interface names (e.g. "eth0") cannot be resolved to an IP here,
+# so the healthcheck will fail when LISTEN_ADDRESS is set to an interface name.
+set -eu
+
+port="${PORT:-5580}"
+addr="${LISTEN_ADDRESS%%,*}"
+addr="${addr:-localhost}"
+
+case "$addr" in
+    *:*) url="http://[$addr]:${port}/health" ;;
+    *)   url="http://$addr:${port}/health" ;;
+esac
+
+exec curl -fsS --no-progress-meter "$url"

--- a/docker/matterjs-server/healthcheck.sh
+++ b/docker/matterjs-server/healthcheck.sh
@@ -6,7 +6,8 @@
 set -eu
 
 port="${PORT:-5580}"
-addr="${LISTEN_ADDRESS%%,*}"
+listen="${LISTEN_ADDRESS:-}"
+addr="${listen%%,*}"
 addr="${addr:-localhost}"
 
 case "$addr" in

--- a/docker/matterjs-server/healthcheck.sh
+++ b/docker/matterjs-server/healthcheck.sh
@@ -15,4 +15,4 @@ case "$addr" in
     *)   url="http://$addr:${port}/health" ;;
 esac
 
-exec curl -fsS --no-progress-meter "$url"
+exec curl -fsS -o /dev/null -m 5 "$url"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -119,6 +119,10 @@ All CLI options can be configured via environment variables, making it easy to c
 > [!NOTE]
 > The `LISTEN_ADDRESS` environment variable only supports a single address. Use the CLI `--listen-address` option (repeatable) to bind to multiple addresses.
 > The value can either be an ip address or the network interface name (i.e. `192.168.1.10` or `eth0`)
+>
+> When `LISTEN_ADDRESS` is an interface name the built-in container health
+> check cannot resolve it and will mark the container unhealthy — see
+> [Health Check](#health-check) for the workaround.
 
 ### Advanced matter.js Configuration
 
@@ -201,6 +205,19 @@ The container includes a built-in health check that verifies the server is respo
 ```bash
 docker inspect --format='{{.State.Health.Status}}' matterjs-server
 ```
+
+The health check honours `LISTEN_ADDRESS` and `PORT`: it uses the first
+address from `LISTEN_ADDRESS` (or `localhost` when unset) and the configured
+port. IPv6 literals are bracketed automatically.
+
+> [!NOTE]
+> **Limitation:** The health check cannot resolve interface names. If you set
+> `LISTEN_ADDRESS=eth0` (or another interface name), the server binds to the
+> resolved IPs but the health check still receives `eth0` and fails to
+> connect. To keep the health check working in that case, either set
+> `LISTEN_ADDRESS` to an explicit IP literal, or use the CLI form with the
+> repeatable `--listen-address` flag and include a literal IP that resolves
+> from inside the container (e.g. `--listen-address eth0 --listen-address 127.0.0.1`).
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `curl http://localhost:5580/health` in the container healthcheck with a small `healthcheck.sh` that picks the first address from `LISTEN_ADDRESS` (falling back to `localhost`), uses `PORT`, brackets IPv6 literals, and passes `--no-progress-meter`.
- Same fix applied to `Dockerfile.dev` (which additionally was hitting `/` instead of `/health`).
- `docs/docker.md` documents the new behavior and the one limitation: interface names (e.g. `eth0`) cannot be resolved from the shell, so set `LISTEN_ADDRESS` to a literal IP — or use the repeatable `--listen-address` CLI flag and include a literal loopback alongside — to keep the healthcheck working.

Addresses #659.

🤖 Generated with [Claude Code](https://claude.com/claude-code)