### PR TITLE
fix(dashboard): show full BSSID in WiFi graph AP labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Enhancement: Dashboard WiFi graph shows the full BSSID in access point labels, so APs differing only in leading octets are distinguishable
+
 ## 0.8.0 (2026-06-02)
 
 - Breaking: The server now requires at least Node.js 22.13.0 (LTS)

--- a/packages/dashboard/src/pages/network/wifi-graph.ts
+++ b/packages/dashboard/src/pages/network/wifi-graph.ts
@@ -112,7 +112,7 @@ export class WiFiGraph extends BaseNetworkGraph {
 
             graphNodes.push({
                 id: apId,
-                label: `AP ${bssid.slice(-8)}`,
+                label: `AP ${bssid}`,
                 image: createWiFiRouterIconDataUrl(isSelected),
                 shape: "image",
                 networkType: "wifi",


### PR DESCRIPTION
## Summary
- WiFi graph AP node labels now show the full BSSID instead of only the last 3 octets
- Fixes the "duplicate AP" confusion in #716: two devices reporting BSSIDs that differ only in leading octets (typical for dual-band/multi-SSID APs deriving per-radio BSSIDs) rendered identical truncated labels, making one physical AP look duplicated

## Notes
- Grouping logic is unchanged — APs were always keyed by full BSSID; only the label hid the difference
- Details panel already showed the full BSSID, now consistent with the graph

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)