### PR TITLE
chore: support Node.js 24/26, bump Docker base image to node:24

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,12 +32,14 @@ npm run format-verify
 ```
 
 > **MANDATORY — no exceptions:** After every code change, always run these four commands **in this exact order** before considering the work done:
+>
 > ```bash
 > npm run format   # rewrites files in-place — MUST be first
 > npm run lint
 > npm run build
 > npm test
 > ```
+>
 > Skipping `format` is the most common mistake — oxfmt rewrites files in-place and the build/lint validate the formatted output. If you skip it, CI will fail.
 
 **CI enforces formatting and linting.** The `check-and-lint` job in `build-test.js.yml` runs `npm run format-verify` and `npm run lint` and all other CI jobs (`test`, `build-non-linux`) are gated on it. PRs will fail if either check does not pass.
@@ -78,19 +80,21 @@ npm run python:test-integration
 
 npm workspaces with six packages:
 
-| Package | Name | Role |
-|---------|------|------|
-| `packages/tools` | `@matter/tools` | Private build infrastructure (esbuild + TSC). Provides `matter-build`, `matter-run`, `matter-version` binaries. **Never published.** |
-| `packages/custom-clusters` | `@matter-server/custom-clusters` | Vendor-specific Matter cluster definitions (Eve, Inovelli, Heiman, etc.) registered into the Matter model at startup |
-| `packages/ws-controller` | `@matter-server/ws-controller` | Core library: wraps `@project-chip/matter.js`, exports `MatterController`, `ControllerCommandHandler`, `WebSocketControllerHandler`, `ConfigStorage` |
-| `packages/ws-client` | `@matter-server/ws-client` | WebSocket client library (used by the dashboard and for external consumers) |
-| `packages/dashboard` | `@matter-server/dashboard` | Web UI (Lit + Material Web + Rollup) |
-| `packages/matter-server` | `matter-server` | Main entry point: Express HTTP server, wires everything together |
+| Package                    | Name                             | Role                                                                                                                                                 |
+| -------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/tools`           | `@matter/tools`                  | Private build infrastructure (esbuild + TSC). Provides `matter-build`, `matter-run`, `matter-version` binaries. **Never published.**                 |
+| `packages/custom-clusters` | `@matter-server/custom-clusters` | Vendor-specific Matter cluster definitions (Eve, Inovelli, Heiman, etc.) registered into the Matter model at startup                                 |
+| `packages/ws-controller`   | `@matter-server/ws-controller`   | Core library: wraps `@project-chip/matter.js`, exports `MatterController`, `ControllerCommandHandler`, `WebSocketControllerHandler`, `ConfigStorage` |
+| `packages/ws-client`       | `@matter-server/ws-client`       | WebSocket client library (used by the dashboard and for external consumers)                                                                          |
+| `packages/dashboard`       | `@matter-server/dashboard`       | Web UI (Lit + Material Web + Rollup)                                                                                                                 |
+| `packages/matter-server`   | `matter-server`                  | Main entry point: Express HTTP server, wires everything together                                                                                     |
 
 ## Architecture
 
 ### Server startup flow
+
 `MatterServer.ts` → CLI options → Logger setup → `ConfigStorage` + `MatterController` → `WebServer` with:
+
 - `WebSocketControllerHandler` — Python Matter Server-compatible WS API on `/ws`
 - `StaticFileHandler` — serves dashboard assets
 - `HealthHandler` — `/health` endpoint
@@ -98,6 +102,7 @@ npm workspaces with six packages:
 Custom clusters are registered at import time via `import "@matter-server/custom-clusters"` in `MatterServer.ts`. The registration in `custom-clusters/src/register.ts` pushes each cluster definition into `Matter` and `ClusterRegistry`.
 
 ### WebSocket Protocol (Schema version 11)
+
 Messages follow the Python Matter Server protocol. Key commands: `start_listening`, `commission_with_code`, `commission_on_network`, `device_command`, `read_attribute`, `write_attribute`, `subscribe_attribute`, `get_nodes`, `get_node`, `server_info`, `diagnostics`.
 
 Events emitted to all clients: `node_added`, `node_updated`, `node_removed`, `attribute_updated`.
@@ -105,15 +110,19 @@ Events emitted to all clients: `node_added`, `node_updated`, `node_removed`, `at
 `start_listening` response is not logged (see `skipMessageContentInLogFor` in `WebSocketControllerHandler.ts`).
 
 ### Attribute path format
+
 All `MatterNode.attributes` keys and attribute event paths use `"endpointId/clusterId/attributeId"` as decimal strings (e.g., `"0/40/4"` = endpoint 0, BasicInformation cluster, SoftwareVersion). Wildcards (`*`) are supported in read/subscribe commands.
 
 ### BigInt handling
+
 The WS protocol uses a custom JSON serialiser (`toBigIntAwareJson`) and parser (`parseBigIntAwareJson`). Large numbers (≥15 digits, exceeding `MAX_SAFE_INTEGER`) are transmitted as raw decimal numbers (not quoted). Use these helpers — not `JSON.stringify/parse` — whenever serialising WS messages.
 
 ### Event broadcasting rules
+
 Attribute changes normally emit granular `attribute_updated` events. Changes to the **BasicInformation** (0x28) or **BridgedDeviceBasicInformation** (0x39) clusters trigger a full `node_updated` broadcast instead (firmware version, product name, etc. are reflected in the node object).
 
 ### `ModelMapper` / cluster metadata
+
 `ClusterMap` in `ws-controller/src/model/ModelMapper.ts` is built at module load time from `Matter`. It indexes clusters by lowercase name and numeric ID. `GlobalAttributes` (IDs 65528–65533) are indexed by both name and numeric ID to support decoding in custom/unknown clusters.
 
 ## Dashboard
@@ -121,32 +130,38 @@ Attribute changes normally emit granular `attribute_updated` events. Changes to 
 Built with **Lit 3.x**, **Material Web 2.4.x** (`md-*` elements), and **`@mdi/js`** SVG icons.
 
 ### Critical styling rule
+
 **Never use hardcoded colors.** Always use CSS variables defined in `public/index.html`:
+
 ```css
 /* Correct */
-color: var(--text-color, rgba(0,0,0,0.6));
+color: var(--text-color, rgba(0, 0, 0, 0.6));
 background: var(--md-sys-color-surface);
 
 /* Wrong */
 color: #333;
 color: grey;
 ```
+
 Key variables: `--md-sys-color-primary/surface/on-surface/on-surface-variant`, `--text-color`, `--danger-color`, `--primary-color`.
 
 Dark mode is applied via `html.dark-theme body` overrides. Always verify changes in both themes.
 
 ### Dashboard build pipeline
+
 The dashboard build runs: `generate` (produces `src/client/models/descriptions.ts` from cluster definitions) → `matter-build` (TSC + esbuild) → `bundle` (Rollup + Babel). The root `npm run build` orchestrates this automatically.
 
 ### Dashboard conventions
+
 - Component styles: `static override styles = css\`...\`` (Lit inline pattern)
 - Icons: import SVG paths from `@mdi/js` (e.g., `mdiSignalCellular3`) and render via `<ha-svg-icon .path=${...}>`
