### PR TITLE
feat(ble): add dbus-next dependency for noble D-Bus backend

### DIFF
--- a/.github/workflows/build-test.js.yml
+++ b/.github/workflows/build-test.js.yml
@@ -17,6 +17,7 @@ jobs:
     check-and-lint:
         outputs:
             package-changes: ${{ steps.changes.outputs.src }}
+            docker-changes: ${{ steps.changes.outputs.docker }}
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v6
@@ -28,6 +29,12 @@ jobs:
                       src:
                         - "package.json"
                         - "packages/**/package.json"
+                        - ".github/workflows/build-test.js.yml"
+                      docker:
+                        - "package.json"
+                        - "package-lock.json"
+                        - "packages/**"
+                        - "docker/**"
                         - ".github/workflows/build-test.js.yml"
             - name: Prepare testing environment
               uses: ./.github/actions/prepare-env
@@ -70,3 +77,27 @@ jobs:
                   node-version: ${{ matrix.node-version }}
             - name: Execute tests
               run: npm run test
+
+    docker-build:
+        # Builds the dev image from source (scripts enabled) so native module
+        # compilation and the Dockerfile itself are exercised on every relevant PR,
+        # instead of only at release time.
+        needs: [check-and-lint]
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+              if: needs.check-and-lint.outputs.docker-changes == 'true' || github.event.pull_request.user.login == 'dependabot[bot]'
+            - name: Set up Docker Buildx
+              if: needs.check-and-lint.outputs.docker-changes == 'true' || github.event.pull_request.user.login == 'dependabot[bot]'
+              uses: docker/setup-buildx-action@v3
+            - name: Build dev image from source
+              if: needs.check-and-lint.outputs.docker-changes == 'true' || github.event.pull_request.user.login == 'dependabot[bot]'
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  file: ./docker/matterjs-server/Dockerfile.dev
+                  push: false
+                  load: true
+                  tags: matterjs-server:ci
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,13 @@ This page shows a detailed overview of the changes between versions without the 
 - Enhancement: (rspier) Added inline NodeLabel editing to the Node detail view
 - Enhancement: Dashboard network visualization fills the full window width on large/4K displays
 - Enhancement: Dashboard Thread mesh icons reflect each node's Thread and Border Router roles
-- Enhancement: Allows to find a node in the thread network chart by its node label additionally to the extended address and Node-ID
+- Enhancement: Allows finding a node in the thread network chart by its node label in addition to the extended address and Node-ID
 - Enhancement: Optimize the error message when commissioning a device with a test/dev certificate but without the "Test Net DCL" configuration enabled
 - Enhancement: Update matter.js to the latest 0.17.1-nightly
     - Removed invalid FabricIndex field requirements for some command types and models
     - Standardized log levels and logged messages
     - Fix: Event reports are now decoded in wire (EventNumber) order
+- Enhancement: Adds the dbus-next package to support BLE commissioning in D-Bus mode (see [docker](./docs/docker.md) and [os_requirements](./docs/os_requirements.md) for details)
 - Adjustment: Standardized log levels and logged messages
 
 ## 0.7.1 (2026-05-21)

--- a/docker/matterjs-server/Dockerfile.dev
+++ b/docker/matterjs-server/Dockerfile.dev
@@ -4,9 +4,14 @@ FROM node:24-trixie-slim
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install required system dependencies
+# Runtime dependencies:
 # - iputils-ping: Required for node ping functionality
 # - curl: For health checks and general utility
 # - git: Required for npm install from git repos
+# - bluez: Bluetooth stack for BLE commissioning
+# Build dependencies (kept in the dev image for fast incremental rebuilds):
+# - python3, make, gcc, g++: toolchain for native module compilation
+# - libbluetooth-dev, libudev-dev: headers for native BLE/udev bindings
 RUN \
     set -x \
     && apt-get update \
@@ -14,7 +19,13 @@ RUN \
         iputils-ping \
         curl \
         git \
