### PR TITLE
feat(dashboard): Thread role badges + shared NodeLabel write logic

### DIFF
--- a/packages/dashboard/public/index.html
+++ b/packages/dashboard/public/index.html
@@ -63,6 +63,9 @@
     --node-color-unknown: #ff9800;
     --node-color-default: #666666;
     --node-color-thread-leader: #f9a825;
+    --node-color-thread-router: #1e88e5;
+    --node-color-thread-enddevice: #90a4ae;
+    --node-color-primary-bbr: #00897b;
     --graph-font-color: #333333;
     --graph-edge-dimmed: #cccccc;
     --graph-node-fallback: #999999;
@@ -123,6 +126,9 @@
     --node-color-unknown: #ffa726;
     --node-color-default: #b0b0b0;
     --node-color-thread-leader: #ffca28;
+    --node-color-thread-router: #64b5f6;
+    --node-color-thread-enddevice: #78909c;
+    --node-color-primary-bbr: #4db6ac;
     --graph-font-color: #e0e0e0;
     --graph-edge-dimmed: #555555;
     --graph-node-fallback: #999999;

--- a/packages/dashboard/src/components/dialogs/node-label-dialog/node-label-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/node-label-dialog/node-label-dialog.ts
@@ -8,7 +8,7 @@ import "@material/web/button/text-button";
 import "@material/web/dialog/dialog";
 import "@material/web/textfield/outlined-text-field";
 import type { MdDialog } from "@material/web/dialog/dialog.js";
