### PR TITLE
ble-proxy: demote expected logs to `DEBUG`

### DIFF
--- a/python_ble_proxy/matter_ble_proxy/client.py
+++ b/python_ble_proxy/matter_ble_proxy/client.py
@@ -208,7 +208,7 @@ class MatterBleProxy:
                 f"BLE proxy handshake failed: {response.get('error')} - {response.get('message')}",
             )
 
-        _LOGGER.info("BLE proxy connected (protocol v%s)", response.get("version"))
+        _LOGGER.debug("BLE proxy connected (protocol v%s)", response.get("version"))
 
         self._loop = asyncio.get_running_loop()
         self._closed_event.clear()
@@ -285,7 +285,7 @@ class MatterBleProxy:
         except Exception:
             _LOGGER.exception("Error in BLE proxy message loop")
         finally:
-            _LOGGER.warning("BLE proxy WebSocket connection ended")
+            _LOGGER.debug("BLE proxy WebSocket connection ended")
             # Release scan + peripherals so an unexpected WS close doesn't leave the
             # adapter scanning or peripherals connected until the caller calls disconnect().
             await self._release_ble_resources()
@@ -300,10 +300,10 @@ class MatterBleProxy:
             _LOGGER.warning("Received invalid command: %s", msg)
             return
 
-        if _LOGGER.isEnabledFor(logging.INFO):
-            # Strip base64 payloads from INFO logs; full args remain at DEBUG via aiohttp's frame log.
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            # Strip base64 payloads from the summary; full args remain available via aiohttp's frame log.
             summary = {k: v for k, v in args.items() if k not in {"value"}}
-            _LOGGER.info("[←CMD] id=%s %s%s", cmd_id, command, f" {summary}" if summary else "")
+            _LOGGER.debug("[←CMD] id=%s %s%s", cmd_id, command, f" {summary}" if summary else "")
 
         handler = {
             "start_scan": self._handle_start_scan,

--- a/python_ble_proxy/matter_ble_proxy/client.py
+++ b/python_ble_proxy/matter_ble_proxy/client.py
@@ -313,7 +313,7 @@ class MatterBleProxy:
             return
 
         if _LOGGER.isEnabledFor(logging.DEBUG):
-            # Strip base64 payloads from the summary; full args remain available via aiohttp's frame log.
+            # Drop the base64 `value` payload to keep the per-command line readable.
             summary = {k: v for k, v in args.items() if k not in {"value"}}
             _LOGGER.debug("[←CMD] id=%s %s%s", cmd_id, command, f" {summary}" if summary else "")
 

--- a/python_ble_proxy/matter_ble_proxy/client.py
+++ b/python_ble_proxy/matter_ble_proxy/client.py
@@ -287,11 +287,9 @@ class MatterBleProxy:
         except Exception:
             _LOGGER.exception("Error in BLE proxy message loop")
         else:
-            # The server closed the socket. Warn only on an abnormal closure (1006: no
-            # close handshake — crash / network loss), which has no other reporter on the
-            # BLE proxy connection. A graceful server shutdown, including a matter-server
-            # add-on update/restart, completes the close handshake (bare close -> code 0,
-            # or 1000/1001), so it stays quiet at DEBUG.
+            # Server closed the socket. Warn only on an abnormal closure (1006: no close
+            # handshake — crash / network loss). A graceful shutdown, including a
+            # matter-server add-on update, completes the handshake and stays quiet.
             close_code = ws.close_code
             if close_code == aiohttp.WSCloseCode.ABNORMAL_CLOSURE:
                 _LOGGER.warning("BLE proxy WebSocket connection lost unexpectedly (code %s)", close_code)

--- a/python_ble_proxy/matter_ble_proxy/client.py
+++ b/python_ble_proxy/matter_ble_proxy/client.py
@@ -266,10 +266,11 @@ class MatterBleProxy:
         return loop.create_task(coro)
 
     async def _message_loop(self) -> None:
-        if self._ws is None:
+        ws = self._ws
+        if ws is None:
             return
         try:
-            async for msg in self._ws:
+            async for msg in ws:
                 if msg.type == aiohttp.WSMsgType.TEXT:
                     await self._handle_command(msg.json())
                 elif msg.type == aiohttp.WSMsgType.BINARY:
@@ -281,11 +282,22 @@ class MatterBleProxy:
                 ):
                     break
         except asyncio.CancelledError:
+            # Intentional disconnect() cancels this task; nothing to report.
             return
         except Exception:
             _LOGGER.exception("Error in BLE proxy message loop")
+        else:
+            # The server closed the socket. Warn only on an abnormal closure (1006: no
+            # close handshake — crash / network loss), which has no other reporter on the
+            # BLE proxy connection. A graceful server shutdown, including a matter-server
+            # add-on update/restart, completes the close handshake (bare close -> code 0,
+            # or 1000/1001), so it stays quiet at DEBUG.
+            close_code = ws.close_code
+            if close_code == aiohttp.WSCloseCode.ABNORMAL_CLOSURE:
+                _LOGGER.warning("BLE proxy WebSocket connection lost unexpectedly (code %s)", close_code)
+            else:
+                _LOGGER.debug("BLE proxy WebSocket connection closed (code %s)", close_code)
         finally:
-            _LOGGER.debug("BLE proxy WebSocket connection ended")
             # Release scan + peripherals so an unexpected WS close doesn't leave the
             # adapter scanning or peripherals connected until the caller calls disconnect().
             await self._release_ble_resources()

--- a/python_ble_proxy/matter_ble_proxy/client.py
+++ b/python_ble_proxy/matter_ble_proxy/client.py
@@ -282,7 +282,7 @@ class MatterBleProxy:
                 ):
                     break
         except asyncio.CancelledError:
-            # Intentional disconnect() cancels this task; nothing to report.
+            _LOGGER.debug("BLE proxy WebSocket connection closed (disconnect)")
             return
         except Exception:
             _LOGGER.exception("Error in BLE proxy message loop")


### PR DESCRIPTION
Quiets the Python BLE proxy's normal-operation logging and makes connection-close logging meaningful.

**Demoted to `DEBUG`** (fired at INFO/WARNING during ordinary use):
- "BLE proxy connected" (once per connect; the CLI already logs "Connected.")
- per-command echo `[←CMD] …` (one line per inbound command)

**Connection close** now classified by WebSocket close code instead of a blanket level:
- intentional `disconnect()` → DEBUG
- graceful server shutdown, incl. matter-server add-on update (completes close handshake) → DEBUG
- abnormal drop — code `1006`, no close handshake (crash / network loss) → WARNING
- exception in the message loop → ERROR

The proxy connection has no HA-side listener (unlike the main matter_server client), so a proxy-only abnormal drop has no other reporter — hence the `1006` WARNING — while routine shutdowns stay quiet.

Genuine anomalies (invalid command, short binary frame, write error) remain at WARNING. Also fixes a misleading per-command log comment.