### PR TITLE
fix(ble-proxy): deliver binary frames arriving before their command response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,11 @@ This page shows a detailed overview of the changes between versions without the 
     - Fix: Event reports are now decoded in wire (EventNumber) order
 - Enhancement: Adds the dbus-next package to support BLE commissioning in D-Bus mode (see [docker](./docs/docker.md) and [os_requirements](./docs/os_requirements.md) for details)
 - Adjustment: Standardized log levels and logged messages
+- Fix: Ensure that we correctly process handshake messages when using the BLE proxy
 
 ## 0.7.1 (2026-05-21)
 
-- Feature: Added BLE proxy commissioning support (enabled with `--ble-proxy` CLI option)
+- Feature: Added (experimental) BLE proxy commissioning support (enabled with `--ble-proxy` CLI option)
 - Enhancement: Dashboard shows Thread protocol version on Thread node details
 - Enhancement: Dashboard always shows Thread/WiFi navigation tabs (removed small-screen gate)
 - Maintenance: Update matter.js to the official 0.17.0

--- a/packages/ble-proxy/src/BleProxyHandler.ts
+++ b/packages/ble-proxy/src/BleProxyHandler.ts
@@ -6,6 +6,7 @@
 
 import type { WebServerHandler } from "@matter-server/ws-controller";
 import { createPromise, Logger, Observable, Seconds, Time, Timer, withTimeout } from "@matter/main";
