### PR TITLE
feat(dashboard): Thread version, always-on nav tabs, pairing autofocus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ This page shows a detailed overview of the changes between versions without the 
 ## **WORK IN PROGRESS**
 
 - Feature: Added BLE proxy commissioning support (enabled with `--ble-proxy` CLI option)
+- Enhancement: Dashboard shows Thread protocol version on Thread node details
+- Enhancement: Dashboard always shows Thread/WiFi navigation tabs (removed small-screen gate)
 - Maintenance: Update matter.js to the official 0.17.0
 - Fix: Fix the Docker-Health-Checks when a custom Listen address was used
+- Fix: Dashboard auto-focuses pairing-code field when commission-node dialog opens
 
 ## 0.7.0 (2026-05-18)
 

--- a/packages/dashboard/src/components/dialogs/commission-node-dialog/commission-node-existing.ts
+++ b/packages/dashboard/src/components/dialogs/commission-node-dialog/commission-node-existing.ts
@@ -28,6 +28,15 @@ export class CommissionNodeExisting extends LitElement {
     @query("md-outlined-text-field[label='Share code']")
     private _pairingCodeField!: MdOutlinedTextField;
 
+    protected override firstUpdated(): void {
+        void this._autofocusPairingCode().catch(err => console.warn("Autofocus failed:", err));
+    }
+
+    private async _autofocusPairingCode(): Promise<void> {
+        await this._pairingCodeField.updateComplete;
+        this._pairingCodeField.focus();
+    }
+
     protected override render() {
         return html`<md-outlined-text-field label="Share code" .disabled="${this._loading}"> </md-outlined-text-field>
             <br />

--- a/packages/dashboard/src/components/dialogs/commission-node-dialog/commission-node-thread.ts
+++ b/packages/dashboard/src/components/dialogs/commission-node-dialog/commission-node-thread.ts
@@ -63,6 +63,25 @@ export class CommissionNodeThread extends LitElement {
     @query("md-outlined-text-field[label='Pairing code']")
     private _pairingCodeField!: MdOutlinedTextField;
 
+    private _pairingFocused = false;
+    private _credsFocused = false;
+
+    protected override updated(): void {
+        void this._maybeAutofocus().catch(err => console.warn("Autofocus failed:", err));
+    }
+
+    private async _maybeAutofocus(): Promise<void> {
+        if (this._pairingCodeField && !this._pairingFocused) {
+            this._pairingFocused = true;
+            await this._pairingCodeField.updateComplete;
+            this._pairingCodeField.focus();
+        } else if (this._datasetField && !this._credsFocused) {
+            this._credsFocused = true;
+            await this._datasetField.updateComplete;
+            this._datasetField.focus();
+        }
+    }
+
     protected override render() {
         if (!this.client.serverInfo.thread_credentials_set) {
             return html`<md-outlined-text-field

--- a/packages/dashboard/src/components/dialogs/commission-node-dialog/commission-node-wifi.ts
+++ b/packages/dashboard/src/components/dialogs/commission-node-dialog/commission-node-wifi.ts
@@ -65,6 +65,25 @@ export class CommissionNodeWifi extends LitElement {
     @query("md-outlined-text-field[label='Pairing code']")
     private _pairingCodeField!: MdOutlinedTextField;
 
+    private _pairingFocused = false;
+    private _credsFocused = false;
+
+    protected override updated(): void {
+        void this._maybeAutofocus().catch(err => console.warn("Autofocus failed:", err));
+    }
+
+    private async _maybeAutofocus(): Promise<void> {
+        if (this._pairingCodeField && !this._pairingFocused) {
+            this._pairingFocused = true;
+            await this._pairingCodeField.updateComplete;
+            this._pairingCodeField.focus();
+        } else if (this._ssidField && !this._credsFocused) {
+            this._credsFocused = true;
+            await this._ssidField.updateComplete;
+            this._ssidField.focus();
+        }
+    }
+
     protected override render() {
         if (!this.client.serverInfo.wifi_credentials_set) {
             return html`<md-outlined-text-field

--- a/packages/dashboard/src/pages/components/header.ts
+++ b/packages/dashboard/src/pages/components/header.ts
@@ -259,12 +259,6 @@ export class DashboardHeader extends LitElement {
                 border-bottom: 2px solid var(--md-sys-color-on-primary);
             }
 
-            @media (max-width: 768px) {
-                .nav-tabs {
-                    display: none;
-                }
-            }
-
             .dev-badge {
                 font-family: var(--monospace-font);
                 font-size: 0.7rem;

--- a/packages/dashboard/src/pages/network/network-details.ts
+++ b/packages/dashboard/src/pages/network/network-details.ts
@@ -25,6 +25,7 @@ import type { SignalLevel, ThreadEdgePair, ThreadExternalDevice } from "./networ
 import type { NodeConnection } from "./network-utils.js";
 import {
     decodeMeshcopStateBitmap,
+    formatThreadVersion,
     getDeviceName,
     getNetworkType,
     getNodeConnectionsFromPairs,
@@ -34,6 +35,7 @@ import {
     getThreadExtendedAddressHex,
     getThreadRole,
     getThreadRoleName,
+    getThreadVersion,
     getWiFiDiagnostics,
     getWiFiSecurityTypeName,
     getWiFiVersionName,
@@ -206,6 +208,7 @@ export class NetworkDetails extends LitElement {
         const threadRole = getThreadRole(node);
         const channel = getThreadChannel(node);
         const extAddressHex = getThreadExtendedAddressHex(node);
+        const threadVersion = getThreadVersion(node);
         // Get connections from edge pairs with the same filter pipeline as the graph
         const nodeId = String(node.node_id);
         const connections = getNodeConnectionsFromPairs(nodeId, this.threadEdgePairs, this.nodes, {
@@ -222,6 +225,14 @@ export class NetworkDetails extends LitElement {
                     <span class="label">Role:</span>
                     <span class="value">${getThreadRoleName(threadRole)}</span>
                 </div>
+                ${threadVersion !== undefined
+                    ? html`
+                          <div class="info-row">
+                              <span class="label">Thread version:</span>
+                              <span class="value">${formatThreadVersion(threadVersion)}</span>
+                          </div>
+                      `
+                    : nothing}
                 ${channel !== undefined
                     ? html`
                           <div class="info-row">

--- a/packages/dashboard/src/pages/network/network-utils.ts
+++ b/packages/dashboard/src/pages/network/network-utils.ts
@@ -128,6 +128,36 @@ export function getNetworkType(node: MatterNode): NetworkType {
     return "unknown";
 }
 
+// NetworkCommissioning ThreadVersion (attr 0x0A) follows the Thread spec
+// "Version TLV" mapping. Spec is open-ended; unknown values render with the
+// raw TLV so newer-than-table devices stay visible.
+const THREAD_VERSION_NAMES: Record<number, string> = {
+    1: "1.0",
+    2: "1.1",
+    3: "1.2",
+    4: "1.3",
+    5: "1.4",
+};
+
+/**
+ * Thread protocol version supported by the device's Thread interface.
+ * Uses NetworkCommissioning cluster (0x31/49) ThreadVersion attribute (0x0A/10).
+ */
+export function getThreadVersion(node: MatterNode): number | undefined {
+    const v = node.attributes["0/49/10"];
+    return typeof v === "number" ? v : undefined;
+}
+
+/**
+ * Human-readable Thread version string from the Version TLV value.
+ * Unmapped TLVs render as `Thread unknown (N)` so the raw value stays
+ * visible for diagnostics.
+ */
+export function formatThreadVersion(tlv: number): string {
+    const name = THREAD_VERSION_NAMES[tlv];
+    return name !== undefined ? `Thread ${name}` : `Thread unknown (${tlv})`;
+}
+
 /**
  * Categorizes nodes by their network type.
  * Node IDs are stored as strings to avoid BigInt precision loss.


### PR DESCRIPTION
## Summary
- Show Thread protocol version on Thread node details, read from NetworkCommissioning cluster `ThreadVersion` attribute (`0x31` / `0x0A`). Maps Thread Version TLV `1..5` to `1.0..1.4`; unmapped values render as `Thread unknown (N)`.
- Always show the Thread/WiFi navigation tabs — removed the `@media (max-width: 768px) { .nav-tabs { display: none } }` gate so tabs remain visible on small viewports.
- Auto-focus the pairing-code field when the commission-node dialog opens. For WiFi/Thread, the credentials-step field is focused first when credentials are not yet set, then the pairing-code field once it appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)