### PR TITLE
Pin Node.js 24.15  for Docker for now

### DIFF
--- a/docker/matterjs-server/Dockerfile
+++ b/docker/matterjs-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:24-trixie-slim
+FROM node:24.15-trixie-slim
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/docker/matterjs-server/Dockerfile.dev
+++ b/docker/matterjs-server/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:24-trixie-slim
+FROM node:24.15-trixie-slim
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
... because of a regression in Node.js when destroy of readable-streams. Just to be sure