### PR TITLE
feat(dashboard): full-width network view + Thread leader BR marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Enhancement: Dashboard network visualization fills the full window width on large/4K displays
+- Enhancement: Dashboard Thread mesh marks the network Leader Border Router with a distinct crown icon and amber color
+
 ## 0.7.1 (2026-05-21)
 
 - Feature: Added BLE proxy commissioning support (enabled with `--ble-proxy` CLI option)

--- a/packages/dashboard/public/index.html
+++ b/packages/dashboard/public/index.html
@@ -62,6 +62,7 @@
     --node-color-selected-offline: #b71c1c;
     --node-color-unknown: #ff9800;
     --node-color-default: #666666;
+    --node-color-thread-leader: #f9a825;
     --graph-font-color: #333333;
     --graph-edge-dimmed: #cccccc;
     --graph-node-fallback: #999999;
@@ -121,6 +122,7 @@
     --node-color-selected-offline: #e53935;
     --node-color-unknown: #ffa726;
     --node-color-default: #b0b0b0;
+    --node-color-thread-leader: #ffca28;
     --graph-font-color: #e0e0e0;
     --graph-edge-dimmed: #555555;
     --graph-node-fallback: #999999;

--- a/packages/dashboard/src/pages/matter-network-view.ts
+++ b/packages/dashboard/src/pages/matter-network-view.ts
@@ -479,8 +479,6 @@ class MatterNetworkView extends LitElement {
                 flex: 1 1 0;
                 padding: 8px 16px;
                 gap: 8px;
-                max-width: 1600px;
-                margin: 0 auto;
                 width: 100%;
                 box-sizing: border-box;
                 min-height: 0;
@@ -683,7 +681,7 @@ class MatterNetworkView extends LitElement {
             }
 
             .details-sidebar {
-                width: 320px;
+                width: clamp(320px, 22vw, 480px);
                 flex-shrink: 0;
                 display: none;
                 min-height: 0;

--- a/packages/dashboard/src/pages/network/thread-graph.ts
+++ b/packages/dashboard/src/pages/network/thread-graph.ts
@@ -24,6 +24,7 @@ import {
     buildExtAddrMap,
     buildRloc16Map,
     buildThreadEdgePairs,
+    decodeMeshcopStateBitmap,
     findUnknownDevices,
     getDeviceName,
     getEdgeSignalScore,
@@ -257,10 +258,11 @@ export class ThreadGraph extends BaseNetworkGraph {
                         ? `\n${device.networkName}`
                         : "";
                 const label = `${top}${suffix}`;
+                const isLeader = decodeMeshcopStateBitmap(device.stateBitmapHex)?.threadRoleValue === 3;
                 graphNodes.push({
                     id: device.id,
                     label,
-                    image: createBorderRouterIconDataUrl(isSelected),
+                    image: createBorderRouterIconDataUrl(isSelected, isLeader),
                     shape: "image" as const,
                     networkType: "thread" as const,
                     isUnknown: false,
@@ -620,9 +622,10 @@ export class ThreadGraph extends BaseNetworkGraph {
         }
         const external = this._unknownDevicesMapCache.get(nodeId);
         if (external?.kind === "br") {
+            const isLeader = decodeMeshcopStateBitmap(external.stateBitmapHex)?.threadRoleValue === 3;
             this._nodesDataSet.update({
                 id: nodeId,
-                image: createBorderRouterIconDataUrl(isHighlighted),
+                image: createBorderRouterIconDataUrl(isHighlighted, isLeader),
             });
         } else if (nodeId.startsWith("unknown_") || nodeId.startsWith("br_")) {
             this._nodesDataSet.update({

--- a/packages/dashboard/src/util/device-icons.ts
+++ b/packages/dashboard/src/util/device-icons.ts
@@ -17,6 +17,7 @@ import {
     mdiCast,
     mdiCctv,
     mdiChip,
+    mdiCrown,
     mdiDishwasher,
     mdiDoorbell,
     mdiDoorbellVideo,
@@ -511,14 +512,22 @@ export function createUnknownDeviceIconDataUrl(isRouter: boolean = false, isSele
 
 /**
  * Creates an SVG data URL for a Thread Border Router identified via mDNS.
+ * Leader BRs render with a crown glyph and amber color to differentiate from peers.
  * @param isSelected - Whether the node is selected
+ * @param isLeader - Whether this BR is the Thread network leader (from MeshCoP state bitmap)
  * @returns A data URL containing the SVG
  */
-export function createBorderRouterIconDataUrl(isSelected: boolean = false): string {
-    const color = isSelected
-        ? getCssVar("--node-color-selected", "#1976d2")
-        : getCssVar("--md-sys-color-primary", "#03a9f4");
-    return createIconDataUrl(mdiRouterWireless, color);
+export function createBorderRouterIconDataUrl(isSelected: boolean = false, isLeader: boolean = false): string {
+    if (isSelected) {
+        return createIconDataUrl(
+            isLeader ? mdiCrown : mdiRouterWireless,
+            getCssVar("--node-color-selected", "#1976d2"),
+        );
+    }
+    if (isLeader) {
+        return createIconDataUrl(mdiCrown, getCssVar("--node-color-thread-leader", "#f9a825"));
+    }
+    return createIconDataUrl(mdiRouterWireless, getCssVar("--md-sys-color-primary", "#03a9f4"));
 }
 
 /**


### PR DESCRIPTION
## Summary

Two dashboard network-visualization enhancements:

- **Full-width network view** — removed the fixed `max-width: 1600px` content cap so the visualization fills the full window on large/4K displays. The details sidebar now scales with the viewport via `clamp(320px, 22vw, 480px)` instead of a fixed `320px`. The graph itself was already responsive (vis-network + ResizeObserver); only the outer wrapper limited it.
- **Thread Leader Border Router marker** — the Thread mesh now marks the network Leader BR with a crown glyph and a theme-aware amber color (`#f9a825` light / `#ffca28` dark), distinguishing it from peer border routers (which keep the wireless-router glyph in primary blue). Leader detection reuses the existing `decodeMeshcopStateBitmap()` parser (`threadRoleValue === 3`). BRs without a state bitmap fall back to the normal BR icon.

## Changes

- `packages/dashboard/public/index.html` — new `--node-color-thread-leader` CSS var (light + dark)
- `packages/dashboard/src/util/device-icons.ts` — `createBorderRouterIconDataUrl(isSelected, isLeader)`; crown + amber for leader
- `packages/dashboard/src/pages/network/thread-graph.ts` — leader detection at node render + highlight update
- `packages/dashboard/src/pages/matter-network-view.ts` — drop 1600px cap, scale sidebar
- `CHANGELOG.md` — WIP entries

## Verification

`npm run format`, `npm run lint`, `npm run build` all pass. CSS/icon-only change to the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)