### PR TITLE
Fix: prevent duplicate Node-ID allocation on parallel commissioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
-- Enhancement: Dashboard WiFi graph shows the full BSSID in access point labels, so APs differing only in leading octets are distinguishable
+- Enhancement: Dashboard Wi-Fi graph shows the full BSSID in access point labels, so APs differing only in leading octets are distinguishable
+- Enhancement: Update matter.js to 0.17.2
+- Fix: Ensures that multiple parallel commissioning tries do not allocate the same Node-ID, and recovers automatically when the stored Node-ID counter drifts out of sync with the fabric by skipping/retrying with the next free id
 
 ## 0.8.0 (2026-06-02)
 

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -542,6 +542,14 @@ export class ControllerCommandHandler {
     }
 
     /**
+     * Whether a node id is already reserved on the fabric, either by a commissioned peer or the commissioner itself.
+     * Authoritative against matter.js rather than the locally tracked node set, which can drift from the fabric.
+     */
+    isNodeIdInUse(nodeId: NodeId): boolean {
+        return nodeId === this.#controller.nodeId || this.#controller.isNodeCommissioned(nodeId);
+    }
+
+    /**
      * Alias for decommissionNode to match NodeCommandHandler interface.
      */
     removeNode(nodeId: NodeId) {

--- a/packages/ws-controller/src/server/ConfigStorage.ts
+++ b/packages/ws-controller/src/server/ConfigStorage.ts
@@ -102,10 +102,17 @@ export class ConfigStorage {
      */
     async allocateNodeId(isInUse: (nodeId: number | bigint) => boolean): Promise<number | bigint> {
         return this.#nodeIdMutex.produce(async () => {
-            let candidate = this.#data.nextNodeId;
+            const start = this.#data.nextNodeId;
+            let candidate = start;
+            let skipped = 0;
             while (isInUse(candidate)) {
-                logger.notice(`Node ID ${candidate} already in use on the fabric, skipping`);
                 candidate = incrementNodeId(candidate);
+                skipped++;
+            }
+            if (skipped > 0) {
+                logger.notice(
+                    `Skipped ${skipped} node id(s) from ${start} already in use on the fabric, allocated ${candidate} instead`,
+                );
             }
             await this.set({ nextNodeId: incrementNodeId(candidate) });
             return candidate;

--- a/packages/ws-controller/src/server/ConfigStorage.ts
+++ b/packages/ws-controller/src/server/ConfigStorage.ts
@@ -104,7 +104,7 @@ export class ConfigStorage {
         return this.#nodeIdMutex.produce(async () => {
             let candidate = this.#data.nextNodeId;
             while (isInUse(candidate)) {
-                logger.warn(`Node ID ${candidate} already in use on the fabric, skipping`);
+                logger.notice(`Node ID ${candidate} already in use on the fabric, skipping`);
                 candidate = incrementNodeId(candidate);
             }
             await this.set({ nextNodeId: incrementNodeId(candidate) });

--- a/packages/ws-controller/src/server/ConfigStorage.ts
+++ b/packages/ws-controller/src/server/ConfigStorage.ts
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Environment, Logger, StorageContext, StorageManager, StorageService } from "@matter/main";
+import { Environment, Logger, Mutex, StorageContext, StorageManager, StorageService } from "@matter/main";
 
 const logger = new Logger("ConfigStorage");
+
+function incrementNodeId(value: number | bigint): number | bigint {
+    return typeof value === "bigint" ? value + 1n : value + 1;
+}
 
 const SENSITIVE_KEYS: ReadonlySet<keyof ConfigData> = new Set(["wifiCredentials", "threadDataset"]);
 
@@ -31,6 +35,7 @@ export class ConfigStorage {
     #storageService?: StorageService;
     #storage?: StorageManager;
     #configStore?: StorageContext;
+    readonly #nodeIdMutex = new Mutex(this);
     readonly #data: ConfigData = {
         nextNodeId: 1,
         fabricLabel: "HomeAssistant",
@@ -87,6 +92,24 @@ export class ConfigStorage {
     }
     get nextNodeId() {
         return this.#data.nextNodeId;
+    }
+
+    /**
+     * Atomically allocate the next free node id and persist the advanced counter.
+     *
+     * The mutex serializes concurrent commissioning requests so they cannot read the same counter and collide.
+     * `isInUse` lets a drifted counter skip ids already assigned on the fabric instead of colliding with them.
+     */
+    async allocateNodeId(isInUse: (nodeId: number | bigint) => boolean): Promise<number | bigint> {
+        return this.#nodeIdMutex.produce(async () => {
+            let candidate = this.#data.nextNodeId;
+            while (isInUse(candidate)) {
+                logger.warn(`Node ID ${candidate} already in use on the fabric, skipping`);
+                candidate = incrementNodeId(candidate);
+            }
+            await this.set({ nextNodeId: incrementNodeId(candidate) });
+            return candidate;
+        });
     }
     get wifiSsid() {
         return this.#data.wifiSsid;

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -706,8 +706,9 @@ export class WebSocketControllerHandler implements WebServerHandler {
                 );
             }
         }
+        const reason = lastError instanceof Error ? `: ${lastError.message}` : "";
         throw ServerError.nodeCommissionFailed(
-            `Commission failed: could not find a free node id after ${MAX_COMMISSION_NODE_ID_ATTEMPTS} attempts`,
+            `Commission failed: could not find a free node id after ${MAX_COMMISSION_NODE_ID_ATTEMPTS} attempts${reason}`,
             lastError instanceof Error ? lastError : undefined,
         );
     }

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -55,6 +55,19 @@ import {
 
 const logger = Logger.get("WebSocketControllerHandler");
 
+/** Maximum number of commissioning attempts when the chosen node id keeps colliding on the fabric. */
+const MAX_COMMISSION_NODE_ID_ATTEMPTS = 5;
+
+/** Whether an error (or any error in its cause chain) is a matter.js node id collision. */
+function isIdentityConflict(error: unknown): boolean {
+    for (let current: unknown = error; current instanceof Error; current = current.cause) {
+        if (current instanceof MatterError && current.id === "identity-conflict") {
+            return true;
+        }
+    }
+    return false;
+}
+
 /** Maximum number of events to keep in the history buffer */
 const EVENT_HISTORY_SIZE = 25;
 
@@ -666,11 +679,42 @@ export class WebSocketControllerHandler implements WebServerHandler {
         return null;
     }
 
+    /**
+     * Commission a node, allocating a fresh node id for each attempt.
+     *
+     * The node id counter can drift out of sync with the fabric (e.g. after manual storage edits or legacy imports).
+     * When that happens matter.js rejects the chosen id with an identity conflict; we then allocate the next id and
+     * retry rather than failing the commissioning outright.
+     */
+    async #commissionWithRetry(buildRequest: (nodeId: NodeId) => CommissioningRequest): Promise<NodeId> {
+        let lastError: unknown;
+        for (let attempt = 1; attempt <= MAX_COMMISSION_NODE_ID_ATTEMPTS; attempt++) {
+            const nodeId = NodeId(
+                await this.#config.allocateNodeId(id => this.#commandHandler.isNodeIdInUse(NodeId(id))),
+            );
+            try {
+                const { nodeId: committed } = await this.#commandHandler.commissionNode(buildRequest(nodeId));
+                return committed;
+            } catch (error) {
+                if (!isIdentityConflict(error)) {
+                    throw error;
+                }
+                lastError = error;
+                logger.warn(
+                    `Node id ${nodeId} conflicts with an existing node on the fabric ` +
+                        `(attempt ${attempt}/${MAX_COMMISSION_NODE_ID_ATTEMPTS}), retrying with the next id`,
+                );
+            }
+        }
+        throw ServerError.nodeCommissionFailed(
+            `Commission failed: could not find a free node id after ${MAX_COMMISSION_NODE_ID_ATTEMPTS} attempts`,
+            lastError instanceof Error ? lastError : undefined,
+        );
+    }
+
     async #handleCommissionWithCode(args: ArgsOf<"commission_with_code">): Promise<ResponseOf<"commission_with_code">> {
         const { code, network_only } = args;
         const isQrCode = code.startsWith("MT:");