+import { Mark } from "@matter/main/protocol";
 import type { createServer } from "node:http";
 import { WebSocket, WebSocketServer } from "ws";
 import {
@@ -25,6 +26,11 @@ import {
 type HttpServer = ReturnType<typeof createServer>;
 
 const logger = Logger.get("BleProxyHandler");
+
+const frameHead = (payload: Uint8Array): string =>
+    Array.from(payload.subarray(0, 8))
+        .map(b => b.toString(16).padStart(2, "0"))
+        .join("");
 
 const HANDSHAKE_TIMEOUT = Seconds(10);
 /**
@@ -232,6 +238,9 @@ export class BleProxyHandler implements WebServerHandler {
             throw new Error("BLE proxy client not connected");
         }
         const frame = encodeBinaryFrame(opcode, connectionHandle, payload);
+        logger.debug(
+            `[FRAME] ${Mark.OUTBOUND} opcode=${opcode} handle=${connectionHandle} len=${payload.length} head=${frameHead(payload)}`,
+        );
         this.#client.send(frame);
     }
 
@@ -333,11 +342,8 @@ export class BleProxyHandler implements WebServerHandler {
 
         try {
             const frame = decodeBinaryFrame(new Uint8Array(data));
-            const head = Array.from(frame.payload.subarray(0, 8))
-                .map(b => b.toString(16).padStart(2, "0"))
-                .join("");
             logger.debug(
-                `[FRAME] opcode=${frame.opcode} handle=${frame.connectionHandle} len=${frame.payload.length} head=${head}`,
+                `[FRAME] ${Mark.INBOUND} opcode=${frame.opcode} handle=${frame.connectionHandle} len=${frame.payload.length} head=${frameHead(frame.payload)}`,
             );
             this.binaryFrameReceived.emit(frame);
         } catch (err) {

--- a/packages/ble-proxy/src/ProxyBleChannel.ts
+++ b/packages/ble-proxy/src/ProxyBleChannel.ts
@@ -97,6 +97,10 @@ export class ProxyBleCentralInterface implements Transport {
         }
         logger.debug(`Connected to ${peripheralAddress}, handle=${connection_handle}, mtu=${mtu}`);
 
+        // The handler is shared across connections, so a leaked observer corrupts the next one;
+        // detach on every exit path. Assigned once the observers are registered.
+        let detachObservers: (() => void) | undefined;
+
         try {
             // 2. Discover services
             const { services } = await this.#handler.sendCommand(BleProxyCommand.DiscoverServices, {
@@ -144,26 +148,9 @@ export class ProxyBleCentralInterface implements Transport {
                 // it's handled by matter.js commissioning flow internally
             }
 
-            // 5. Send BTP handshake request on C1 and atomically subscribe to C2 for the
-            // response indication. The combo eliminates the WebSocket round-trip between
-            // Write Response and CCCD enable — without it, a peripheral that pushes the
-            // handshake indication immediately after Write Response can fire before the
-            // proxy client has enabled notifications, and the indication is lost.
-            const btpHandshakeRequest = BtpCodec.encodeBtpHandshakeRequest({
-                versions: MatterBle.BTP_SUPPORTED_VERSIONS,
-                attMtu: mtu,
-                clientWindowSize: MatterBle.BTP_MAXIMUM_WINDOW_SIZE,
-            });
-            logger.debug(`Sending BTP handshake request on C1 and subscribing C2 atomically`);
-            await this.#handler.sendCommand(BleProxyCommand.WriteAndSubscribe, {
-                connection_handle,
-                write_uuid: c1Uuid,
-                write_value: Buffer.from(btpHandshakeRequest as ArrayBuffer).toString("base64"),
-                write_response: true,
-                subscribe_uuid: c2Uuid,
-            });
-
-            // 6. Wait for BTP handshake response via binary frame
+            // 5. Register the handshake observer BEFORE sending: the C2 indication is a separate
+            // binary frame that can beat the WriteAndSubscribe response, and binaryFrameReceived
+            // drops frames emitted with no listener attached.
             const {
                 promise: handshakePromise,
                 resolver: handshakeResolver,
@@ -193,19 +180,59 @@ export class ProxyBleCentralInterface implements Transport {
             };
             this.#handler.binaryFrameReceived.on(handshakeObserver);
 
+            // 6. Write C1 and subscribe C2 atomically so the peripheral can't fire its indication
+            // before notifications are enabled (no round-trip between Write Response and CCCD enable).
+            const btpHandshakeRequest = BtpCodec.encodeBtpHandshakeRequest({
+                versions: MatterBle.BTP_SUPPORTED_VERSIONS,
+                attMtu: mtu,
+                clientWindowSize: MatterBle.BTP_MAXIMUM_WINDOW_SIZE,
+            });
+            logger.debug(`Sending BTP handshake request on C1 and subscribing C2 atomically`);
+
             let handshakeResponse: Uint8Array;
             try {
+                await this.#handler.sendCommand(BleProxyCommand.WriteAndSubscribe, {
+                    connection_handle,
+                    write_uuid: c1Uuid,
+                    write_value: Buffer.from(btpHandshakeRequest as ArrayBuffer).toString("base64"),
+                    write_response: true,
+                    subscribe_uuid: c2Uuid,
+                });
                 handshakeResponse = await handshakePromise;
             } finally {
                 this.#handler.binaryFrameReceived.off(handshakeObserver);
                 btpHandshakeTimeout.stop();
             }
 
-            // 7. Create BTP session
-            // Use a ref object so closures can access the channel after it's created
+            // 7. Register the live observer BEFORE creating the session (same non-buffering frame
+            // race as step 5); frames seen before the session exists are buffered, then flushed below.
             const onMatterMessageListener = this.#onMatterMessageListener;
             const channelRef: { channel?: ProxyBleChannel } = {};
+            const sessionRef: { session?: BtpSessionHandler } = {};
+            const earlyFrames = new Array<Uint8Array>();
 
+            const forwardToBtp = (payload: Uint8Array) => {
+                sessionRef.session
+                    ?.handleIncomingBleData(payload)
+                    .catch(error =>
+                        logger.warn(`Peripheral ${peripheralAddress}: Error handling incoming BLE data`, error),
+                    );
+            };
+
+            const binaryObserver = (frame: { connectionHandle: number; opcode: number; payload: Uint8Array }) => {
+                if (frame.connectionHandle === connection_handle && frame.opcode === BinaryFrameOpcode.Notification) {
+                    const payload = new Uint8Array(frame.payload);
+                    if (sessionRef.session) {
+                        forwardToBtp(payload);
+                    } else {
+                        earlyFrames.push(payload);
+                    }
+                }
+            };
+            this.#handler.binaryFrameReceived.on(binaryObserver);
+            detachObservers = () => this.#handler.binaryFrameReceived.off(binaryObserver);
+
+            // 8. Create the BTP session.
             const btpSession = await BtpSessionHandler.createAsCentral(
                 handshakeResponse,
                 // Write callback: send binary frame to proxy client
@@ -234,18 +261,12 @@ export class ProxyBleCentralInterface implements Transport {
                     }
                 },
             );
+            sessionRef.session = btpSession;
 
-            // 8. Wire up binary frame notifications to BTP session
-            const binaryObserver = (frame: { connectionHandle: number; opcode: number; payload: Uint8Array }) => {
-                if (frame.connectionHandle === connection_handle && frame.opcode === BinaryFrameOpcode.Notification) {
-                    btpSession
-                        .handleIncomingBleData(new Uint8Array(frame.payload))
-                        .catch(error =>
-                            logger.warn(`Peripheral ${peripheralAddress}: Error handling incoming BLE data`, error),
-                        );
-                }
-            };
-            this.#handler.binaryFrameReceived.on(binaryObserver);
+            for (const payload of earlyFrames) {
+                forwardToBtp(payload);
+            }
+            earlyFrames.length = 0;
 
             // 9. Handle unexpected disconnects from proxy client
             const eventObserver = (event: string, data: Record<string, unknown>) => {
@@ -262,18 +283,17 @@ export class ProxyBleCentralInterface implements Transport {
                 }
             };
             this.#handler.eventReceived.on(eventObserver);
-
-            // Cleanup function to remove observers when channel closes
-            const cleanupObservers = () => {
+            detachObservers = () => {
                 this.#handler.binaryFrameReceived.off(binaryObserver);
                 this.#handler.eventReceived.off(eventObserver);
             };
 
-            const proxyChannel = new ProxyBleChannel(peripheralAddress, btpSession, cleanupObservers);
+            const proxyChannel = new ProxyBleChannel(peripheralAddress, btpSession, detachObservers);
             channelRef.channel = proxyChannel;
             return proxyChannel;
         } catch (error) {
-            // Clean up on failure — best-effort tear-down of the peripheral on the proxy side
+            // Clean up on failure — detach observers and best-effort tear-down on the proxy side
+            detachObservers?.();
             try {
                 await this.#handler.sendCommand(BleProxyCommand.Disconnect, { connection_handle });
             } catch (cleanupError) {

--- a/packages/ble-proxy/test/BleProxyIntegrationTest.ts
+++ b/packages/ble-proxy/test/BleProxyIntegrationTest.ts
@@ -250,6 +250,40 @@ describe("BLE Proxy Integration", function () {
             await channel.close();
         });
 
+        it("should complete handshake when the indication arrives before the WriteAndSubscribe response", async () => {
+            const proxyBle = new ProxyBle(handler);
+            const mockDevice = new MockBleDevice({ discriminator: 4242, vendorId: 0xfff1, productId: 0x8000 });
+
+            await discoverDevice(proxyBle, mockDevice);
+
+            testClient.onCommand(BleProxyCommand.Connect, async () => ({ connection_handle: 1, mtu: 247 }));
+            testClient.onCommand(BleProxyCommand.DiscoverServices, async () => ({ services: mockDevice.services }));
+            testClient.onCommand(BleProxyCommand.DiscoverCharacteristics, async () => ({
+                characteristics: mockDevice.characteristics,
+            }));
+            // Emit the indication before returning the command result, so the binary frame reaches
+            // the server ahead of the WriteAndSubscribe reply — the ordering that broke commissioning.
+            testClient.onCommand(BleProxyCommand.WriteAndSubscribe, async () => {
+                testClient.sendBinaryFrame(
+                    BinaryFrameOpcode.Notification,
+                    1,
+                    mockDevice.generateBtpHandshakeResponse(),
+                );
+                return {};
+            });
+
+            const central = proxyBle.centralInterface as ProxyBleCentralInterface;
+            central.onData(() => {});
+
+            const channel = (await central.openChannel({
+                type: "ble",
+                peripheralAddress: mockDevice.address,
+            })) as ProxyBleChannel;
+
+            expect(channel.connected).to.be.true;
+            await channel.close();
+        });
+
         it("should reject when openChannel is called before onData listener is installed", async () => {
             const proxyBle = new ProxyBle(handler);
             const mockDevice = new MockBleDevice({ discriminator: 1234, vendorId: 0xfff1, productId: 0x8000 });


### PR DESCRIPTION
## Problem

Addresses #694 

`binaryFrameReceived` is a non-buffering matter.js `Observable`, so a frame emitted with no listener attached is silently dropped.

The BTP handshake observer was registered only **after** `await sendCommand(WriteAndSubscribe)` resolved. The C2 handshake indication arrives as a binary WS frame independent of the command response and can reach the server first — when it did, it was dropped and commissioning failed with a 5s `BTP handshake response not received` timeout.

Observed in the wild:
```
24.676  Sending BTP handshake request on C1 and subscribing C2 atomically
24.940  [FRAME] « opcode=2 handle=1 len=6 head=656c04f10005   ← indication arrives, no observer yet
29.978  Failed: BTP handshake response not received (timeout +5s)
```

## Fix

- Register the handshake observer **before** sending `WriteAndSubscribe`; clean up in `try/finally`.
- Register the live session observer **before** `BtpSessionHandler.createAsCentral`; buffer frames that arrive before the session exists and flush them in order once it does.
- Unify observer teardown (`detachObservers`) so no failure path leaks observers on the shared handler.

The same fire-and-forget `handleIncomingBleData(...).catch(...)` as matter.js `NobleBleChannel` is retained — `BtpSessionHandler` handles BTP sequencing itself.

## Logging

Adds a frame direction indicator to the proxy debug logs (`«` inbound from device, `»` outbound to device), matching the matter.js `Mark` convention, and logs outbound frames too:
```
[FRAME] « opcode=2 handle=1 len=6 head=656c04f10005
[FRAME] » opcode=1 handle=1 len=21 head=...
```

## Test

New regression test emits the indication **inside** the `WriteAndSubscribe` handler (before its response), forcing the frame ahead of the command reply. It **times out on the old code, passes on the new**. All 22 ble-proxy tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)