-import { MatterClient, MatterNode } from "@matter-server/ws-client";
+import type { MatterClient, MatterNode } from "@matter-server/ws-client";
 import { html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { MAX_NODE_LABEL_LENGTH, writeNodeLabel } from "../../../util/node-label.js";

--- a/packages/dashboard/src/components/dialogs/node-label-dialog/node-label-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/node-label-dialog/node-label-dialog.ts
@@ -11,12 +11,9 @@ import type { MdDialog } from "@material/web/dialog/dialog.js";
 import { MatterClient, MatterNode } from "@matter-server/ws-client";
 import { html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { MAX_NODE_LABEL_LENGTH, writeNodeLabel } from "../../../util/node-label.js";
 import { preventDefault } from "../../../util/prevent_default.js";
 import { showAlertDialog } from "../../dialog-box/show-dialog-box.js";
-
-const CLUSTER_ID = 0x28; // BasicInformation cluster (40 decimal)
-const NODE_LABEL_ATTRIBUTE_ID = 5;
-const MAX_NODE_LABEL_LENGTH = 32;
 
 @customElement("node-label-dialog")
 export class NodeLabelDialog extends LitElement {
@@ -33,14 +30,7 @@ export class NodeLabelDialog extends LitElement {
     private _saving: boolean = false;
 
     protected override firstUpdated() {
-        this._nodeLabel = this.node.nodeLabel || "";
-        if (!this._nodeLabel) {
-            const attributePath = `0/${CLUSTER_ID}/${NODE_LABEL_ATTRIBUTE_ID}`;
-            const currentValue = this.node.attributes[attributePath];
-            if (typeof currentValue === "string") {
-                this._nodeLabel = currentValue;
-            }
-        }
+        this._nodeLabel = this.node.nodeLabel;
     }
 
     protected override render() {
@@ -82,8 +72,7 @@ export class NodeLabelDialog extends LitElement {
     private async _save() {
         this._saving = true;
         try {
-            const attributePath = `0/${CLUSTER_ID}/${NODE_LABEL_ATTRIBUTE_ID}`;
-            await this.client.writeAttribute(this.node.node_id, attributePath, this._nodeLabel);
+            await writeNodeLabel(this.client, this.node, this._nodeLabel);
             this._close();
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);

--- a/packages/dashboard/src/pages/cluster-commands/clusters/basic-information-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/basic-information-commands.ts
@@ -99,6 +99,7 @@ export class BasicInformationClusterCommands extends BaseClusterCommands {
         try {
             const label = this._nodeLabel.trim();
             await writeNodeLabel(this.client, this.node, label);
+            this._nodeLabel = label;
 
             showAlertDialog({
                 title: "Success",

--- a/packages/dashboard/src/pages/cluster-commands/clusters/basic-information-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/basic-information-commands.ts
@@ -10,12 +10,9 @@ import { css, html, nothing, type CSSResultGroup } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { showAlertDialog } from "../../../components/dialog-box/show-dialog-box.js";
 import { handleAsync } from "../../../util/async-handler.js";
+import { MAX_NODE_LABEL_LENGTH, NODE_LABEL_CLUSTER_ID, writeNodeLabel } from "../../../util/node-label.js";
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
-
-const CLUSTER_ID = 0x28; // BasicInformation cluster (40 decimal)
-const NODE_LABEL_ATTRIBUTE_ID = 5;
-const MAX_NODE_LABEL_LENGTH = 32;
 
 /**
  * Command panel for BasicInformation cluster (ID: 0x28 / 40).
@@ -44,22 +41,7 @@ export class BasicInformationClusterCommands extends BaseClusterCommands {
         if (!this.node) {
             return;
         }
-
-        // First check the direct nodeLabel property on the node
-        if (this.node.nodeLabel) {
-            this._nodeLabel = this.node.nodeLabel;
-            return;
-        }
-
-        // Fallback to attribute path: endpoint/cluster/attribute = 0/40/5
-        // BasicInformation cluster is always on endpoint 0 per Matter specification
-        const attributePath = `0/${CLUSTER_ID}/${NODE_LABEL_ATTRIBUTE_ID}`;
-        const currentValue = this.node.attributes[attributePath];
-        if (typeof currentValue === "string") {
-            this._nodeLabel = currentValue;
-        } else {
-            this._nodeLabel = "";
-        }
+        this._nodeLabel = this.node.nodeLabel;
     }
 
     /**
@@ -115,13 +97,12 @@ export class BasicInformationClusterCommands extends BaseClusterCommands {
         this._saving = true;
 
         try {
-            // BasicInformation cluster is always on endpoint 0 per Matter specification
-            const attributePath = `0/${CLUSTER_ID}/${NODE_LABEL_ATTRIBUTE_ID}`;
-            await this.client.writeAttribute(this.node.node_id, attributePath, this._nodeLabel);
+            const label = this._nodeLabel.trim();
+            await writeNodeLabel(this.client, this.node, label);
 
             showAlertDialog({
                 title: "Success",
-                text: `Node label set to "${this._nodeLabel}"`,
+                text: `Node label set to "${label}"`,
             });
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
@@ -161,8 +142,7 @@ export class BasicInformationClusterCommands extends BaseClusterCommands {
     ];
 }
 
-// Register this component for cluster ID 0x28 (40 decimal)
-registerClusterCommands(CLUSTER_ID, "basic-information-cluster-commands");
+registerClusterCommands(NODE_LABEL_CLUSTER_ID, "basic-information-cluster-commands");
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/dashboard/src/pages/network/thread-graph.ts
+++ b/packages/dashboard/src/pages/network/thread-graph.ts
@@ -258,11 +258,13 @@ export class ThreadGraph extends BaseNetworkGraph {
                         ? `\n${device.networkName}`
                         : "";
                 const label = `${top}${suffix}`;
-                const isLeader = decodeMeshcopStateBitmap(device.stateBitmapHex)?.threadRoleValue === 3;
+                const decodedState = decodeMeshcopStateBitmap(device.stateBitmapHex);
+                const isLeader = decodedState?.threadRoleValue === 3;
+                const isPrimaryBbr = decodedState?.bbr === true && decodedState.bbrFunction === "primary";
                 graphNodes.push({
                     id: device.id,
                     label,
-                    image: createBorderRouterIconDataUrl(isSelected, isLeader),
+                    image: createBorderRouterIconDataUrl(isSelected, isLeader, isPrimaryBbr),
                     shape: "image" as const,
                     networkType: "thread" as const,
                     isUnknown: false,
@@ -622,10 +624,12 @@ export class ThreadGraph extends BaseNetworkGraph {
         }
         const external = this._unknownDevicesMapCache.get(nodeId);
         if (external?.kind === "br") {
-            const isLeader = decodeMeshcopStateBitmap(external.stateBitmapHex)?.threadRoleValue === 3;
+            const decodedState = decodeMeshcopStateBitmap(external.stateBitmapHex);
+            const isLeader = decodedState?.threadRoleValue === 3;
+            const isPrimaryBbr = decodedState?.bbr === true && decodedState.bbrFunction === "primary";
             this._nodesDataSet.update({
                 id: nodeId,
-                image: createBorderRouterIconDataUrl(isHighlighted, isLeader),
+                image: createBorderRouterIconDataUrl(isHighlighted, isLeader, isPrimaryBbr),
             });
         } else if (nodeId.startsWith("unknown_") || nodeId.startsWith("br_")) {
             this._nodesDataSet.update({

--- a/packages/dashboard/src/util/device-icons.ts
+++ b/packages/dashboard/src/util/device-icons.ts
@@ -471,6 +471,7 @@ export function getNetworkTypeIcon(networkType: string): string {
  * @param iconPath - The MDI icon path
  * @param color - The icon color (CSS color string)
  * @param size - The icon size in pixels
+ * @param badge - Optional top-right corner badge: an MDI glyph filled white on a colored disc
  * @returns A data URL containing the SVG
  */
 export function createIconDataUrl(

--- a/packages/dashboard/src/util/device-icons.ts
+++ b/packages/dashboard/src/util/device-icons.ts
@@ -17,6 +17,7 @@ import {
     mdiCast,
     mdiCctv,
     mdiChip,
+    mdiCircleMedium,
     mdiCrown,
     mdiDishwasher,
     mdiDoorbell,
@@ -41,12 +42,15 @@ import {
     mdiRobotVacuum,
     mdiRouter,
     mdiRouterWireless,
+    mdiSleep,
     mdiSmokeDetector,
     mdiSnowflakeAlert,
     mdiSolarPower,
     mdiSpeaker,
     mdiSprinkler,
+    mdiStar,
     mdiStove,
+    mdiSwapHorizontal,
     mdiTelevision,
     mdiThermometer,
     mdiToggleSwitch,
@@ -305,6 +309,19 @@ const threadRoleToIcon: Record<number, string> = {
 };
 
 /**
+ * Corner badge marking a node's Thread RoutingRole (attr 0/53/1) — a role-rank indicator overlaid on
+ * the device icon. The Leader is the rare, high-signal exception (amber crown); routers and end
+ * devices use progressively lower-key glyphs. Unassigned/Unspecified and unknown roles get no badge.
+ */
+const THREAD_ROLE_BADGES: Record<number, { iconPath: string; colorVar: string; colorFallback: string }> = {
+    2: { iconPath: mdiSleep, colorVar: "--node-color-thread-enddevice", colorFallback: "#90a4ae" }, // Sleepy End Device
+    3: { iconPath: mdiCircleMedium, colorVar: "--node-color-thread-enddevice", colorFallback: "#90a4ae" }, // End Device
+    4: { iconPath: mdiCircleMedium, colorVar: "--node-color-thread-enddevice", colorFallback: "#90a4ae" }, // REED
+    5: { iconPath: mdiSwapHorizontal, colorVar: "--node-color-thread-router", colorFallback: "#1e88e5" }, // Router
+    6: { iconPath: mdiCrown, colorVar: "--node-color-thread-leader", colorFallback: "#f9a825" }, // Leader
+};
+
+/**
  * Utility device types (per Matter spec) deprioritized when selecting the primary type for icon display.
  * These are commonly reported alongside the actual application type (e.g., a light also reports as
  * OTA Requestor + Root Node + Electrical Sensor). Their icons are only used if no application type is found.
@@ -456,12 +473,23 @@ export function getNetworkTypeIcon(networkType: string): string {
  * @param size - The icon size in pixels
  * @returns A data URL containing the SVG
  */
-export function createIconDataUrl(iconPath: string, color: string, size: number = 48): string {
+export function createIconDataUrl(
+    iconPath: string,
+    color: string,
+    size: number = 48,
+    badge?: { iconPath: string; color: string },
+): string {
     // MDI icons use a 24x24 viewBox
+    const badgeMarkup =
+        badge !== undefined
+            ? `<circle cx="18" cy="6" r="4" fill="${badge.color}"/>
+            <path d="${badge.iconPath}" fill="white" transform="translate(14.64,2.64) scale(0.28)"/>`
+            : "";
     const svg = `
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="${size}" height="${size}">
             <circle cx="12" cy="12" r="11" fill="white" stroke="${color}" stroke-width="1"/>
             <path d="${iconPath}" fill="${color}" transform="scale(0.6) translate(8,8)"/>
+            ${badgeMarkup}
         </svg>
     `.trim();
 
@@ -493,7 +521,14 @@ export function createNodeIconDataUrl(
     } else {
         color = getDefaultIconColor(); // Theme-aware default
     }
-    return createIconDataUrl(iconPath, color);
+    // Thread RoutingRole (incl. Leader) applies to any router node, not just BRs. Badge it over the
+    // device icon rather than replacing the icon, preserving device identity.
+    const roleBadge = threadRole !== undefined ? THREAD_ROLE_BADGES[threadRole] : undefined;
+    const badge =
+        roleBadge !== undefined
+            ? { iconPath: roleBadge.iconPath, color: getCssVar(roleBadge.colorVar, roleBadge.colorFallback) }
+            : undefined;
+    return createIconDataUrl(iconPath, color, 48, badge);
 }
 
 /**
@@ -512,22 +547,31 @@ export function createUnknownDeviceIconDataUrl(isRouter: boolean = false, isSele
 
 /**
  * Creates an SVG data URL for a Thread Border Router identified via mDNS.
- * Leader BRs render with a crown glyph and amber color to differentiate from peers.
+ *
+ * Thread Leader (mesh routing role) and Primary BBR (backbone role) are orthogonal: the central
+ * glyph reflects the mesh role (crown for leader, router otherwise) while a corner star badge marks
+ * the primary BBR. A BR that is both shows both.
+ *
  * @param isSelected - Whether the node is selected
  * @param isLeader - Whether this BR is the Thread network leader (from MeshCoP state bitmap)
+ * @param isPrimaryBbr - Whether this BR is the primary Backbone Border Router (from MeshCoP state bitmap)
  * @returns A data URL containing the SVG
  */
-export function createBorderRouterIconDataUrl(isSelected: boolean = false, isLeader: boolean = false): string {
-    if (isSelected) {
-        return createIconDataUrl(
-            isLeader ? mdiCrown : mdiRouterWireless,
-            getCssVar("--node-color-selected", "#1976d2"),
-        );
-    }
-    if (isLeader) {
-        return createIconDataUrl(mdiCrown, getCssVar("--node-color-thread-leader", "#f9a825"));
-    }
-    return createIconDataUrl(mdiRouterWireless, getCssVar("--md-sys-color-primary", "#03a9f4"));
+export function createBorderRouterIconDataUrl(
+    isSelected: boolean = false,
+    isLeader: boolean = false,
+    isPrimaryBbr: boolean = false,
+): string {
+    const glyph = isLeader ? mdiCrown : mdiRouterWireless;
+    const color = isSelected
+        ? getCssVar("--node-color-selected", "#1976d2")
+        : isLeader
+          ? getCssVar("--node-color-thread-leader", "#f9a825")
+          : getCssVar("--md-sys-color-primary", "#03a9f4");
+    const badge = isPrimaryBbr
+        ? { iconPath: mdiStar, color: getCssVar("--node-color-primary-bbr", "#00897b") }
+        : undefined;
+    return createIconDataUrl(glyph, color, 48, badge);
 }
 
 /**

--- a/packages/dashboard/src/util/node-label.ts
+++ b/packages/dashboard/src/util/node-label.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MatterClient, MatterNode } from "@matter-server/ws-client";
+
+// BasicInformation cluster (0x28 / 40), always on endpoint 0 per Matter specification.
+export const NODE_LABEL_CLUSTER_ID = 0x28;
+export const NODE_LABEL_ATTRIBUTE_ID = 5;
+export const MAX_NODE_LABEL_LENGTH = 32;
+
+export const NODE_LABEL_ATTRIBUTE_PATH = `0/${NODE_LABEL_CLUSTER_ID}/${NODE_LABEL_ATTRIBUTE_ID}`;
+
+/**
+ * Write the BasicInformation NodeLabel attribute for a node.
+ * Trims surrounding whitespace so the stored value matches what MatterNode.nodeLabel reads back.
+ */
+export function writeNodeLabel(client: MatterClient, node: MatterNode, label: string): Promise<unknown> {
+    return client.writeAttribute(node.node_id, NODE_LABEL_ATTRIBUTE_PATH, label.trim());
+}


### PR DESCRIPTION
## Summary

Two dashboard changes, bundled in one PR.

### 1. Thread role badges on the network graph
Surfaces Thread routing topology directly on the graph with corner badges:

- **Commissioned nodes** — a role-rank badge overlaid on the existing device icon, driven by `RoutingRole` (attr `0/53/1`). Device identity is preserved rather than replaced:
  - 👑 crown — Leader
  - ⇄ two-arrows — Router
  - • dot — End Device / REED
  - 💤 sleep — Sleepy End Device
  - Unassigned/Unspecified/unknown — no badge
- **Border Router (mDNS) nodes** — a ⭐ star badge marks the **primary Backbone Border Router (BBR)**. The central crown stays the **mesh-Leader** marker (from the MeshCoP state bitmap). Leader and primary-BBR are *orthogonal* Thread roles and render independently; a BR that is both shows both.
- New theme-aware colors (`--node-color-thread-router`, `--node-color-thread-enddevice`, `--node-color-primary-bbr`) for light and dark.

> ⚠️ The two "leader" signals use **different encodings** and are kept separate: MeshCoP bitmap `threadRoleValue === 3` (BR path) vs ThreadNetworkDiagnostics `RoutingRole === 6` (commissioned-node path).

### 2. NodeLabel editing cleanup (follow-up to #681)
Addresses post-merge review comments on the inline NodeLabel editor:

- Extracts shared constants + `writeNodeLabel()` into `util/node-label.ts`; both the node-label dialog and the BasicInformation cluster panel now use it (no more duplicated constants/logic that could drift).
- `writeNodeLabel()` trims, matching what `MatterNode.nodeLabel` reads back on load.
- Drops the redundant attribute fallback in `firstUpdated` / `_loadCurrentNodeLabel` — it duplicated the getter's path and would re-introduce the null-padded value the getter intentionally rejects.

## Known follow-up (out of scope)
If a Border Router is also a commissioned Matter node, it can appear as two graph nodes (mDNS BR + commissioned), so a leader BR could be crowned twice. Pre-existing graph-dedup behavior, not introduced here.

## Test plan
- `npm run format` / `npm run lint` / `npm run build` — clean
- `PRIMARY_INTERFACE=en0 MATTER_MDNS_NETWORKINTERFACE=en0 npm test` — all suites pass (ws-controller 244, WebRtc 91, ws-client 43, BLE Proxy 21)
- Manual: verified badge rendering on the Thread graph in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)