-Base tsconfig targets **ES2022**. The dashboard includes the `"es2023"` lib to enable ES2023 features such as `Array.prototype.toSorted()`.
+  Base tsconfig targets **ES2022**. The dashboard includes the `"es2023"` lib to enable ES2023 features such as `Array.prototype.toSorted()`.
 - Theme management: `src/util/theme-service.ts` singleton; supports `light`/`dark`/`system`; persisted in `localStorage` as `matterTheme`
 - The dashboard connects to the server via `@matter-server/ws-client`; avoid `location.reload()` when server may be offline — use WebSocket reconnect instead
 - Connection lists (Thread neighbors, WiFi nodes) are sorted by signal quality descending: RSSI preferred, LQI as fallback, missing values sort last
 
 ### TypeScript target
+
 Base tsconfig targets **ES2022**. The dashboard adds `"ES2023.Array"` to its lib to enable `Array.prototype.toSorted()`.
 
 ## Test Nodes
@@ -162,6 +177,7 @@ To import test nodes, send `import_test_nodes` with a JSON dump string (HA diagn
 ## Custom Clusters
 
 To add a vendor cluster:
+
 1. Create `packages/custom-clusters/src/clusters/<vendor>.ts` using the decorator-based DSL (`@cluster`, `@attribute`, `@writable`, etc. from `@matter/main/model`)
 2. Export it from `packages/custom-clusters/src/clusters/index.ts`
 3. Run `npm run generate` (inside `packages/dashboard`) to regenerate `descriptions.ts`
@@ -172,4 +188,4 @@ Files in `docs/plans/` are working documents only — **never commit them to git
 
 ## Node.js Requirement
 
-`>=20.19.0 <22.0.0 || >=22.13.0`
+`>=22.13.0`

--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -2,71 +2,71 @@
 name: Build and test
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-  merge_group:
+    push:
+        branches: ["main"]
+    pull_request:
+        branches: ["main"]
+    merge_group:
 
 # Cancel previous PR/branch runs when a new commit is pushed
 concurrency:
-  group: ${{ github.ref }}-build-tests
-  cancel-in-progress: true
+    group: ${{ github.ref }}-build-tests
+    cancel-in-progress: true
 
 jobs:
-  check-and-lint:
-    outputs:
-      package-changes: ${{ steps.changes.outputs.src }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - uses: dorny/paths-filter@v4
-      id: changes
-      if: github.event.pull_request.user.login != 'dependabot[bot]'
-      with:
-        filters: |
-          src:
-            - "package.json"
-            - "packages/**/package.json"
-            - ".github/workflows/build-test.js.yml"
-    - name: Prepare testing environment
-      uses: ./.github/actions/prepare-env
-    - run: npm run format-verify
-    - run: npm run lint
+    check-and-lint:
+        outputs:
+            package-changes: ${{ steps.changes.outputs.src }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: dorny/paths-filter@v4
+              id: changes
+              if: github.event.pull_request.user.login != 'dependabot[bot]'
+              with:
+                  filters: |
+                      src:
+                        - "package.json"
+                        - "packages/**/package.json"
+                        - ".github/workflows/build-test.js.yml"
+            - name: Prepare testing environment
+              uses: ./.github/actions/prepare-env
+            - run: npm run format-verify
+            - run: npm run lint
 
-  build-non-linux:
-    needs: [ check-and-lint ]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        node-version: [ 22.x, 24.x ]
-        os: [ macos-latest, windows-latest ]
-    steps:
-      - uses: actions/checkout@v6
-        if: needs.check-and-lint.outputs.package-changes == 'true' || github.event.pull_request.user.login == 'dependabot[bot]'
-      - uses: actions/setup-python@v6
-        if: needs.check-and-lint.outputs.package-changes == 'true' || github.event.pull_request.user.login == 'dependabot[bot]'
-        # needed as long as we test Node.js 16 and npm <10.2.2 is used for Node.js 18/20
-        with:
-          python-version: '3.11'
-      - name: Build on ${{ matrix.os }}
-        if: needs.check-and-lint.outputs.package-changes == 'true' || github.event.pull_request.user.login == 'dependabot[bot]'
-        uses: ./.github/actions/prepare-env
-        with:
-          node-version: ${{ matrix.node-version }}
-          os: ${{ matrix.os }}
+    build-non-linux:
+        needs: [check-and-lint]
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                node-version: [22.x, 24.x, 26.x]
+                os: [macos-latest, windows-latest]
+        steps:
+            - uses: actions/checkout@v6
+              if: needs.check-and-lint.outputs.package-changes == 'true' || github.event.pull_request.user.login == 'dependabot[bot]'
+            - uses: actions/setup-python@v6
+              if: needs.check-and-lint.outputs.package-changes == 'true' || github.event.pull_request.user.login == 'dependabot[bot]'
+              # needed as long as we test Node.js 16 and npm <10.2.2 is used for Node.js 18/20
+              with:
+                  python-version: "3.11"
+            - name: Build on ${{ matrix.os }}
+              if: needs.check-and-lint.outputs.package-changes == 'true' || github.event.pull_request.user.login == 'dependabot[bot]'
+              uses: ./.github/actions/prepare-env
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  os: ${{ matrix.os }}
 
-  test:
-    needs: [ check-and-lint ]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [ 22.x, 24.x ]
-    steps:
-      - uses: actions/checkout@v6
-      - name: Prepare testing environment
-        uses: ./.github/actions/prepare-env
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Execute tests
-        run: npm run test
+    test:
+        needs: [check-and-lint]
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [22.x, 24.x, 26.x]
+        steps:
+            - uses: actions/checkout@v6
+            - name: Prepare testing environment
+              uses: ./.github/actions/prepare-env
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: Execute tests
+              run: npm run test

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -3,390 +3,390 @@
 name: Automatic Labeled NPM Release
 
 permissions:
-  contents: write
-  pull-requests: write
-  packages: write  # Required for ghcr.io
-  id-token: write  # Required for OIDC
+    contents: write
+    pull-requests: write
+    packages: write # Required for ghcr.io
+    id-token: write # Required for OIDC
 
 on:
-  pull_request:
-    types: [labeled]
+    pull_request:
+        types: [labeled]
 
 # Cancel previous PR/branch runs when a new commit is pushed
 concurrency:
-  group: ${{ github.ref }}-auto-npm-release
-  cancel-in-progress: true
+    group: ${{ github.ref }}-auto-npm-release
+    cancel-in-progress: true
 
 jobs:
-  check-and-lint:
-    if: github.repository == 'matter-js/matterjs-server' && contains(github.event.pull_request.labels.*.name, 'automated-npm-release')
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Prepare testing environment
-        uses: ./.github/actions/prepare-env
-      - run: npm run format-verify
-      - run: npm run lint
+    check-and-lint:
+        if: github.repository == 'matter-js/matterjs-server' && contains(github.event.pull_request.labels.*.name, 'automated-npm-release')
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - name: Prepare testing environment
+              uses: ./.github/actions/prepare-env
+            - run: npm run format-verify
+            - run: npm run lint
 
-  build-non-linux:
-    if: github.repository == 'matter-js/matterjs-server' && contains(github.event.pull_request.labels.*.name, 'automated-npm-release')
-    needs: [ check-and-lint ]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        node-version: [ 22.x, 24.x ]
-        os: [ macos-latest, windows-latest ]
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        # needed as long as we test Node.js 16 and npm <10.2.2 is used for Node.js 18/20
-        with:
-          python-version: '3.11'
-      - name: Build on ${{ matrix.os }}
-        uses: ./.github/actions/prepare-env
-        with:
-          node-version: ${{ matrix.node-version }}
-          os: ${{ matrix.os }}
+    build-non-linux:
+        if: github.repository == 'matter-js/matterjs-server' && contains(github.event.pull_request.labels.*.name, 'automated-npm-release')
+        needs: [check-and-lint]
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                node-version: [22.x, 24.x, 26.x]
+                os: [macos-latest, windows-latest]
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              # needed as long as we test Node.js 16 and npm <10.2.2 is used for Node.js 18/20
+              with:
+                  python-version: "3.11"
+            - name: Build on ${{ matrix.os }}
+              uses: ./.github/actions/prepare-env
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  os: ${{ matrix.os }}
 
-  test:
-    if: github.repository == 'matter-js/matterjs-server' && contains(github.event.pull_request.labels.*.name, 'automated-npm-release')
-    needs: [ check-and-lint ]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [ 22.x, 24.x ]
-    steps:
-      - uses: actions/checkout@v6
-      - name: Prepare testing environment
-        uses: ./.github/actions/prepare-env
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Execute tests
-        run: npm run test
+    test:
+        if: github.repository == 'matter-js/matterjs-server' && contains(github.event.pull_request.labels.*.name, 'automated-npm-release')
+        needs: [check-and-lint]
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [22.x, 24.x, 26.x]
+        steps:
+            - uses: actions/checkout@v6
+            - name: Prepare testing environment
+              uses: ./.github/actions/prepare-env
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - name: Execute tests
+              run: npm run test
 
-  auto-merge:
-    if: |
-      always() &&
-      github.event_name == 'pull_request' &&
-      github.repository == 'matter-js/matterjs-server' &&
-      contains(github.event.pull_request.labels.*.name, 'automated-npm-release')
-    needs: [ test, build-non-linux, check-and-lint ]
-    runs-on: ubuntu-latest
-    steps:
-      - id: automerge
-        name: automerge
-        uses: "pascalgn/automerge-action@v0.16.4"
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          MERGE_LABELS: "automated-npm-release"
-          MERGE_FILTER_AUTHOR: "Automator77"
-          MERGE_FORKS: "false"
-          MERGE_DELETE_BRANCH: "false"
-          UPDATE_LABELS: "automated-npm-release"
-          MERGE_METHOD: "squash"
-          MERGE_RETRIES: "50"
-          MERGE_RETRY_SLEEP: "60000"
+    auto-merge:
+        if: |
+            always() &&
+            github.event_name == 'pull_request' &&
+            github.repository == 'matter-js/matterjs-server' &&
+            contains(github.event.pull_request.labels.*.name, 'automated-npm-release')
+        needs: [test, build-non-linux, check-and-lint]
+        runs-on: ubuntu-latest
+        steps:
+            - id: automerge
+              name: automerge
+              uses: "pascalgn/automerge-action@v0.16.4"
+              env:
+                  GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+                  MERGE_LABELS: "automated-npm-release"
+                  MERGE_FILTER_AUTHOR: "Automator77"
+                  MERGE_FORKS: "false"
+                  MERGE_DELETE_BRANCH: "false"
+                  UPDATE_LABELS: "automated-npm-release"
+                  MERGE_METHOD: "squash"
+                  MERGE_RETRIES: "50"
+                  MERGE_RETRY_SLEEP: "60000"
 
-      - name: Use Node.js 24.x
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.x
+            - name: Use Node.js 24.x
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24.x
 
-      - name: Determine publish tasks
-        id: publish_tasks
-        env:
-          MERGE_RESULT: ${{ steps.automerge.outputs.mergeResult }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO_OWNER: ${{ github.repository_owner }}
-          REPO: ${{ github.repository }}
-        run: |
-          # Extract version from PR title: "[...RELEASE] x.y.z..." → "x.y.z..."
-          VERSION=$(echo "$PR_TITLE" | sed 's/.*] //')
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Detected version: ${VERSION}"
+            - name: Determine publish tasks
+              id: publish_tasks
+              env:
+                  MERGE_RESULT: ${{ steps.automerge.outputs.mergeResult }}
+                  PR_NUMBER: ${{ github.event.pull_request.number }}
+                  PR_TITLE: ${{ github.event.pull_request.title }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  REPO_OWNER: ${{ github.repository_owner }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  # Extract version from PR title: "[...RELEASE] x.y.z..." → "x.y.z..."
+                  VERSION=$(echo "$PR_TITLE" | sed 's/.*] //')
+                  echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+                  echo "Detected version: ${VERSION}"
 
-          if [[ "$MERGE_RESULT" == "merged" ]]; then
-            echo "PR just merged — all publish steps needed"
-            echo "pr_merged=true" >> "$GITHUB_OUTPUT"
-            echo "npm_needed=true" >> "$GITHUB_OUTPUT"
-            echo "pypi_needed=true" >> "$GITHUB_OUTPUT"
-            echo "pypi_ble_proxy_needed=true" >> "$GITHUB_OUTPUT"
-            echo "docker_needed=true" >> "$GITHUB_OUTPUT"
-            echo "release_needed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+                  if [[ "$MERGE_RESULT" == "merged" ]]; then
+                    echo "PR just merged — all publish steps needed"
+                    echo "pr_merged=true" >> "$GITHUB_OUTPUT"
+                    echo "npm_needed=true" >> "$GITHUB_OUTPUT"
+                    echo "pypi_needed=true" >> "$GITHUB_OUTPUT"
+                    echo "pypi_ble_proxy_needed=true" >> "$GITHUB_OUTPUT"
+                    echo "docker_needed=true" >> "$GITHUB_OUTPUT"
+                    echo "release_needed=true" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
 
-          if [[ "$MERGE_RESULT" != "skipped" ]]; then
-            echo "Unexpected merge result: ${MERGE_RESULT} — stopping"
-            echo "pr_merged=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+                  if [[ "$MERGE_RESULT" != "skipped" ]]; then
+                    echo "Unexpected merge result: ${MERGE_RESULT} — stopping"
+                    echo "pr_merged=false" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
 
-          # mergeResult is 'skipped' — check if PR was already merged (re-run scenario)
-          PR_STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state --jq '.state')
-          echo "PR state: ${PR_STATE}"
+                  # mergeResult is 'skipped' — check if PR was already merged (re-run scenario)
+                  PR_STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state --jq '.state')
+                  echo "PR state: ${PR_STATE}"
 
-          if [[ "$PR_STATE" != "MERGED" ]]; then
-            echo "PR is not merged — stopping"
-            echo "pr_merged=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
+                  if [[ "$PR_STATE" != "MERGED" ]]; then
+                    echo "PR is not merged — stopping"
+                    echo "pr_merged=false" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
 
-          echo "PR was already merged — checking which publish targets are missing"
-          echo "pr_merged=true" >> "$GITHUB_OUTPUT"
+                  echo "PR was already merged — checking which publish targets are missing"
+                  echo "pr_merged=true" >> "$GITHUB_OUTPUT"
 
-          # Check npm
-          if npm view "matter-server@${VERSION}" version 2>/dev/null; then
-            echo "npm: already published"
-            echo "npm_needed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "npm: NOT published — will publish"
-            echo "npm_needed=true" >> "$GITHUB_OUTPUT"
-          fi
+                  # Check npm
+                  if npm view "matter-server@${VERSION}" version 2>/dev/null; then
+                    echo "npm: already published"
+                    echo "npm_needed=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "npm: NOT published — will publish"
+                    echo "npm_needed=true" >> "$GITHUB_OUTPUT"
+                  fi
 
-          # Check PyPI (needs semver → PEP 440 conversion)
-          PEP440=$(VERSION="$VERSION" python3 -c "
-          import re, os
-          v = os.environ['VERSION']
-          m = re.match(r'^(\d+\.\d+\.\d+)(?:-(.+))?$', v)
-          base, pre = m.group(1), m.group(2)
-          if pre:
-              pm = re.match(r'(alpha|beta|rc)(?:\.(\d+))?(?:-(\d+))?', pre)
-              t = {'alpha':'a','beta':'b','rc':'rc'}[pm.group(1)]
-              n = pm.group(2) or '0'
-              d = f'.dev{pm.group(3)}' if pm.group(3) else ''
-              print(f'{base}{t}{n}{d}')
-          else:
-              print(base)
-          ")
-          echo "PEP 440 version: ${PEP440}"
-          if curl -sf "https://pypi.org/pypi/matter-python-client/${PEP440}/json" >/dev/null 2>&1; then
-            echo "PyPI (matter-python-client): already published"
-            echo "pypi_needed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "PyPI (matter-python-client): NOT published — will publish"
-            echo "pypi_needed=true" >> "$GITHUB_OUTPUT"
-          fi
+                  # Check PyPI (needs semver → PEP 440 conversion)
+                  PEP440=$(VERSION="$VERSION" python3 -c "
+                  import re, os
+                  v = os.environ['VERSION']
+                  m = re.match(r'^(\d+\.\d+\.\d+)(?:-(.+))?$', v)
+                  base, pre = m.group(1), m.group(2)
+                  if pre:
+                      pm = re.match(r'(alpha|beta|rc)(?:\.(\d+))?(?:-(\d+))?', pre)
+                      t = {'alpha':'a','beta':'b','rc':'rc'}[pm.group(1)]
+                      n = pm.group(2) or '0'
+                      d = f'.dev{pm.group(3)}' if pm.group(3) else ''
+                      print(f'{base}{t}{n}{d}')
+                  else:
+                      print(base)
+                  ")
+                  echo "PEP 440 version: ${PEP440}"
+                  if curl -sf "https://pypi.org/pypi/matter-python-client/${PEP440}/json" >/dev/null 2>&1; then
+                    echo "PyPI (matter-python-client): already published"
+                    echo "pypi_needed=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "PyPI (matter-python-client): NOT published — will publish"
+                    echo "pypi_needed=true" >> "$GITHUB_OUTPUT"
+                  fi
 
-          if curl -sf "https://pypi.org/pypi/matter-ble-proxy/${PEP440}/json" >/dev/null 2>&1; then
-            echo "PyPI (matter-ble-proxy): already published"
-            echo "pypi_ble_proxy_needed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "PyPI (matter-ble-proxy): NOT published — will publish"
-            echo "pypi_ble_proxy_needed=true" >> "$GITHUB_OUTPUT"
-          fi
+                  if curl -sf "https://pypi.org/pypi/matter-ble-proxy/${PEP440}/json" >/dev/null 2>&1; then
+                    echo "PyPI (matter-ble-proxy): already published"
+                    echo "pypi_ble_proxy_needed=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "PyPI (matter-ble-proxy): NOT published — will publish"
+                    echo "pypi_ble_proxy_needed=true" >> "$GITHUB_OUTPUT"
+                  fi
 
-          # Check Docker (ghcr.io) via OCI registry API
-          DOCKER_TOKEN=$(curl -sf "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_OWNER}/matterjs-server:pull" | jq -r '.token // empty' || true)
-          if [[ -n "$DOCKER_TOKEN" ]] && curl -sf -H "Authorization: Bearer $DOCKER_TOKEN" \
-            "https://ghcr.io/v2/${REPO_OWNER}/matterjs-server/manifests/${VERSION}" >/dev/null 2>&1; then
-            echo "Docker: already published"
-            echo "docker_needed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Docker: NOT published — will build and push"
-            echo "docker_needed=true" >> "$GITHUB_OUTPUT"
-          fi
+                  # Check Docker (ghcr.io) via OCI registry API
+                  DOCKER_TOKEN=$(curl -sf "https://ghcr.io/token?service=ghcr.io&scope=repository:${REPO_OWNER}/matterjs-server:pull" | jq -r '.token // empty' || true)
+                  if [[ -n "$DOCKER_TOKEN" ]] && curl -sf -H "Authorization: Bearer $DOCKER_TOKEN" \
+                    "https://ghcr.io/v2/${REPO_OWNER}/matterjs-server/manifests/${VERSION}" >/dev/null 2>&1; then
+                    echo "Docker: already published"
+                    echo "docker_needed=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "Docker: NOT published — will build and push"
+                    echo "docker_needed=true" >> "$GITHUB_OUTPUT"
+                  fi
 
-          # Check GitHub Release
-          if gh release view "v${VERSION}" --repo "$REPO" >/dev/null 2>&1; then
-            echo "GitHub Release: already exists"
-            echo "release_needed=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "GitHub Release: NOT found — will create"
-            echo "release_needed=true" >> "$GITHUB_OUTPUT"
-          fi
+                  # Check GitHub Release
+                  if gh release view "v${VERSION}" --repo "$REPO" >/dev/null 2>&1; then
+                    echo "GitHub Release: already exists"
+                    echo "release_needed=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "GitHub Release: NOT found — will create"
+                    echo "release_needed=true" >> "$GITHUB_OUTPUT"
+                  fi
 
-      - name: Checkout repository
-        if: steps.publish_tasks.outputs.pr_merged == 'true'
-        uses: actions/checkout@v6
+            - name: Checkout repository
+              if: steps.publish_tasks.outputs.pr_merged == 'true'
+              uses: actions/checkout@v6
 
-      - name: Install dependencies and build
-        if: steps.publish_tasks.outputs.pr_merged == 'true'
-        run: npm ci
+            - name: Install dependencies and build
+              if: steps.publish_tasks.outputs.pr_merged == 'true'
+              run: npm ci
 
-      - name: Determine version
-        if: steps.publish_tasks.outputs.pr_merged == 'true'
-        id: version
-        uses: actions/github-script@v9
-        with:
-          result-encoding: string
-          script: |
-            const fs = require('fs');
-            return fs.readFileSync(`${process.env.GITHUB_WORKSPACE}/version.txt`, "utf8");
+            - name: Determine version
+              if: steps.publish_tasks.outputs.pr_merged == 'true'
+              id: version
+              uses: actions/github-script@v9
+              with:
+                  result-encoding: string
+                  script: |
+                      const fs = require('fs');
+                      return fs.readFileSync(`${process.env.GITHUB_WORKSPACE}/version.txt`, "utf8");
 
-      - name: Apply new version to package files
-        if: steps.publish_tasks.outputs.pr_merged == 'true'
-        run: npm run version -- --apply
+            - name: Apply new version to package files
+              if: steps.publish_tasks.outputs.pr_merged == 'true'
+              run: npm run version -- --apply
 
-      - name: Publish npm
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.npm_needed == 'true'
-        env:
-          PRERELEASE: ${{ contains(steps.version.outputs.result, '-') }}
-        run: |
-          npm install -g npm@latest
+            - name: Publish npm
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.npm_needed == 'true'
+              env:
+                  PRERELEASE: ${{ contains(steps.version.outputs.result, '-') }}
+              run: |
+                  npm install -g npm@latest
 
-          if [[ "$PRERELEASE" == "true" ]]; then
-            npm publish --workspaces --tag dev
-          else
-            npm publish --workspaces
-          fi
+                  if [[ "$PRERELEASE" == "true" ]]; then
+                    npm publish --workspaces --tag dev
+                  else
+                    npm publish --workspaces
+                  fi
 
-      - name: Wait for npm registry
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.npm_needed == 'true'
-        run: sleep 120
+            - name: Wait for npm registry
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.npm_needed == 'true'
+              run: sleep 120
 
-      - name: Set up Python for PyPI publish
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && (steps.publish_tasks.outputs.pypi_needed == 'true' || steps.publish_tasks.outputs.pypi_ble_proxy_needed == 'true')
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
+            - name: Set up Python for PyPI publish
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && (steps.publish_tasks.outputs.pypi_needed == 'true' || steps.publish_tasks.outputs.pypi_ble_proxy_needed == 'true')
+              uses: actions/setup-python@v6
+              with:
+                  python-version: "3.12"
 
-      - name: Install Python build tools
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && (steps.publish_tasks.outputs.pypi_needed == 'true' || steps.publish_tasks.outputs.pypi_ble_proxy_needed == 'true')
-        run: pip install build tomli tomli-w
+            - name: Install Python build tools
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && (steps.publish_tasks.outputs.pypi_needed == 'true' || steps.publish_tasks.outputs.pypi_ble_proxy_needed == 'true')
+              run: pip install build tomli tomli-w
 
-      - name: Convert version to PEP 440 and set in pyproject.toml files
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && (steps.publish_tasks.outputs.pypi_needed == 'true' || steps.publish_tasks.outputs.pypi_ble_proxy_needed == 'true')
-        id: python_version
-        shell: python
-        env:
-          SEMVER_VERSION: ${{ steps.version.outputs.result }}
-          PYPI_NEEDED: ${{ steps.publish_tasks.outputs.pypi_needed }}
-          PYPI_BLE_PROXY_NEEDED: ${{ steps.publish_tasks.outputs.pypi_ble_proxy_needed }}
-        run: |
-          import re, os, tomli, tomli_w
+            - name: Convert version to PEP 440 and set in pyproject.toml files
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && (steps.publish_tasks.outputs.pypi_needed == 'true' || steps.publish_tasks.outputs.pypi_ble_proxy_needed == 'true')
+              id: python_version
+              shell: python
+              env:
+                  SEMVER_VERSION: ${{ steps.version.outputs.result }}
+                  PYPI_NEEDED: ${{ steps.publish_tasks.outputs.pypi_needed }}
+                  PYPI_BLE_PROXY_NEEDED: ${{ steps.publish_tasks.outputs.pypi_ble_proxy_needed }}
+              run: |
+                  import re, os, tomli, tomli_w
 
-          version = os.environ["SEMVER_VERSION"]
+                  version = os.environ["SEMVER_VERSION"]
 
-          # Convert semver to PEP 440
-          match = re.match(r'^(\d+\.\d+\.\d+)(?:-(.+))?$', version)
-          if not match:
-              raise SystemExit(
-                  f"Invalid SEMVER_VERSION format: {version!r}. "
-                  "Expected 'MAJOR.MINOR.PATCH' or 'MAJOR.MINOR.PATCH-prerelease'."
-              )
-          base = match.group(1)
-          prerelease = match.group(2)
+                  # Convert semver to PEP 440
+                  match = re.match(r'^(\d+\.\d+\.\d+)(?:-(.+))?$', version)
+                  if not match:
+                      raise SystemExit(
+                          f"Invalid SEMVER_VERSION format: {version!r}. "
+                          "Expected 'MAJOR.MINOR.PATCH' or 'MAJOR.MINOR.PATCH-prerelease'."
+                      )
+                  base = match.group(1)
+                  prerelease = match.group(2)
 
-          if prerelease:
-              # Expected: alpha.N-YYYYMMDD[-sha] or beta.N-YYYYMMDD[-sha] or rc.N-...
-              pre_match = re.match(r'^(alpha|beta|rc)(?:\.(\d+))?(?:-(\d+))?', prerelease)
-              if not pre_match:
-                  raise SystemExit(
-                      f"Invalid prerelease format in SEMVER_VERSION: {version!r}. "
-                      "Expected 'alpha[.N][-DATE]', 'beta[.N][-DATE]', or 'rc[.N][-DATE]'."
-                  )
-              pre_type = pre_match.group(1)
-              pre_num = pre_match.group(2) or "0"
-              date_str = pre_match.group(3)
-              pep440_pre = {'alpha': 'a', 'beta': 'b', 'rc': 'rc'}[pre_type]
-              pep440_version = f"{base}{pep440_pre}{pre_num}"
-              if date_str:
-                  pep440_version = f"{pep440_version}.dev{date_str}"
-          else:
-              pep440_version = base
+                  if prerelease:
+                      # Expected: alpha.N-YYYYMMDD[-sha] or beta.N-YYYYMMDD[-sha] or rc.N-...
+                      pre_match = re.match(r'^(alpha|beta|rc)(?:\.(\d+))?(?:-(\d+))?', prerelease)
+                      if not pre_match:
+                          raise SystemExit(
+                              f"Invalid prerelease format in SEMVER_VERSION: {version!r}. "
+                              "Expected 'alpha[.N][-DATE]', 'beta[.N][-DATE]', or 'rc[.N][-DATE]'."
+                          )
+                      pre_type = pre_match.group(1)
+                      pre_num = pre_match.group(2) or "0"
+                      date_str = pre_match.group(3)
+                      pep440_pre = {'alpha': 'a', 'beta': 'b', 'rc': 'rc'}[pre_type]
+                      pep440_version = f"{base}{pep440_pre}{pre_num}"
+                      if date_str:
+                          pep440_version = f"{pep440_version}.dev{date_str}"
+                  else:
+                      pep440_version = base
 
-          print(f"Semver: {version} -> PEP 440: {pep440_version}")
+                  print(f"Semver: {version} -> PEP 440: {pep440_version}")
 
-          def _patch(path: str) -> None:
-              with open(path, "rb") as f:
-                  pyproject = tomli.load(f)
-              pyproject["project"]["version"] = pep440_version
-              with open(path, "wb") as f:
-                  tomli_w.dump(pyproject, f)
+                  def _patch(path: str) -> None:
+                      with open(path, "rb") as f:
+                          pyproject = tomli.load(f)
+                      pyproject["project"]["version"] = pep440_version
+                      with open(path, "wb") as f:
+                          tomli_w.dump(pyproject, f)
 
-          if os.environ.get("PYPI_NEEDED") == "true":
-              _patch("python_client/pyproject.toml")
-          if os.environ.get("PYPI_BLE_PROXY_NEEDED") == "true":
-              _patch("python_ble_proxy/pyproject.toml")
+                  if os.environ.get("PYPI_NEEDED") == "true":
+                      _patch("python_client/pyproject.toml")
+                  if os.environ.get("PYPI_BLE_PROXY_NEEDED") == "true":
+                      _patch("python_ble_proxy/pyproject.toml")
 
-          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
-              f.write(f"pep440_version={pep440_version}\n")
+                  with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+                      f.write(f"pep440_version={pep440_version}\n")
 
-      - name: Build Python client package
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.pypi_needed == 'true'
-        run: python3 -m build python_client/
+            - name: Build Python client package
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.pypi_needed == 'true'
+              run: python3 -m build python_client/
 
-      - name: Publish Python client to PyPI
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.pypi_needed == 'true'
-        uses: pypa/gh-action-pypi-publish@v1.14.0
-        with:
-          packages-dir: python_client/dist/
+            - name: Publish Python client to PyPI
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.pypi_needed == 'true'
+              uses: pypa/gh-action-pypi-publish@v1.14.0
+              with:
+                  packages-dir: python_client/dist/
 
-      - name: Build Python BLE proxy package
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.pypi_ble_proxy_needed == 'true'
-        run: python3 -m build python_ble_proxy/
+            - name: Build Python BLE proxy package
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.pypi_ble_proxy_needed == 'true'
+              run: python3 -m build python_ble_proxy/
 
-      - name: Publish Python BLE proxy to PyPI
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.pypi_ble_proxy_needed == 'true'
-        uses: pypa/gh-action-pypi-publish@v1.14.0
-        with:
-          packages-dir: python_ble_proxy/dist/
+            - name: Publish Python BLE proxy to PyPI
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.pypi_ble_proxy_needed == 'true'
+              uses: pypa/gh-action-pypi-publish@v1.14.0
+              with:
+                  packages-dir: python_ble_proxy/dist/
 
-      - name: Log in to GitHub Container Registry
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.docker_needed == 'true'
-        uses: docker/login-action@v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Log in to GitHub Container Registry
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.docker_needed == 'true'
+              uses: docker/login-action@v4.2.0
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.docker_needed == 'true'
-        uses: docker/setup-buildx-action@v4.1.0
+            - name: Set up Docker Buildx
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.docker_needed == 'true'
+              uses: docker/setup-buildx-action@v4.1.0
 
-      - name: Version number for Docker tags
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.docker_needed == 'true'
-        id: docker_tags
-        shell: bash
-        run: |
-          version="${{ steps.version.outputs.result }}"
-          echo "patch=${version}" >> $GITHUB_OUTPUT
-          echo "minor=${version%.*}" >> $GITHUB_OUTPUT
-          echo "major=${version%.*.*}" >> $GITHUB_OUTPUT
+            - name: Version number for Docker tags
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.docker_needed == 'true'
+              id: docker_tags
+              shell: bash
+              run: |
+                  version="${{ steps.version.outputs.result }}"
+                  echo "patch=${version}" >> $GITHUB_OUTPUT
+                  echo "minor=${version%.*}" >> $GITHUB_OUTPUT
+                  echo "major=${version%.*.*}" >> $GITHUB_OUTPUT
 
-      - name: Build and push Docker image (release)
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.docker_needed == 'true' && !contains(steps.version.outputs.result, '-')
-        uses: docker/build-push-action@v7.2.0
-        with:
-          context: ./docker/matterjs-server
-          platforms: linux/amd64,linux/arm64
-          file: ./docker/matterjs-server/Dockerfile
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/matterjs-server:${{ steps.docker_tags.outputs.patch }}
-            ghcr.io/${{ github.repository_owner }}/matterjs-server:${{ steps.docker_tags.outputs.minor }}
-            ghcr.io/${{ github.repository_owner }}/matterjs-server:${{ steps.docker_tags.outputs.major }}
-            ghcr.io/${{ github.repository_owner }}/matterjs-server:stable
-            ghcr.io/${{ github.repository_owner }}/matterjs-server:latest
-            ghcr.io/${{ github.repository_owner }}/matterjs-server:dev
-          push: true
-          build-args: |
-            MATTERJS_SERVER_VERSION=${{ steps.version.outputs.result }}
+            - name: Build and push Docker image (release)
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.docker_needed == 'true' && !contains(steps.version.outputs.result, '-')
+              uses: docker/build-push-action@v7.2.0
+              with:
+                  context: ./docker/matterjs-server
+                  platforms: linux/amd64,linux/arm64
+                  file: ./docker/matterjs-server/Dockerfile
+                  tags: |
+                      ghcr.io/${{ github.repository_owner }}/matterjs-server:${{ steps.docker_tags.outputs.patch }}
+                      ghcr.io/${{ github.repository_owner }}/matterjs-server:${{ steps.docker_tags.outputs.minor }}
+                      ghcr.io/${{ github.repository_owner }}/matterjs-server:${{ steps.docker_tags.outputs.major }}
+                      ghcr.io/${{ github.repository_owner }}/matterjs-server:stable
+                      ghcr.io/${{ github.repository_owner }}/matterjs-server:latest
+                      ghcr.io/${{ github.repository_owner }}/matterjs-server:dev
+                  push: true
+                  build-args: |
+                      MATTERJS_SERVER_VERSION=${{ steps.version.outputs.result }}
 
-      - name: Build and push Docker image (pre-release)
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.docker_needed == 'true' && contains(steps.version.outputs.result, '-')
-        uses: docker/build-push-action@v7.2.0
-        with:
-          context: ./docker/matterjs-server
-          platforms: linux/amd64,linux/arm64
-          file: ./docker/matterjs-server/Dockerfile
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/matterjs-server:${{ steps.docker_tags.outputs.patch }}
-            ghcr.io/${{ github.repository_owner }}/matterjs-server:dev
-          push: true
-          build-args: |
-            MATTERJS_SERVER_VERSION=${{ steps.version.outputs.result }}
+            - name: Build and push Docker image (pre-release)
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.docker_needed == 'true' && contains(steps.version.outputs.result, '-')
+              uses: docker/build-push-action@v7.2.0
+              with:
+                  context: ./docker/matterjs-server
+                  platforms: linux/amd64,linux/arm64
+                  file: ./docker/matterjs-server/Dockerfile
+                  tags: |
+                      ghcr.io/${{ github.repository_owner }}/matterjs-server:${{ steps.docker_tags.outputs.patch }}
+                      ghcr.io/${{ github.repository_owner }}/matterjs-server:dev
+                  push: true
+                  build-args: |
+                      MATTERJS_SERVER_VERSION=${{ steps.version.outputs.result }}
 
-      - name: Create Github Release
-        if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.release_needed == 'true'
-        uses: ncipollo/release-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag: v${{ steps.version.outputs.result }}
-          name: Release v${{ steps.version.outputs.result }}
-          draft: false
-          prerelease: ${{ contains(steps.version.outputs.result, '-') }}
-          body: ${{ contains(steps.version.outputs.result, '-') && 'Nightly release' || format('Official release, check [CHANGELOG.md]({0}) for details', 'https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md') }}
+            - name: Create Github Release
+              if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.release_needed == 'true'
+              uses: ncipollo/release-action@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  tag: v${{ steps.version.outputs.result }}
+                  name: Release v${{ steps.version.outputs.result }}
+                  draft: false
+                  prerelease: ${{ contains(steps.version.outputs.result, '-') }}
+                  body: ${{ contains(steps.version.outputs.result, '-') && 'Nightly release' || format('Official release, check [CHANGELOG.md]({0}) for details', 'https://github.com/matter-js/matterjs-server/blob/main/CHANGELOG.md') }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -379,7 +379,7 @@ jobs:
                   build-args: |
                       MATTERJS_SERVER_VERSION=${{ steps.version.outputs.result }}
 
-            - name: Create Github Release
+            - name: Create GitHub Release
               if: steps.publish_tasks.outputs.pr_merged == 'true' && steps.publish_tasks.outputs.release_needed == 'true'
               uses: ncipollo/release-action@v1
               env:

--- a/ALPHABETATESTS.md
+++ b/ALPHABETATESTS.md
@@ -81,7 +81,7 @@ Ensure you follow the networking preparation instructions in the [OS requirement
 
 #### Step 1: Installation Steps (Preparation)
 
-1. Ensure you have Node.js 22.13+, or 24.x (22.x recommended) installed
+1. Ensure you have Node.js 22.13+, 24.x or 26.x (24.x recommended) installed
 2. `git clone https://github.com/matter-js/matterjs-server.git` (clone this repository)
 3. `cd matterjs-server` (change directory to the repository)
 4. `npm install` (install dependencies, only execute this in the repository base directory)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ This page shows a detailed overview of the changes between versions without the 
 
 - Breaking: The server now requires at least Node.js 22.13.0 (LTS)
 - (Dev)Breaking: (rspier) Change Dev-Docker-Container to use the same user like the production container – might require permission updates
+- Enhancement: (rspier) Added inline NodeLabel editing to the Node detail view
 - Enhancement: Dashboard network visualization fills the full window width on large/4K displays
-- Enhancement: Dashboard Thread mesh marks the network Leader Border Router with a distinct crown icon and amber color
+- Enhancement: Dashboard Thread mesh icons reflect each node's Thread and Border Router roles
 - Enhancement: Optimize the error message when commissioning a device with a test/dev certificate but without the "Test Net DCL" configuration enabled
 - Enhancement: Update matter.js to the latest 0.17.1-nightly
     - Removed invalid FabricIndex field requirements for some command types and models

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,16 +51,21 @@ This is an npm workspaces monorepo with four packages:
 ## Architecture
 
 ### Server Flow
+
 `MatterServer.ts` → creates `ConfigStorage` + `MatterController` → creates `WebServer` with handlers:
+
 - `WebSocketControllerHandler`: Python Matter Server compatible WS API on `/ws`
 - `StaticFileHandler`: Serves dashboard assets
 
 ### WebSocket Protocol
+
 The server implements a protocol compatible with Home Assistant's Python Matter Server. Key commands:
+
 - `start_listening`, `commission_with_code`, `device_command`, `read_attribute`, `write_attribute`
 - Events: `node_added`, `node_updated`, `node_removed`, `attribute_updated`
 
 ### Key Dependencies
+
 - `@project-chip/matter.js`: Core Matter protocol implementation
 - `@matter/main`, `@matter/main/general`: Matter.js utilities
 - `@matter/nodejs-ble`: Optional BLE support (enable with `--ble` flag)
@@ -68,6 +73,7 @@ The server implements a protocol compatible with Home Assistant's Python Matter 
 ## Build System
 
 Uses external `@nacho-iot/js-tools` build system:
+
 - TSC for type checking and declaration files
 - esbuild for transpilation (ESM + CJS)
 - Dashboard uses Rollup for bundling with Babel
@@ -79,11 +85,12 @@ Dashboard has additional `npm run generate` step for cluster descriptions.
 
 ## Node.js Requirements
 
-Engine requirement: `>=20.19.0 <22.0.0 || >=22.13.0`
+Engine requirement: `>=22.13.0`
 
 ## Code Quality
 
 ### Tooling
+
 - **Linter**: [oxlint](https://oxc.rs) with type-aware checking (config: `.oxlintrc.json`)
 - **Formatter**: [oxfmt](https://oxc.rs) (config: `.oxfmtrc.json`)
 - Both are Rust-based and run in <1s across the entire monorepo
@@ -118,18 +125,21 @@ Plan/design documents in `docs/plans/` are working files only. **Never commit th
 ## Dashboard Development
 
 ### Technology Stack
+
 - **Lit 3.x**: Web components framework with TypeScript decorators
 - **Material Web 2.4.x**: Material Design 3 components (`md-*` elements)
 - **@mdi/js**: Material Design Icons as SVG paths
 - **CSS Variables**: All colors use CSS custom properties for theming
 
 ### Styling Patterns
+
 - All components use inline `static override styles = css\`...\`` (Lit pattern)
 - Colors must use CSS variables from `public/index.html`, not hardcoded values
 - Key variables: `--md-sys-color-primary`, `--md-sys-color-surface`, `--md-sys-color-on-surface`, `--md-sys-color-on-surface-variant`
 - Dark mode: Variables overridden in `html.dark-theme body` selector
 
 ### Theme-Aware Colors
+
 When defining colors in dashboard components, **always use CSS variables** that are defined for both light and dark themes:
 
 ```css
@@ -144,6 +154,7 @@ color: grey;
 ```
 
 Available theme variables defined in `public/index.html`:
+
 - `--text-color`: Secondary text (grey) - adapts for light/dark
 - `--danger-color`: Error/warning red
 - `--primary-color`: Primary accent color
@@ -152,12 +163,14 @@ Available theme variables defined in `public/index.html`:
 Always verify new colors look correct in both light AND dark themes before committing.
 
 ### Theme System
+
 - `src/util/theme-service.ts`: Singleton managing theme state
 - Supports: `light`, `dark`, `system` (OS auto-detect)
 - Persisted in localStorage (`matterTheme` key)
 - Query parameter override: `?theme=dark|light|system`
 
 ### Key Dashboard Files
+
 - `public/index.html`: CSS variables for light/dark themes
 - `src/util/theme-service.ts`: Theme management singleton
 - `src/pages/components/header.ts`: Header bar with theme toggle
@@ -165,6 +178,7 @@ Always verify new colors look correct in both light AND dark themes before commi
 - `src/components/ha-svg-icon.ts`: Custom SVG icon component
 
 ### Common Pitfalls
+
 - Don't use hardcoded colors like `#673ab7` or `cornsilk` - use CSS variables
 - Material Web components need proper `--md-sys-color-*` variables to render correctly in dark mode
 - When adding status/error pages, include the header component for consistent UX
@@ -173,22 +187,27 @@ Always verify new colors look correct in both light AND dark themes before commi
 ## Design Context
 
 ### Users
+
 Two distinct audiences served equally:
+
 1. **Home Assistant power users** — technically capable smart home enthusiasts managing their Matter network. Need clear device status, easy commissioning, and network health at a glance.
 2. **Developers and testers** — building or debugging Matter integrations. Need raw data, attribute inspection, cluster details, and diagnostic information.
 
 Both audiences benefit from information density. Neither needs hand-holding.
 
 ### Brand Personality
+
 **Utilitarian, dense, reliable.** Tool-first. The dashboard should feel like a well-built instrument panel — everything needed visible, nothing decorative for its own sake.
 
 ### Aesthetic Direction
+
 - Material Design 3 as foundation — refine rather than replace
 - Both light and dark modes, equal quality in each
 - Current design is acceptable baseline — improvements focus on polish, color mode consistency, spacing, and information hierarchy
 - Anti-references: not a "hacker dashboard", not overly decorative, not consumer marketing
 
 ### Design Principles
+
 1. **Density over decoration** — Show more data in less space. Every pixel earns its place.
 2. **State clarity** — Online/offline, connection quality, commissioning status must be instantly readable. Color-code consistently.
 3. **Both modes, equal quality** — Light and dark themes both intentional, not one an afterthought.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A preconfigured [dev container](./.devcontainer) is available with all required 
 
 ### Manual installation (from npm)
 
-- Ensure to have Node.js 22.13+, 24.x or 26.x installed (24.x recommended)
+- Ensure you have Node.js 22.13+, 24.x or 26.x installed (24.x recommended)
 - `npm install matter-server`
 - `npx matter-server` or alternatively `cd node_modules/matter-server && npm run server`
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A preconfigured [dev container](./.devcontainer) is available with all required 
 
 ### Manual installation (from npm)
 
-- Ensure to have Node.js 22.13+, or 24.x installed (22.x recommended)
+- Ensure to have Node.js 22.13+, 24.x or 26.x installed (24.x recommended)
 - `npm install matter-server`
 - `npx matter-server` or alternatively `cd node_modules/matter-server && npm run server`
 

--- a/docker/matterjs-server/Dockerfile
+++ b/docker/matterjs-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-trixie-slim
+FROM node:24-trixie-slim
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/docker/matterjs-server/Dockerfile.dev
+++ b/docker/matterjs-server/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:22-trixie-slim
+FROM node:24-trixie-slim
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Summary

- Add Node.js **26.x** to CI test matrices (`build-test.js.yml`, `release-npm.yml`) alongside 22.x/24.x
- Bump production and dev Docker base images from `node:22-trixie-slim` to `node:24-trixie-slim`
- Update install notes in `README.md` and `ALPHABETATESTS.md` → "22.13+, 24.x or 26.x (24.x recommended)"
- CHANGELOG: add inline NodeLabel editing entry; reword Thread mesh role-icon entry
- Correct documented engine requirement to `>=22.13.0` in `CLAUDE.md` and `.github/copilot-instructions.md`

## Notes

- `package.json` `engines` fields already specify `>=22.13.0`, which permits 24.x and 26.x — no engine bump or lockfile relock required.
- The two workflow files carry a large reindent (2→4 space) on top of the real changes; the substantive diff is only the `node-version` matrix additions and python-version quote normalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)