-
-        const nextNodeId = this.#config.nextNodeId;
 
         let wifiCredentials: ControllerCommissioningFlowOptions["wifiNetwork"] | undefined = undefined;
         let threadCredentials: ControllerCommissioningFlowOptions["threadNetwork"] | undefined = undefined;
@@ -692,17 +736,13 @@ export class WebSocketControllerHandler implements WebServerHandler {
         // Ensure certificates are loaded and initialized
         await this.#controller.certificateService();
 
-        await this.#config.set({
-            nextNodeId: typeof nextNodeId === "bigint" ? nextNodeId + 1n : nextNodeId + 1,
-        });
-
-        const { nodeId } = await this.#commandHandler.commissionNode({
-            nodeId: NodeId(nextNodeId),
+        const nodeId = await this.#commissionWithRetry(nodeId => ({
+            nodeId,
             onNetworkOnly: network_only,
             ...(isQrCode ? { qrCode: code } : { manualCode: code }),
             wifiCredentials,
             threadCredentials,
-        });
+        }));
 
         return this.#collectNodeDetails(nodeId);
     }
@@ -712,14 +752,11 @@ export class WebSocketControllerHandler implements WebServerHandler {
     ): Promise<ResponseOf<"commission_on_network">> {
         const { setup_pin_code, filter_type, filter, ip_addr } = args;
 
-        const nextNodeId = this.#config.nextNodeId;
-
         // Build commissioning request based on filter type
         // Filter types: 0=None, 1=ShortDiscriminator, 2=LongDiscriminator, 3=VendorId, 4=DeviceType
         let commissionRequest: CommissioningRequest;
 
         const baseRequest = {
-            nodeId: NodeId(nextNodeId),
             onNetworkOnly: true, // commission_on_network is always network-only
             // Ignore fe80 addresses and better do generic discovery because could be from mobile devices
             knownAddress: ip_addr && !ip_addr.startsWith("fe80") ? { ip: ip_addr, port: 5540 } : undefined,
@@ -752,11 +789,7 @@ export class WebSocketControllerHandler implements WebServerHandler {
         // Ensure certificates are loaded and initialized
         await this.#controller.certificateService();
 
-        await this.#config.set({
-            nextNodeId: typeof nextNodeId === "bigint" ? nextNodeId + 1n : nextNodeId + 1,
-        });
-
-        const { nodeId } = await this.#commandHandler.commissionNode(commissionRequest);
+        const nodeId = await this.#commissionWithRetry(nodeId => ({ ...commissionRequest, nodeId }));
 
         return this.#collectNodeDetails(nodeId);
     }