-    && apt-get purge -y --auto-remove \
+        bluez \
+        python3 \
+        make \
+        gcc \
+        g++ \
+        libbluetooth-dev \
+        libudev-dev \
     && rm -rf \
         /var/lib/apt/lists/* \
         /usr/src/*
@@ -28,16 +39,21 @@ COPY packages/custom-clusters/package*.json ./packages/custom-clusters/
 COPY packages/ws-controller/package*.json ./packages/ws-controller/
 COPY packages/ws-client/package*.json ./packages/ws-client/
 COPY packages/dashboard/package*.json ./packages/dashboard/
+COPY packages/ble-proxy/package*.json ./packages/ble-proxy/
 COPY packages/matter-server/package*.json ./packages/matter-server/
 
-# Install dependencies
+# Install dependencies. --ignore-scripts is required: the root `prepare` script
+# runs `build-clean`, which needs the source that is only copied below (kept after
+# this layer for caching). Native modules are compiled explicitly after the copy.
 RUN npm ci --ignore-scripts
 
 # Copy source code
 COPY . .
 
-# Build all packages
-RUN npm run build
+# Compile optional native modules (noble/bleno for BLE) now that the toolchain and
+# source are present, then build all packages.
+RUN npm rebuild --foreground-scripts \
+    && npm run build
 
 # Initialize data volume with user permissions
 RUN mkdir -p /data && chown -R 1000:1000 /data

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -251,15 +251,34 @@ docker compose logs -f
 
 ### Device discovery via host BLE
 
-For security reasons, by default the matter.js server is run as an unprivileged user in Docker. Unfortunately, up to now we didn't find a way to grant access to a specific HCI device to unprivileged users.
+For security reasons, by default the matter.js server is run as an unprivileged user in Docker. The Bluetooth backend ([noble](https://github.com/matter-js/matter.js/tree/main/packages/nodejs-ble)) talks to the host adapter in one of two ways, selectable via the `NOBLE_BINDINGS` environment variable:
 
-If you need to discover Matter devices via the hosts BLE, you can use this workaround:
+#### D-Bus / BlueZ backend (recommended)
+
+Set `NOBLE_BINDINGS=dbus` to make noble talk to the host's BlueZ daemon over D-Bus instead of opening a raw HCI socket. This keeps the container unprivileged: the only host resource it needs is the system D-Bus socket, mounted read-only.
+
+```bash
+docker run -d \
+  --name matterjs-server \
+  --restart=unless-stopped \
+  -v $(pwd)/data:/data \
+  -v /run/dbus:/run/dbus:ro \
+  --network=host \
+  -e NOBLE_BINDINGS=dbus \
+  ghcr.io/matter-js/matterjs-server:stable
+```
+
+The `dbus-next` package required by this backend ships as an optional dependency of the server image, so no extra install step is required. Host requirements: BlueZ running on the host (`bluetoothd`) and the adapter powered (`bluetoothctl power on`). Select a specific adapter with `BLUETOOTH_ADAPTER` if more than one is present.
+
+#### Raw HCI socket backend
+
+The default (`NOBLE_BINDINGS=hci`) opens the HCI socket directly, which requires elevated privileges the unprivileged container user does not have. If you must use it, this workaround grants the access:
 
 1. Stop the docker container
 2. Use `chown -R 0:0 /path-to-data-volume`
 3. Run docker with the root user `docker run --user=0:0 …` (for compose: `user: 0:0`)
 
-However, be aware this workaround effectively disables container isolation. For this reason, using other means of device commissioning (e.g. via the Home Assistant app) are preferred to applying this workaround.
+However, be aware this workaround effectively disables container isolation. For this reason, the D-Bus backend above (or other means of device commissioning such as the Home Assistant app) are preferred.
 
 ### Battery devices (Sleepy End Devices) drop subscriptions every 15–30 min
 

--- a/docs/os_requirements.md
+++ b/docs/os_requirements.md
@@ -130,3 +130,5 @@ Diagnostic sentinel: a per-instance firewall chain drop counter climbing in step
 ## Bluetooth Low Energy requirements
 
 When working without Docker, please see the BLE requirements for your platform in the ["noble" relevant BLE documentation](https://github.com/matter-js/matter.js/tree/main/packages/nodejs-ble#prerequisites-and-limitations).
+
+On Linux the Bluetooth backend can talk to the host adapter either through a raw HCI socket (the default, `NOBLE_BINDINGS=hci`, which needs elevated privileges) or through the BlueZ daemon over D-Bus (`NOBLE_BINDINGS=dbus`). The D-Bus backend avoids raw-socket privileges and is the recommended option for containerized deployments — see [Device discovery via host BLE](docker.md#device-discovery-via-host-ble). It requires a running BlueZ daemon and the `dbus-next` package, which ships as an optional dependency of the server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2793,6 +2793,16 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@nornagon/put": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/@nornagon/put/-/put-0.0.8.tgz",
+            "integrity": "sha512-ugvXJjwF5ldtUpa7D95kruNJ41yFQDEKyF5CW4TgKJnh+W/zmlBzXXeKTyqIgwMFrkePN2JqOBqcF0M0oOunow==",
+            "license": "MIT/X11",
+            "optional": true,
+            "engines": {
+                "node": ">=0.3.0"
+            }
+        },
         "node_modules/@oxfmt/binding-android-arm-eabi": {
             "version": "0.52.0",
             "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.52.0.tgz",
@@ -2920,6 +2930,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2937,6 +2950,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2954,6 +2970,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2971,6 +2990,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2988,6 +3010,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3005,6 +3030,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3022,6 +3050,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3039,6 +3070,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3201,9 +3235,9 @@
             ]
         },
         "node_modules/@oxlint/binding-android-arm-eabi": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.67.0.tgz",
-            "integrity": "sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.68.0.tgz",
+            "integrity": "sha512-wEdsIspexXLLMCPAEOcCuFLMt6aE3AzTuA/nQKLPRnoJ+EQTturmGheDkhHuuVHx0GbutjQ3JKmEn+Gz6Ag28Q==",
             "cpu": [
                 "arm"
             ],
@@ -3218,9 +3252,9 @@
             }
         },
         "node_modules/@oxlint/binding-android-arm64": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.67.0.tgz",
-            "integrity": "sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.68.0.tgz",
+            "integrity": "sha512-6aZRNNXQTsYtgaus8HTb9nuCcsrQTlKXGnktwvwW0n/SooRWNxNb3925grDkC63aEYZuCIyOVLV16IdYIoC2aQ==",
             "cpu": [
                 "arm64"
             ],
@@ -3235,9 +3269,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-arm64": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.67.0.tgz",
-            "integrity": "sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.68.0.tgz",
+            "integrity": "sha512-lVTbsE3kO4bLpZELgjRZuAJc8kP98wb83yMXWH8gaPaFZ+cM2IDeZto4ByoUAYj0Mxv2rvw+A1ssZequSepVSg==",
             "cpu": [
                 "arm64"
             ],
@@ -3252,9 +3286,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-x64": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.67.0.tgz",
-            "integrity": "sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.68.0.tgz",
+            "integrity": "sha512-nCmw2XrmQskjBUh/sfP5yKs93V68LijQgjd1cuuZ/q4SCARngLYs60/qqyzuMsg8QQ9KArDI98hxs/RDGE4KRQ==",
             "cpu": [
                 "x64"
             ],
@@ -3269,9 +3303,9 @@
             }
         },
         "node_modules/@oxlint/binding-freebsd-x64": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.67.0.tgz",
-            "integrity": "sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.68.0.tgz",
+            "integrity": "sha512-TI4ovQJliYE9V6e06cEv+qEI9uj7Ao65fmif4er4HD+aouyYyh0P31q2jh3KtqsOHHcQqv2PZ61TjJFLpBDGWQ==",
             "cpu": [
                 "x64"
             ],
@@ -3286,9 +3320,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.67.0.tgz",
-            "integrity": "sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.68.0.tgz",
+            "integrity": "sha512-LcNnEi9g71Cmry5ZpLbKT+oVv+/zYG3hYVAbBBB5X85nOQZSk8l92CnDkxJMcxUg0NCnMCOFZuaVDlMyv4tYJw==",
             "cpu": [
                 "arm"
             ],
@@ -3303,9 +3337,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.67.0.tgz",
-            "integrity": "sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.68.0.tgz",
+            "integrity": "sha512-OovHahL3FX4UaK+hgSf11llUx2vszqjSdQQ61Ck9InOEI/ptZoC4XSQJurITqItVvd53JSlmkLMeaNjM1PoQew==",
             "cpu": [
                 "arm"
             ],
@@ -3320,13 +3354,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-gnu": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.67.0.tgz",
-            "integrity": "sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.68.0.tgz",
+            "integrity": "sha512-YbzTglnHLzzi9zv5or8Ztz5fykAoZE8W9iM42/bOrF4HBSB6rJTqdLQWuoP76EHQw9DuKl76K1QmFlG29sPJXQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3337,13 +3374,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-musl": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.67.0.tgz",
-            "integrity": "sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.68.0.tgz",
+            "integrity": "sha512-qVKtCZNic+OoNnOr/hCQAu22HSQzflI7Fsq/Blzkw02SnLuv163k3kfmrVpZjSBlUHgsRKj6WgQiw30d3SX02Q==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3354,13 +3394,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.67.0.tgz",
-            "integrity": "sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.68.0.tgz",
+            "integrity": "sha512-zExyZ8ZOUuAyQ0y9jpTcyjKUz62YY9JhKPyVxzvjTpXzZ3ujdqiVwfPWDdnA1SsIOrxdtxHn7KErDHLWskFjXg==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3371,13 +3414,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.67.0.tgz",
-            "integrity": "sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.68.0.tgz",
+            "integrity": "sha512-6C4MPuwewyDavA7sxM14wzgRi5GGL68HPIxRCdVyS75U4MDbpFVYzKO9WNR6KLKTMPq2pcz3THwo1sK2uiqngw==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3388,13 +3434,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-musl": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.67.0.tgz",
-            "integrity": "sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.68.0.tgz",
+            "integrity": "sha512-bnZooVeHAcvA+dH0EDLgx+7HY/DRi6e0hFszg3P+OBatuUjV6EvfIyNIzWOusmqAVh4L6r21GGTZtiKE4iqM4Q==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3405,13 +3454,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-s390x-gnu": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.67.0.tgz",
-            "integrity": "sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.68.0.tgz",
+            "integrity": "sha512-dIqnZnJSmHCMOUpUcWQOiV14o3DDPVx1DSsMaSzvdhNjC1tB1iEPZbdiMSCIEYbkgbsYznHXWqFdKL8WUB3F8g==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3422,13 +3474,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-gnu": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.67.0.tgz",
-            "integrity": "sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.68.0.tgz",
+            "integrity": "sha512-zc9lEnfV/HreDTY6gdMlZe+irkwHSxQ4/B1pS9GyK7RVaA5LxhoZY/w6/o2vIwLLEYiXQ5ujGxOM1ZazeFAAIA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3439,13 +3494,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-musl": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.67.0.tgz",
-            "integrity": "sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.68.0.tgz",
+            "integrity": "sha512-Dl5QEX0TCo/40Cdh1o1JdPS//+YiWqjC+Hrrya5OQmStZZr4svAFtdlqcpCrU9yq2Mo3vRVyO9B3h0dzD8s36Q==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3456,9 +3514,9 @@
             }
         },
         "node_modules/@oxlint/binding-openharmony-arm64": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.67.0.tgz",
-            "integrity": "sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.68.0.tgz",
+            "integrity": "sha512-/qy6dOvi4S3/LeXq0l5BT5pRKPYA7oj3uKwJOAZOr5HRLL+HK6jdBynvWuXIA2wwfE01RzNYmbBdM7vwYx00sA==",
             "cpu": [
                 "arm64"
             ],
@@ -3473,9 +3531,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-arm64-msvc": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.67.0.tgz",
-            "integrity": "sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.68.0.tgz",
+            "integrity": "sha512-fHNtVqPHSYE7UFDSLVFUjxQjnSVXxseNJmRW+XuP4pXXDwePdPda43NL7/BBCFTxHjycOc44JNDaOPtFDNui9A==",
             "cpu": [
                 "arm64"
             ],
@@ -3490,9 +3548,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-ia32-msvc": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.67.0.tgz",
-            "integrity": "sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.68.0.tgz",
+            "integrity": "sha512-NnKXr4Wgo4nps3erhrE0f8shBvBPZMHg72nDsvX0JyrRvsNiP3f1JNvbCKh+A6VFvpF7ZoJxu904P3cKMhvZnA==",
             "cpu": [
                 "ia32"
             ],
@@ -3507,9 +3565,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-x64-msvc": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.67.0.tgz",
-            "integrity": "sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.68.0.tgz",
+            "integrity": "sha512-zg5pA+84AlU6XHJ3ruiRxziO71QTrz8nLsk6u01JGS5+tL9/bnlakFiklFrcy4R1/V7ktWtaNitN3JZWmKnf6g==",
             "cpu": [
                 "x64"
             ],
@@ -3886,6 +3944,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3900,6 +3961,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3914,6 +3978,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3928,6 +3995,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3942,6 +4012,9 @@
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3956,6 +4029,9 @@
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3970,6 +4046,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3984,6 +4063,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3998,6 +4080,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4012,6 +4097,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4026,6 +4114,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4040,6 +4131,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4054,6 +4148,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4759,14 +4856,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.60.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
-            "integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
+            "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.60.0",
-                "@typescript-eslint/types": "^8.60.0",
+                "@typescript-eslint/tsconfig-utils": "^8.60.1",
+                "@typescript-eslint/types": "^8.60.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -4781,9 +4878,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.60.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
-            "integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
+            "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4798,9 +4895,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.60.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
-            "integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
+            "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4812,16 +4909,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.60.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
-            "integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
+            "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.60.0",
-                "@typescript-eslint/tsconfig-utils": "8.60.0",
-                "@typescript-eslint/types": "8.60.0",
-                "@typescript-eslint/visitor-keys": "8.60.0",
+                "@typescript-eslint/project-service": "8.60.1",
+                "@typescript-eslint/tsconfig-utils": "8.60.1",
+                "@typescript-eslint/types": "8.60.1",
+                "@typescript-eslint/visitor-keys": "8.60.1",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -4840,13 +4937,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.60.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
-            "integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
+            "version": "8.60.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
+            "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.60.0",
+                "@typescript-eslint/types": "8.60.1",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -6082,6 +6179,29 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/dbus-next": {
+            "name": "@jellybrick/dbus-next",
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@jellybrick/dbus-next/-/dbus-next-0.10.3.tgz",
+            "integrity": "sha512-7MLAiQS/UCa8V8/G3eyoWIzMhCUv3GaNxIpclu1wauDGUsL48ZT0CrilEO739gP/bviPiCUhy00DtvCNmYfPhA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@nornagon/put": "0.0.8",
+                "event-stream": "4.0.1",
+                "jsbi": "^4.3.0",
+                "long": "^4.0.0",
+                "safe-buffer": "^5.2.1",
+                "xml2js": "^0.6.2"
+            }
+        },
+        "node_modules/dbus-next/node_modules/long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+            "license": "Apache-2.0",
+            "optional": true
+        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6260,6 +6380,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/duplexer": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
@@ -6458,6 +6585,22 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/event-stream": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+            "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "duplexer": "^0.1.1",
+                "from": "^0.1.7",
+                "map-stream": "0.0.7",
+                "pause-stream": "^0.0.11",
+                "split": "^1.0.1",
+                "stream-combiner": "^0.2.2",
+                "through": "^2.3.8"
             }
         },
         "node_modules/execa": {
@@ -6698,6 +6841,13 @@
             "engines": {
                 "node": ">= 0.8"
             }
+        },
+        "node_modules/from": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/fs-constants": {
             "version": "1.0.0",
@@ -7424,6 +7574,13 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
+        "node_modules/jsbi": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+            "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+            "license": "Apache-2.0",
+            "optional": true
+        },
         "node_modules/jsesc": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -7685,6 +7842,13 @@
             "bin": {
                 "semver": "bin/semver.js"
             }
+        },
+        "node_modules/map-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+            "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/markdown-it": {
             "version": "14.2.0",
@@ -8340,9 +8504,9 @@
             }
         },
         "node_modules/oxlint": {
-            "version": "1.67.0",
-            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.67.0.tgz",
-            "integrity": "sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ==",
+            "version": "1.68.0",
+            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.68.0.tgz",
+            "integrity": "sha512-dXcbq+xsmLrMy6T8d0euf3IYUfLmjHIE11pOxiUSi5LHkFZaYPv568R6sEjcavVpUxoaQe66UBuK4HEi74NxpA==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -8355,25 +8519,25 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxlint/binding-android-arm-eabi": "1.67.0",
-                "@oxlint/binding-android-arm64": "1.67.0",
-                "@oxlint/binding-darwin-arm64": "1.67.0",
-                "@oxlint/binding-darwin-x64": "1.67.0",
-                "@oxlint/binding-freebsd-x64": "1.67.0",
-                "@oxlint/binding-linux-arm-gnueabihf": "1.67.0",
-                "@oxlint/binding-linux-arm-musleabihf": "1.67.0",
-                "@oxlint/binding-linux-arm64-gnu": "1.67.0",
-                "@oxlint/binding-linux-arm64-musl": "1.67.0",
-                "@oxlint/binding-linux-ppc64-gnu": "1.67.0",
-                "@oxlint/binding-linux-riscv64-gnu": "1.67.0",
-                "@oxlint/binding-linux-riscv64-musl": "1.67.0",
-                "@oxlint/binding-linux-s390x-gnu": "1.67.0",
-                "@oxlint/binding-linux-x64-gnu": "1.67.0",
-                "@oxlint/binding-linux-x64-musl": "1.67.0",
-                "@oxlint/binding-openharmony-arm64": "1.67.0",
-                "@oxlint/binding-win32-arm64-msvc": "1.67.0",
-                "@oxlint/binding-win32-ia32-msvc": "1.67.0",
-                "@oxlint/binding-win32-x64-msvc": "1.67.0"
+                "@oxlint/binding-android-arm-eabi": "1.68.0",
+                "@oxlint/binding-android-arm64": "1.68.0",
+                "@oxlint/binding-darwin-arm64": "1.68.0",
+                "@oxlint/binding-darwin-x64": "1.68.0",
+                "@oxlint/binding-freebsd-x64": "1.68.0",
+                "@oxlint/binding-linux-arm-gnueabihf": "1.68.0",
+                "@oxlint/binding-linux-arm-musleabihf": "1.68.0",
+                "@oxlint/binding-linux-arm64-gnu": "1.68.0",
+                "@oxlint/binding-linux-arm64-musl": "1.68.0",
+                "@oxlint/binding-linux-ppc64-gnu": "1.68.0",
+                "@oxlint/binding-linux-riscv64-gnu": "1.68.0",
+                "@oxlint/binding-linux-riscv64-musl": "1.68.0",
+                "@oxlint/binding-linux-s390x-gnu": "1.68.0",
+                "@oxlint/binding-linux-x64-gnu": "1.68.0",
+                "@oxlint/binding-linux-x64-musl": "1.68.0",
+                "@oxlint/binding-openharmony-arm64": "1.68.0",
+                "@oxlint/binding-win32-arm64-msvc": "1.68.0",
+                "@oxlint/binding-win32-ia32-msvc": "1.68.0",
+                "@oxlint/binding-win32-x64-msvc": "1.68.0"
             },
             "peerDependencies": {
                 "oxlint-tsgolint": ">=0.22.1",
@@ -8573,6 +8737,19 @@
             "license": "MIT",
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/pause-stream": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+            "license": [
+                "MIT",
+                "Apache2"
+            ],
+            "optional": true,
+            "dependencies": {
+                "through": "~2.3"
             }
         },
         "node_modules/picocolors": {
@@ -9147,7 +9324,7 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
+            "devOptional": true,
             "funding": [
                 {
                     "type": "github",
@@ -9174,7 +9351,7 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
             "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-            "dev": true,
+            "devOptional": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=11.0.0"
@@ -9633,6 +9810,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/split": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+            "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "through": "2"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/split-ca": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
@@ -9665,6 +9855,17 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/stream-combiner": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+            "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "duplexer": "~0.1.1",
+                "through": "~2.3.4"
             }
         },
         "node_modules/string_decoder": {
@@ -9901,6 +10102,13 @@
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/tinyglobby": {
             "version": "0.2.17",
@@ -10564,7 +10772,7 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
             "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "dependencies": {
                 "sax": ">=0.6.0",
@@ -10578,7 +10786,7 @@
             "version": "11.0.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4.0"
@@ -10697,10 +10905,11 @@
                 "@types/ws": "^8.18.1"
             },
             "engines": {
-                "node": ">=20.19.0 <22.0.0 || >=22.13.0"
+                "node": ">=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.1-alpha.0-20260601-9386e30f9"
+                "@matter/nodejs-ble": "0.17.1-alpha.0-20260601-9386e30f9",
+                "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
             }
         },
         "packages/custom-clusters": {
@@ -10710,7 +10919,7 @@
                 "@matter/main": "0.17.1-alpha.0-20260601-9386e30f9"
             },
             "engines": {
-                "node": ">=20.19.0 <22.0.0 || >=22.13.0"
+                "node": ">=22.13.0"
             }
         },
         "packages/dashboard": {
@@ -10760,7 +10969,7 @@
                 "@types/node": "^25.9.1"
             },
             "engines": {
-                "node": ">=20.19.0 <22.0.0 || >=22.13.0"
+                "node": ">=22.13.0"
             }
         },
         "packages/matter-server/node_modules/commander": {
@@ -10783,7 +10992,7 @@
                 "ws": "^8.21.0"
             },
             "engines": {
-                "node": ">=20.19.0 <22.0.0 || >=22.13.0"
+                "node": ">=22.13.0"
             }
         },
         "packages/ws-controller": {
@@ -10801,10 +11010,11 @@
                 "@types/ws": "^8.18.1"
             },
             "engines": {
-                "node": ">=20.19.0 <22.0.0 || >=22.13.0"
+                "node": ">=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.1-alpha.0-20260601-9386e30f9"
+                "@matter/nodejs-ble": "0.17.1-alpha.0-20260601-9386e30f9",
+                "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
             }
         }
     }

--- a/packages/ble-proxy/package.json
+++ b/packages/ble-proxy/package.json
@@ -38,7 +38,8 @@
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.1-alpha.0-20260601-9386e30f9"
+        "@matter/nodejs-ble": "0.17.1-alpha.0-20260601-9386e30f9",
+        "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
     },
     "engines": {
         "node": ">=22.13.0"

--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -51,7 +51,8 @@
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.1-alpha.0-20260601-9386e30f9"
+        "@matter/nodejs-ble": "0.17.1-alpha.0-20260601-9386e30f9",
+        "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
     },
     "engines": {
         "node": ">=22.13.0"


### PR DESCRIPTION
## Summary

Addresses #705. Running the Bluetooth backend in D-Bus mode (`NOBLE_BINDINGS=dbus`) failed with *"noble dbus backend requires the 'dbus-next' package."* — noble declares `dbus-next` only as an optional peer dependency, so it was never installed.

## Changes

- Add `dbus-next` to `optionalDependencies` of `ws-controller` and `ble-proxy`. noble loads the backend via `require('dbus-next')`, so it is installed under that name via an npm **alias to `@jellybrick/dbus-next`** (`"dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"`).
- `docs/docker.md`: split *Device discovery via host BLE* into the recommended **D-Bus / BlueZ backend** (`NOBLE_BINDINGS=dbus` + read-only `/run/dbus` mount, container stays unprivileged) and the raw-HCI root workaround.
- `docs/os_requirements.md`: note the hci-vs-dbus backend choice, cross-link.
- CI: add a PR-time `docker-build` job (builds `Dockerfile.dev` from source, no push) and fix `Dockerfile.dev` to compile native modules (missing ble-proxy COPY, build toolchain, `npm rebuild` after source copy).

## Why a fork of dbus-next

Upstream `dbus-next` pulls the optional native module `usocket`, whose ancient `node-gyp@^7.1.2` fails on Node 22+ (`Cannot assign to read only property 'cflags'`). Once hoisted it also breaks the prebuild-fallback native builds of `@stoprocent/noble` and `@stoprocent/bleno`. It additionally pins a prototype-pollution-vulnerable `xml2js@^0.4`.

`@jellybrick/dbus-next@0.10.3` is a maintained fork that **drops `usocket`** and bumps **`xml2js` to `^0.6.2`**, fixing both at the source — no `node-gyp`/`nan` deps, no root `overrides`, `npm audit` clean, and the fix reaches npm consumers because the aliased dependency is published (npm `overrides` are not). It satisfies noble's `dbus-next@^0.10.0` optional peer exactly. Its only runtime divergence from upstream is additive (non-string dict keys, a `MessageBus` export, a match-rule arg-order fix, `SystemBus` options passthrough).

## Why D-Bus mode matters

The dbus backend talks to the host's BlueZ daemon instead of opening a raw HCI socket, so the container needs no raw-Bluetooth capabilities — only the host system D-Bus socket mounted read-only. Much smaller privilege surface than the `--user=0:0` HCI workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)