### PR TITLE
feat(dashboard): search Thread Mesh by label and node id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This page shows a detailed overview of the changes between versions without the 
 - Enhancement: (rspier) Added inline NodeLabel editing to the Node detail view
 - Enhancement: Dashboard network visualization fills the full window width on large/4K displays
 - Enhancement: Dashboard Thread mesh icons reflect each node's Thread and Border Router roles
+- Enhancement: Allows to find a node in the thread network chart by its node label additionally to the extended address and Node-ID
 - Enhancement: Optimize the error message when commissioning a device with a test/dev certificate but without the "Test Net DCL" configuration enabled
 - Enhancement: Update matter.js to the latest 0.17.1-nightly
     - Removed invalid FabricIndex field requirements for some command types and models

--- a/packages/dashboard/src/pages/matter-network-view.ts
+++ b/packages/dashboard/src/pages/matter-network-view.ts
@@ -291,7 +291,7 @@ class MatterNetworkView extends LitElement {
             return;
         }
 
-        const found = graph.selectByExtendedAddress(searchValue);
+        const found = graph.selectBySearch(searchValue);
         this._threadAddressSearchStatus = found ? "found" : "not-found";
     }
 
@@ -306,8 +306,8 @@ class MatterNetworkView extends LitElement {
                                 type="text"
                                 .value=${this._threadAddressSearch}
                                 @input=${this._handleThreadAddressSearchInput}
-                                placeholder="Search extended address"
-                                title="Find device by Thread extended address (EUI-64)"
+                                placeholder="Search label, node id, or address"
+                                title="Find a Thread device by node label, node id, or extended address (EUI-64)"
                             />
                             <button type="submit" class="search-button">Find</button>
                         </form>
@@ -371,7 +371,7 @@ class MatterNetworkView extends LitElement {
                     : html`<div class="thread-search-status ${this._threadAddressSearchStatus}">
                           ${this._threadAddressSearchStatus === "found"
                               ? "Node highlighted."
-                              : "No matching extended address found."}
+                              : "No matching device found."}
                       </div>`}
                 <thread-graph
                     .nodes=${this.nodes}

--- a/packages/dashboard/src/pages/network/thread-graph.ts
+++ b/packages/dashboard/src/pages/network/thread-graph.ts
@@ -114,36 +114,56 @@ export class ThreadGraph extends BaseNetworkGraph {
     }
 
     /**
-     * Searches for a Thread node (known or unknown) by extended address and selects it.
-     * Accepts formats like:
-     * - AABBCCDDEEFF0011
-     * - AA:BB:CC:DD:EE:FF:00:11
-     * - 0xAABBCCDDEEFF0011
+     * Searches for a Thread node (known or unknown) and selects it. Matches, in priority order:
+     * 1. Extended address (EUI-64), accepting `AABBCCDDEEFF0011`, `AA:BB:...`, or `0x...` forms.
+     * 2. Node id (exact).
+     * 3. Visible device label (case-insensitive substring).
      * Returns true when a match is found.
      */
-    public selectByExtendedAddress(address: string): boolean {
-        const normalized = normalizeExtendedAddressInput(address);
-        if (!normalized) {
+    public selectBySearch(query: string): boolean {
+        const trimmed = query.trim();
+        if (!trimmed) {
             return false;
         }
 
-        // Search commissioned Thread devices first
-        for (const node of Object.values(this.nodes)) {
-            if (getNetworkType(node) !== "thread") {
-                continue;
+        // Only visible nodes are selectable — focusing a hidden node would report a
+        // match the user can't see on the graph.
+        const threadNodes = Object.values(this.nodes).filter(
+            node => getNetworkType(node) === "thread" && !(this.hideOfflineNodes && node.available === false),
+        );
+
+        // 1. Extended address — commissioned devices first, then unknown/external neighbors.
+        const normalized = normalizeExtendedAddressInput(trimmed);
+        if (normalized) {
+            for (const node of threadNodes) {
+                const extAddressHex = getThreadExtendedAddressHex(node);
+                if (extAddressHex && extAddressHex === normalized) {
+                    this.selectNode(String(node.node_id));
+                    return true;
+                }
             }
 
-            const extAddressHex = getThreadExtendedAddressHex(node);
-            if (extAddressHex && extAddressHex === normalized) {
+            for (const [unknownId, unknown] of this._unknownDevicesMapCache) {
+                if (normalizeExtendedAddressInput(unknown.extAddressHex) === normalized) {
+                    this.selectNode(unknownId);
+                    return true;
+                }
+            }
+        }
+
+        // 2. Node id (exact).
+        for (const node of threadNodes) {
+            if (String(node.node_id) === trimmed) {
                 this.selectNode(String(node.node_id));
                 return true;
             }
         }
 
-        // Then search unknown/external Thread devices
-        for (const [unknownId, unknown] of this._unknownDevicesMapCache) {
-            if (normalizeExtendedAddressInput(unknown.extAddressHex) === normalized) {
-                this.selectNode(unknownId);
+        // 3. Device label as shown on the graph (case-insensitive substring).
+        const needle = trimmed.toLowerCase();
+        for (const node of threadNodes) {
+            if (getDeviceName(node).toLowerCase().includes(needle)) {
+                this.selectNode(String(node.node_id));
                 return true;
             }
         }


### PR DESCRIPTION
## Summary

Addresses #703. The Thread Mesh search only matched the Thread extended address (EUI-64) — any other input returned "not found", so device labels and node ids could not be searched.

Broadens `ThreadGraph.selectBySearch` (renamed from `selectByExtendedAddress`) to match, in priority order:

1. **Extended address** (EUI-64) — existing behaviour, accepts `AABBCCDDEEFF0011`, `AA:BB:…`, `0x…`
2. **Node id** — exact match
3. **Device label as shown on the graph** — case-insensitive substring (`getDeviceName`: node label, else `productName (serial)`)

Matching is restricted to **visible** nodes, fixing a latent issue where a hidden offline node (with the offline-nodes filter on) reported a match the user couldn't see on the graph.

UI text updated: placeholder, input title, and not-found message now reflect the broader search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)