--- a/packages/ws-controller/test/ConfigStorageTest.ts
+++ b/packages/ws-controller/test/ConfigStorageTest.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Environment, MockStorageService } from "@matter/general";
+import { ConfigStorage } from "../src/server/ConfigStorage.js";
+
+async function createConfig(): Promise<ConfigStorage> {
+    const env = new Environment("test");
+    new MockStorageService(env);
+    return ConfigStorage.create(env);
+}
+
+describe("ConfigStorage", () => {
+    describe("allocateNodeId", () => {
+        let config: ConfigStorage;
+
+        beforeEach(async () => {
+            config = await createConfig();
+        });
+
+        afterEach(async () => {
+            await config.close();
+        });
+
+        it("returns the current counter and advances it", async () => {
+            expect(config.nextNodeId).to.equal(1);
+
+            const first = await config.allocateNodeId(() => false);
+            expect(first).to.equal(1);
+            expect(config.nextNodeId).to.equal(2);
+
+            const second = await config.allocateNodeId(() => false);
+            expect(second).to.equal(2);
+            expect(config.nextNodeId).to.equal(3);
+        });
+
+        it("skips ids that are already in use", async () => {
+            const inUse = new Set<number | bigint>([1, 2, 3]);
+            const allocated = await config.allocateNodeId(id => inUse.has(id));
+            expect(allocated).to.equal(4);
+            expect(config.nextNodeId).to.equal(5);
+        });
+
+        it("serializes concurrent allocations so ids never collide", async () => {
+            const results = await Promise.all(Array.from({ length: 10 }, () => config.allocateNodeId(() => false)));
+
+            const unique = new Set(results.map(id => id.toString()));
+            expect(unique.size).to.equal(results.length);
+            expect([...unique].sort((a, b) => Number(a) - Number(b))).to.deep.equal(
+                Array.from({ length: 10 }, (_, i) => String(i + 1)),
+            );
+            expect(config.nextNodeId).to.equal(11);
+        });
+
+        it("preserves the bigint counter type when advancing", async () => {
+            await config.set({ nextNodeId: 100n });
+
+            const allocated = await config.allocateNodeId(() => false);
+            expect(allocated).to.equal(100n);
+            expect(config.nextNodeId).to.equal(101n);
+            expect(typeof config.nextNodeId).to.equal("bigint");
+        });
+    });
+});


### PR DESCRIPTION
## Problem

A user hit during commissioning:

```
WARN  ParallelPa~Discovery  Unexpected error from parallel commissioning attempt:
[identity-conflict] Cannot assign NodeId 88 on fabric 1: the peer address is already in use
```

The server keeps its own `nextNodeId` counter in `ConfigStorage`, incremented per commission. Two problems:

1. **Race** — the read-modify-write of `nextNodeId` is not atomic, so two concurrent `commission_*` requests read the same id and both try to commission it.
2. **Drift** — if the counter falls behind the fabric's actual peer set (manual storage edits, legacy import, lost write, or a decommissioned-but-not-released address), matter.js rejects the id with `IdentityConflictError` and commissioning fails outright.

## Fix

Three layers:

| Layer | Where | What |
|---|---|---|
| Race | `ConfigStorage.allocateNodeId()` | Wraps read→skip-used→persist in a matter.js `Mutex.produce()` so concurrent allocations serialize and never reuse an id. |
| Drift | `ControllerCommandHandler.isNodeIdInUse()` | Authoritative pre-check against matter.js (`controller.nodeId` + `isNodeCommissioned()`) instead of the drift-prone local node set; skips used ids before commissioning. |
| Residual | `WebSocketControllerHandler.#commissionWithRetry()` | Bounded (5) retry: on an `identity-conflict` (detected by walking the `error.cause` chain for a `MatterError` with id `identity-conflict`), allocate the next id and retry. |

The own counter is kept as the source of allocation; it still advances per allocation, so a failed commission continues to burn its id (unchanged behavior).

## Tests

- New `ConfigStorageTest`: sequential allocation, skip-used, concurrent-no-collision, bigint-counter preservation
- Full `ws-controller` suite: 95/95
- `matter-server` `DclAttestationTest` (commissions a simulated device end-to-end through the new allocation path): passing
- format / build / lint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)