### PR TITLE
Dashboard ACL & Binding cluster editors + matter.js 0.17.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Enhancement: Revamped the experimental Binding overview and editor in Dashboard
+- Enhancement: Added ACL overview and limited management options to Access Control cluster view (Root endpoint)
+- Enhancement: Update matter.js to 0.17.3 with many fixes and optimizations, especially:
+    - Fixes attestation certificate validation error for Nuki SmartLocks
+    - Ensures to use the increased thread message retransmission timings also for commands
+- Adjustment: Ensure that Matter-Server CLI options do not interfere with matter.js
+
 ## 1.0.0 (2026-06-09)
 
 - Enhancement: Update matter.js to 0.17.2 with many fixes and optimizations

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "packages/matter-server"
             ],
             "devDependencies": {
-                "@matter/testing": "0.17.2",
+                "@matter/testing": "0.17.3",
                 "@nacho-iot/js-tools": "^0.1.7",
                 "@types/mocha": "^10.0.10",
                 "glob": "^13.0.6",
@@ -1642,9 +1642,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-            "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+            "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -1659,9 +1659,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-            "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+            "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
             "cpu": [
                 "arm"
             ],
@@ -1676,9 +1676,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-            "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+            "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
             "cpu": [
                 "arm64"
             ],
@@ -1693,9 +1693,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-            "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+            "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
             "cpu": [
                 "x64"
             ],
@@ -1710,9 +1710,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-            "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+            "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1727,9 +1727,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-            "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+            "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
             "cpu": [
                 "x64"
             ],
@@ -1744,9 +1744,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-            "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
             "cpu": [
                 "arm64"
             ],
@@ -1761,9 +1761,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-            "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
             "cpu": [
                 "x64"
             ],
@@ -1778,9 +1778,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-            "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+            "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
             "cpu": [
                 "arm"
             ],
@@ -1795,9 +1795,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-            "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+            "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
             "cpu": [
                 "arm64"
             ],
@@ -1812,9 +1812,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-            "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+            "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
             "cpu": [
                 "ia32"
             ],
@@ -1829,9 +1829,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-            "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+            "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
             "cpu": [
                 "loong64"
             ],
@@ -1846,9 +1846,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-            "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+            "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
             "cpu": [
                 "mips64el"
             ],
@@ -1863,9 +1863,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-            "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+            "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -1880,9 +1880,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-            "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+            "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -1897,9 +1897,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-            "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+            "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
             "cpu": [
                 "s390x"
             ],
@@ -1914,9 +1914,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-            "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+            "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
             "cpu": [
                 "x64"
             ],
@@ -1931,9 +1931,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-            "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
             "cpu": [
                 "arm64"
             ],
@@ -1948,9 +1948,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-            "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
             "cpu": [
                 "x64"
             ],
@@ -1965,9 +1965,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-            "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+            "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
             "cpu": [
                 "arm64"
             ],
@@ -1982,9 +1982,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-            "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+            "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
             "cpu": [
                 "x64"
             ],
@@ -1999,9 +1999,9 @@
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-            "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+            "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
             "cpu": [
                 "arm64"
             ],
@@ -2016,9 +2016,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-            "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+            "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
             "cpu": [
                 "x64"
             ],
@@ -2033,9 +2033,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-            "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+            "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
             "cpu": [
                 "arm64"
             ],
@@ -2050,9 +2050,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-            "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+            "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
             "cpu": [
                 "ia32"
             ],
@@ -2067,9 +2067,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-            "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+            "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
             "cpu": [
                 "x64"
             ],
@@ -2548,86 +2548,86 @@
             "link": true
         },
         "node_modules/@matter/dcl-data": {
-            "version": "2026.6.9",
-            "resolved": "https://registry.npmjs.org/@matter/dcl-data/-/dcl-data-2026.6.9.tgz",
-            "integrity": "sha512-SiGEttAhhVfUyFS2IwPtd8Pz0CIRVAlrq00oK/R8YMNlY9NF00Kn4mm0QhMvZ0J76VAc1YaUzpKIZU9DYaWMhA==",
+            "version": "2026.6.16",
+            "resolved": "https://registry.npmjs.org/@matter/dcl-data/-/dcl-data-2026.6.16.tgz",
+            "integrity": "sha512-hQvrn/5eYeyeAtxnkGmG77i5aLcVDbLLlFDndaN/iF16MFwOcJ1yj2lj0MXEN6xQcVnpYNnAlBORFEwgtFC+lQ==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@matter/general": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.2.tgz",
-            "integrity": "sha512-n4u5SN2WU1u9dMVL90qgOnA298Rw4bPeAM1sBqxeAw7S9yGwgW+Tqbbt3MtodesMcDGMRrGx6vJDNMPmKtBtlA==",
+            "version": "0.17.3",
+            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.3.tgz",
+            "integrity": "sha512-5DRM/sA+4gQj/p0cBOBPSXcLjCQ3Qix9rCE23sGGonVWY4PMi+SWzZHvQVe5mYvCl+HU3pL+aJq8HalyOqjEGQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/curves": "^2.2.0"
             }
         },
         "node_modules/@matter/main": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.2.tgz",
-            "integrity": "sha512-TdZ7vhO5QEY20beS2IvNY2PnccW4pRyXmDQ2XFkoCVIgV5NtLTvhnI7TtlqMNQuGqE1uPkt2AqZMJNtuIWyCyQ==",
+            "version": "0.17.3",
+            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.3.tgz",
+            "integrity": "sha512-0JE1qtN7ne0P3rCCSWP2pFONFRlOpZvV+BmTyl4YFJtWapIcTUzak9gZ4/WJ0VAUQX4GtbnIAinwyLoysWewIA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.2",
-                "@matter/model": "0.17.2",
-                "@matter/node": "0.17.2",
-                "@matter/protocol": "0.17.2",
-                "@matter/types": "0.17.2"
+                "@matter/general": "0.17.3",
+                "@matter/model": "0.17.3",
+                "@matter/node": "0.17.3",
+                "@matter/protocol": "0.17.3",
+                "@matter/types": "0.17.3"
             },
             "optionalDependencies": {
-                "@matter/nodejs": "0.17.2"
+                "@matter/nodejs": "0.17.3"
             }
         },
         "node_modules/@matter/model": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.2.tgz",
-            "integrity": "sha512-mXNYv4rASTmYZYJqYCX/PtIGzrmeZ4xJ42CJurUkvSp2vrtOamlk+PATHf59JmZypxFJlqk3ATu8IMQuseDqXw==",
+            "version": "0.17.3",
+            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.3.tgz",
+            "integrity": "sha512-WfUCmoy71BAOumExCxpgQp2OjfzSEcQtUkft1WkVF1yOToju/0CAhMg0hoqB+XPoEDEwmARgi/AIhgoiJOhGng==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.2"
+                "@matter/general": "0.17.3"
             }
         },
         "node_modules/@matter/node": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.2.tgz",
-            "integrity": "sha512-CaKWrfKiuX8MAJSJPGGMrT+j/LOvxLloJ2HgKn1YCxRFo33zaKphFJ0+QUYx+szqO9h/CCCJs0IWcYGiZkj2vg==",
+            "version": "0.17.3",
+            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.3.tgz",
+            "integrity": "sha512-d6SGETjsE/z9NGPove39eu6WI6qA4svp1IQ/W45+iCWhKidaMu58DX7EZpNCOjWsTfXdjgQA8WnD9K1Ujbuzfg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.2",
-                "@matter/model": "0.17.2",
-                "@matter/protocol": "0.17.2",
-                "@matter/types": "0.17.2"
+                "@matter/general": "0.17.3",
+                "@matter/model": "0.17.3",
+                "@matter/protocol": "0.17.3",
+                "@matter/types": "0.17.3"
             }
         },
         "node_modules/@matter/nodejs": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.2.tgz",
-            "integrity": "sha512-h7usJRNiw8bQCE4GldtLVGjWY1XtAcviqo5tZsZUyNCcm5nYGpcB0uqDAUw/Hsojc2W2xGrSiVMbYp/4WxvyJw==",
+            "version": "0.17.3",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.3.tgz",
+            "integrity": "sha512-lrhK12Uk5W7WmboF6JE9UV68sj0E2hiYJvpIuZTCnKFmvHs0AwF080eZAIOXcIfsf3Gg6rHHzq5FpR7Zvqiflg==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.2",
-                "@matter/node": "0.17.2",
-                "@matter/protocol": "0.17.2",
-                "@matter/types": "0.17.2"
+                "@matter/general": "0.17.3",
+                "@matter/node": "0.17.3",
+                "@matter/protocol": "0.17.3",
+                "@matter/types": "0.17.3"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
             }
         },
         "node_modules/@matter/nodejs-ble": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.2.tgz",
-            "integrity": "sha512-cnuChbfDKocLm+S5FaL9CylD6au9exUUO6chdgK6uJq4JgW4pVsdqJ1sGu7zN8ZVIMXwV8s1cTP2lqxOjUYWHg==",
+            "version": "0.17.3",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.3.tgz",
+            "integrity": "sha512-WNgGiZCp3QkflinpT0gvOg7JY2mouMYgbYybc1UaJ4eg0oIscUFyIakXUt4G/+6RTxsZSfSg7w8oOZOsYyNqWg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@matter/general": "0.17.2",
-                "@matter/protocol": "0.17.2",
-                "@matter/types": "0.17.2"
+                "@matter/general": "0.17.3",
+                "@matter/protocol": "0.17.3",
+                "@matter/types": "0.17.3"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -2638,20 +2638,20 @@
             }
         },
         "node_modules/@matter/protocol": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.2.tgz",
-            "integrity": "sha512-lYJgPEAyt7pa9Fj80BGmPYYSMUvZjgV4jjSmZwtJUE2PhITcpJgDeE1JT9bP4LYz5HK3C9AssXbsR/rbWi4ssQ==",
+            "version": "0.17.3",
+            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.3.tgz",
+            "integrity": "sha512-Sf8O2IUhqzKqKR4ssY8epF+aSCrszUiTBkSJ5u/fYDaoADjxIPHFOKXdYcjKrfuydyxhzYDK6eh3XPzyXrir3w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.2",
-                "@matter/model": "0.17.2",
-                "@matter/types": "0.17.2"
+                "@matter/general": "0.17.3",
+                "@matter/model": "0.17.3",
+                "@matter/types": "0.17.3"
             }
         },
         "node_modules/@matter/testing": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.2.tgz",
-            "integrity": "sha512-1bxBgoXBUVb0eFuAI/xCnWHbpKAwa4mRcpvPengpNQnhx/ddcbW0hrgUBXBV0QSquntpS07iQCYdl1w2SLgKFw==",
+            "version": "0.17.3",
+            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.3.tgz",
+            "integrity": "sha512-sqTpDIbRxKkAxX06vPk+9ELhPjjNFN5tCFH9Q2Zk7lH8yMYt6ApPvhMhtDcSIUgc6sZ3bVDc8X8BT4ReypmU/Q==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -2661,10 +2661,10 @@
                 "chai": "^4.5.0",
                 "chai-as-promised": "^7.1.2",
                 "dockerode": "^5.0.0",
-                "esbuild": "^0.28.0",
+                "esbuild": "^0.28.1",
                 "express": "^5.2.1",
                 "mocha": "^11.7.6",
-                "playwright": "^1.60.0",
+                "playwright": "^1.61.0",
                 "trace-unhandled": "^2.0.1",
                 "wtfnode": "^0.10.1",
                 "xml2js": "^0.6.2",
@@ -2676,13 +2676,13 @@
             }
         },
         "node_modules/@matter/types": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.2.tgz",
-            "integrity": "sha512-Jtc4dvuwPvEGtNAekO5wdgb+Bcu6MK3FCR0OnBlN197FyCsfjWFeGEzIN1nw0cAmVeBPdn0tAmZ3z6i8erEsKA==",
+            "version": "0.17.3",
+            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.3.tgz",
+            "integrity": "sha512-7I49NkCAnsytxoFm6mwgpBTgwnODPxpJBkWQfzrWRRW6KBY0syJj+LkI7CIPK37VCc7AAzGrWIRHN7wylKaPeg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.2",
-                "@matter/model": "0.17.2"
+                "@matter/general": "0.17.3",
+                "@matter/model": "0.17.3"
             }
         },
         "node_modules/@mdi/js": {
@@ -2930,6 +2930,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2947,6 +2950,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2964,6 +2970,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2981,6 +2990,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2998,6 +3010,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3015,6 +3030,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3032,6 +3050,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3049,6 +3070,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3211,9 +3235,9 @@
             ]
         },
         "node_modules/@oxlint/binding-android-arm-eabi": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.69.0.tgz",
-            "integrity": "sha512-DKQQbD5cZ/MYfDgDI7YGyGD9FSxABlsBsYFo5p26lloob543tP9+4N3guwdXIYJN+7HSZxLe8YJuwcOWw5qnHg==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.70.0.tgz",
+            "integrity": "sha512-zFh0P4cswmRvw6nkyb89dr18rRanuaCPAsEXsFDoQY8WdaquI8Pt4NWFjaMJg6L23cy5NeN8J9cBnREbWzZhaw==",
             "cpu": [
                 "arm"
             ],
@@ -3228,9 +3252,9 @@
             }
         },
         "node_modules/@oxlint/binding-android-arm64": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.69.0.tgz",
-            "integrity": "sha512-lEhb+I5pr4inux+JFwfCa1HRq3Os7NirEFQ0H1I35SVEHPm6byX0Ah47xmRha3qi6LAkxUcxViL8o/9PivjzBg==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.70.0.tgz",
+            "integrity": "sha512-qI8o4HZjeGiBrWv+pJv4lH0Yi2Gl/JSp/EumBUApezJprIKa5PS4nU0lQsQngtky8k+SplQIOjv6hwu0SSxeyg==",
             "cpu": [
                 "arm64"
             ],
@@ -3245,9 +3269,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-arm64": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.69.0.tgz",
-            "integrity": "sha512-GY2YE8lOZW59BW1Ia1y+1gR0XyjrZRvVWHAr8LGeGhYHE0OQJ/7cRKXTkx1P+E9/6awEc3SX8a68SFTjh/E//A==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.70.0.tgz",
+            "integrity": "sha512-8KjgVVHI5F9nVwHCRwwA78Ty7zNKP4Wd9OeN5PSv3iu/F/u1RVXoOCgLhWqust6HmwQG6xc8c+RCyaWENy24+w==",
             "cpu": [
                 "arm64"
             ],
@@ -3262,9 +3286,9 @@
             }
         },
         "node_modules/@oxlint/binding-darwin-x64": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.69.0.tgz",
-            "integrity": "sha512-ax1oZnOjHX3LB7myQyHEaQkDwfLb6str3/nSP6O7EVUviQGNkEGzGV0EqcBJWK+Ufwx0l4xPgyYayurvhAdl2Q==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.70.0.tgz",
+            "integrity": "sha512-WVydssv5PSUBXFJTdNBWlmGkbNmvPGaFt/2SUT/EZRB6bq6bEOHmMlbnupZD5jmlEvi9+mZJHi8TCw15lyfSfQ==",
             "cpu": [
                 "x64"
             ],
@@ -3279,9 +3303,9 @@
             }
         },
         "node_modules/@oxlint/binding-freebsd-x64": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.69.0.tgz",
-            "integrity": "sha512-kHWeHv4g2h8NY+mpCxzCtY4uerMJWTN/TSnNj1CPbakFpHEJ6cTya2wWV0pDSYWOJ2+0UiEbhn3AtXxHtsnKjg==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.70.0.tgz",
+            "integrity": "sha512-hJucmUf8OlinHNb1R7fI4Fw6WsAstOz7i8nmkWQfiHoZXtbufNm+MxiDTIMk1ggh2Ro4vLzgQ+bKvRY54MZoRA==",
             "cpu": [
                 "x64"
             ],
@@ -3296,9 +3320,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.69.0.tgz",
-            "integrity": "sha512-gq84vM1a1oEehXo27YCDzGVcxPsZDI1yswZwz2Da1/cbnWtrL16XZZnz0G/+gIU8edtHpfjxq5c+vWEHqJfWoQ==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.70.0.tgz",
+            "integrity": "sha512-1BnS7wbCYDSXwWzJJ+mc3NURoha6m6m6RT5c6vgAY3oz7C3OVXP+S0awo2mRq97arrJkVvO3qRQfyAHL+76xtQ==",
             "cpu": [
                 "arm"
             ],
@@ -3313,9 +3337,9 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm-musleabihf": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.69.0.tgz",
-            "integrity": "sha512-kIqEa98JQ0VRyrcncxA417m2AzasqTlD+FyVT1AksjvjkqQcvm7pBWYvoW3/mpyOP2XYvi5nSCCTIe6De1yu5g==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.70.0.tgz",
+            "integrity": "sha512-yKy/UdbR55+M2yEcuiV5DCNC/gdQAjr/GioUy50QwBzSrKm8ueWADqyRLS9Xk+qjNeCYGg6A8FvUBds56ttfqg==",
             "cpu": [
                 "arm"
             ],
@@ -3330,13 +3354,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-gnu": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.69.0.tgz",
-            "integrity": "sha512-j+xYiXozxGWx2cpjCrwwGR4awTxPFsRv3JZrv23RCogEPMc4R7UqjHW47p/RG0aRlbWiROCJ8coUfCwy0dvzHA==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.70.0.tgz",
+            "integrity": "sha512-0A5XJ4alvmqFUFP/4oYSyaO+qLto/HrKEWTSaegiVl+HOufFngK2BjYw9x4RbwBt/du5QG6l5q1zeWiJYYG5yg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3347,13 +3374,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-arm64-musl": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.69.0.tgz",
-            "integrity": "sha512-xEPpNppTfN1l/nM7gYSf9iocscu/as+p/7vxkLeLEKnYU+09Dm+5V6IhDYDh+Uz6FajEupWwCLt5SOG0y1PCKg==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.70.0.tgz",
+            "integrity": "sha512-JiylyurlB0CLSedNtx1gzv3FvfWPF1h/2Y3BJszPLNt5XQFlBsH5ke0Jle3iJb3uqu5m2e7A/DwzpuCAHdiU+A==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3364,13 +3394,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-ppc64-gnu": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.69.0.tgz",
-            "integrity": "sha512-Ug0+eU7HJBlek+SjklYH62IlOMirEJsdxpihH0kSqX0XdrDD4NdHpQc10fK1JC35yn6KrrcN+uYzlHD38XAf8Q==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.70.0.tgz",
+            "integrity": "sha512-J8VPG7I3/HmgaU4u8pNU2kFx2+0U+vPLS1dXFxXOaR/2TQ0f8AC7DRz0SRGRI1bfphnX2hVYTTtLuhL4nYKL+Q==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3381,13 +3414,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-gnu": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.69.0.tgz",
-            "integrity": "sha512-iEyI3GIg0l/s3G4qy2TlaaWKdzj4PJJStwtlocpDTC00PY9hZueotf6OKUj9+yfQh0lrpBW/pLMgTztbAHKJEg==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.70.0.tgz",
+            "integrity": "sha512-N2+4lV2KLN+oXTIIIwmWDhwkrnvqf5oX7Hw0zPjk+RuIVgiBQSOlJWF7uQoFx2siEYX0ZQ5cfSbEAHm+J3t7Wg==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3398,13 +3434,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-riscv64-musl": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.69.0.tgz",
-            "integrity": "sha512-NjHjpiI4WIKSMwuoJSZi5VToPeoYOS1FR52HLIDG6lidMdqquusgtODb4iLk0+lb1q3Z0nv2/aPRcC/olmpQGg==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.70.0.tgz",
+            "integrity": "sha512-1e2L7cFCvx9QDzq6NPP+0tABKb5z6nWHyddWTNKprEsjO9xNrAtPowuCGpjNXxkTdsMiZ4jc8YQ5SstZd4XK6g==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3415,13 +3454,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-s390x-gnu": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.69.0.tgz",
-            "integrity": "sha512-Ai/prDewoItkDXbp38gwGZi41DycZbUTZJ3UidwoHgQC0/DaqC2TGdtBTQLJ6hSD+SAxASzh8+/eSBPmxfOacA==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.70.0.tgz",
+            "integrity": "sha512-Kwu/l/8GcYibCWA9m9N5pRXMIKVSsL/YbgpLzYkqDhWTiqdRfnNJ/+nqIKRKQiFbHWsdlHEhzMwruJK+qcEruA==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3432,13 +3474,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-gnu": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.69.0.tgz",
-            "integrity": "sha512-Gt3KHgp46mRKz4sJeaASmKvD8ayXookRw07RMf+NowhEztGGDZ7VrXpoW96XuKJLjFukWizOFVNjmYb/u7caNQ==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.70.0.tgz",
+            "integrity": "sha512-tap04CsHYOl0nSAQJfPNIuBxqEPB2HnhQqwaOXLg1jnp2XfRo8Fa814dA4QC4zpvTWXCjAAaCY1W5LOORkEQuQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3449,13 +3494,16 @@
             }
         },
         "node_modules/@oxlint/binding-linux-x64-musl": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.69.0.tgz",
-            "integrity": "sha512-7tQhJ2+p/oHv1zcfnjYI7YVzC/7iBaVOfIvFYtxdJ5F45mWgEdrCyXZXZGfiLey5t/5JhOhsaMnnv1kAzckd7g==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.70.0.tgz",
+            "integrity": "sha512-hzJa/WgvtJpbBD9rgfy0qe+MjbxOXNUT0bfR1S6EQQzfTtBFA9xg5q8KSwRrQ2QfSS+TaP4j+4mVPQrfNc6UNg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3466,9 +3514,9 @@
             }
         },
         "node_modules/@oxlint/binding-openharmony-arm64": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.69.0.tgz",
-            "integrity": "sha512-vmWz6TKp/3hfA4lksR0zHBv/6xuX1jhym6eqOjdH2DXsDDHZWcp2f0KG0VCAnlVbIrjk29G4wAWMXb/Hn1YobA==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.70.0.tgz",
+            "integrity": "sha512-xbsaNSNzVSnaJACCUYr1HQMyY/Q/Q1LkePmHG3UvZPvGCYGNxrsZp9OmtA6ick8xH47ltRRbRrPCM1YXYcyC+A==",
             "cpu": [
                 "arm64"
             ],
@@ -3483,9 +3531,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-arm64-msvc": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.69.0.tgz",
-            "integrity": "sha512-9RExaLgmaw6IoIkU9cTpT71mLfI0xZ86iZH8x518LVsOkjquJMYqb9P7KpC8lgd1t0Dxs41p2pxynq4XR3Ttzw==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.70.0.tgz",
+            "integrity": "sha512-icAEsUI7JbW1TMRdEXV83mVAInhRVQYuuAlPpxdGwJ95chNdnCzjloRW8GglT0WvzOEZSio6fnYSk2DJ2Hv7LQ==",
             "cpu": [
                 "arm64"
             ],
@@ -3500,9 +3548,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-ia32-msvc": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.69.0.tgz",
-            "integrity": "sha512-1907kRPF8/PrcIw1E7LMs9JbVrpgnt/MvFdss3an8oDkYNAACXzTntV3t3869ZZhMZxb2AzRGbz1pA/jdFatXA==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.70.0.tgz",
+            "integrity": "sha512-FHMSWbVsPVs/f+Jcl04ws4JJ2wUnauyTzlpxWRG/lSO/8GpX08Fo2gQZqdA6CrRFI+zvkxl+N/KwJGWfUwYVZA==",
             "cpu": [
                 "ia32"
             ],
@@ -3517,9 +3565,9 @@
             }
         },
         "node_modules/@oxlint/binding-win32-x64-msvc": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.69.0.tgz",
-            "integrity": "sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.70.0.tgz",
+            "integrity": "sha512-ptOlKwCz7n4AKs5VweMqG6DAg677FmKOK+vBkkL9DMNgFATIQ+upqUYBTOEwRQyRAx1ncGlPlXleV2hIcm3z4g==",
             "cpu": [
                 "x64"
             ],
@@ -3545,16 +3593,16 @@
             }
         },
         "node_modules/@project-chip/matter.js": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.2.tgz",
-            "integrity": "sha512-SR1H3gM2v3GcgaH+5NyMAkrV17cwYofLOUsDDfnLt2B6PCA0WHa10gWVXLlM+6IYPIkB5Gh87vMbWT8MjrHxNQ==",
+            "version": "0.17.3",
+            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.3.tgz",
+            "integrity": "sha512-c86SzGDgApXECWNw+//NrpXinDHgKvpfAXn5BCP1Ot3eCrQV8eB/PeEeV1Om8uZWEXonxAf2y/fQ1pHUjrA9Hw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.2",
-                "@matter/model": "0.17.2",
-                "@matter/node": "0.17.2",
-                "@matter/protocol": "0.17.2",
-                "@matter/types": "0.17.2"
+                "@matter/general": "0.17.3",
+                "@matter/model": "0.17.3",
+                "@matter/node": "0.17.3",
+                "@matter/protocol": "0.17.3",
+                "@matter/types": "0.17.3"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -3599,13 +3647,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "dev": true,
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
             "dev": true,
             "license": "BSD-3-Clause"
         },
@@ -3805,9 +3846,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
-            "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+            "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
             "cpu": [
                 "arm"
             ],
@@ -3819,9 +3860,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
-            "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+            "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
             "cpu": [
                 "arm64"
             ],
@@ -3833,9 +3874,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
-            "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+            "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
             "cpu": [
                 "arm64"
             ],
@@ -3847,9 +3888,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
-            "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+            "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
             "cpu": [
                 "x64"
             ],
@@ -3861,9 +3902,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
-            "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+            "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
             "cpu": [
                 "arm64"
             ],
@@ -3875,9 +3916,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
-            "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+            "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
             "cpu": [
                 "x64"
             ],
@@ -3889,13 +3930,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
-            "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+            "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3903,13 +3947,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
-            "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+            "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3917,13 +3964,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
-            "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+            "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3931,13 +3981,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
-            "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+            "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3945,13 +3998,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
-            "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+            "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
             "cpu": [
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3959,13 +4015,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
-            "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+            "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
             "cpu": [
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3973,13 +4032,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
-            "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+            "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -3987,13 +4049,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
-            "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+            "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4001,13 +4066,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
-            "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+            "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4015,13 +4083,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
-            "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+            "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4029,13 +4100,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
-            "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+            "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4043,13 +4117,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
-            "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+            "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4057,13 +4134,16 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
-            "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+            "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -4071,9 +4151,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
-            "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+            "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
             "cpu": [
                 "x64"
             ],
@@ -4085,9 +4165,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
-            "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+            "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
             "cpu": [
                 "arm64"
             ],
@@ -4099,9 +4179,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
-            "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+            "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
             "cpu": [
                 "arm64"
             ],
@@ -4113,9 +4193,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
-            "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+            "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
             "cpu": [
                 "ia32"
             ],
@@ -4127,9 +4207,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
-            "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+            "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
             "cpu": [
                 "x64"
             ],
@@ -4141,9 +4221,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
-            "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+            "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
             "cpu": [
                 "x64"
             ],
@@ -4547,9 +4627,9 @@
             }
         },
         "node_modules/@stoprocent/noble": {
-            "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/@stoprocent/noble/-/noble-2.5.3.tgz",
-            "integrity": "sha512-GCfLqSdWU8a6SsXm/yXMIIXaQqCwtpUSlKbsWzdvnZZmASmys7iKsc7LIzw7riElmJH95DY2105leg6U5jlrDA==",
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/@stoprocent/noble/-/noble-2.5.4.tgz",
+            "integrity": "sha512-MojZwVQPapozemto5VP5RSlPL6lOuiLe/S0Ybcfqu9H6yciFIagjKYe4vIjEIUxhES/iazGiZpP5ErWHvaAP/w==",
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -4687,9 +4767,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "25.9.2",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
-            "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
+            "version": "25.9.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+            "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4769,14 +4849,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
-            "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
+            "version": "8.61.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+            "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.61.0",
-                "@typescript-eslint/types": "^8.61.0",
+                "@typescript-eslint/tsconfig-utils": "^8.61.1",
+                "@typescript-eslint/types": "^8.61.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -4791,9 +4871,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
-            "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
+            "version": "8.61.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+            "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4808,9 +4888,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
-            "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+            "version": "8.61.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+            "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4822,16 +4902,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
-            "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+            "version": "8.61.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+            "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.61.0",
-                "@typescript-eslint/tsconfig-utils": "8.61.0",
-                "@typescript-eslint/types": "8.61.0",
-                "@typescript-eslint/visitor-keys": "8.61.0",
+                "@typescript-eslint/project-service": "8.61.1",
+                "@typescript-eslint/tsconfig-utils": "8.61.1",
+                "@typescript-eslint/types": "8.61.1",
+                "@typescript-eslint/visitor-keys": "8.61.1",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -4850,13 +4930,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.61.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
-            "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+            "version": "8.61.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+            "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.61.0",
+                "@typescript-eslint/types": "8.61.1",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -5036,9 +5116,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+            "version": "8.17.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+            "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -5325,9 +5405,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.34",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz",
-            "integrity": "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==",
+            "version": "2.10.37",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+            "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -5360,21 +5440,34 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
             "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "debug": "^4.4.3",
-                "http-errors": "^2.0.0",
-                "iconv-lite": "^0.7.0",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.1",
-                "raw-body": "^3.0.1",
-                "type-is": "^2.0.1"
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
             },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -5681,9 +5774,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001797",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
-            "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
+            "version": "1.0.30001799",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+            "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
             "dev": true,
             "funding": [
                 {
@@ -6315,9 +6408,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.370",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.370.tgz",
-            "integrity": "sha512-D5tSHJReAb/Kf3Hu9F/GO4lJuSWzEWHwvQ/kKSUP7pimNgvxkSKj+gUQhHpKKACwrin7rS3byU7IxreF56rl5g==",
+            "version": "1.5.375",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
+            "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
             "dev": true,
             "license": "ISC"
         },
@@ -6391,9 +6484,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-            "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+            "version": "0.28.1",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+            "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -6404,32 +6497,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.28.0",
-                "@esbuild/android-arm": "0.28.0",
-                "@esbuild/android-arm64": "0.28.0",
-                "@esbuild/android-x64": "0.28.0",
-                "@esbuild/darwin-arm64": "0.28.0",
-                "@esbuild/darwin-x64": "0.28.0",
-                "@esbuild/freebsd-arm64": "0.28.0",
-                "@esbuild/freebsd-x64": "0.28.0",
-                "@esbuild/linux-arm": "0.28.0",
-                "@esbuild/linux-arm64": "0.28.0",
-                "@esbuild/linux-ia32": "0.28.0",
-                "@esbuild/linux-loong64": "0.28.0",
-                "@esbuild/linux-mips64el": "0.28.0",
-                "@esbuild/linux-ppc64": "0.28.0",
-                "@esbuild/linux-riscv64": "0.28.0",
-                "@esbuild/linux-s390x": "0.28.0",
-                "@esbuild/linux-x64": "0.28.0",
-                "@esbuild/netbsd-arm64": "0.28.0",
-                "@esbuild/netbsd-x64": "0.28.0",
-                "@esbuild/openbsd-arm64": "0.28.0",
-                "@esbuild/openbsd-x64": "0.28.0",
-                "@esbuild/openharmony-arm64": "0.28.0",
-                "@esbuild/sunos-x64": "0.28.0",
-                "@esbuild/win32-arm64": "0.28.0",
-                "@esbuild/win32-ia32": "0.28.0",
-                "@esbuild/win32-x64": "0.28.0"
+                "@esbuild/aix-ppc64": "0.28.1",
+                "@esbuild/android-arm": "0.28.1",
+                "@esbuild/android-arm64": "0.28.1",
+                "@esbuild/android-x64": "0.28.1",
+                "@esbuild/darwin-arm64": "0.28.1",
+                "@esbuild/darwin-x64": "0.28.1",
+                "@esbuild/freebsd-arm64": "0.28.1",
+                "@esbuild/freebsd-x64": "0.28.1",
+                "@esbuild/linux-arm": "0.28.1",
+                "@esbuild/linux-arm64": "0.28.1",
+                "@esbuild/linux-ia32": "0.28.1",
+                "@esbuild/linux-loong64": "0.28.1",
+                "@esbuild/linux-mips64el": "0.28.1",
+                "@esbuild/linux-ppc64": "0.28.1",
+                "@esbuild/linux-riscv64": "0.28.1",
+                "@esbuild/linux-s390x": "0.28.1",
+                "@esbuild/linux-x64": "0.28.1",
+                "@esbuild/netbsd-arm64": "0.28.1",
+                "@esbuild/netbsd-x64": "0.28.1",
+                "@esbuild/openbsd-arm64": "0.28.1",
+                "@esbuild/openbsd-x64": "0.28.1",
+                "@esbuild/openharmony-arm64": "0.28.1",
+                "@esbuild/sunos-x64": "0.28.1",
+                "@esbuild/win32-arm64": "0.28.1",
+                "@esbuild/win32-ia32": "0.28.1",
+                "@esbuild/win32-x64": "0.28.1"
             }
         },
         "node_modules/escalade": {
@@ -8417,9 +8510,9 @@
             }
         },
         "node_modules/oxlint": {
-            "version": "1.69.0",
-            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.69.0.tgz",
-            "integrity": "sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==",
+            "version": "1.70.0",
+            "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.70.0.tgz",
+            "integrity": "sha512-D6JgHtzkhRwvEC+A0Nw5AEc5bk8x5i1pHzvZIEf/a0C4hOzmAACNGtkDGPyFaxxX3ZVGxCPeig3P3rMM8XU3/g==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -8432,25 +8525,25 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxlint/binding-android-arm-eabi": "1.69.0",
-                "@oxlint/binding-android-arm64": "1.69.0",
-                "@oxlint/binding-darwin-arm64": "1.69.0",
-                "@oxlint/binding-darwin-x64": "1.69.0",
-                "@oxlint/binding-freebsd-x64": "1.69.0",
-                "@oxlint/binding-linux-arm-gnueabihf": "1.69.0",
-                "@oxlint/binding-linux-arm-musleabihf": "1.69.0",
-                "@oxlint/binding-linux-arm64-gnu": "1.69.0",
-                "@oxlint/binding-linux-arm64-musl": "1.69.0",
-                "@oxlint/binding-linux-ppc64-gnu": "1.69.0",
-                "@oxlint/binding-linux-riscv64-gnu": "1.69.0",
-                "@oxlint/binding-linux-riscv64-musl": "1.69.0",
-                "@oxlint/binding-linux-s390x-gnu": "1.69.0",
-                "@oxlint/binding-linux-x64-gnu": "1.69.0",
-                "@oxlint/binding-linux-x64-musl": "1.69.0",
-                "@oxlint/binding-openharmony-arm64": "1.69.0",
-                "@oxlint/binding-win32-arm64-msvc": "1.69.0",
-                "@oxlint/binding-win32-ia32-msvc": "1.69.0",
-                "@oxlint/binding-win32-x64-msvc": "1.69.0"
+                "@oxlint/binding-android-arm-eabi": "1.70.0",
+                "@oxlint/binding-android-arm64": "1.70.0",
+                "@oxlint/binding-darwin-arm64": "1.70.0",
+                "@oxlint/binding-darwin-x64": "1.70.0",
+                "@oxlint/binding-freebsd-x64": "1.70.0",
+                "@oxlint/binding-linux-arm-gnueabihf": "1.70.0",
+                "@oxlint/binding-linux-arm-musleabihf": "1.70.0",
+                "@oxlint/binding-linux-arm64-gnu": "1.70.0",
+                "@oxlint/binding-linux-arm64-musl": "1.70.0",
+                "@oxlint/binding-linux-ppc64-gnu": "1.70.0",
+                "@oxlint/binding-linux-riscv64-gnu": "1.70.0",
+                "@oxlint/binding-linux-riscv64-musl": "1.70.0",
+                "@oxlint/binding-linux-s390x-gnu": "1.70.0",
+                "@oxlint/binding-linux-x64-gnu": "1.70.0",
+                "@oxlint/binding-linux-x64-musl": "1.70.0",
+                "@oxlint/binding-openharmony-arm64": "1.70.0",
+                "@oxlint/binding-win32-arm64-msvc": "1.70.0",
+                "@oxlint/binding-win32-ia32-msvc": "1.70.0",
+                "@oxlint/binding-win32-x64-msvc": "1.70.0"
             },
             "peerDependencies": {
                 "oxlint-tsgolint": ">=0.22.1",
@@ -8686,13 +8779,13 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.60.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-            "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+            "version": "1.61.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+            "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.60.0"
+                "playwright-core": "1.61.0"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -8705,9 +8798,9 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.60.0",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-            "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+            "version": "1.61.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+            "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -8718,9 +8811,9 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.6.2",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
-            "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+            "version": "7.6.4",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+            "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
@@ -8731,7 +8824,6 @@
                 "@protobufjs/eventemitter": "^1.1.1",
                 "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.2",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",
@@ -8961,9 +9053,9 @@
             "license": "MIT"
         },
         "node_modules/regjsparser": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
-            "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
+            "version": "0.13.2",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.2.tgz",
+            "integrity": "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -9097,9 +9189,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.61.1",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
-            "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+            "version": "4.62.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+            "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -9113,31 +9205,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.61.1",
-                "@rollup/rollup-android-arm64": "4.61.1",
-                "@rollup/rollup-darwin-arm64": "4.61.1",
-                "@rollup/rollup-darwin-x64": "4.61.1",
-                "@rollup/rollup-freebsd-arm64": "4.61.1",
-                "@rollup/rollup-freebsd-x64": "4.61.1",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
-                "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
-                "@rollup/rollup-linux-arm64-gnu": "4.61.1",
-                "@rollup/rollup-linux-arm64-musl": "4.61.1",
-                "@rollup/rollup-linux-loong64-gnu": "4.61.1",
-                "@rollup/rollup-linux-loong64-musl": "4.61.1",
-                "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
-                "@rollup/rollup-linux-ppc64-musl": "4.61.1",
-                "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
-                "@rollup/rollup-linux-riscv64-musl": "4.61.1",
-                "@rollup/rollup-linux-s390x-gnu": "4.61.1",
-                "@rollup/rollup-linux-x64-gnu": "4.61.1",
-                "@rollup/rollup-linux-x64-musl": "4.61.1",
-                "@rollup/rollup-openbsd-x64": "4.61.1",
-                "@rollup/rollup-openharmony-arm64": "4.61.1",
-                "@rollup/rollup-win32-arm64-msvc": "4.61.1",
-                "@rollup/rollup-win32-ia32-msvc": "4.61.1",
-                "@rollup/rollup-win32-x64-gnu": "4.61.1",
-                "@rollup/rollup-win32-x64-msvc": "4.61.1",
+                "@rollup/rollup-android-arm-eabi": "4.62.0",
+                "@rollup/rollup-android-arm64": "4.62.0",
+                "@rollup/rollup-darwin-arm64": "4.62.0",
+                "@rollup/rollup-darwin-x64": "4.62.0",
+                "@rollup/rollup-freebsd-arm64": "4.62.0",
+                "@rollup/rollup-freebsd-x64": "4.62.0",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+                "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+                "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+                "@rollup/rollup-linux-arm64-musl": "4.62.0",
+                "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+                "@rollup/rollup-linux-loong64-musl": "4.62.0",
+                "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+                "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+                "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+                "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+                "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+                "@rollup/rollup-linux-x64-gnu": "4.62.0",
+                "@rollup/rollup-linux-x64-musl": "4.62.0",
+                "@rollup/rollup-openbsd-x64": "4.62.0",
+                "@rollup/rollup-openharmony-arm64": "4.62.0",
+                "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+                "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+                "@rollup/rollup-win32-x64-gnu": "4.62.0",
+                "@rollup/rollup-win32-x64-msvc": "4.62.0",
                 "fsevents": "~2.3.2"
             }
         },
@@ -9271,9 +9363,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
-            "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+            "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
             "devOptional": true,
             "license": "ISC",
             "bin": {
@@ -10810,7 +10902,7 @@
             "version": "0.0.0-git",
             "dependencies": {
                 "@matter-server/ws-controller": "*",
-                "@matter/main": "0.17.2",
+                "@matter/main": "0.17.3",
                 "ws": "^8.21.0"
             },
             "devDependencies": {
@@ -10821,7 +10913,7 @@
                 "node": ">=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.2",
+                "@matter/nodejs-ble": "0.17.3",
                 "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
             }
         },
@@ -10829,7 +10921,7 @@
             "name": "@matter-server/custom-clusters",
             "version": "0.0.0-git",
             "dependencies": {
-                "@matter/main": "0.17.2"
+                "@matter/main": "0.17.3"
             },
             "engines": {
                 "node": ">=22.13.0"
@@ -10851,7 +10943,7 @@
             },
             "devDependencies": {
                 "@babel/preset-env": "^7.29.7",
-                "@matter/main": "0.17.2",
+                "@matter/main": "0.17.3",
                 "@rollup/plugin-babel": "^7.1.0",
                 "@rollup/plugin-commonjs": "^29.0.3",
                 "@rollup/plugin-json": "^6.1.0",
@@ -10870,14 +10962,14 @@
                 "@matter-server/custom-clusters": "*",
                 "@matter-server/dashboard": "*",
                 "@matter-server/ws-controller": "*",
-                "@matter/main": "0.17.2",
+                "@matter/main": "0.17.3",
                 "commander": "^15.0.0",
                 "express": "^5.2.1"
             },
             "devDependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/nodejs": "0.17.2",
-                "@matter/testing": "0.17.2",
+                "@matter/nodejs": "0.17.3",
+                "@matter/testing": "0.17.3",
                 "@types/express": "^5.0.6",
                 "@types/node": "^25.9.1"
             },
@@ -10899,7 +10991,7 @@
             "version": "0.0.0-git",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@matter/testing": "0.17.2",
+                "@matter/testing": "0.17.3",
                 "@types/node": "^25.9.1",
                 "@types/ws": "^8.18.1",
                 "ws": "^8.21.0"
@@ -10914,8 +11006,8 @@
             "dependencies": {
                 "@matter-server/ws-client": "*",
                 "@matter/dcl-data": ">=2026.6.9",
-                "@matter/main": "0.17.2",
-                "@project-chip/matter.js": "0.17.2",
+                "@matter/main": "0.17.3",
+                "@project-chip/matter.js": "0.17.3",
                 "ws": "^8.21.0"
             },
             "devDependencies": {
@@ -10926,7 +11018,7 @@
                 "node": ">=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.2",
+                "@matter/nodejs-ble": "0.17.3",
                 "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,8 @@
                 "@types/mocha": "^10.0.10",
                 "glob": "^13.0.6",
                 "globals": "^17.6.0",
-                "oxfmt": "^0.54.0",
-                "oxlint": "^1.67.0",
+                "oxfmt": "^0.55.0",
+                "oxlint": "^1.70.0",
                 "oxlint-tsgolint": "^0.23.0",
                 "tsx": "^4.22.4",
                 "typescript": "~6.0.3"
@@ -2804,9 +2804,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm-eabi": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.54.0.tgz",
-            "integrity": "sha512-NAtpl/SiaeU103e7/OmZw0MvUnsUUopW7hEm/ecegJg7YM0skQaA0IXEZoyTV6NUdiNPupdIUreRqUZTShbn/g==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.55.0.tgz",
+            "integrity": "sha512-+rFDOqQe5LOWgxrAJaZgLRudr6GQm0wGI6gtu7vVkrdLGjNMUSGbAlaCr8j7F2H2Er97vYQCU8WDb30onqMM1g==",
             "cpu": [
                 "arm"
             ],
@@ -2821,9 +2821,9 @@
             }
         },
         "node_modules/@oxfmt/binding-android-arm64": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.54.0.tgz",
-            "integrity": "sha512-B4VZfBUlKK1rmMChsssNZbkZjE8+FzG3avMjGgMDwbGxXRoXkoeXiAZ+78Oa+eyDPHvDCiUb4zH/vmCOUSafLQ==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.55.0.tgz",
+            "integrity": "sha512-ctulLq8s3x8Zmvw6+iccB09TIKERAklRSmbJ10gk8mlAn05qZxoyo52dj3Hi9IJcmDSwF54fQaTVh2CbL6PInw==",
             "cpu": [
                 "arm64"
             ],
@@ -2838,9 +2838,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-arm64": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.54.0.tgz",
-            "integrity": "sha512-i02vF75b+ePsQP3tHqSxVYI5S6b8X/xqdPu7/mDHXtpgXLTYXi3jJmfHU0j+dnZZDKaYTx/ioCK7QYJmtiJR2g==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.55.0.tgz",
+            "integrity": "sha512-xDQczLH9pw/RBk1h/GH0qcGMm8hQtmtVHBNLSH3lk1gEIR09hZ4L+mJQl4VqiVAvPK9VG9PYrWWuSQLt7xTbiA==",
             "cpu": [
                 "arm64"
             ],
@@ -2855,9 +2855,9 @@
             }
         },
         "node_modules/@oxfmt/binding-darwin-x64": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.54.0.tgz",
-            "integrity": "sha512-8VMFvGvooXj7mswkbrhdVZ2/sgiDaBzWpkkbtO+qGDLV4EfJd67nQadHkQC0ZNbaWA9ajXfqI6i7PZLIeDzxEQ==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.55.0.tgz",
+            "integrity": "sha512-JaNoFCkF2CJdGgpPSMbuO9HVyXyoNGIhMHPvp6NYAjeVKw9XEYc0HcUWJLPQa3Q69WV5wMa9m5jPMJPtbLtcRg==",
             "cpu": [
                 "x64"
             ],
@@ -2872,9 +2872,9 @@
             }
         },
         "node_modules/@oxfmt/binding-freebsd-x64": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.54.0.tgz",
-            "integrity": "sha512-0cRHnp43WN1Jrc5s0BdbdKgR1XirdvHy7TAFi3JEsoEVQVJxTXMbpVd76sxXlgRswNMDhVFSJw+y7Eb8mEavFQ==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.55.0.tgz",
+            "integrity": "sha512-DNbszhpg6S2MIzax5azdHFTTBIVkR5xr8yyRZuA4yoDAwOkzIp3tmldgKZM2+VlT+hJIG0xUksA+elISzMEAfA==",
             "cpu": [
                 "x64"
             ],
@@ -2889,9 +2889,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.54.0.tgz",
-            "integrity": "sha512-JyQAk3hK/OEtup7Rw6kZwfdzbKqTVD5jXXb8Xpfay29suwZyfBDMVW/bj4RqEPySYWc6zCp198pOluf8n5uYzg==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.55.0.tgz",
+            "integrity": "sha512-2snoaoRfFFyGnbOcKUK36rREBYxe/Xgz3uHbiA5zbCB/s6R4DQj4mHqYAaWWhgizCUSDxV8cE9zAZ0XleNpKGw==",
             "cpu": [
                 "arm"
             ],
@@ -2906,9 +2906,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.54.0.tgz",
-            "integrity": "sha512-qnvLatTpM8vtvjOfcckBOzJjk+n6ce/wwpP8OFeUrD5aNLYcKyWAitwj+Rk3PK9jGanbZvKsJnv14JGQ6XqFdw==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.55.0.tgz",
+            "integrity": "sha512-q1aktHF/WRpSK81BX1dE/9vWrS2jGw1Nax2kb4DBLGAewubCLcoNyp4Zl/NSMgbv3vUS46Z33wIQkBVYOP3PYg==",
             "cpu": [
                 "arm"
             ],
@@ -2923,9 +2923,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-gnu": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.54.0.tgz",
-            "integrity": "sha512-SMkhnCzIYZYDk9vw3W/80eeYKmrMpGF0Giuxt4HruFlCH7jEtnPeb3SdQKMfgYi/dgtaf+hZAb5XWPYnxqCQ3w==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.55.0.tgz",
+            "integrity": "sha512-VD0y36aENezl/3tsclA/4G53Cc7iV+7Uoh7gz4yvcOTaEYBtJpQsE6PKDGTtUtOvGS4kv51ybfXY/nWZejO5IA==",
             "cpu": [
                 "arm64"
             ],
@@ -2943,9 +2943,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-arm64-musl": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.54.0.tgz",
-            "integrity": "sha512-QrwJlBFFKnxOd95TAaszpMbZBLzMoYMpGaQTZF8oibacnF5rv8l12IhILhQRPmksWiBqg0YSe2Mnl7ayeJAHSA==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.55.0.tgz",
+            "integrity": "sha512-r8xlKJFcsRmn0H5jZrdORae6RX9jDBrZVvOoxF+bCQtampQJClv80aZEHsv+NsLsp2KCE5ql79O7DpPVzYWpXA==",
             "cpu": [
                 "arm64"
             ],
@@ -2963,9 +2963,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.54.0.tgz",
-            "integrity": "sha512-WILatiol/TUHTlhod7R09+7Az/XlhKwmY1MHfLZNmewltPWNN/EwxP2rQSHahibZ/cB8gmckEBjBOByD+5bYsQ==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.55.0.tgz",
+            "integrity": "sha512-GRKv/HXHcwIVld/WU61rF0g0R16hl5EJ+ScKdpjevT57lnLnagj/U2YUbXf2mT+2Pg1uCzWC+mvGicPV3CDdLQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -2983,9 +2983,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.54.0.tgz",
-            "integrity": "sha512-f05YMG4BH4G8S4ME6UM6fi1MnJ9094mrnvO5Pa4SJlMfWlUM+1/ZWMEF4NnjM7shZAvbHsHRuVYpUo0PHC4P9Q==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.55.0.tgz",
+            "integrity": "sha512-rdv57enTiPtpSYRMKfAiEbQb0Puw5t9N7isVinDoo5qeLDScro2gznmZqSgSWbVZRzLisTeCTW8Qwgw0bOHv3A==",
             "cpu": [
                 "riscv64"
             ],
@@ -3003,9 +3003,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-riscv64-musl": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.54.0.tgz",
-            "integrity": "sha512-UfL+2hj1ClNqcCRT9s8vBU4axDpjxgVxX96G+9DYAYjoc5b0u15CJtn2jgsi9iM+EbGNc5CW1HVRgwVu76UsSA==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.55.0.tgz",
+            "integrity": "sha512-7v1nNrlD43VY6+sYQ6efYyb3lE6QY182304PD/768ZxTjOmFd/3dQa3u/nGBUAXYdGSWOQc5N3PnS0QzUXyEIA==",
             "cpu": [
                 "riscv64"
             ],
@@ -3023,9 +3023,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-s390x-gnu": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.54.0.tgz",
-            "integrity": "sha512-3/XZe931Hka+J6NjnaqJzYpsWWxDTuRdUdwSQHnOuJEgbC+SehIMFJS8hsEjV7LBhVSL2OCnRLvbVW8O97XIyw==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.55.0.tgz",
+            "integrity": "sha512-f4lJLUSPOgScjFl9LiflKCTocyNRwE25JmTMbN4XQdDjoZzEHjqf3wA3VESF1/csg7i8m7+EQLbrZyYDqe10UQ==",
             "cpu": [
                 "s390x"
             ],
@@ -3043,9 +3043,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-gnu": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.54.0.tgz",
-            "integrity": "sha512-Ik93RlObtu43GbxApafayFjwYE06L6Xr08cSwpBPYbDrLp2ReZx0Jm1DqwRyYRnukUJy+rK2WaEvUQOxdytU9Q==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.55.0.tgz",
+            "integrity": "sha512-MihqiPziJNoWy4MqNSV+jVA1g+07iQDjZiR0vaCaDoPgFEiJpCMsxamktzLV07cEeQsSJ04vQaU4CzCQwIvtDA==",
             "cpu": [
                 "x64"
             ],
@@ -3063,9 +3063,9 @@
             }
         },
         "node_modules/@oxfmt/binding-linux-x64-musl": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.54.0.tgz",
-            "integrity": "sha512-yZcakmPlD86CNymknd7KfW+FH+qfbqJH+i0h69CYfV1+KMoVeM9UED+8+TDVoU4haxI0NxY7RPCvRLy3Sqd2Qg==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.55.0.tgz",
+            "integrity": "sha512-Yqghym7KYAVjP9MmSrNZiDeerMuoejNjo0r3ox5H3GDKk8eAfl8VyJm9i+pWCLDCTnAbcTUMMN2ZKjUYXH1v3g==",
             "cpu": [
                 "x64"
             ],
@@ -3083,9 +3083,9 @@
             }
         },
         "node_modules/@oxfmt/binding-openharmony-arm64": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.54.0.tgz",
-            "integrity": "sha512-GiVBZNnEZnKu00f1jTg49nomv187d0GQX+O+ocykoLeiaALuEO+swoTehHn9TehTfi7V8H0i0e/yvUjCqnwk1w==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.55.0.tgz",
+            "integrity": "sha512-s5SDvVVSbyQl1V5UU3Yl12M+XLUQ3rl5SglNqgAA2K4PXUtQhyNSS00wivONPEnNo5W01rCou8WkDNyvI/RGHg==",
             "cpu": [
                 "arm64"
             ],
@@ -3100,9 +3100,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-arm64-msvc": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.54.0.tgz",
-            "integrity": "sha512-J0SSB8Z1Fre2sxRolYcW6Rl1RQmKdQ2hnHyq4YJrfBRiXTObLw4DXnIVraM/UyqGqwOi7yTrQA4VT7DPxlHVKA==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.55.0.tgz",
+            "integrity": "sha512-7p9FB5R32tw2KyyNX3wpQrR2WHwEHvMEiBlGXxeTCaRMCVNx3UtFMAUbaQ/pRNWIrEUZmYhJ6tcUH52uPTRYjQ==",
             "cpu": [
                 "arm64"
             ],
@@ -3117,9 +3117,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-ia32-msvc": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.54.0.tgz",
-            "integrity": "sha512-O61UDVj8zz6yXJjkHPf05VaMLOXmEF8P5kf/N0W7AQMmd6bcQogl+KJc7rMutKTL524oE9iH32JXZClBFmEQIg==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.55.0.tgz",
+            "integrity": "sha512-ZYqj3fDnOT1IaVGMP5kpmkQl4F3tQIm2ZyAxvqkJYmI0xgWWak4ss4XYwv3VDfM+TWXeC9K4uQ/wW5jm/5XABA==",
             "cpu": [
                 "ia32"
             ],
@@ -3134,9 +3134,9 @@
             }
         },
         "node_modules/@oxfmt/binding-win32-x64-msvc": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.54.0.tgz",
-            "integrity": "sha512-1MDpqJPiFqxWtIHas8vkb1VZ7f7eKyTffAwmO8isxQYMaG1OFKsH666BWLeXQLO+IWNfiMssLD55hbR1lIPTqg==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.55.0.tgz",
+            "integrity": "sha512-eEYT5tivGnGbPHuOHuQpi6CGLObhh0re/5jcNQHihD2GRYkTM85dyi5a19zjP8Q00t1uqAx+/QGLUGdHeqzWyg==",
             "cpu": [
                 "x64"
             ],
@@ -8458,9 +8458,9 @@
             }
         },
         "node_modules/oxfmt": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.54.0.tgz",
-            "integrity": "sha512-DjnMwn7smSLF+Mc2+pRItnuPftm/dkUFpY/d4+33y9TfKrsHZo8GLhmUg9BrOIUEy94Rlom1Q11N6vuhE+e0oQ==",
+            "version": "0.55.0",
+            "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.55.0.tgz",
+            "integrity": "sha512-jSj2wCTakwgPMxkfiVZX0jf+nX+Nz6xlyAZjqNE0qXTFdCBPYlP6JAN+ODjmealw7DXBjOzYbdsqwBMAZnPZ6A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -8476,25 +8476,25 @@
                 "url": "https://github.com/sponsors/Boshen"
             },
             "optionalDependencies": {
-                "@oxfmt/binding-android-arm-eabi": "0.54.0",
-                "@oxfmt/binding-android-arm64": "0.54.0",
-                "@oxfmt/binding-darwin-arm64": "0.54.0",
-                "@oxfmt/binding-darwin-x64": "0.54.0",
-                "@oxfmt/binding-freebsd-x64": "0.54.0",
-                "@oxfmt/binding-linux-arm-gnueabihf": "0.54.0",
-                "@oxfmt/binding-linux-arm-musleabihf": "0.54.0",
-                "@oxfmt/binding-linux-arm64-gnu": "0.54.0",
-                "@oxfmt/binding-linux-arm64-musl": "0.54.0",
-                "@oxfmt/binding-linux-ppc64-gnu": "0.54.0",
-                "@oxfmt/binding-linux-riscv64-gnu": "0.54.0",
-                "@oxfmt/binding-linux-riscv64-musl": "0.54.0",
-                "@oxfmt/binding-linux-s390x-gnu": "0.54.0",
-                "@oxfmt/binding-linux-x64-gnu": "0.54.0",
-                "@oxfmt/binding-linux-x64-musl": "0.54.0",
-                "@oxfmt/binding-openharmony-arm64": "0.54.0",
-                "@oxfmt/binding-win32-arm64-msvc": "0.54.0",
-                "@oxfmt/binding-win32-ia32-msvc": "0.54.0",
-                "@oxfmt/binding-win32-x64-msvc": "0.54.0"
+                "@oxfmt/binding-android-arm-eabi": "0.55.0",
+                "@oxfmt/binding-android-arm64": "0.55.0",
+                "@oxfmt/binding-darwin-arm64": "0.55.0",
+                "@oxfmt/binding-darwin-x64": "0.55.0",
+                "@oxfmt/binding-freebsd-x64": "0.55.0",
+                "@oxfmt/binding-linux-arm-gnueabihf": "0.55.0",
+                "@oxfmt/binding-linux-arm-musleabihf": "0.55.0",
+                "@oxfmt/binding-linux-arm64-gnu": "0.55.0",
+                "@oxfmt/binding-linux-arm64-musl": "0.55.0",
+                "@oxfmt/binding-linux-ppc64-gnu": "0.55.0",
+                "@oxfmt/binding-linux-riscv64-gnu": "0.55.0",
+                "@oxfmt/binding-linux-riscv64-musl": "0.55.0",
+                "@oxfmt/binding-linux-s390x-gnu": "0.55.0",
+                "@oxfmt/binding-linux-x64-gnu": "0.55.0",
+                "@oxfmt/binding-linux-x64-musl": "0.55.0",
+                "@oxfmt/binding-openharmony-arm64": "0.55.0",
+                "@oxfmt/binding-win32-arm64-msvc": "0.55.0",
+                "@oxfmt/binding-win32-ia32-msvc": "0.55.0",
+                "@oxfmt/binding-win32-x64-msvc": "0.55.0"
             },
             "peerDependencies": {
                 "svelte": "^5.0.0",
@@ -10906,7 +10906,7 @@
                 "ws": "^8.21.0"
             },
             "devDependencies": {
-                "@types/node": "^25.9.1",
+                "@types/node": "^25.9.3",
                 "@types/ws": "^8.18.1"
             },
             "engines": {
@@ -10971,7 +10971,7 @@
                 "@matter/nodejs": "0.17.3",
                 "@matter/testing": "0.17.3",
                 "@types/express": "^5.0.6",
-                "@types/node": "^25.9.1"
+                "@types/node": "^25.9.3"
             },
             "engines": {
                 "node": ">=22.13.0"
@@ -10992,7 +10992,7 @@
             "license": "Apache-2.0",
             "devDependencies": {
                 "@matter/testing": "0.17.3",
-                "@types/node": "^25.9.1",
+                "@types/node": "^25.9.3",
                 "@types/ws": "^8.18.1",
                 "ws": "^8.21.0"
             },
@@ -11005,13 +11005,13 @@
             "version": "0.0.0-git",
             "dependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/dcl-data": ">=2026.6.9",
+                "@matter/dcl-data": ">=2026.6.16",
                 "@matter/main": "0.17.3",
                 "@project-chip/matter.js": "0.17.3",
                 "ws": "^8.21.0"
             },
             "devDependencies": {
-                "@types/node": "^25.9.1",
+                "@types/node": "^25.9.3",
                 "@types/ws": "^8.18.1"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "python-ble-proxy:run": "cd python_ble_proxy && { [ -x .venv/bin/matter-ble-proxy ] || (python3 -m venv .venv && .venv/bin/pip install -e .); } && .venv/bin/matter-ble-proxy"
     },
     "devDependencies": {
-        "@matter/testing": "0.17.2",
+        "@matter/testing": "0.17.3",
         "@nacho-iot/js-tools": "^0.1.7",
         "@types/mocha": "^10.0.10",
         "glob": "^13.0.6",

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
         "@types/mocha": "^10.0.10",
         "glob": "^13.0.6",
         "globals": "^17.6.0",
-        "oxfmt": "^0.54.0",
-        "oxlint": "^1.67.0",
+        "oxfmt": "^0.55.0",
+        "oxlint": "^1.70.0",
         "oxlint-tsgolint": "^0.23.0",
         "tsx": "^4.22.4",
         "typescript": "~6.0.3"

--- a/packages/ble-proxy/package.json
+++ b/packages/ble-proxy/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@matter-server/ws-controller": "*",
-        "@matter/main": "0.17.3-alpha.0-20260614-888c310c5",
+        "@matter/main": "0.17.3",
         "ws": "^8.21.0"
     },
     "devDependencies": {
@@ -38,7 +38,7 @@
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.3-alpha.0-20260614-888c310c5",
+        "@matter/nodejs-ble": "0.17.3",
         "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
     },
     "engines": {

--- a/packages/ble-proxy/package.json
+++ b/packages/ble-proxy/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@matter-server/ws-controller": "*",
-        "@matter/main": "0.17.2",
+        "@matter/main": "0.17.3-alpha.0-20260614-888c310c5",
         "ws": "^8.21.0"
     },
     "devDependencies": {
@@ -38,7 +38,7 @@
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.2",
+        "@matter/nodejs-ble": "0.17.3-alpha.0-20260614-888c310c5",
         "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
     },
     "engines": {

--- a/packages/ble-proxy/package.json
+++ b/packages/ble-proxy/package.json
@@ -34,7 +34,7 @@
         "ws": "^8.21.0"
     },
     "devDependencies": {
-        "@types/node": "^25.9.1",
+        "@types/node": "^25.9.3",
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {

--- a/packages/custom-clusters/package.json
+++ b/packages/custom-clusters/package.json
@@ -39,7 +39,7 @@
         "build-clean": "nacho-build --clean"
     },
     "dependencies": {
-        "@matter/main": "0.17.2"
+        "@matter/main": "0.17.3-alpha.0-20260614-888c310c5"
     },
     "engines": {
         "node": ">=22.13.0"

--- a/packages/custom-clusters/package.json
+++ b/packages/custom-clusters/package.json
@@ -39,7 +39,7 @@
         "build-clean": "nacho-build --clean"
     },
     "dependencies": {
-        "@matter/main": "0.17.3-alpha.0-20260614-888c310c5"
+        "@matter/main": "0.17.3"
     },
     "engines": {
         "node": ">=22.13.0"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -42,7 +42,7 @@
     },
     "devDependencies": {
         "@babel/preset-env": "^7.29.7",
-        "@matter/main": "0.17.3-alpha.0-20260614-888c310c5",
+        "@matter/main": "0.17.3",
         "@rollup/plugin-babel": "^7.1.0",
         "@rollup/plugin-commonjs": "^29.0.3",
         "@rollup/plugin-json": "^6.1.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -42,7 +42,7 @@
     },
     "devDependencies": {
         "@babel/preset-env": "^7.29.7",
-        "@matter/main": "0.17.2",
+        "@matter/main": "0.17.3-alpha.0-20260614-888c310c5",
         "@rollup/plugin-babel": "^7.1.0",
         "@rollup/plugin-commonjs": "^29.0.3",
         "@rollup/plugin-json": "^6.1.0",

--- a/packages/dashboard/src/components/dialogs/acl/acl-actions.ts
+++ b/packages/dashboard/src/components/dialogs/acl/acl-actions.ts
@@ -5,7 +5,7 @@
  */
 
 import { AccessControlEntry, MatterClient } from "@matter-server/ws-client";
-import { Privilege, aclEntryKey } from "../../../util/access-control.js";
+import { Privilege, aclEntryKey, attributeArray } from "../../../util/access-control.js";
 import { AccessControlEntryDataTransformer, type AccessControlEntryStruct } from "./model.js";
 
 function toApiAcl(e: AccessControlEntryStruct): AccessControlEntry {
@@ -24,9 +24,7 @@ function toApiAcl(e: AccessControlEntryStruct): AccessControlEntry {
 
 async function freshAcl(client: MatterClient, nodeId: number | bigint): Promise<AccessControlEntryStruct[]> {
     const res = await client.readAttribute(nodeId, "0/31/0");
-    const raw = res["0/31/0"] as unknown[] | undefined;
-    if (!raw) return new Array<AccessControlEntryStruct>();
-    return Object.values(raw).map(v => AccessControlEntryDataTransformer.transform(v));
+    return attributeArray(res["0/31/0"]).map(v => AccessControlEntryDataTransformer.transform(v));
 }
 
 export async function addAclEntry(

--- a/packages/dashboard/src/components/dialogs/acl/acl-actions.ts
+++ b/packages/dashboard/src/components/dialogs/acl/acl-actions.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AccessControlEntry, MatterClient } from "@matter-server/ws-client";
+import { Privilege, aclEntryKey } from "../../../util/access-control.js";
+import { AccessControlEntryDataTransformer, type AccessControlEntryStruct } from "./model.js";
+
+function toApiAcl(e: AccessControlEntryStruct): AccessControlEntry {
+    return {
+        privilege: e.privilege,
+        auth_mode: e.authMode,
+        subjects: e.subjects ?? null,
+        targets:
+            e.targets?.map(t => ({
+                cluster: t.cluster ?? null,
+                endpoint: t.endpoint ?? null,
+                device_type: t.deviceType ?? null,
+            })) ?? null,
+    };
+}
+
+async function freshAcl(client: MatterClient, nodeId: number | bigint): Promise<AccessControlEntryStruct[]> {
+    const res = await client.readAttribute(nodeId, "0/31/0");
+    const raw = res["0/31/0"] as unknown[] | undefined;
+    if (!raw) return new Array<AccessControlEntryStruct>();
+    return Object.values(raw).map(v => AccessControlEntryDataTransformer.transform(v));
+}
+
+export async function addAclEntry(
+    client: MatterClient,
+    nodeId: number | bigint,
+    entry: AccessControlEntryStruct,
+): Promise<void> {
+    const acl = await freshAcl(client, nodeId);
+    acl.push(entry);
+    await client.setACLEntry(nodeId, acl.map(toApiAcl));
+}
+
+export async function deleteAclEntry(client: MatterClient, nodeId: number | bigint, key: string): Promise<void> {
+    const acl = await freshAcl(client, nodeId);
+    const kept = acl.filter(e => aclEntryKey(e) !== key);
+    await client.setACLEntry(nodeId, kept.map(toApiAcl));
+}
+
+/** Downgrade the given entries (by key) to Operate privilege. */
+export async function downgradeToOperate(
+    client: MatterClient,
+    nodeId: number | bigint,
+    keys: Set<string>,
+): Promise<void> {
+    const acl = await freshAcl(client, nodeId);
+    const updated = acl.map(e => (keys.has(aclEntryKey(e)) ? { ...e, privilege: Privilege.Operate } : e));
+    await client.setACLEntry(nodeId, updated.map(toApiAcl));
+}

--- a/packages/dashboard/src/components/dialogs/acl/acl-actions.ts
+++ b/packages/dashboard/src/components/dialogs/acl/acl-actions.ts
@@ -39,7 +39,14 @@ export async function addAclEntry(
 
 export async function deleteAclEntry(client: MatterClient, nodeId: number | bigint, key: string): Promise<void> {
     const acl = await freshAcl(client, nodeId);
-    const kept = acl.filter(e => aclEntryKey(e) !== key);
+    let removed = false;
+    const kept = acl.filter(e => {
+        if (!removed && aclEntryKey(e) === key) {
+            removed = true;
+            return false;
+        }
+        return true;
+    });
     await client.setACLEntry(nodeId, kept.map(toApiAcl));
 }
 

--- a/packages/dashboard/src/components/dialogs/acl/acl-actions.ts
+++ b/packages/dashboard/src/components/dialogs/acl/acl-actions.ts
@@ -5,14 +5,7 @@
  */
 
 import { AccessControlEntry, MatterClient } from "@matter-server/ws-client";
-import {
-    Privilege,
-    aclEntryKey,
-    attributeArray,
-    entriesForFabric,
-    nodeFabricIndex,
-    nodeIdKey,
-} from "../../../util/access-control.js";
+import { Privilege, aclEntryKey, attributeArray, entriesForFabric } from "../../../util/access-control.js";
 import { AccessControlEntryDataTransformer, type AccessControlEntryStruct } from "./model.js";
 
 function toApiAcl(e: AccessControlEntryStruct): AccessControlEntry {
@@ -29,12 +22,18 @@ function toApiAcl(e: AccessControlEntryStruct): AccessControlEntry {
     };
 }
 
-/** Read the node's ACL fresh (explicit reads are not fabric-filtered) and narrow to our fabric. */
+/**
+ * Read the node's ACL + CurrentFabricIndex fresh (explicit reads are not fabric-filtered) and narrow
+ * to our fabric. Fails rather than risk writing back other fabrics' entries if the index is unknown.
+ */
 async function freshOurAcl(client: MatterClient, nodeId: number | bigint): Promise<AccessControlEntryStruct[]> {
-    const res = await client.readAttribute(nodeId, "0/31/0");
+    const res = await client.readAttribute(nodeId, ["0/31/0", "0/62/5"]);
     const all = attributeArray(res["0/31/0"]).map(v => AccessControlEntryDataTransformer.transform(v));
-    const node = client.nodes[nodeIdKey(nodeId)];
-    return entriesForFabric(all, node ? nodeFabricIndex(node) : undefined);
+    const fi = res["0/62/5"];
+    if (typeof fi !== "number") {
+        throw new Error(`Cannot determine the current fabric index (0/62/5) for node ${nodeId}`);
+    }
+    return entriesForFabric(all, fi);
 }
 
 export async function addAclEntry(

--- a/packages/dashboard/src/components/dialogs/acl/acl-actions.ts
+++ b/packages/dashboard/src/components/dialogs/acl/acl-actions.ts
@@ -5,7 +5,14 @@
  */
 
 import { AccessControlEntry, MatterClient } from "@matter-server/ws-client";
-import { Privilege, aclEntryKey, attributeArray } from "../../../util/access-control.js";
+import {
+    Privilege,
+    aclEntryKey,
+    attributeArray,
+    entriesForFabric,
+    nodeFabricIndex,
+    nodeIdKey,
+} from "../../../util/access-control.js";
 import { AccessControlEntryDataTransformer, type AccessControlEntryStruct } from "./model.js";
 
 function toApiAcl(e: AccessControlEntryStruct): AccessControlEntry {
@@ -22,9 +29,12 @@ function toApiAcl(e: AccessControlEntryStruct): AccessControlEntry {
     };
 }
 
-async function freshAcl(client: MatterClient, nodeId: number | bigint): Promise<AccessControlEntryStruct[]> {
+/** Read the node's ACL fresh (explicit reads are not fabric-filtered) and narrow to our fabric. */
+async function freshOurAcl(client: MatterClient, nodeId: number | bigint): Promise<AccessControlEntryStruct[]> {
     const res = await client.readAttribute(nodeId, "0/31/0");
-    return attributeArray(res["0/31/0"]).map(v => AccessControlEntryDataTransformer.transform(v));
+    const all = attributeArray(res["0/31/0"]).map(v => AccessControlEntryDataTransformer.transform(v));
+    const node = client.nodes[nodeIdKey(nodeId)];
+    return entriesForFabric(all, node ? nodeFabricIndex(node) : undefined);
 }
 
 export async function addAclEntry(
@@ -32,13 +42,13 @@ export async function addAclEntry(
     nodeId: number | bigint,
     entry: AccessControlEntryStruct,
 ): Promise<void> {
-    const acl = await freshAcl(client, nodeId);
+    const acl = await freshOurAcl(client, nodeId);
     acl.push(entry);
     await client.setACLEntry(nodeId, acl.map(toApiAcl));
 }
 
 export async function deleteAclEntry(client: MatterClient, nodeId: number | bigint, key: string): Promise<void> {
-    const acl = await freshAcl(client, nodeId);
+    const acl = await freshOurAcl(client, nodeId);
     let removed = false;
     const kept = acl.filter(e => {
         if (!removed && aclEntryKey(e) === key) {
@@ -56,7 +66,7 @@ export async function downgradeToOperate(
     nodeId: number | bigint,
     keys: Set<string>,
 ): Promise<void> {
-    const acl = await freshAcl(client, nodeId);
+    const acl = await freshOurAcl(client, nodeId);
     const updated = acl.map(e => (keys.has(aclEntryKey(e)) ? { ...e, privilege: Privilege.Operate } : e));
     await client.setACLEntry(nodeId, updated.map(toApiAcl));
 }

--- a/packages/dashboard/src/components/dialogs/acl/model.ts
+++ b/packages/dashboard/src/components/dialogs/acl/model.ts
@@ -52,7 +52,8 @@ export class AccessControlTargetTransformer {
                 const mappedKey = keyMapping[key];
                 if (mappedKey) {
                     const value = input[key];
-                    if (value === undefined) continue;
+                    // Treat unset/wildcard fields (null or absent) as omitted, not numeric 0.
+                    if (value == null) continue;
                     result[mappedKey] = Number(value);
                 }
             }
@@ -85,7 +86,7 @@ export class AccessControlEntryDataTransformer {
                 const mappedKey = keyMapping[key];
                 if (mappedKey) {
                     const value = input[key];
-                    if (value === undefined) continue;
+                    if (value == null) continue;
                     if (mappedKey === "subjects") {
                         result.subjects = Array.isArray(value) ? value : undefined;
                     } else if (mappedKey === "targets") {

--- a/packages/dashboard/src/components/dialogs/acl/model.ts
+++ b/packages/dashboard/src/components/dialogs/acl/model.ts
@@ -26,6 +26,10 @@ export type AccessControlEntryStruct = {
     fabricIndex: number;
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
 export class AccessControlTargetTransformer {
     private static readonly KEY_MAPPING: {
         [inputKey: string]: keyof AccessControlTargetStruct;
@@ -35,8 +39,8 @@ export class AccessControlTargetTransformer {
         "2": "deviceType",
     };
 
-    public static transform(input: any): AccessControlTargetStruct {
-        if (!input || typeof input !== "object") {
+    public static transform(input: unknown): AccessControlTargetStruct {
+        if (!isRecord(input)) {
             throw new Error("Invalid input: expected an object");
         }
 
@@ -49,7 +53,7 @@ export class AccessControlTargetTransformer {
                 if (mappedKey) {
                     const value = input[key];
                     if (value === undefined) continue;
-                    result[mappedKey] = value;
+                    result[mappedKey] = Number(value);
                 }
             }
         }
@@ -68,8 +72,8 @@ export class AccessControlEntryDataTransformer {
         "254": "fabricIndex",
     };
 
-    public static transform(input: any): AccessControlEntryStruct {
-        if (!input || typeof input !== "object") {
+    public static transform(input: unknown): AccessControlEntryStruct {
+        if (!isRecord(input)) {
             throw new Error("Invalid input: expected an object");
         }
 
@@ -83,18 +87,14 @@ export class AccessControlEntryDataTransformer {
                     const value = input[key];
                     if (value === undefined) continue;
                     if (mappedKey === "subjects") {
-                        result[mappedKey] = Array.isArray(value) ? value : undefined;
+                        result.subjects = Array.isArray(value) ? value : undefined;
                     } else if (mappedKey === "targets") {
-                        if (Array.isArray(value)) {
-                            const _targets = Object.values(value).map(val =>
-                                AccessControlTargetTransformer.transform(val),
-                            );
-                            result[mappedKey] = _targets;
-                        } else {
-                            result[mappedKey] = undefined;
-                        }
+                        result.targets = Array.isArray(value)
+                            ? value.map(val => AccessControlTargetTransformer.transform(val))
+                            : undefined;
                     } else {
-                        result[mappedKey] = value;
+                        // privilege, authMode, fabricIndex are numeric
+                        result[mappedKey] = Number(value);
                     }
                 }
             }

--- a/packages/dashboard/src/components/dialogs/acl/node-acl-add-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/acl/node-acl-add-dialog.ts
@@ -17,8 +17,10 @@ import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import "../../../components/ha-svg-icon.js";
 import { clientContext } from "../../../client/client-context.js";
+import { clusters } from "../../../client/models/descriptions.js";
 import { AuthMode, Privilege, PRIVILEGE_NAMES, aclCapacity, nodeIdKey } from "../../../util/access-control.js";
 import { handleAsync } from "../../../util/async-handler.js";
+import { targetServerClusters } from "../../../util/binding.js";
 import { preventDefault } from "../../../util/prevent_default.js";
 import { showAlertDialog } from "../../dialog-box/show-dialog-box.js";
 import { addAclEntry } from "./acl-actions.js";
@@ -42,7 +44,11 @@ export class NodeAclAddDialog extends LitElement {
     @state() private _busy = false;
 
     private _knownNodes(): MatterNode[] {
-        return Object.values(this.client.nodes).sort((a, b) => (a.nodeLabel || "").localeCompare(b.nodeLabel || ""));
+        return Object.values(this.client.nodes).sort((a, b) => {
+            const x = BigInt(a.node_id);
+            const y = BigInt(b.node_id);
+            return x < y ? -1 : x > y ? 1 : 0;
+        });
     }
 
     private _addSubject(raw: string) {
@@ -64,28 +70,46 @@ export class NodeAclAddDialog extends LitElement {
         this._subjects = this._subjects.filter(s => nodeIdKey(s) !== key);
     }
 
-    private _addTarget() {
-        const ep = parseInt(this._targetEndpoint, 10);
-        if (Number.isNaN(ep) || ep < 0 || ep > 0xfffe) {
-            void showAlertDialog({ title: "Validation error", text: "Enter a valid endpoint." });
-            return;
+    private _nodeEndpoints(): number[] {
+        const eps = new Set<number>();
+        for (const key of Object.keys(this.node.attributes)) {
+            const m = /^(\d+)\/29\/0$/.exec(key);
+            if (m) eps.add(Number(m[1]));
         }
+        return Array.from(eps).sort((a, b) => a - b);
+    }
+
+    private _clusterOptions(): number[] {
+        if (this._targetEndpoint === "all") {
+            const all = new Set<number>();
+            for (const ep of this._nodeEndpoints()) targetServerClusters(this.node, ep).forEach(c => all.add(c));
+            return Array.from(all).sort((a, b) => a - b);
+        }
+        return targetServerClusters(this.node, Number(this._targetEndpoint)).sort((a, b) => a - b);
+    }
+
+    private _clusterLabel(id: number): string {
+        return `${clusters[id]?.label ?? "Cluster"} (0x${id.toString(16).padStart(2, "0").toUpperCase()})`;
+    }
+
+    private _addTarget() {
         const max = aclCapacity(this.node).targetsMax;
         if (max > 0 && this._targets.length >= max) {
             void showAlertDialog({ title: "Limit reached", text: `At most ${max} targets per entry.` });
             return;
         }
-        const clusterRaw = this._targetCluster.trim();
-        let cluster: number | undefined;
-        if (clusterRaw !== "") {
-            const c = parseInt(clusterRaw, 10);
-            if (Number.isNaN(c) || c < 0 || c > 0x7fff) {
-                void showAlertDialog({ title: "Validation error", text: "Enter a valid cluster id (or leave empty)." });
-                return;
-            }
-            cluster = c;
+        const endpoint =
+            this._targetEndpoint === "all" || this._targetEndpoint === "" ? undefined : Number(this._targetEndpoint);
+        const cluster =
+            this._targetCluster === "all" || this._targetCluster === "" ? undefined : Number(this._targetCluster);
+        if (endpoint === undefined && cluster === undefined) {
+            void showAlertDialog({
+                title: "Validation error",
+                text: "Pick an endpoint and/or a cluster for the target.",
+            });
+            return;
         }
-        this._targets = [...this._targets, { endpoint: ep, cluster, deviceType: undefined }];
+        this._targets = [...this._targets, { endpoint, cluster, deviceType: undefined }];
         this._targetEndpoint = "";
         this._targetCluster = "";
     }
@@ -204,10 +228,10 @@ export class NodeAclAddDialog extends LitElement {
                                 : this._targets.map(
                                       (t, i) =>
                                           html`<span class="chip"
-                                              >EP
-                                              ${t.endpoint}${t.cluster != null
-                                                  ? ` · 0x${t.cluster.toString(16).toUpperCase()}`
-                                                  : " · all clusters"}
+                                              >${t.endpoint != null ? `EP ${t.endpoint}` : "All endpoints"}
+                                              ${t.cluster != null
+                                                  ? `· ${this._clusterLabel(t.cluster)}`
+                                                  : "· all clusters"}
                                               <ha-svg-icon
                                                   class="x"
                                                   .path=${mdiClose}
@@ -217,24 +241,39 @@ export class NodeAclAddDialog extends LitElement {
                                   )}
                         </div>
                         <div class="row">
-                            <md-outlined-text-field
+                            <md-outlined-select
                                 label="endpoint"
-                                type="number"
-                                min="0"
-                                max="65534"
                                 .value=${this._targetEndpoint}
                                 ?disabled=${this._busy}
-                                @input=${(e: Event) => (this._targetEndpoint = (e.target as HTMLInputElement).value)}
-                            ></md-outlined-text-field>
-                            <md-outlined-text-field
-                                label="cluster id (optional)"
-                                type="number"
-                                min="0"
-                                max="32767"
+                                @change=${(e: Event) => {
+                                    this._targetEndpoint = (e.target as HTMLSelectElement).value;
+                                    this._targetCluster = "";
+                                }}
+                            >
+                                <md-select-option value="all"
+                                    ><div slot="headline">All endpoints</div></md-select-option
+                                >
+                                ${this._nodeEndpoints().map(
+                                    ep =>
+                                        html`<md-select-option value=${String(ep)}
+                                            ><div slot="headline">EP ${ep}</div></md-select-option
+                                        >`,
+                                )}
+                            </md-outlined-select>
+                            <md-outlined-select
+                                label="cluster"
                                 .value=${this._targetCluster}
                                 ?disabled=${this._busy}
-                                @input=${(e: Event) => (this._targetCluster = (e.target as HTMLInputElement).value)}
-                            ></md-outlined-text-field>
+                                @change=${(e: Event) => (this._targetCluster = (e.target as HTMLSelectElement).value)}
+                            >
+                                <md-select-option value="all"><div slot="headline">All clusters</div></md-select-option>
+                                ${this._clusterOptions().map(
+                                    c =>
+                                        html`<md-select-option value=${String(c)}
+                                            ><div slot="headline">${this._clusterLabel(c)}</div></md-select-option
+                                        >`,
+                                )}
+                            </md-outlined-select>
                             <md-text-button ?disabled=${this._busy} @click=${() => this._addTarget()}
                                 >Add target</md-text-button
                             >

--- a/packages/dashboard/src/components/dialogs/acl/node-acl-add-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/acl/node-acl-add-dialog.ts
@@ -40,7 +40,7 @@ export class NodeAclAddDialog extends LitElement {
     @state() private _subjects = new Array<number | bigint>();
     @state() private _subjectInput = "";
     @state() private _targets = new Array<AccessControlTargetStruct>();
-    @state() private _targetEndpoint = "";
+    @state() private _targetEndpoint = "all";
     @state() private _targetCluster = "";
     @state() private _busy = false;
 
@@ -111,8 +111,8 @@ export class NodeAclAddDialog extends LitElement {
             return;
         }
         this._targets = [...this._targets, { endpoint, cluster, deviceType: undefined }];
-        this._targetEndpoint = "";
-        this._targetCluster = "";
+        this._targetEndpoint = "all";
+        this._targetCluster = "all";
     }
 
     private _removeTarget(index: number) {

--- a/packages/dashboard/src/components/dialogs/acl/node-acl-add-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/acl/node-acl-add-dialog.ts
@@ -1,0 +1,302 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import "@material/web/button/text-button";
+import "@material/web/dialog/dialog";
+import "@material/web/select/outlined-select";
+import "@material/web/select/select-option";
+import "@material/web/textfield/outlined-text-field";
+import { consume } from "@lit/context";
+import type { MdDialog } from "@material/web/dialog/dialog.js";
+import { mdiClose } from "@mdi/js";
+import { MatterClient, MatterNode } from "@matter-server/ws-client";
+import { css, html, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import "../../../components/ha-svg-icon.js";
+import { clientContext } from "../../../client/client-context.js";
+import { AuthMode, Privilege, PRIVILEGE_NAMES, aclCapacity, nodeIdKey } from "../../../util/access-control.js";
+import { handleAsync } from "../../../util/async-handler.js";
+import { preventDefault } from "../../../util/prevent_default.js";
+import { showAlertDialog } from "../../dialog-box/show-dialog-box.js";
+import { addAclEntry } from "./acl-actions.js";
+import type { AccessControlEntryStruct, AccessControlTargetStruct } from "./model.js";
+
+@customElement("node-acl-add-dialog")
+export class NodeAclAddDialog extends LitElement {
+    @consume({ context: clientContext, subscribe: true })
+    @property({ attribute: false })
+    public client!: MatterClient;
+
+    @property({ attribute: false })
+    public node!: MatterNode;
+
+    @state() private _privilege = Privilege.Operate;
+    @state() private _subjects = new Array<number | bigint>();
+    @state() private _subjectInput = "";
+    @state() private _targets = new Array<AccessControlTargetStruct>();
+    @state() private _targetEndpoint = "";
+    @state() private _targetCluster = "";
+    @state() private _busy = false;
+
+    private _knownNodes(): MatterNode[] {
+        return Object.values(this.client.nodes).sort((a, b) => (a.nodeLabel || "").localeCompare(b.nodeLabel || ""));
+    }
+
+    private _addSubject(raw: string) {
+        const value = raw.trim();
+        if (!/^\d+$/.test(value)) return;
+        const id = BigInt(value);
+        const key = nodeIdKey(id);
+        if (this._subjects.some(s => nodeIdKey(s) === key)) return;
+        const max = aclCapacity(this.node).subjectsMax;
+        if (max > 0 && this._subjects.length >= max) {
+            void showAlertDialog({ title: "Limit reached", text: `At most ${max} subjects per entry.` });
+            return;
+        }
+        this._subjects = [...this._subjects, id];
+        this._subjectInput = "";
+    }
+
+    private _removeSubject(key: string) {
+        this._subjects = this._subjects.filter(s => nodeIdKey(s) !== key);
+    }
+
+    private _addTarget() {
+        const ep = parseInt(this._targetEndpoint, 10);
+        if (Number.isNaN(ep) || ep < 0 || ep > 0xfffe) {
+            void showAlertDialog({ title: "Validation error", text: "Enter a valid endpoint." });
+            return;
+        }
+        const max = aclCapacity(this.node).targetsMax;
+        if (max > 0 && this._targets.length >= max) {
+            void showAlertDialog({ title: "Limit reached", text: `At most ${max} targets per entry.` });
+            return;
+        }
+        const clusterRaw = this._targetCluster.trim();
+        let cluster: number | undefined;
+        if (clusterRaw !== "") {
+            const c = parseInt(clusterRaw, 10);
+            if (Number.isNaN(c) || c < 0 || c > 0x7fff) {
+                void showAlertDialog({ title: "Validation error", text: "Enter a valid cluster id (or leave empty)." });
+                return;
+            }
+            cluster = c;
+        }
+        this._targets = [...this._targets, { endpoint: ep, cluster, deviceType: undefined }];
+        this._targetEndpoint = "";
+        this._targetCluster = "";
+    }
+
+    private _removeTarget(index: number) {
+        this._targets = this._targets.filter((_, i) => i !== index);
+    }
+
+    private async _save() {
+        if (this._subjects.length === 0) {
+            await showAlertDialog({ title: "Validation error", text: "Add at least one subject node." });
+            return;
+        }
+        const entry: AccessControlEntryStruct = {
+            privilege: this._privilege,
+            authMode: AuthMode.Case,
+            subjects: this._subjects,
+            targets: this._targets.length ? this._targets : undefined,
+            fabricIndex: 0,
+        };
+        this._busy = true;
+        try {
+            await addAclEntry(this.client, this.node.node_id, entry);
+            this._close();
+        } catch (err) {
+            await showAlertDialog({ title: "Failed to add entry", text: err instanceof Error ? err.message : String(err) });
+        } finally {
+            this._busy = false;
+        }
+    }
+
+    private _close() {
+        this.shadowRoot!.querySelector<MdDialog>("md-dialog")!.close();
+    }
+
+    private _handleClosed() {
+        this.parentNode?.removeChild(this);
+    }
+
+    protected override render() {
+        return html`
+            <md-dialog open @cancel=${preventDefault} @closed=${this._handleClosed}>
+                <div slot="headline">Add ACL entry</div>
+                <div slot="content">
+                    <div class="form">
+                        <md-outlined-select
+                            label="Privilege"
+                            .value=${String(this._privilege)}
+                            ?disabled=${this._busy}
+                            @change=${(e: Event) => (this._privilege = Number((e.target as HTMLSelectElement).value))}
+                        >
+                            ${[Privilege.View, Privilege.Operate, Privilege.Manage, Privilege.Administer].map(
+                                p =>
+                                    html`<md-select-option value=${String(p)}
+                                        ><div slot="headline">${PRIVILEGE_NAMES[p]} · ${p}</div></md-select-option
+                                    >`,
+                            )}
+                        </md-outlined-select>
+                        <div class="note">Auth mode: CASE (node). Group subjects are not supported yet.</div>
+
+                        <div class="label">Subjects (nodes)</div>
+                        <div class="chips">
+                            ${this._subjects.length === 0
+                                ? html`<span class="mut">none — add at least one</span>`
+                                : this._subjects.map(s => {
+                                      const known = this.client.nodes[nodeIdKey(s)];
+                                      return html`<span class="chip"
+                                          >${known ? known.nodeLabel || "Unknown" : "Node"} · ${s.toString()}
+                                          <ha-svg-icon
+                                              class="x"
+                                              .path=${mdiClose}
+                                              @click=${() => this._removeSubject(nodeIdKey(s))}
+                                          ></ha-svg-icon
+                                      ></span>`;
+                                  })}
+                        </div>
+                        <div class="row">
+                            <md-outlined-select
+                                label="Known nodes"
+                                ?disabled=${this._busy}
+                                @change=${(e: Event) => {
+                                    const v = (e.target as HTMLSelectElement).value;
+                                    if (v) this._addSubject(v);
+                                }}
+                            >
+                                <md-select-option value=""><div slot="headline">— pick —</div></md-select-option>
+                                ${this._knownNodes().map(
+                                    n =>
+                                        html`<md-select-option value=${nodeIdKey(n.node_id)}
+                                            ><div slot="headline">
+                                                ${n.nodeLabel || "Unknown"} · ${n.node_id.toString()}
+                                            </div></md-select-option
+                                        >`,
+                                )}
+                            </md-outlined-select>
+                            <md-outlined-text-field
+                                label="or raw node id"
+                                type="text"
+                                pattern="[0-9]+"
+                                .value=${this._subjectInput}
+                                ?disabled=${this._busy}
+                                @input=${(e: Event) => (this._subjectInput = (e.target as HTMLInputElement).value)}
+                            ></md-outlined-text-field>
+                            <md-text-button ?disabled=${this._busy} @click=${() => this._addSubject(this._subjectInput)}
+                                >Add</md-text-button
+                            >
+                        </div>
+
+                        <div class="label">Targets (optional — none means whole node)</div>
+                        <div class="chips">
+                            ${this._targets.length === 0
+                                ? html`<span class="mut">whole node</span>`
+                                : this._targets.map(
+                                      (t, i) =>
+                                          html`<span class="chip"
+                                              >EP ${t.endpoint}${t.cluster != null
+                                                  ? ` · 0x${t.cluster.toString(16).toUpperCase()}`
+                                                  : " · all clusters"}
+                                              <ha-svg-icon
+                                                  class="x"
+                                                  .path=${mdiClose}
+                                                  @click=${() => this._removeTarget(i)}
+                                              ></ha-svg-icon
+                                          ></span>`,
+                                  )}
+                        </div>
+                        <div class="row">
+                            <md-outlined-text-field
+                                label="endpoint"
+                                type="number"
+                                min="0"
+                                max="65534"
+                                .value=${this._targetEndpoint}
+                                ?disabled=${this._busy}
+                                @input=${(e: Event) => (this._targetEndpoint = (e.target as HTMLInputElement).value)}
+                            ></md-outlined-text-field>
+                            <md-outlined-text-field
+                                label="cluster id (optional)"
+                                type="number"
+                                min="0"
+                                max="32767"
+                                .value=${this._targetCluster}
+                                ?disabled=${this._busy}
+                                @input=${(e: Event) => (this._targetCluster = (e.target as HTMLInputElement).value)}
+                            ></md-outlined-text-field>
+                            <md-text-button ?disabled=${this._busy} @click=${() => this._addTarget()}>Add target</md-text-button>
+                        </div>
+                    </div>
+                </div>
+                <div slot="actions">
+                    <md-text-button ?disabled=${this._busy} @click=${handleAsync(() => this._save())}>Add</md-text-button>
+                    <md-text-button ?disabled=${this._busy} @click=${this._close}>Cancel</md-text-button>
+                </div>
+            </md-dialog>
+        `;
+    }
+
+    static override styles = css`
+        .form {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            min-width: 360px;
+        }
+        .label {
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            opacity: 0.65;
+            margin-top: 6px;
+        }
+        .note {
+            font-size: 12px;
+            opacity: 0.7;
+        }
+        .row {
+            display: flex;
+            gap: 8px;
+            align-items: center;
+            flex-wrap: wrap;
+        }
+        .chips {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+        .chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            padding: 3px 8px;
+            border-radius: 6px;
+            font-size: 12px;
+            background: var(--md-sys-color-surface-container-high);
+            color: var(--md-sys-color-on-surface);
+        }
+        .chip .x {
+            cursor: pointer;
+            --mdc-icon-size: 16px;
+            width: 16px;
+            height: 16px;
+        }
+        .mut {
+            opacity: 0.6;
+            font-size: 12px;
+        }
+    `;
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "node-acl-add-dialog": NodeAclAddDialog;
+    }
+}

--- a/packages/dashboard/src/components/dialogs/acl/node-acl-add-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/acl/node-acl-add-dialog.ts
@@ -11,8 +11,8 @@ import "@material/web/select/select-option";
 import "@material/web/textfield/outlined-text-field";
 import { consume } from "@lit/context";
 import type { MdDialog } from "@material/web/dialog/dialog.js";
-import { mdiClose } from "@mdi/js";
 import { MatterClient, MatterNode } from "@matter-server/ws-client";
+import { mdiClose } from "@mdi/js";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import "../../../components/ha-svg-icon.js";
@@ -111,7 +111,10 @@ export class NodeAclAddDialog extends LitElement {
             await addAclEntry(this.client, this.node.node_id, entry);
             this._close();
         } catch (err) {
-            await showAlertDialog({ title: "Failed to add entry", text: err instanceof Error ? err.message : String(err) });
+            await showAlertDialog({
+                title: "Failed to add entry",
+                text: err instanceof Error ? err.message : String(err),
+            });
         } finally {
             this._busy = false;
         }
@@ -201,7 +204,8 @@ export class NodeAclAddDialog extends LitElement {
                                 : this._targets.map(
                                       (t, i) =>
                                           html`<span class="chip"
-                                              >EP ${t.endpoint}${t.cluster != null
+                                              >EP
+                                              ${t.endpoint}${t.cluster != null
                                                   ? ` · 0x${t.cluster.toString(16).toUpperCase()}`
                                                   : " · all clusters"}
                                               <ha-svg-icon
@@ -231,12 +235,16 @@ export class NodeAclAddDialog extends LitElement {
                                 ?disabled=${this._busy}
                                 @input=${(e: Event) => (this._targetCluster = (e.target as HTMLInputElement).value)}
                             ></md-outlined-text-field>
-                            <md-text-button ?disabled=${this._busy} @click=${() => this._addTarget()}>Add target</md-text-button>
+                            <md-text-button ?disabled=${this._busy} @click=${() => this._addTarget()}
+                                >Add target</md-text-button
+                            >
                         </div>
                     </div>
                 </div>
                 <div slot="actions">
-                    <md-text-button ?disabled=${this._busy} @click=${handleAsync(() => this._save())}>Add</md-text-button>
+                    <md-text-button ?disabled=${this._busy} @click=${handleAsync(() => this._save())}
+                        >Add</md-text-button
+                    >
                     <md-text-button ?disabled=${this._busy} @click=${this._close}>Cancel</md-text-button>
                 </div>
             </md-dialog>

--- a/packages/dashboard/src/components/dialogs/acl/node-acl-add-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/acl/node-acl-add-dialog.ts
@@ -203,7 +203,7 @@ export class NodeAclAddDialog extends LitElement {
                                     n =>
                                         html`<md-select-option value=${nodeIdKey(n.node_id)}
                                             ><div slot="headline">
-                                                ${n.nodeLabel || "Unknown"} · ${n.node_id.toString()}
+                                                ${n.node_id.toString()} · ${n.nodeLabel || "Unknown"}
                                             </div></md-select-option
                                         >`,
                                 )}

--- a/packages/dashboard/src/components/dialogs/acl/node-acl-add-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/acl/node-acl-add-dialog.ts
@@ -21,6 +21,7 @@ import { clusters } from "../../../client/models/descriptions.js";
 import { AuthMode, Privilege, PRIVILEGE_NAMES, aclCapacity, nodeIdKey } from "../../../util/access-control.js";
 import { handleAsync } from "../../../util/async-handler.js";
 import { targetServerClusters } from "../../../util/binding.js";
+import { getDeviceName } from "../../../util/node-name.js";
 import { preventDefault } from "../../../util/prevent_default.js";
 import { showAlertDialog } from "../../dialog-box/show-dialog-box.js";
 import { addAclEntry } from "./acl-actions.js";
@@ -180,7 +181,7 @@ export class NodeAclAddDialog extends LitElement {
                                 : this._subjects.map(s => {
                                       const known = this.client.nodes[nodeIdKey(s)];
                                       return html`<span class="chip"
-                                          >${known ? known.nodeLabel || "Unknown" : "Node"} · ${s.toString()}
+                                          >${known ? getDeviceName(known) : "Node"} · ${s.toString()}
                                           <ha-svg-icon
                                               class="x"
                                               .path=${mdiClose}
@@ -203,7 +204,7 @@ export class NodeAclAddDialog extends LitElement {
                                     n =>
                                         html`<md-select-option value=${nodeIdKey(n.node_id)}
                                             ><div slot="headline">
-                                                ${n.node_id.toString()} · ${n.nodeLabel || "Unknown"}
+                                                ${n.node_id.toString()} · ${getDeviceName(n)}
                                             </div></md-select-option
                                         >`,
                                 )}

--- a/packages/dashboard/src/components/dialogs/acl/show-node-acl-add-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/acl/show-node-acl-add-dialog.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MatterNode } from "@matter-server/ws-client";
+
+export const showNodeAclAddDialog = async (node: MatterNode) => {
+    await import("./node-acl-add-dialog.js");
+    const dialog = document.createElement("node-acl-add-dialog");
+    dialog.node = node;
+    document.querySelector("matter-dashboard-app")?.renderRoot.appendChild(dialog);
+};

--- a/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
+++ b/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
@@ -12,7 +12,6 @@ import {
     entriesForFabric,
     entryMatchesTarget,
     isWholeNode,
-    nodeFabricIndex,
     nodeIdKey,
     subjectsInclude,
 } from "../../../util/access-control.js";
@@ -37,16 +36,22 @@ function toApiAcl(e: AccessControlEntryStruct): AccessControlEntry {
     };
 }
 
-function fabricOf(client: MatterClient, nodeId: number | bigint): number | undefined {
-    const node = client.nodes[nodeIdKey(nodeId)];
-    return node ? nodeFabricIndex(node) : undefined;
+function requireFabricIndex(res: Record<string, unknown>, nodeId: number | bigint): number {
+    const fi = res["0/62/5"];
+    if (typeof fi !== "number") {
+        throw new Error(`Cannot determine the current fabric index (0/62/5) for node ${nodeId}`);
+    }
+    return fi;
 }
 
-/** Read the node's ACL fresh (explicit reads are not fabric-filtered) and narrow to our fabric. */
+/**
+ * Read the node's ACL + CurrentFabricIndex fresh (explicit reads are not fabric-filtered) and narrow
+ * to our fabric. Fails rather than risk writing back other fabrics' entries if the index is unknown.
+ */
 async function freshOurAcl(client: MatterClient, nodeId: number | bigint): Promise<AccessControlEntryStruct[]> {
-    const res = await client.readAttribute(nodeId, "0/31/0");
+    const res = await client.readAttribute(nodeId, ["0/31/0", "0/62/5"]);
     const all = attributeArray(res["0/31/0"]).map(v => AccessControlEntryDataTransformer.transform(v));
-    return entriesForFabric(all, fabricOf(client, nodeId));
+    return entriesForFabric(all, requireFabricIndex(res, nodeId));
 }
 
 async function freshOurBindings(
@@ -54,10 +59,10 @@ async function freshOurBindings(
     nodeId: number | bigint,
     endpoint: number,
 ): Promise<BindingEntryStruct[]> {
-    const res = await client.readAttribute(nodeId, `${endpoint}/30/0`);
+    const res = await client.readAttribute(nodeId, [`${endpoint}/30/0`, "0/62/5"]);
     const all = attributeArray(res[`${endpoint}/30/0`]).map(v => BindingEntryDataTransformer.transform(v));
-    const fabricIndex = fabricOf(client, nodeId);
-    return fabricIndex === undefined ? all : all.filter(b => b.fabricIndex === fabricIndex);
+    const fabricIndex = requireFabricIndex(res, nodeId);
+    return all.filter(b => b.fabricIndex === fabricIndex);
 }
 
 function hasTarget(e: AccessControlEntryStruct, endpoint: number, cluster: number | undefined): boolean {

--- a/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
+++ b/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AccessControlEntry, BindingTarget, MatterClient, MatterNode } from "@matter-server/ws-client";
+import { AccessControlEntryDataTransformer, type AccessControlEntryStruct } from "../acl/model.js";
+import { AuthMode, Privilege, isWholeNode, subjectsInclude } from "../../../util/access-control.js";
+import { BindingEntryDataTransformer, type BindingEntryStruct } from "./model.js";
+
+function toBindingTarget(e: BindingEntryStruct): BindingTarget {
+    return { node: e.node ?? null, group: e.group ?? null, endpoint: e.endpoint ?? null, cluster: e.cluster ?? null };
+}
+
+function toApiAcl(e: AccessControlEntryStruct): AccessControlEntry {
+    return {
+        privilege: e.privilege,
+        auth_mode: e.authMode,
+        subjects: e.subjects ?? null,
+        targets:
+            e.targets?.map(t => ({
+                cluster: t.cluster ?? null,
+                endpoint: t.endpoint ?? null,
+                device_type: t.deviceType ?? null,
+            })) ?? null,
+    };
+}
+
+async function freshAcl(client: MatterClient, nodeId: number | bigint): Promise<AccessControlEntryStruct[]> {
+    const res = await client.readAttribute(nodeId, "0/31/0");
+    const raw = res["0/31/0"] as unknown[] | undefined;
+    if (!raw) return new Array<AccessControlEntryStruct>();
+    return Object.values(raw).map(v => AccessControlEntryDataTransformer.transform(v));
+}
+
+async function freshBindings(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+): Promise<BindingEntryStruct[]> {
+    const res = await client.readAttribute(nodeId, `${endpoint}/30/0`);
+    const raw = res[`${endpoint}/30/0`] as unknown[] | undefined;
+    if (!raw) return new Array<BindingEntryStruct>();
+    return Object.values(raw).map(v => BindingEntryDataTransformer.transform(v));
+}
+
+/**
+ * Grant the source Operate access to the target (merging into an existing subject entry where
+ * possible so no extra ACL slot is consumed), then add the binding. Both writes read the current
+ * list fresh first to avoid clobbering concurrent changes.
+ */
+export async function addBinding(
+    client: MatterClient,
+    sourceNode: MatterNode,
+    sourceEndpoint: number,
+    targetNodeId: number | bigint,
+    targetEndpoint: number,
+    cluster: number | undefined,
+): Promise<void> {
+    const acl = await freshAcl(client, targetNodeId);
+    const reusable = acl.find(
+        e => e.authMode === AuthMode.Case && e.privilege >= Privilege.Operate && subjectsInclude(e, sourceNode.node_id),
+    );
+    if (reusable) {
+        if (!isWholeNode(reusable)) {
+            reusable.targets = reusable.targets ?? [];
+            const exists = reusable.targets.some(
+                t => t.endpoint === targetEndpoint && (t.cluster ?? undefined) === cluster,
+            );
+            if (!exists) reusable.targets.push({ endpoint: targetEndpoint, cluster, deviceType: undefined });
+        }
+    } else {
+        acl.push({
+            privilege: Privilege.Operate,
+            authMode: AuthMode.Case,
+            subjects: [sourceNode.node_id],
+            targets: [{ endpoint: targetEndpoint, cluster, deviceType: undefined }],
+            fabricIndex: 0,
+        });
+    }
+    await client.setACLEntry(targetNodeId, acl.map(toApiAcl));
+
+    const bindings = await freshBindings(client, sourceNode.node_id, sourceEndpoint);
+    bindings.push({ node: targetNodeId, group: undefined, endpoint: targetEndpoint, cluster, fabricIndex: undefined });
+    await client.setNodeBinding(sourceNode.node_id, sourceEndpoint, bindings.map(toBindingTarget));
+}
+
+/**
+ * Remove the binding at `index`, then drop the matching target endpoint from the source's ACL
+ * entry on the (binding) target node. Matches on the binding's TARGET endpoint.
+ */
+export async function deleteBindingAtIndex(
+    client: MatterClient,
+    sourceNode: MatterNode,
+    sourceEndpoint: number,
+    index: number,
+): Promise<void> {
+    const bindings = await freshBindings(client, sourceNode.node_id, sourceEndpoint);
+    const removed = bindings[index];
+    if (!removed) return;
+    const updated = [...bindings.slice(0, index), ...bindings.slice(index + 1)];
+    await client.setNodeBinding(sourceNode.node_id, sourceEndpoint, updated.map(toBindingTarget));
+
+    if (removed.node == null || removed.endpoint == null) return;
+    const targetEndpoint = removed.endpoint;
+    const acl = await freshAcl(client, removed.node);
+    const kept = acl
+        .map(e => {
+            if (!subjectsInclude(e, sourceNode.node_id) || isWholeNode(e)) return e;
+            const targets = e.targets!.filter(t => t.endpoint !== targetEndpoint);
+            if (targets.length === 0) return undefined;
+            return { ...e, targets };
+        })
+        .filter((e): e is AccessControlEntryStruct => e !== undefined);
+    await client.setACLEntry(removed.node, kept.map(toApiAcl));
+}

--- a/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
+++ b/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
@@ -5,8 +5,8 @@
  */
 
 import { AccessControlEntry, BindingTarget, MatterClient, MatterNode } from "@matter-server/ws-client";
+import { AuthMode, Privilege, attributeArray, isWholeNode, subjectsInclude } from "../../../util/access-control.js";
 import { AccessControlEntryDataTransformer, type AccessControlEntryStruct } from "../acl/model.js";
-import { AuthMode, Privilege, isWholeNode, subjectsInclude } from "../../../util/access-control.js";
 import { BindingEntryDataTransformer, type BindingEntryStruct } from "./model.js";
 
 function toBindingTarget(e: BindingEntryStruct): BindingTarget {
@@ -29,9 +29,7 @@ function toApiAcl(e: AccessControlEntryStruct): AccessControlEntry {
 
 async function freshAcl(client: MatterClient, nodeId: number | bigint): Promise<AccessControlEntryStruct[]> {
     const res = await client.readAttribute(nodeId, "0/31/0");
-    const raw = res["0/31/0"] as unknown[] | undefined;
-    if (!raw) return new Array<AccessControlEntryStruct>();
-    return Object.values(raw).map(v => AccessControlEntryDataTransformer.transform(v));
+    return attributeArray(res["0/31/0"]).map(v => AccessControlEntryDataTransformer.transform(v));
 }
 
 async function freshBindings(
@@ -40,9 +38,7 @@ async function freshBindings(
     endpoint: number,
 ): Promise<BindingEntryStruct[]> {
     const res = await client.readAttribute(nodeId, `${endpoint}/30/0`);
-    const raw = res[`${endpoint}/30/0`] as unknown[] | undefined;
-    if (!raw) return new Array<BindingEntryStruct>();
-    return Object.values(raw).map(v => BindingEntryDataTransformer.transform(v));
+    return attributeArray(res[`${endpoint}/30/0`]).map(v => BindingEntryDataTransformer.transform(v));
 }
 
 /**

--- a/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
+++ b/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
@@ -183,16 +183,24 @@ export async function deleteBindingAtIndex(
     if (removed.node == null || removed.endpoint == null) return;
     const targetEndpoint = removed.endpoint;
     const removedCluster = removed.cluster ?? undefined;
-    const acl = await freshOurAcl(client, removed.node);
-    const kept = acl
-        .map(e => {
-            if (!subjectsInclude(e, sourceNode.node_id) || isWholeNode(e)) return e;
-            const targets = e.targets!.filter(
-                t => !(t.endpoint === targetEndpoint && (t.cluster ?? undefined) === removedCluster),
-            );
-            if (targets.length === 0) return undefined;
-            return { ...e, targets };
-        })
-        .filter((e): e is AccessControlEntryStruct => e !== undefined);
-    await client.setACLEntry(removed.node, kept.map(toApiAcl));
+    try {
+        const acl = await freshOurAcl(client, removed.node);
+        const kept = acl
+            .map(e => {
+                if (!subjectsInclude(e, sourceNode.node_id) || isWholeNode(e)) return e;
+                const targets = e.targets!.filter(
+                    t => !(t.endpoint === targetEndpoint && (t.cluster ?? undefined) === removedCluster),
+                );
+                if (targets.length === 0) return undefined;
+                return { ...e, targets };
+            })
+            .filter((e): e is AccessControlEntryStruct => e !== undefined);
+        await client.setACLEntry(removed.node, kept.map(toApiAcl));
+    } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        throw new Error(
+            `Binding removed, but cleaning up the access control entry on the target node failed: ${detail}. ` +
+                "The target may retain a stale access grant.",
+        );
+    }
 }

--- a/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
+++ b/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
@@ -12,6 +12,7 @@ import {
     entriesForFabric,
     entryMatchesTarget,
     isWholeNode,
+    nodeFabricIndex,
     nodeIdKey,
     subjectsInclude,
 } from "../../../util/access-control.js";
@@ -36,25 +37,38 @@ function toApiAcl(e: AccessControlEntryStruct): AccessControlEntry {
     };
 }
 
-async function freshAcl(client: MatterClient, nodeId: number | bigint): Promise<AccessControlEntryStruct[]> {
-    const res = await client.readAttribute(nodeId, "0/31/0");
-    return attributeArray(res["0/31/0"]).map(v => AccessControlEntryDataTransformer.transform(v));
+function fabricOf(client: MatterClient, nodeId: number | bigint): number | undefined {
+    const node = client.nodes[nodeIdKey(nodeId)];
+    return node ? nodeFabricIndex(node) : undefined;
 }
 
-async function freshBindings(
+/** Read the node's ACL fresh (explicit reads are not fabric-filtered) and narrow to our fabric. */
+async function freshOurAcl(client: MatterClient, nodeId: number | bigint): Promise<AccessControlEntryStruct[]> {
+    const res = await client.readAttribute(nodeId, "0/31/0");
+    const all = attributeArray(res["0/31/0"]).map(v => AccessControlEntryDataTransformer.transform(v));
+    return entriesForFabric(all, fabricOf(client, nodeId));
+}
+
+async function freshOurBindings(
     client: MatterClient,
     nodeId: number | bigint,
     endpoint: number,
 ): Promise<BindingEntryStruct[]> {
     const res = await client.readAttribute(nodeId, `${endpoint}/30/0`);
-    return attributeArray(res[`${endpoint}/30/0`]).map(v => BindingEntryDataTransformer.transform(v));
+    const all = attributeArray(res[`${endpoint}/30/0`]).map(v => BindingEntryDataTransformer.transform(v));
+    const fabricIndex = fabricOf(client, nodeId);
+    return fabricIndex === undefined ? all : all.filter(b => b.fabricIndex === fabricIndex);
 }
 
-/**
- * Grant the source Operate access to the target (merging into an existing subject entry where
- * possible so no extra ACL slot is consumed), then add the binding. Both writes read the current
- * list fresh first to avoid clobbering concurrent changes.
- */
+function hasTarget(e: AccessControlEntryStruct, endpoint: number, cluster: number | undefined): boolean {
+    return (e.targets ?? []).some(t => t.endpoint === endpoint && (t.cluster ?? undefined) === cluster);
+}
+
+function aclTargetsMax(client: MatterClient, nodeId: number | bigint): number {
+    const raw = client.nodes[nodeIdKey(nodeId)]?.attributes["0/31/3"];
+    return typeof raw === "number" && raw > 0 ? raw : Number.MAX_SAFE_INTEGER;
+}
+
 /** Ensure the target grants the source an Operate ACL for {endpoint, cluster}, merging where possible. */
 export async function ensureBindingAcl(
     client: MatterClient,
@@ -62,9 +76,8 @@ export async function ensureBindingAcl(
     targetNodeId: number | bigint,
     targetEndpoint: number,
     cluster: number | undefined,
-    fabricIndex?: number,
 ): Promise<void> {
-    const acl = entriesForFabric(await freshAcl(client, targetNodeId), fabricIndex);
+    const acl = await freshOurAcl(client, targetNodeId);
     const targetsMax = aclTargetsMax(client, targetNodeId);
     const reusable = acl.find(
         e =>
@@ -97,9 +110,8 @@ export async function fixOverPrivilegedBindingAcl(
     targetNodeId: number | bigint,
     targetEndpoint: number,
     cluster: number | undefined,
-    fabricIndex?: number,
 ): Promise<void> {
-    const acl = entriesForFabric(await freshAcl(client, targetNodeId), fabricIndex);
+    const acl = await freshOurAcl(client, targetNodeId);
     const updated = acl.map(e =>
         e.authMode === AuthMode.Case &&
         subjectsInclude(e, sourceNodeId) &&
@@ -118,36 +130,25 @@ export async function addBinding(
     targetNodeId: number | bigint,
     targetEndpoint: number,
     cluster: number | undefined,
-    fabricIndex?: number,
 ): Promise<void> {
-    await ensureBindingAcl(client, sourceNode.node_id, targetNodeId, targetEndpoint, cluster, fabricIndex);
+    await ensureBindingAcl(client, sourceNode.node_id, targetNodeId, targetEndpoint, cluster);
 
-    const bindings = await freshBindings(client, sourceNode.node_id, sourceEndpoint);
+    const bindings = await freshOurBindings(client, sourceNode.node_id, sourceEndpoint);
     bindings.push({ node: targetNodeId, group: undefined, endpoint: targetEndpoint, cluster, fabricIndex: undefined });
     await client.setNodeBinding(sourceNode.node_id, sourceEndpoint, bindings.map(toBindingTarget));
 }
 
-function hasTarget(e: AccessControlEntryStruct, endpoint: number, cluster: number | undefined): boolean {
-    return (e.targets ?? []).some(t => t.endpoint === endpoint && (t.cluster ?? undefined) === cluster);
-}
-
-function aclTargetsMax(client: MatterClient, nodeId: number | bigint): number {
-    const raw = client.nodes[nodeIdKey(nodeId)]?.attributes["0/31/3"];
-    return typeof raw === "number" && raw > 0 ? raw : Number.MAX_SAFE_INTEGER;
-}
-
 /**
- * Remove the binding at `index`, then drop the matching target endpoint from the source's ACL
- * entry on the (binding) target node. Matches on the binding's TARGET endpoint.
+ * Remove the binding at `index`, then drop the matching target from the source's ACL entry on the
+ * (binding) target node. Matches on the binding's TARGET endpoint + cluster.
  */
 export async function deleteBindingAtIndex(
     client: MatterClient,
     sourceNode: MatterNode,
     sourceEndpoint: number,
     index: number,
-    fabricIndex?: number,
 ): Promise<void> {
-    const bindings = await freshBindings(client, sourceNode.node_id, sourceEndpoint);
+    const bindings = await freshOurBindings(client, sourceNode.node_id, sourceEndpoint);
     const removed = bindings[index];
     if (!removed) return;
     const updated = [...bindings.slice(0, index), ...bindings.slice(index + 1)];
@@ -156,7 +157,7 @@ export async function deleteBindingAtIndex(
     if (removed.node == null || removed.endpoint == null) return;
     const targetEndpoint = removed.endpoint;
     const removedCluster = removed.cluster ?? undefined;
-    const acl = entriesForFabric(await freshAcl(client, removed.node), fabricIndex);
+    const acl = await freshOurAcl(client, removed.node);
     const kept = acl
         .map(e => {
             if (!subjectsInclude(e, sourceNode.node_id) || isWholeNode(e)) return e;

--- a/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
+++ b/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
@@ -78,6 +78,18 @@ export async function ensureBindingAcl(
     cluster: number | undefined,
 ): Promise<void> {
     const acl = await freshOurAcl(client, targetNodeId);
+
+    // Duplicate check: if an existing entry already grants the source Operate+ access to this
+    // endpoint/cluster (or wider), no ACL change is needed.
+    const alreadyGranted = acl.some(
+        e =>
+            e.authMode === AuthMode.Case &&
+            e.privilege >= Privilege.Operate &&
+            subjectsInclude(e, sourceNodeId) &&
+            entryMatchesTarget(e, targetEndpoint, cluster),
+    );
+    if (alreadyGranted) return;
+
     const targetsMax = aclTargetsMax(client, targetNodeId);
     const reusable = acl.find(
         e =>
@@ -134,6 +146,15 @@ export async function addBinding(
     await ensureBindingAcl(client, sourceNode.node_id, targetNodeId, targetEndpoint, cluster);
 
     const bindings = await freshOurBindings(client, sourceNode.node_id, sourceEndpoint);
+    const targetKey = nodeIdKey(targetNodeId);
+    const exists = bindings.some(
+        b =>
+            b.node != null &&
+            nodeIdKey(b.node) === targetKey &&
+            b.endpoint === targetEndpoint &&
+            (b.cluster ?? undefined) === cluster,
+    );
+    if (exists) return;
     bindings.push({ node: targetNodeId, group: undefined, endpoint: targetEndpoint, cluster, fabricIndex: undefined });
     await client.setNodeBinding(sourceNode.node_id, sourceEndpoint, bindings.map(toBindingTarget));
 }

--- a/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
+++ b/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
@@ -66,7 +66,7 @@ async function freshOurBindings(
 }
 
 function hasTarget(e: AccessControlEntryStruct, endpoint: number, cluster: number | undefined): boolean {
-    return (e.targets ?? []).some(t => t.endpoint === endpoint && (t.cluster ?? undefined) === cluster);
+    return (e.targets ?? []).some(t => t.endpoint === endpoint && t.cluster === cluster);
 }
 
 function aclTargetsMax(client: MatterClient, nodeId: number | bigint): number {
@@ -84,8 +84,6 @@ export async function ensureBindingAcl(
 ): Promise<void> {
     const acl = await freshOurAcl(client, targetNodeId);
 
-    // Duplicate check: if an existing entry already grants the source Operate+ access to this
-    // endpoint/cluster (or wider), no ACL change is needed.
     const alreadyGranted = acl.some(
         e =>
             e.authMode === AuthMode.Case &&
@@ -154,10 +152,7 @@ export async function addBinding(
     const targetKey = nodeIdKey(targetNodeId);
     const exists = bindings.some(
         b =>
-            b.node != null &&
-            nodeIdKey(b.node) === targetKey &&
-            b.endpoint === targetEndpoint &&
-            (b.cluster ?? undefined) === cluster,
+            b.node != null && nodeIdKey(b.node) === targetKey && b.endpoint === targetEndpoint && b.cluster === cluster,
     );
     if (exists) return;
     bindings.push({ node: targetNodeId, group: undefined, endpoint: targetEndpoint, cluster, fabricIndex: undefined });
@@ -182,14 +177,14 @@ export async function deleteBindingAtIndex(
 
     if (removed.node == null || removed.endpoint == null) return;
     const targetEndpoint = removed.endpoint;
-    const removedCluster = removed.cluster ?? undefined;
+    const removedCluster = removed.cluster;
     try {
         const acl = await freshOurAcl(client, removed.node);
         const kept = acl
             .map(e => {
                 if (!subjectsInclude(e, sourceNode.node_id) || isWholeNode(e)) return e;
                 const targets = e.targets!.filter(
-                    t => !(t.endpoint === targetEndpoint && (t.cluster ?? undefined) === removedCluster),
+                    t => !(t.endpoint === targetEndpoint && t.cluster === removedCluster),
                 );
                 if (targets.length === 0) return undefined;
                 return { ...e, targets };

--- a/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
+++ b/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
@@ -10,6 +10,7 @@ import {
     Privilege,
     attributeArray,
     entriesForFabric,
+    entryMatchesTarget,
     isWholeNode,
     nodeIdKey,
     subjectsInclude,
@@ -54,10 +55,10 @@ async function freshBindings(
  * possible so no extra ACL slot is consumed), then add the binding. Both writes read the current
  * list fresh first to avoid clobbering concurrent changes.
  */
-export async function addBinding(
+/** Ensure the target grants the source an Operate ACL for {endpoint, cluster}, merging where possible. */
+export async function ensureBindingAcl(
     client: MatterClient,
-    sourceNode: MatterNode,
-    sourceEndpoint: number,
+    sourceNodeId: number | bigint,
     targetNodeId: number | bigint,
     targetEndpoint: number,
     cluster: number | undefined,
@@ -69,7 +70,7 @@ export async function addBinding(
         e =>
             e.authMode === AuthMode.Case &&
             e.privilege >= Privilege.Operate &&
-            subjectsInclude(e, sourceNode.node_id) &&
+            subjectsInclude(e, sourceNodeId) &&
             (isWholeNode(e) || hasTarget(e, targetEndpoint, cluster) || (e.targets?.length ?? 0) < targetsMax),
     );
     if (reusable) {
@@ -81,12 +82,45 @@ export async function addBinding(
         acl.push({
             privilege: Privilege.Operate,
             authMode: AuthMode.Case,
-            subjects: [sourceNode.node_id],
+            subjects: [sourceNodeId],
             targets: [{ endpoint: targetEndpoint, cluster, deviceType: undefined }],
             fabricIndex: 0,
         });
     }
     await client.setACLEntry(targetNodeId, acl.map(toApiAcl));
+}
+
+/** Downgrade an over-privileged (>Operate) binding ACL on the target back to Operate. */
+export async function fixOverPrivilegedBindingAcl(
+    client: MatterClient,
+    sourceNodeId: number | bigint,
+    targetNodeId: number | bigint,
+    targetEndpoint: number,
+    cluster: number | undefined,
+    fabricIndex?: number,
+): Promise<void> {
+    const acl = entriesForFabric(await freshAcl(client, targetNodeId), fabricIndex);
+    const updated = acl.map(e =>
+        e.authMode === AuthMode.Case &&
+        subjectsInclude(e, sourceNodeId) &&
+        e.privilege > Privilege.Operate &&
+        entryMatchesTarget(e, targetEndpoint, cluster)
+            ? { ...e, privilege: Privilege.Operate }
+            : e,
+    );
+    await client.setACLEntry(targetNodeId, updated.map(toApiAcl));
+}
+
+export async function addBinding(
+    client: MatterClient,
+    sourceNode: MatterNode,
+    sourceEndpoint: number,
+    targetNodeId: number | bigint,
+    targetEndpoint: number,
+    cluster: number | undefined,
+    fabricIndex?: number,
+): Promise<void> {
+    await ensureBindingAcl(client, sourceNode.node_id, targetNodeId, targetEndpoint, cluster, fabricIndex);
 
     const bindings = await freshBindings(client, sourceNode.node_id, sourceEndpoint);
     bindings.push({ node: targetNodeId, group: undefined, endpoint: targetEndpoint, cluster, fabricIndex: undefined });

--- a/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
+++ b/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
@@ -5,7 +5,15 @@
  */
 
 import { AccessControlEntry, BindingTarget, MatterClient, MatterNode } from "@matter-server/ws-client";
-import { AuthMode, Privilege, attributeArray, isWholeNode, subjectsInclude } from "../../../util/access-control.js";
+import {
+    AuthMode,
+    Privilege,
+    attributeArray,
+    entriesForFabric,
+    isWholeNode,
+    nodeIdKey,
+    subjectsInclude,
+} from "../../../util/access-control.js";
 import { AccessControlEntryDataTransformer, type AccessControlEntryStruct } from "../acl/model.js";
 import { BindingEntryDataTransformer, type BindingEntryStruct } from "./model.js";
 
@@ -53,18 +61,21 @@ export async function addBinding(
     targetNodeId: number | bigint,
     targetEndpoint: number,
     cluster: number | undefined,
+    fabricIndex?: number,
 ): Promise<void> {
-    const acl = await freshAcl(client, targetNodeId);
+    const acl = entriesForFabric(await freshAcl(client, targetNodeId), fabricIndex);
+    const targetsMax = aclTargetsMax(client, targetNodeId);
     const reusable = acl.find(
-        e => e.authMode === AuthMode.Case && e.privilege >= Privilege.Operate && subjectsInclude(e, sourceNode.node_id),
+        e =>
+            e.authMode === AuthMode.Case &&
+            e.privilege >= Privilege.Operate &&
+            subjectsInclude(e, sourceNode.node_id) &&
+            (isWholeNode(e) || hasTarget(e, targetEndpoint, cluster) || (e.targets?.length ?? 0) < targetsMax),
     );
     if (reusable) {
-        if (!isWholeNode(reusable)) {
+        if (!isWholeNode(reusable) && !hasTarget(reusable, targetEndpoint, cluster)) {
             reusable.targets = reusable.targets ?? [];
-            const exists = reusable.targets.some(
-                t => t.endpoint === targetEndpoint && (t.cluster ?? undefined) === cluster,
-            );
-            if (!exists) reusable.targets.push({ endpoint: targetEndpoint, cluster, deviceType: undefined });
+            reusable.targets.push({ endpoint: targetEndpoint, cluster, deviceType: undefined });
         }
     } else {
         acl.push({
@@ -82,6 +93,15 @@ export async function addBinding(
     await client.setNodeBinding(sourceNode.node_id, sourceEndpoint, bindings.map(toBindingTarget));
 }
 
+function hasTarget(e: AccessControlEntryStruct, endpoint: number, cluster: number | undefined): boolean {
+    return (e.targets ?? []).some(t => t.endpoint === endpoint && (t.cluster ?? undefined) === cluster);
+}
+
+function aclTargetsMax(client: MatterClient, nodeId: number | bigint): number {
+    const raw = client.nodes[nodeIdKey(nodeId)]?.attributes["0/31/3"];
+    return typeof raw === "number" && raw > 0 ? raw : Number.MAX_SAFE_INTEGER;
+}
+
 /**
  * Remove the binding at `index`, then drop the matching target endpoint from the source's ACL
  * entry on the (binding) target node. Matches on the binding's TARGET endpoint.
@@ -91,6 +111,7 @@ export async function deleteBindingAtIndex(
     sourceNode: MatterNode,
     sourceEndpoint: number,
     index: number,
+    fabricIndex?: number,
 ): Promise<void> {
     const bindings = await freshBindings(client, sourceNode.node_id, sourceEndpoint);
     const removed = bindings[index];
@@ -100,11 +121,14 @@ export async function deleteBindingAtIndex(
 
     if (removed.node == null || removed.endpoint == null) return;
     const targetEndpoint = removed.endpoint;
-    const acl = await freshAcl(client, removed.node);
+    const removedCluster = removed.cluster ?? undefined;
+    const acl = entriesForFabric(await freshAcl(client, removed.node), fabricIndex);
     const kept = acl
         .map(e => {
             if (!subjectsInclude(e, sourceNode.node_id) || isWholeNode(e)) return e;
-            const targets = e.targets!.filter(t => t.endpoint !== targetEndpoint);
+            const targets = e.targets!.filter(
+                t => !(t.endpoint === targetEndpoint && (t.cluster ?? undefined) === removedCluster),
+            );
             if (targets.length === 0) return undefined;
             return { ...e, targets };
         })

--- a/packages/dashboard/src/components/dialogs/binding/model.ts
+++ b/packages/dashboard/src/components/dialogs/binding/model.ts
@@ -44,7 +44,8 @@ export class BindingEntryDataTransformer {
                 const mappedKey = keyMapping[key];
                 if (mappedKey) {
                     const value = input[key];
-                    if (value === undefined) {
+                    // Treat unset/wildcard fields (null or absent) as omitted, not numeric 0.
+                    if (value == null) {
                         continue;
                     }
                     if (mappedKey === "node") {

--- a/packages/dashboard/src/components/dialogs/binding/model.ts
+++ b/packages/dashboard/src/components/dialogs/binding/model.ts
@@ -16,6 +16,10 @@ export interface BindingEntryStruct {
     fabricIndex: number | undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
 export class BindingEntryDataTransformer {
     private static readonly KEY_MAPPING: {
         [inputKey: string]: keyof BindingEntryStruct;
@@ -27,8 +31,8 @@ export class BindingEntryDataTransformer {
         "254": "fabricIndex",
     };
 
-    public static transform(input: any): BindingEntryStruct {
-        if (!input || typeof input !== "object") {
+    public static transform(input: unknown): BindingEntryStruct {
+        if (!isRecord(input)) {
             throw new Error("Invalid input: expected an object");
         }
 
@@ -45,7 +49,9 @@ export class BindingEntryDataTransformer {
                     }
                     if (mappedKey === "node") {
                         // Node IDs can be bigint - preserve the original type
-                        result[mappedKey] = value;
+                        if (typeof value === "number" || typeof value === "bigint") {
+                            result.node = value;
+                        }
                     } else {
                         // group, endpoint, cluster, fabricIndex are all numeric
                         result[mappedKey] = Number(value);

--- a/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
@@ -116,7 +116,7 @@ export class NodeBindingDialog extends LitElement {
 
         this._busy = true;
         try {
-            await addBinding(this.client, this.node!, this.endpoint, targetNodeId, endpoint, cluster);
+            await addBinding(this.client, this.node!, this.endpoint, targetNodeId, endpoint, cluster, fabricIndex);
             this._close();
         } catch (err) {
             await showAlertDialog({

--- a/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
@@ -20,6 +20,7 @@ import { nodeIdKey } from "../../../util/access-control.js";
 import { handleAsync } from "../../../util/async-handler.js";
 import { bindableClusters, targetAclCapacityForBinding } from "../../../util/binding.js";
 import { getEndpointDeviceTypes } from "../../../util/endpoints.js";
+import { getDeviceName } from "../../../util/node-name.js";
 import { preventDefault } from "../../../util/prevent_default.js";
 import { showAlertDialog } from "../../dialog-box/show-dialog-box.js";
 import { addBinding } from "./binding-actions.js";
@@ -223,7 +224,7 @@ export class NodeBindingDialog extends LitElement {
                             ${this._knownNodes().map(
                                 n =>
                                     html`<md-select-option value=${nodeIdKey(n.node_id)}>
-                                        <div slot="headline">${n.node_id.toString()} · ${n.nodeLabel || "Unknown"}</div>
+                                        <div slot="headline">${n.node_id.toString()} · ${getDeviceName(n)}</div>
                                     </md-select-option>`,
                             )}
                         </md-outlined-select>

--- a/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
@@ -6,27 +6,26 @@
 
 import "@material/web/button/text-button";
 import "@material/web/dialog/dialog";
-import { consume } from "@lit/context";
-import "@material/web/list/list";
-import "@material/web/list/list-item";
+import "@material/web/select/outlined-select";
+import "@material/web/select/select-option";
 import "@material/web/textfield/outlined-text-field";
+import { consume } from "@lit/context";
 import type { MdDialog } from "@material/web/dialog/dialog.js";
-import "../../../components/ha-svg-icon";
-import type { MdOutlinedTextField } from "@material/web/textfield/outlined-text-field.js";
-import { AccessControlEntry, BindingTarget, MatterClient, MatterNode } from "@matter-server/ws-client";
+import { MatterClient, MatterNode } from "@matter-server/ws-client";
 import { css, html, LitElement, nothing } from "lit";
-import { customElement, property, query } from "lit/decorators.js";
-import { clientContext } from "../../../client/client-context.js";
+import { customElement, property, state } from "lit/decorators.js";
+import { clusters } from "../../../client/models/descriptions.js";
+import { getEndpointDeviceTypes } from "../../../pages/matter-endpoint-view.js";
+import { nodeIdKey } from "../../../util/access-control.js";
 import { handleAsync } from "../../../util/async-handler.js";
-import { analyzeBatchResults, type MatterBatchResult } from "../../../util/matter-status.js";
+import { bindableClusters, targetAclCapacityForBinding } from "../../../util/binding.js";
+import { clientContext } from "../../../client/client-context.js";
 import { preventDefault } from "../../../util/prevent_default.js";
-import { showAlertDialog, showPromptDialog } from "../../dialog-box/show-dialog-box.js";
-import {
-    AccessControlEntryDataTransformer,
-    AccessControlEntryStruct,
-    AccessControlTargetStruct,
-} from "../acl/model.js";
-import { BindingEntryDataTransformer, BindingEntryStruct, InputType } from "./model.js";
+import { showAlertDialog } from "../../dialog-box/show-dialog-box.js";
+import { addBinding } from "./binding-actions.js";
+
+const ALL_CLUSTERS = "all";
+const CUSTOM_CLUSTER = "custom";
 
 @customElement("node-binding-dialog")
 export class NodeBindingDialog extends LitElement {
@@ -40,290 +39,92 @@ export class NodeBindingDialog extends LitElement {
     @property({ attribute: false })
     endpoint!: number;
 
-    @query("md-outlined-text-field[name='NodeId']")
-    private _targetNodeId!: MdOutlinedTextField;
+    @state() private _nodeIdInput = "";
+    @state() private _endpointInput = "";
+    @state() private _clusterSelection = ALL_CLUSTERS;
+    @state() private _customClusterInput = "";
+    @state() private _busy = false;
 
-    @query("md-outlined-text-field[name='Endpoint']")
-    private _targetEndpoint!: MdOutlinedTextField;
-
-    @query("md-outlined-text-field[name='Cluster']")
-    private _targetCluster!: MdOutlinedTextField;
-
-    private fetchBindingEntry(): BindingEntryStruct[] {
-        const bindings_raw = this.node!.attributes[this.endpoint + "/30/0"] as InputType[] | undefined;
-        if (!bindings_raw) return [];
-        return Object.values(bindings_raw).map(value => BindingEntryDataTransformer.transform(value));
+    private _knownNodes(): MatterNode[] {
+        return Object.values(this.client.nodes)
+            .filter(n => nodeIdKey(n.node_id) !== nodeIdKey(this.node!.node_id))
+            .sort((a, b) => (a.nodeLabel || "").localeCompare(b.nodeLabel || ""));
     }
 
-    private fetchACLEntry(targetNodeId: number | bigint): AccessControlEntryStruct[] {
-        const acl_cluster_raw = this.client.nodes[String(targetNodeId)]?.attributes["0/31/0"] as
-            | InputType[]
-            | undefined;
-        if (!acl_cluster_raw) return [];
-        return Object.values(acl_cluster_raw).map((value: InputType) =>
-            AccessControlEntryDataTransformer.transform(value),
-        );
+    private _resolveTarget(): MatterNode | undefined {
+        const raw = this._nodeIdInput.trim();
+        if (!/^\d+$/.test(raw)) return undefined;
+        return this.client.nodes[nodeIdKey(BigInt(raw))];
     }
 
-    private async deleteBindingHandler(index: number): Promise<void> {
-        const rawBindings = this.fetchBindingEntry();
-        try {
-            const targetNodeId = rawBindings[index].node;
-            const endpoint = rawBindings[index].endpoint;
-            if (targetNodeId === undefined || endpoint === undefined) return;
-            let aclCleanedUp = false;
-            try {
-                await this.removeNodeAtACLEntry(this.node!.node_id, endpoint, targetNodeId);
-                aclCleanedUp = true;
-            } catch (aclError) {
-                const errorMessage = aclError instanceof Error ? aclError.message : String(aclError);
-                const proceed = await showPromptDialog({
-                    title: "ACL cleanup failed",
-                    text:
-                        `Could not clean up ACL on target node ${targetNodeId}: ${errorMessage}. ` +
-                        "The target node may no longer exist or be unreachable. " +
-                        "Do you want to remove the binding anyway? " +
-                        "Note: The target device may retain an outdated ACL entry.",
-                    confirmText: "Remove binding",
-                });
-                if (!proceed) return;
-            }
-            try {
-                const updatedBindings = this.removeBindingAtIndex(rawBindings, index);
-                await this.syncBindingUpdates(updatedBindings, index);
-            } catch (bindingError) {
-                const errorMessage = bindingError instanceof Error ? bindingError.message : String(bindingError);
-                await showAlertDialog({
-                    title: "Binding removal failed",
-                    text:
-                        `Failed to remove the binding: ${errorMessage}. ` +
-                        (aclCleanedUp
-                            ? "The ACL on the target device was already updated. " +
-                              "The binding and ACL may now be out of sync."
-                            : "No changes were made."),
-                });
-                return;
-            }
-        } catch (error) {
-            this.handleBindingDeletionError(error);
+    private _nodeEndpoints(target: MatterNode): number[] {
+        const eps = new Set<number>();
+        for (const key of Object.keys(target.attributes)) {
+            const m = /^(\d+)\/29\/0$/.exec(key);
+            if (m) eps.add(Number(m[1]));
         }
+        return Array.from(eps).sort((a, b) => a - b);
     }
 
-    private async removeNodeAtACLEntry(
-        sourceNodeId: number | bigint,
-        sourceEndpoint: number,
-        targetNodeId: number | bigint,
-    ): Promise<void> {
-        const aclEntries = this.fetchACLEntry(targetNodeId);
-
-        const updatedACLEntries = aclEntries
-            .map(entry => this.removeEntryAtACL(sourceNodeId, sourceEndpoint, entry))
-            .filter((entry): entry is AccessControlEntryStruct => entry !== undefined);
-
-        // Convert to API format (without fabricIndex - server handles it)
-        const apiEntries = updatedACLEntries.map(e => this.toAccessControlEntry(e));
-        await this.client.setACLEntry(targetNodeId, apiEntries);
+    private _clusterLabel(id: number): string {
+        return `${clusters[id]?.label ?? "Cluster"} (0x${id.toString(16).padStart(2, "0").toUpperCase()})`;
     }
 
-    private removeEntryAtACL(
-        nodeId: number | bigint,
-        sourceEndpoint: number,
-        entry: AccessControlEntryStruct,
-    ): AccessControlEntryStruct | undefined {
-        const hasSubject = entry.subjects.includes(nodeId);
-        if (!hasSubject) return entry;
-
-        const hasTarget = entry.targets!.filter(item => item.endpoint === sourceEndpoint);
-        return hasTarget.length > 0 ? undefined : entry;
+    private _onNodeSelect(e: Event) {
+        const select = e.target as HTMLSelectElement;
+        this._nodeIdInput = select.value;
+        this._endpointInput = "";
+        this._clusterSelection = ALL_CLUSTERS;
     }
 
-    private removeBindingAtIndex(bindings: BindingEntryStruct[], index: number): BindingEntryStruct[] {
-        return [...bindings.slice(0, index), ...bindings.slice(index + 1)];
-    }
-
-    private async syncBindingUpdates(updatedBindings: BindingEntryStruct[], index: number): Promise<void> {
-        // Convert to API format (without fabricIndex - server handles it)
-        const apiBindings = updatedBindings.map(b => this.toBindingTarget(b));
-        await this.client.setNodeBinding(this.node!.node_id, this.endpoint, apiBindings);
-
-        const attributePath = `${this.endpoint}/30/0`;
-        const currentBindings = this.node!.attributes[attributePath] as BindingEntryStruct[] | undefined;
-        const updatedAttributes = {
-            ...this.node!.attributes,
-            [attributePath]: currentBindings ? this.removeBindingAtIndex(currentBindings, index) : [],
-        };
-
-        this.node!.attributes = updatedAttributes;
-        this.requestUpdate();
-    }
-
-    private handleBindingDeletionError(error: unknown): void {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error(`Binding deletion failed: ${errorMessage}`);
-    }
-
-    private async add_target_acl(
-        targetNodeId: number | bigint,
-        entry: AccessControlEntryStruct,
-    ): Promise<MatterBatchResult> {
-        try {
-            // Fetch existing ACL entries and transform to local struct format
-            const rawEntries = this.client.nodes[String(targetNodeId)]?.attributes["0/31/0"] as InputType[] | undefined;
-            const entries = rawEntries
-                ? Object.values(rawEntries).map(v => AccessControlEntryDataTransformer.transform(v))
-                : [];
-            entries.push(entry);
-
-            // Convert to API format (without fabricIndex - server handles it)
-            const apiEntries = entries.map(e => this.toAccessControlEntry(e));
-            const results = await this.client.setACLEntry(targetNodeId, apiEntries);
-
-            const batchResult = analyzeBatchResults(results);
-            if (batchResult.outcome !== "all_success") {
-                console.error(`Set ACL entry: ${batchResult.message}`);
-            }
-            return batchResult;
-        } catch (err) {
-            console.error("Add ACL error:", err);
-            return {
-                outcome: "all_failed",
-                successCount: 0,
-                failureCount: 1,
-                errorCounts: { 1: 1 },
-                message: `Exception: ${err instanceof Error ? err.message : String(err)}`,
-            };
+    private async _add() {
+        const target = this._resolveTarget();
+        const rawNodeId = this._nodeIdInput.trim();
+        if (!/^\d+$/.test(rawNodeId) || BigInt(rawNodeId) <= 0n) {
+            await showAlertDialog({ title: "Validation error", text: "Please enter a valid target node id." });
+            return;
         }
-    }
-
-    /** Convert local BindingEntryStruct to API BindingTarget (without fabricIndex) */
-    private toBindingTarget(entry: BindingEntryStruct): BindingTarget {
-        return {
-            node: entry.node ?? null,
-            group: entry.group ?? null,
-            endpoint: entry.endpoint ?? null,
-            cluster: entry.cluster ?? null,
-        };
-    }
-
-    /** Convert local AccessControlEntryStruct to API AccessControlEntry (without fabricIndex) */
-    private toAccessControlEntry(entry: AccessControlEntryStruct): AccessControlEntry {
-        return {
-            privilege: entry.privilege,
-            auth_mode: entry.authMode,
-            subjects: entry.subjects ?? null,
-            targets:
-                entry.targets?.map(t => ({
-                    cluster: t.cluster ?? null,
-                    endpoint: t.endpoint ?? null,
-                    device_type: t.deviceType ?? null,
-                })) ?? null,
-        };
-    }
-
-    private async add_bindings(endpoint: number, bindingEntry: BindingEntryStruct): Promise<MatterBatchResult> {
-        const bindings = this.fetchBindingEntry();
-        bindings.push(bindingEntry);
-        try {
-            // Convert to API format (without fabricIndex - server handles it)
-            const apiBindings = bindings.map(b => this.toBindingTarget(b));
-            const results = await this.client.setNodeBinding(this.node!.node_id, endpoint, apiBindings);
-
-            const batchResult = analyzeBatchResults(results);
-            if (batchResult.outcome !== "all_success") {
-                console.error(`Set binding: ${batchResult.message}`);
-            }
-            return batchResult;
-        } catch (err) {
-            console.error("Add bindings error:", err);
-            return {
-                outcome: "all_failed",
-                successCount: 0,
-                failureCount: 1,
-                errorCounts: { 1: 1 },
-                message: `Exception: ${err instanceof Error ? err.message : String(err)}`,
-            };
-        }
-    }
-
-    async addBindingHandler() {
-        let targetNodeId: bigint | undefined;
-        const rawNodeId = this._targetNodeId.value?.trim();
-        if (rawNodeId) {
-            if (!/^\d+$/.test(rawNodeId)) {
-                showAlertDialog({ title: "Validation error", text: "Please enter a valid target node ID" });
-                return;
-            }
-            targetNodeId = BigInt(rawNodeId);
-        }
-        const targetEndpoint = this._targetEndpoint.value ? parseInt(this._targetEndpoint.value, 10) : undefined;
-        const targetCluster = this._targetCluster.value ? parseInt(this._targetCluster.value, 10) : undefined;
-
-        if (targetNodeId === undefined || targetNodeId <= 0n) {
-            showAlertDialog({ title: "Validation error", text: "Please enter a valid target node ID" });
+        const targetNodeId = BigInt(rawNodeId);
+        const endpoint = parseInt(this._endpointInput, 10);
+        if (Number.isNaN(endpoint) || endpoint < 0 || endpoint > 0xfffe) {
+            await showAlertDialog({ title: "Validation error", text: "Please enter a valid target endpoint." });
             return;
         }
 
-        if (targetEndpoint === undefined || targetEndpoint <= 0 || targetEndpoint > 0xfffe) {
-            showAlertDialog({ title: "Validation error", text: "Please enter a valid target endpoint" });
-            return;
-        }
-
-        // cluster optional
-        if (targetCluster !== undefined) {
-            // We ignore vendor specific clusters for now
-            if (targetCluster < 0 || targetCluster > 0x7fff) {
-                showAlertDialog({ title: "Validation error", text: "Please enter a valid target cluster" });
+        let cluster: number | undefined;
+        if (this._clusterSelection === ALL_CLUSTERS) {
+            cluster = undefined;
+        } else if (this._clusterSelection === CUSTOM_CLUSTER) {
+            const c = parseInt(this._customClusterInput, 10);
+            if (Number.isNaN(c) || c < 0 || c > 0x7fff) {
+                await showAlertDialog({ title: "Validation error", text: "Please enter a valid cluster id." });
                 return;
             }
-        }
-
-        const targets: AccessControlTargetStruct = {
-            endpoint: targetEndpoint,
-            cluster: targetCluster,
-            deviceType: undefined,
-        };
-
-        // Note: fabricIndex is assigned by the server based on the device's fabric table
-        const acl_entry: AccessControlEntryStruct = {
-            privilege: 3,
-            authMode: 2,
-            subjects: [this.node!.node_id],
-            targets: [targets],
-            fabricIndex: 0, // Placeholder - server will use correct fabric index
-        };
-
-        const aclResult = await this.add_target_acl(targetNodeId, acl_entry);
-        if (aclResult.outcome === "all_failed") {
-            showAlertDialog({ title: "Failed to add ACL entry", text: aclResult.message });
-            return;
-        }
-        if (aclResult.outcome === "partial") {
-            showAlertDialog({ title: "ACL entry partially failed", text: aclResult.message });
-            // Continue with binding attempt since some ACL entries succeeded
-        }
-
-        const endpoint = this.endpoint;
-        // Note: fabricIndex is assigned by the server based on the device's fabric table
-        const bindingEntry: BindingEntryStruct = {
-            node: targetNodeId,
-            endpoint: targetEndpoint,
-            group: undefined,
-            cluster: targetCluster,
-            fabricIndex: undefined, // Server will use correct fabric index
-        };
-
-        const bindingResult = await this.add_bindings(endpoint, bindingEntry);
-
-        if (bindingResult.outcome === "all_success") {
-            this._targetNodeId.value = "";
-            this._targetEndpoint.value = "";
-            this._targetCluster.value = "";
-            this.requestUpdate();
-        } else if (bindingResult.outcome === "partial") {
-            showAlertDialog({ title: "Binding partially failed", text: bindingResult.message });
-            this.requestUpdate(); // Update UI to show what succeeded
+            cluster = c;
         } else {
-            showAlertDialog({ title: "Failed to add binding", text: bindingResult.message });
+            cluster = parseInt(this._clusterSelection, 10);
+        }
+
+        const fabricIndex = this.client.serverInfo?.fabric_index;
+        if (target) {
+            const capacity = targetAclCapacityForBinding(target, this.node!.node_id, fabricIndex);
+            if (!capacity.canAdd) {
+                await showAlertDialog({ title: "Cannot add binding", text: capacity.reason ?? "Target ACL is full." });
+                return;
+            }
+        }
+
+        this._busy = true;
+        try {
+            await addBinding(this.client, this.node!, this.endpoint, targetNodeId, endpoint, cluster);
+            this._close();
+        } catch (err) {
+            await showAlertDialog({
+                title: "Failed to add binding",
+                text: err instanceof Error ? err.message : String(err),
+            });
+        } finally {
+            this._busy = false;
         }
     }
 
@@ -332,149 +133,167 @@ export class NodeBindingDialog extends LitElement {
     }
 
     private _handleClosed() {
-        this.parentNode!.removeChild(this);
+        this.parentNode?.removeChild(this);
     }
 
-    private onChange(e: Event) {
-        const textfield = e.target as MdOutlinedTextField;
-        if (textfield.type === "number" && textfield.max && textfield.min) {
-            const value = parseInt(textfield.value, 10);
-            if (parseInt(textfield.max, 10) < value || value < parseInt(textfield.min, 10)) {
-                textfield.error = true;
-                textfield.errorText = "value error";
-            } else {
-                textfield.error = false;
-            }
-        } else {
-            // Text field with pattern validation (e.g. node ID)
-            textfield.error = textfield.value !== "" && !/^[0-9]+$/.test(textfield.value);
-            if (textfield.error) {
-                textfield.errorText = "must be a numeric value";
-            }
-        }
+    private _renderClusterField(target: MatterNode | undefined, endpoint: number | undefined) {
+        const known = target !== undefined && endpoint !== undefined && !Number.isNaN(endpoint);
+        const split = known ? bindableClusters(this.node!, this.endpoint, target, endpoint) : undefined;
+        const nonBindable =
+            split !== undefined &&
+            this._clusterSelection !== ALL_CLUSTERS &&
+            this._clusterSelection !== CUSTOM_CLUSTER &&
+            split.otherTarget.includes(parseInt(this._clusterSelection, 10));
+
+        return html`
+            <md-outlined-select
+                label="Cluster"
+                .value=${this._clusterSelection}
+                ?disabled=${this._busy}
+                @change=${(e: Event) => (this._clusterSelection = (e.target as HTMLSelectElement).value)}
+            >
+                <md-select-option value=${ALL_CLUSTERS}>
+                    <div slot="headline">All clusters (any eligible)</div>
+                </md-select-option>
+                ${split && split.bindable.length
+                    ? html`<md-select-option disabled><div slot="headline">— Bindable —</div></md-select-option>
+                          ${split.bindable.map(
+                              c =>
+                                  html`<md-select-option value=${String(c)}
+                                      ><div slot="headline">${this._clusterLabel(c)}</div></md-select-option
+                                  >`,
+                          )}`
+                    : nothing}
+                ${split && split.otherTarget.length
+                    ? html`<md-select-option disabled
+                              ><div slot="headline">— Other target clusters (⚠) —</div></md-select-option
+                          >
+                          ${split.otherTarget.map(
+                              c =>
+                                  html`<md-select-option value=${String(c)}
+                                      ><div slot="headline">${this._clusterLabel(c)}</div></md-select-option
+                                  >`,
+                          )}`
+                    : nothing}
+                <md-select-option value=${CUSTOM_CLUSTER}><div slot="headline">Custom cluster id…</div></md-select-option>
+            </md-outlined-select>
+            ${this._clusterSelection === CUSTOM_CLUSTER
+                ? html`<md-outlined-text-field
+                      label="cluster id"
+                      type="number"
+                      min="0"
+                      max="32767"
+                      .value=${this._customClusterInput}
+                      ?disabled=${this._busy}
+                      @input=${(e: Event) => (this._customClusterInput = (e.target as HTMLInputElement).value)}
+                  ></md-outlined-text-field>`
+                : nothing}
+            ${nonBindable
+                ? html`<div class="warn">
+                      ⚠ This cluster is not a client cluster on the source endpoint. The binding may not function — it
+                      will be added anyway on your request.
+                  </div>`
+                : nothing}
+        `;
     }
 
     protected override render() {
-        const rawBindings = this.node!.attributes[this.endpoint + "/30/0"] as InputType[] | undefined;
-        const bindings = rawBindings
-            ? Object.values(rawBindings).map(entry => BindingEntryDataTransformer.transform(entry))
-            : [];
+        if (!this.node) return nothing;
+        const target = this._resolveTarget();
+        const endpoint = this._endpointInput === "" ? undefined : parseInt(this._endpointInput, 10);
+        const endpoints = target ? this._nodeEndpoints(target) : [];
 
         return html`
             <md-dialog open @cancel=${preventDefault} @closed=${this._handleClosed}>
-                <div slot="headline">
-                    <div>Binding</div>
-                </div>
+                <div slot="headline">Add binding</div>
                 <div slot="content">
-                    <div>
-                        <md-list style="padding-bottom:16px;">
-                            ${Object.values(bindings).map(
-                                (entry, index) => html`
-                  <md-list-item class="binding-item">
-                    <div style="display:flex;gap:8px;">
-                        <div>node:${entry["node"]}</div>
-                        <div>endpoint:${entry["endpoint"]}</div>
-                        ${entry["cluster"] ? html` <div>cluster:${entry["cluster"]}</div> ` : nothing}
-                    </div>
-                    <div slot="end">
-                      <md-text-button
-                        @click=${handleAsync(() => this.deleteBindingHandler(index))}
-                      >delete</md-text-button
-                    </div>
-                  </md-list-item>
-                `,
+                    <div class="form">
+                        <md-outlined-select
+                            label="Known nodes"
+                            ?disabled=${this._busy}
+                            .value=${target ? this._nodeIdInput : ""}
+                            @change=${this._onNodeSelect}
+                        >
+                            <md-select-option value=""><div slot="headline">— pick a node —</div></md-select-option>
+                            ${this._knownNodes().map(
+                                n =>
+                                    html`<md-select-option value=${nodeIdKey(n.node_id)}>
+                                        <div slot="headline">${n.nodeLabel || "Unknown"} · ${n.node_id.toString()}</div>
+                                    </md-select-option>`,
                             )}
-                        </md-list>
-                        <div class="inline-group">
-                            <div class="group-label">target</div>
-                            <div class="group-input">
-                                <md-outlined-text-field
-                                    label="node id"
-                                    name="NodeId"
-                                    type="text"
-                                    pattern="[0-9]+"
-                                    class="target-item"
-                                    @change=${this.onChange}
-                                    supporting-text="required"
-                                ></md-outlined-text-field>
-                                <md-outlined-text-field
-                                    label="endpoint"
-                                    name="Endpoint"
-                                    type="number"
-                                    min="0"
-                                    max="65534"
-                                    @change=${this.onChange}
-                                    class="target-item"
-                                    supporting-text="required"
-                                ></md-outlined-text-field>
-                                <md-outlined-text-field
-                                    label="cluster"
-                                    name="Cluster"
-                                    type="number"
-                                    min="0"
-                                    max="32767"
-                                    @change=${this.onChange}
-                                    class="target-item"
-                                    supporting-text="optional"
-                                ></md-outlined-text-field>
-                            </div>
-                        </div>
-                        <div style="margin:8px;">
-                            <span style="font-size: 0.75rem;font-style: italic;font-weight: bold;">
-                                Note: The Cluster ID field is optional according to the Matter specification. If you
-                                leave it blank, the binding applies to all eligible clusters on the target endpoint.
-                                However, some devices may require a specific cluster to be set in order for the binding
-                                to function correctly. If you experience unexpected behavior, try specifying the cluster
-                                explicitly.
-                            </span>
-                        </div>
+                        </md-outlined-select>
+                        <md-outlined-text-field
+                            label="Target node id"
+                            type="text"
+                            pattern="[0-9]+"
+                            supporting-text="required — pick above or enter a raw node id"
+                            .value=${this._nodeIdInput}
+                            ?disabled=${this._busy}
+                            @input=${(e: Event) => {
+                                this._nodeIdInput = (e.target as HTMLInputElement).value;
+                                this._endpointInput = "";
+                                this._clusterSelection = ALL_CLUSTERS;
+                            }}
+                        ></md-outlined-text-field>
+
+                        ${target
+                            ? html`<md-outlined-select
+                                  label="Target endpoint"
+                                  ?disabled=${this._busy}
+                                  .value=${this._endpointInput}
+                                  @change=${(e: Event) => {
+                                      this._endpointInput = (e.target as HTMLSelectElement).value;
+                                      this._clusterSelection = ALL_CLUSTERS;
+                                  }}
+                              >
+                                  ${endpoints.map(
+                                      ep =>
+                                          html`<md-select-option value=${String(ep)}>
+                                              <div slot="headline">
+                                                  EP ${ep}${getEndpointDeviceTypes(target, ep)[0]
+                                                      ? ` · ${getEndpointDeviceTypes(target, ep)[0].label}`
+                                                      : ""}
+                                              </div>
+                                          </md-select-option>`,
+                                  )}
+                              </md-outlined-select>`
+                            : html`<md-outlined-text-field
+                                  label="Target endpoint"
+                                  type="number"
+                                  min="0"
+                                  max="65534"
+                                  supporting-text=${this._nodeIdInput.trim() === ""
+                                      ? "enter a node id first"
+                                      : "unknown node — enter endpoint manually"}
+                                  ?disabled=${this._busy || this._nodeIdInput.trim() === ""}
+                                  .value=${this._endpointInput}
+                                  @input=${(e: Event) => (this._endpointInput = (e.target as HTMLInputElement).value)}
+                              ></md-outlined-text-field>`}
+
+                        ${this._renderClusterField(target, endpoint)}
                     </div>
                 </div>
                 <div slot="actions">
-                    <md-text-button @click=${handleAsync(() => this.addBindingHandler())}>Add</md-text-button>
-                    <md-text-button @click=${this._close}>Cancel</md-text-button>
+                    <md-text-button ?disabled=${this._busy} @click=${handleAsync(() => this._add())}>Add</md-text-button>
+                    <md-text-button ?disabled=${this._busy} @click=${this._close}>Cancel</md-text-button>
                 </div>
             </md-dialog>
         `;
     }
 
     static override styles = css`
-        .binding-item {
-            background: var(--md-sys-color-surface-container-high);
-        }
-
-        .inline-group {
+        .form {
             display: flex;
-            border: 2px solid var(--md-sys-color-primary);
-            padding: 1px;
-            border-radius: 8px;
-            position: relative;
-            margin: 8px;
+            flex-direction: column;
+            gap: 12px;
+            min-width: 320px;
         }
-
-        .group-input {
-            display: flex;
-            width: -webkit-fill-available;
-        }
-
-        .target-item {
-            display: inline-block;
-            padding: 16px 8px 8px 8px;
-            border-radius: 4px;
-            vertical-align: middle;
-            min-width: 80px;
-            text-align: center;
-            width: -webkit-fill-available;
-        }
-
-        .group-label {
-            position: absolute;
-            left: 16px;
-            top: -12px;
-            background: var(--md-sys-color-primary);
-            color: var(--md-sys-color-on-primary);
-            padding: 4px 16px;
-            border-radius: 4px;
+        .warn {
+            font-size: 12px;
+            padding: 8px 10px;
+            border-radius: 7px;
+            background: var(--md-sys-color-error-container);
+            color: var(--md-sys-color-on-error-container);
         }
     `;
 }

--- a/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
@@ -14,12 +14,12 @@ import type { MdDialog } from "@material/web/dialog/dialog.js";
 import { MatterClient, MatterNode } from "@matter-server/ws-client";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { clientContext } from "../../../client/client-context.js";
 import { clusters } from "../../../client/models/descriptions.js";
 import { getEndpointDeviceTypes } from "../../../pages/matter-endpoint-view.js";
 import { nodeIdKey } from "../../../util/access-control.js";
 import { handleAsync } from "../../../util/async-handler.js";
 import { bindableClusters, targetAclCapacityForBinding } from "../../../util/binding.js";
-import { clientContext } from "../../../client/client-context.js";
 import { preventDefault } from "../../../util/prevent_default.js";
 import { showAlertDialog } from "../../dialog-box/show-dialog-box.js";
 import { addBinding } from "./binding-actions.js";
@@ -175,7 +175,9 @@ export class NodeBindingDialog extends LitElement {
                                   >`,
                           )}`
                     : nothing}
-                <md-select-option value=${CUSTOM_CLUSTER}><div slot="headline">Custom cluster id…</div></md-select-option>
+                <md-select-option value=${CUSTOM_CLUSTER}
+                    ><div slot="headline">Custom cluster id…</div></md-select-option
+                >
             </md-outlined-select>
             ${this._clusterSelection === CUSTOM_CLUSTER
                 ? html`<md-outlined-text-field
@@ -250,7 +252,8 @@ export class NodeBindingDialog extends LitElement {
                                       ep =>
                                           html`<md-select-option value=${String(ep)}>
                                               <div slot="headline">
-                                                  EP ${ep}${getEndpointDeviceTypes(target, ep)[0]
+                                                  EP
+                                                  ${ep}${getEndpointDeviceTypes(target, ep)[0]
                                                       ? ` · ${getEndpointDeviceTypes(target, ep)[0].label}`
                                                       : ""}
                                               </div>
@@ -269,12 +272,13 @@ export class NodeBindingDialog extends LitElement {
                                   .value=${this._endpointInput}
                                   @input=${(e: Event) => (this._endpointInput = (e.target as HTMLInputElement).value)}
                               ></md-outlined-text-field>`}
-
                         ${this._renderClusterField(target, endpoint)}
                     </div>
                 </div>
                 <div slot="actions">
-                    <md-text-button ?disabled=${this._busy} @click=${handleAsync(() => this._add())}>Add</md-text-button>
+                    <md-text-button ?disabled=${this._busy} @click=${handleAsync(() => this._add())}
+                        >Add</md-text-button
+                    >
                     <md-text-button ?disabled=${this._busy} @click=${this._close}>Cancel</md-text-button>
                 </div>
             </md-dialog>

--- a/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
@@ -16,10 +16,10 @@ import { css, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { clientContext } from "../../../client/client-context.js";
 import { clusters } from "../../../client/models/descriptions.js";
-import { getEndpointDeviceTypes } from "../../../pages/matter-endpoint-view.js";
 import { nodeIdKey } from "../../../util/access-control.js";
 import { handleAsync } from "../../../util/async-handler.js";
 import { bindableClusters, targetAclCapacityForBinding } from "../../../util/binding.js";
+import { getEndpointDeviceTypes } from "../../../util/endpoints.js";
 import { preventDefault } from "../../../util/prevent_default.js";
 import { showAlertDialog } from "../../dialog-box/show-dialog-box.js";
 import { addBinding } from "./binding-actions.js";
@@ -223,7 +223,7 @@ export class NodeBindingDialog extends LitElement {
                             ${this._knownNodes().map(
                                 n =>
                                     html`<md-select-option value=${nodeIdKey(n.node_id)}>
-                                        <div slot="headline">${n.nodeLabel || "Unknown"} · ${n.node_id.toString()}</div>
+                                        <div slot="headline">${n.node_id.toString()} · ${n.nodeLabel || "Unknown"}</div>
                                     </md-select-option>`,
                             )}
                         </md-outlined-select>

--- a/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
@@ -48,7 +48,11 @@ export class NodeBindingDialog extends LitElement {
     private _knownNodes(): MatterNode[] {
         return Object.values(this.client.nodes)
             .filter(n => nodeIdKey(n.node_id) !== nodeIdKey(this.node!.node_id))
-            .sort((a, b) => (a.nodeLabel || "").localeCompare(b.nodeLabel || ""));
+            .sort((a, b) => {
+                const x = BigInt(a.node_id);
+                const y = BigInt(b.node_id);
+                return x < y ? -1 : x > y ? 1 : 0;
+            });
     }
 
     private _resolveTarget(): MatterNode | undefined {

--- a/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
@@ -252,17 +252,12 @@ export class NodeBindingDialog extends LitElement {
                                       this._clusterSelection = ALL_CLUSTERS;
                                   }}
                               >
-                                  ${endpoints.map(
-                                      ep =>
-                                          html`<md-select-option value=${String(ep)}>
-                                              <div slot="headline">
-                                                  EP
-                                                  ${ep}${getEndpointDeviceTypes(target, ep)[0]
-                                                      ? ` · ${getEndpointDeviceTypes(target, ep)[0].label}`
-                                                      : ""}
-                                              </div>
-                                          </md-select-option>`,
-                                  )}
+                                  ${endpoints.map(ep => {
+                                      const dt = getEndpointDeviceTypes(target, ep)[0];
+                                      return html`<md-select-option value=${String(ep)}>
+                                          <div slot="headline">EP ${ep}${dt ? ` · ${dt.label}` : ""}</div>
+                                      </md-select-option>`;
+                                  })}
                               </md-outlined-select>`
                             : html`<md-outlined-text-field
                                   label="Target endpoint"

--- a/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
@@ -109,9 +109,8 @@ export class NodeBindingDialog extends LitElement {
             cluster = parseInt(this._clusterSelection, 10);
         }
 
-        const fabricIndex = this.client.serverInfo?.fabric_index;
         if (target) {
-            const capacity = targetAclCapacityForBinding(target, this.node!.node_id, fabricIndex);
+            const capacity = targetAclCapacityForBinding(target, this.node!.node_id);
             if (!capacity.canAdd) {
                 await showAlertDialog({ title: "Cannot add binding", text: capacity.reason ?? "Target ACL is full." });
                 return;
@@ -120,7 +119,7 @@ export class NodeBindingDialog extends LitElement {
 
         this._busy = true;
         try {
-            await addBinding(this.client, this.node!, this.endpoint, targetNodeId, endpoint, cluster, fabricIndex);
+            await addBinding(this.client, this.node!, this.endpoint, targetNodeId, endpoint, cluster);
             this._close();
         } catch (err) {
             await showAlertDialog({

--- a/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
@@ -21,15 +21,14 @@ import {
     Privilege,
     aclCapacity,
     aclEntryKey,
-    detectBindingRelationship,
     entriesForFabric,
     isProtectedAdmin,
     isWholeNode,
     nodeIdKey,
     readAclEntries,
-    type RelationshipResult,
 } from "../../../util/access-control.js";
 import { handleAsync } from "../../../util/async-handler.js";
+import { detectBindingRelationship, type RelationshipResult } from "../../../util/binding.js";
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
 
@@ -38,6 +37,7 @@ const CLUSTER_ID = 31;
 @customElement("access-control-cluster-commands")
 class AccessControlClusterCommands extends BaseClusterCommands {
     private _unsubscribe?: () => void;
+    private _loadedKey = "";
     @state() private _busy = false;
 
     override updated(changed: Map<string, unknown>) {
@@ -45,11 +45,27 @@ class AccessControlClusterCommands extends BaseClusterCommands {
         if (changed.has("client") && this.client && !this._unsubscribe) {
             this._unsubscribe = this.client.addEventListener("nodes_changed", () => this.requestUpdate());
         }
+        void this._ensureLoaded();
     }
 
     override disconnectedCallback() {
         super.disconnectedCallback();
         this._unsubscribe?.();
+    }
+
+    /** The acl attribute is fabric-scoped and may be absent from the cache until read. Load it on open. */
+    private async _ensureLoaded() {
+        if (!this.client || !this.node) return;
+        const key = nodeIdKey(this.node.node_id);
+        if (this._loadedKey === key) return;
+        this._loadedKey = key;
+        try {
+            const res = await this.client.readAttribute(this.node.node_id, "0/31/0");
+            for (const [k, v] of Object.entries(res)) this.node.attributes[k] = v;
+            this.requestUpdate();
+        } catch (err) {
+            console.error("Failed to load ACL", err);
+        }
     }
 
     private get _controllerNodeId(): number | bigint | undefined {
@@ -112,19 +128,19 @@ class AccessControlClusterCommands extends BaseClusterCommands {
     private _renderSubjects(entry: AccessControlEntryStruct): TemplateResult {
         const subjects = entry.subjects ?? [];
         if (entry.authMode === AuthMode.Case && subjects.length === 0) {
-            return html`<span class="chip mut">Any node on fabric</span>`;
+            return html`<span class="mut">Any node on fabric</span>`;
         }
         if (entry.authMode === AuthMode.Group) {
-            return html`${subjects.map(s => html`<span class="chip">Group ${s.toString()}</span>`)}`;
+            return html`${subjects.map(s => html`<div class="ident">Group ${s.toString()}</div>`)}`;
         }
         return html`${subjects.map(s => {
             const known = this.client.nodes[nodeIdKey(s)];
             const protectedMe =
                 isProtectedAdmin(entry, this._controllerNodeId) && nodeIdKey(s) === nodeIdKey(this._controllerNodeId!);
-            return html`<span class="chip ${protectedMe ? "me" : ""}"
-                >${protectedMe ? "This controller" : known ? known.nodeLabel || "Unknown" : "Unknown node"} ·
-                <span class="nid">${s.toString()}</span><span class="hex">0x${s.toString(16).toUpperCase()}</span></span
-            >`;
+            return html`<div class="ident ${protectedMe ? "me" : ""}">
+                ${protectedMe ? "This controller" : known ? known.nodeLabel || "Unknown" : "Unknown node"} ·
+                <span class="nid">${s.toString()}</span><span class="hex">0x${s.toString(16).toUpperCase()}</span>
+            </div>`;
         })}`;
     }
 
@@ -167,7 +183,7 @@ class AccessControlClusterCommands extends BaseClusterCommands {
         });
 
         return html`
-            <details class="command-panel" open>
+            <details class="command-panel">
                 <summary>Access Control — ACL Entries (${entries.length})</summary>
                 <div class="command-content">
                     ${overPrivilegedKeys.size >= 2
@@ -272,7 +288,17 @@ class AccessControlClusterCommands extends BaseClusterCommands {
             .acl td {
                 padding: 10px;
                 border-bottom: 1px solid var(--md-sys-color-outline-variant);
-                vertical-align: top;
+                vertical-align: middle;
+            }
+            .ident {
+                line-height: 1.4;
+            }
+            .ident.me {
+                color: var(--md-sys-color-primary);
+                font-weight: 600;
+            }
+            .ident .nid {
+                font-weight: 600;
             }
             .row-warn td {
                 background: var(--md-sys-color-error-container);
@@ -282,7 +308,7 @@ class AccessControlClusterCommands extends BaseClusterCommands {
                 display: inline-block;
                 padding: 2px 8px;
                 border-radius: 999px;
-                font-size: 11px;
+                font-size: 12px;
                 font-weight: 700;
             }
             .pv-5 {
@@ -309,7 +335,7 @@ class AccessControlClusterCommands extends BaseClusterCommands {
                 padding: 3px 8px;
                 border-radius: 6px;
                 margin: 2px 4px 2px 0;
-                font-size: 12px;
+                font-size: inherit;
                 background: var(--md-sys-color-surface-container-high);
                 color: var(--md-sys-color-on-surface);
             }

--- a/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
@@ -24,6 +24,7 @@ import {
     entriesForFabric,
     isProtectedAdmin,
     isWholeNode,
+    nodeFabricIndex,
     nodeIdKey,
     readAclEntries,
 } from "../../../util/access-control.js";
@@ -72,12 +73,8 @@ class AccessControlClusterCommands extends BaseClusterCommands {
         return this.client.serverInfo?.controller_node_id;
     }
 
-    private get _fabricIndex(): number | undefined {
-        return this.client.serverInfo?.fabric_index;
-    }
-
     private _entries(): AccessControlEntryStruct[] {
-        return entriesForFabric(readAclEntries(this.node), this._fabricIndex);
+        return entriesForFabric(readAclEntries(this.node), nodeFabricIndex(this.node));
     }
 
     private _clusterName(id: number | undefined): string {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
@@ -56,7 +56,7 @@ class AccessControlClusterCommands extends BaseClusterCommands {
 
     /** The acl attribute is fabric-scoped and may be absent from the cache until read. Load it on open. */
     private async _ensureLoaded() {
-        if (!this.client || !this.node) return;
+        if (!this.client || !this.node || !this.node.available) return;
         const key = nodeIdKey(this.node.node_id);
         if (this._loadedKey === key) return;
         this._loadedKey = key;

--- a/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
@@ -1,0 +1,382 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import "@material/web/button/outlined-button";
+import { mdiAlert, mdiLink, mdiLock, mdiTrashCan } from "@mdi/js";
+import { css, html, nothing, type CSSResultGroup, type TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import "../../../components/ha-svg-icon.js";
+import { clusters } from "../../../client/models/descriptions.js";
+import { showAlertDialog, showPromptDialog } from "../../../components/dialog-box/show-dialog-box.js";
+import { deleteAclEntry, downgradeToOperate } from "../../../components/dialogs/acl/acl-actions.js";
+import type { AccessControlEntryStruct } from "../../../components/dialogs/acl/model.js";
+import { showNodeAclAddDialog } from "../../../components/dialogs/acl/show-node-acl-add-dialog.js";
+import {
+    AUTH_MODE_NAMES,
+    AuthMode,
+    PRIVILEGE_NAMES,
+    Privilege,
+    aclCapacity,
+    aclEntryKey,
+    detectBindingRelationship,
+    entriesForFabric,
+    isProtectedAdmin,
+    isWholeNode,
+    nodeIdKey,
+    readAclEntries,
+    type RelationshipResult,
+} from "../../../util/access-control.js";
+import { handleAsync } from "../../../util/async-handler.js";
+import { BaseClusterCommands } from "../base-cluster-commands.js";
+import { registerClusterCommands } from "../registry.js";
+
+const CLUSTER_ID = 31;
+
+@customElement("access-control-cluster-commands")
+class AccessControlClusterCommands extends BaseClusterCommands {
+    private _unsubscribe?: () => void;
+    @state() private _busy = false;
+
+    override updated(changed: Map<string, unknown>) {
+        super.updated(changed);
+        if (changed.has("client") && this.client && !this._unsubscribe) {
+            this._unsubscribe = this.client.addEventListener("nodes_changed", () => this.requestUpdate());
+        }
+    }
+
+    override disconnectedCallback() {
+        super.disconnectedCallback();
+        this._unsubscribe?.();
+    }
+
+    private get _controllerNodeId(): number | bigint | undefined {
+        return this.client.serverInfo?.controller_node_id;
+    }
+
+    private get _fabricIndex(): number | undefined {
+        return this.client.serverInfo?.fabric_index;
+    }
+
+    private _entries(): AccessControlEntryStruct[] {
+        return entriesForFabric(readAclEntries(this.node), this._fabricIndex);
+    }
+
+    private _clusterName(id: number | undefined): string {
+        if (id == null) return "all clusters";
+        return `${clusters[id]?.label ?? "Cluster"} (0x${id.toString(16).padStart(2, "0").toUpperCase()})`;
+    }
+
+    private _privilegeClass(p: number): string {
+        return `pv pv-${p}`;
+    }
+
+    private async _delete(entry: AccessControlEntryStruct) {
+        const isAdmin = entry.privilege === Privilege.Administer && entry.authMode === AuthMode.Case;
+        const unverified = isAdmin && this._controllerNodeId === undefined;
+        const confirmed = await showPromptDialog({
+            title: "Delete ACL entry",
+            text: unverified
+                ? "This is an Administer entry and the controller cannot verify whether it is its own. Deleting the wrong admin entry can lock the controller out of this device. Continue?"
+                : "Remove this access control entry? Devices relying on it will lose the granted access.",
+            confirmText: "Delete",
+        });
+        if (!confirmed) return;
+        this._busy = true;
+        try {
+            await deleteAclEntry(this.client, this.node.node_id, aclEntryKey(entry));
+        } catch (err) {
+            await showAlertDialog({ title: "Delete failed", text: err instanceof Error ? err.message : String(err) });
+        } finally {
+            this._busy = false;
+        }
+    }
+
+    private async _fix(keys: Set<string>) {
+        this._busy = true;
+        try {
+            await downgradeToOperate(this.client, this.node.node_id, keys);
+        } catch (err) {
+            await showAlertDialog({ title: "Fix failed", text: err instanceof Error ? err.message : String(err) });
+        } finally {
+            this._busy = false;
+        }
+    }
+
+    private async _openAdd() {
+        await showNodeAclAddDialog(this.node);
+    }
+
+    private _renderSubjects(entry: AccessControlEntryStruct): TemplateResult {
+        const subjects = entry.subjects ?? [];
+        if (entry.authMode === AuthMode.Case && subjects.length === 0) {
+            return html`<span class="chip mut">Any node on fabric</span>`;
+        }
+        if (entry.authMode === AuthMode.Group) {
+            return html`${subjects.map(s => html`<span class="chip">Group ${s.toString()}</span>`)}`;
+        }
+        return html`${subjects.map(s => {
+            const known = this.client.nodes[nodeIdKey(s)];
+            const protectedMe =
+                isProtectedAdmin(entry, this._controllerNodeId) && nodeIdKey(s) === nodeIdKey(this._controllerNodeId!);
+            return html`<span class="chip ${protectedMe ? "me" : ""}"
+                >${protectedMe ? "This controller" : known ? known.nodeLabel || "Unknown" : "Unknown node"} ·
+                <span class="nid">${s.toString()}</span><span class="hex">0x${s.toString(16).toUpperCase()}</span></span
+            >`;
+        })}`;
+    }
+
+    private _renderTargets(entry: AccessControlEntryStruct): TemplateResult {
+        if (isWholeNode(entry)) return html`<span class="mut">Whole node</span>`;
+        return html`${entry.targets!.map(t => {
+            if (t.cluster != null)
+                return html`<span class="chip ep">EP ${t.endpoint ?? "*"} · ${this._clusterName(t.cluster)}</span>`;
+            if (t.deviceType != null)
+                return html`<span class="chip ep">EP ${t.endpoint ?? "*"} · device type ${t.deviceType}</span>`;
+            return html`<span class="chip ep">EP ${t.endpoint ?? "*"}</span>`;
+        })}`;
+    }
+
+    private _renderRelationship(rel: RelationshipResult): TemplateResult {
+        if (rel.kind === "none") return html`<span class="mut">—</span>`;
+        const source = rel.sourceNodeId != null ? this.client.nodes[nodeIdKey(rel.sourceNodeId)] : undefined;
+        const label = source ? source.nodeLabel || "node" : "node";
+        if (rel.kind === "overPrivileged") {
+            return html`<span class="chip bug"
+                ><ha-svg-icon .path=${mdiAlert}></ha-svg-icon> over-privileged binding ACL</span
+            >`;
+        }
+        return html`<span class="chip link"
+            ><ha-svg-icon .path=${mdiLink}></ha-svg-icon> backs binding · ${label} EP${rel.sourceEndpoint}</span
+        >`;
+    }
+
+    override render() {
+        if (!this.node || this.cluster !== CLUSTER_ID) return nothing;
+        const entries = this._entries();
+        const allNodes = Object.values(this.client.nodes);
+        const rels = entries.map(e => detectBindingRelationship(e, this.node.node_id, allNodes));
+        const capacity = aclCapacity(this.node);
+        const full = capacity.max > 0 && entries.length >= capacity.max;
+
+        const overPrivilegedKeys = new Set<string>();
+        entries.forEach((e, i) => {
+            if (rels[i].kind === "overPrivileged") overPrivilegedKeys.add(aclEntryKey(e));
+        });
+
+        return html`
+            <details class="command-panel" open>
+                <summary>Access Control — ACL Entries (${entries.length})</summary>
+                <div class="command-content">
+                    ${overPrivilegedKeys.size >= 2
+                        ? html`<div class="banner">
+                              <span
+                                  >${overPrivilegedKeys.size} binding ACL entries grant Administer where Operate is
+                                  sufficient.</span
+                              >
+                              <md-outlined-button
+                                  ?disabled=${this._busy || !this.node.available}
+                                  @click=${handleAsync(() => this._fix(overPrivilegedKeys))}
+                                  >Fix all → Operate</md-outlined-button
+                              >
+                          </div>`
+                        : nothing}
+                    <table class="acl">
+                        <thead>
+                            <tr>
+                                <th>Privilege</th>
+                                <th>Auth</th>
+                                <th>Subjects</th>
+                                <th>Targets</th>
+                                <th>Relationship</th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            ${entries.map((e, i) => this._row(e, rels[i]))}
+                        </tbody>
+                    </table>
+                    <md-outlined-button
+                        ?disabled=${this._busy || full || !this.node.available}
+                        title=${full ? "Access control list is full" : ""}
+                        @click=${handleAsync(() => this._openAdd())}
+                        >Add ACL entry</md-outlined-button
+                    >
+                    ${full ? html`<span class="mut full-note">List full (${capacity.max} entries)</span>` : nothing}
+                </div>
+            </details>
+        `;
+    }
+
+    private _row(entry: AccessControlEntryStruct, rel: RelationshipResult): TemplateResult {
+        const protectedEntry = isProtectedAdmin(entry, this._controllerNodeId);
+        const overPrivileged = rel.kind === "overPrivileged";
+        return html`
+            <tr class=${overPrivileged ? "row-warn" : ""}>
+                <td>
+                    <span class=${this._privilegeClass(entry.privilege)}
+                        >${PRIVILEGE_NAMES[entry.privilege] ?? entry.privilege} · ${entry.privilege}</span
+                    >
+                    ${overPrivileged
+                        ? html`<div>
+                              <md-outlined-button
+                                  class="fix"
+                                  ?disabled=${this._busy || !this.node.available}
+                                  @click=${handleAsync(() => this._fix(new Set([aclEntryKey(entry)])))}
+                                  >Fix → Operate</md-outlined-button
+                              >
+                          </div>`
+                        : nothing}
+                </td>
+                <td>${AUTH_MODE_NAMES[entry.authMode] ?? entry.authMode}</td>
+                <td>${this._renderSubjects(entry)}</td>
+                <td>${this._renderTargets(entry)}</td>
+                <td>${this._renderRelationship(rel)}</td>
+                <td>
+                    ${protectedEntry
+                        ? html`<ha-svg-icon
+                              class="lock"
+                              .path=${mdiLock}
+                              title="Your controller's administrator entry — deleting it would lock you out."
+                          ></ha-svg-icon>`
+                        : html`<md-outlined-button
+                              class="danger"
+                              ?disabled=${this._busy || !this.node.available}
+                              @click=${handleAsync(() => this._delete(entry))}
+                          >
+                              <ha-svg-icon .path=${mdiTrashCan} slot="icon"></ha-svg-icon>delete
+                          </md-outlined-button>`}
+                </td>
+            </tr>
+        `;
+    }
+
+    static override styles: CSSResultGroup = [
+        BaseClusterCommands.styles,
+        css`
+            .acl {
+                width: 100%;
+                border-collapse: collapse;
+                margin-bottom: 12px;
+            }
+            .acl th {
+                text-align: left;
+                font-size: 11px;
+                text-transform: uppercase;
+                opacity: 0.6;
+                padding: 8px 10px;
+                border-bottom: 1px solid var(--md-sys-color-outline-variant);
+            }
+            .acl td {
+                padding: 10px;
+                border-bottom: 1px solid var(--md-sys-color-outline-variant);
+                vertical-align: top;
+            }
+            .row-warn td {
+                background: var(--md-sys-color-error-container);
+                box-shadow: inset 3px 0 0 var(--md-sys-color-error);
+            }
+            .pv {
+                display: inline-block;
+                padding: 2px 8px;
+                border-radius: 999px;
+                font-size: 11px;
+                font-weight: 700;
+            }
+            .pv-5 {
+                background: var(--md-sys-color-error-container);
+                color: var(--md-sys-color-on-error-container);
+            }
+            .pv-4 {
+                background: var(--md-sys-color-tertiary-container);
+                color: var(--md-sys-color-on-tertiary-container);
+            }
+            .pv-3 {
+                background: var(--md-sys-color-primary-container);
+                color: var(--md-sys-color-on-primary-container);
+            }
+            .pv-1,
+            .pv-2 {
+                background: var(--md-sys-color-surface-container-highest);
+                color: var(--md-sys-color-on-surface-variant);
+            }
+            .chip {
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+                padding: 3px 8px;
+                border-radius: 6px;
+                margin: 2px 4px 2px 0;
+                font-size: 12px;
+                background: var(--md-sys-color-surface-container-high);
+                color: var(--md-sys-color-on-surface);
+            }
+            .chip ha-svg-icon {
+                --mdc-icon-size: 14px;
+                width: 14px;
+                height: 14px;
+            }
+            .chip.ep {
+                background: var(--md-sys-color-secondary-container);
+                color: var(--md-sys-color-on-secondary-container);
+            }
+            .chip.me {
+                background: var(--md-sys-color-tertiary-container);
+                color: var(--md-sys-color-on-tertiary-container);
+            }
+            .chip.link {
+                background: var(--md-sys-color-primary-container);
+                color: var(--md-sys-color-on-primary-container);
+            }
+            .chip.bug {
+                background: var(--md-sys-color-error-container);
+                color: var(--md-sys-color-on-error-container);
+            }
+            .nid {
+                font-weight: 600;
+            }
+            .hex {
+                font-family: var(--monospace-font, monospace);
+                font-size: 10px;
+                opacity: 0.6;
+                margin-left: 4px;
+            }
+            .mut {
+                opacity: 0.6;
+            }
+            .full-note {
+                margin-left: 8px;
+                font-size: 12px;
+            }
+            .banner {
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 12px;
+                padding: 10px 12px;
+                margin-bottom: 12px;
+                border-radius: 8px;
+                background: var(--md-sys-color-error-container);
+                color: var(--md-sys-color-on-error-container);
+            }
+            md-outlined-button.danger {
+                --md-outlined-button-label-text-color: var(--md-sys-color-error);
+                --md-outlined-button-outline-color: var(--md-sys-color-error);
+            }
+            md-outlined-button.fix {
+                margin-top: 4px;
+                --md-outlined-button-container-height: 28px;
+            }
+        `,
+    ];
+}
+
+registerClusterCommands(CLUSTER_ID, "access-control-cluster-commands");
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "access-control-cluster-commands": AccessControlClusterCommands;
+    }
+}

--- a/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
@@ -66,6 +66,7 @@ class AccessControlClusterCommands extends BaseClusterCommands {
             for (const [k, v] of Object.entries(res)) this.node.attributes[k] = v;
             this.requestUpdate();
         } catch (err) {
+            this._loadedKey = ""; // allow retry on the next update after a transient failure
             console.error("Failed to load ACL", err);
         }
     }

--- a/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
@@ -62,7 +62,7 @@ class AccessControlClusterCommands extends BaseClusterCommands {
         if (this._loadedKey === key) return;
         this._loadedKey = key;
         try {
-            const res = await this.client.readAttribute(this.node.node_id, "0/31/0");
+            const res = await this.client.readAttribute(this.node.node_id, ["0/31/0", "0/62/5"]);
             for (const [k, v] of Object.entries(res)) this.node.attributes[k] = v;
             this.requestUpdate();
         } catch (err) {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
@@ -30,6 +30,7 @@ import {
 } from "../../../util/access-control.js";
 import { handleAsync } from "../../../util/async-handler.js";
 import { detectBindingRelationship, type RelationshipResult } from "../../../util/binding.js";
+import { getDeviceName } from "../../../util/node-name.js";
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
 
@@ -135,7 +136,7 @@ class AccessControlClusterCommands extends BaseClusterCommands {
             const protectedMe =
                 isProtectedAdmin(entry, this._controllerNodeId) && nodeIdKey(s) === nodeIdKey(this._controllerNodeId!);
             return html`<div class="ident ${protectedMe ? "me" : ""}">
-                ${protectedMe ? "This controller" : known ? known.nodeLabel || "Unknown" : "Unknown node"} ·
+                ${protectedMe ? "This controller" : known ? getDeviceName(known) : "Unknown node"} ·
                 <span class="nid">${s.toString()}</span><span class="hex">0x${s.toString(16).toUpperCase()}</span>
             </div>`;
         })}`;
@@ -155,7 +156,7 @@ class AccessControlClusterCommands extends BaseClusterCommands {
     private _renderRelationship(rel: RelationshipResult): TemplateResult {
         if (rel.kind === "none") return html`<span class="mut">—</span>`;
         const source = rel.sourceNodeId != null ? this.client.nodes[nodeIdKey(rel.sourceNodeId)] : undefined;
-        const label = source ? source.nodeLabel || "node" : "node";
+        const label = source ? getDeviceName(source) : "node";
         if (rel.kind === "overPrivileged") {
             return html`<span class="chip bug"
                 ><ha-svg-icon .path=${mdiAlert}></ha-svg-icon> over-privileged binding ACL</span

--- a/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
@@ -60,10 +60,12 @@ class BindingClusterCommands extends BaseClusterCommands {
                     .map(b => (b.node != null ? nodeIdKey(b.node) : undefined))
                     .filter((k): k is string => k !== undefined),
             );
-            for (const k of targets) {
-                const target = this.client.nodes[k];
-                if (target?.available) await this._readInto(target.node_id, ["0/31/0", "0/62/5"]);
-            }
+            await Promise.all(
+                [...targets].map(k => {
+                    const target = this.client.nodes[k];
+                    return target?.available ? this._readInto(target.node_id, ["0/31/0", "0/62/5"]) : undefined;
+                }),
+            );
             this.requestUpdate();
         } catch (err) {
             console.error("Failed to load binding/ACL data", err);

--- a/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
@@ -6,12 +6,17 @@
 
 import "@material/web/button/outlined-button";
 import { mdiTrashCan } from "@mdi/js";
-import { css, html, nothing, type CSSResultGroup } from "lit";
+import { css, html, nothing, type CSSResultGroup, type TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import "../../../components/ha-svg-icon.js";
 import { clusters } from "../../../client/models/descriptions.js";
 import { showAlertDialog, showPromptDialog } from "../../../components/dialog-box/show-dialog-box.js";
-import { deleteBindingAtIndex } from "../../../components/dialogs/binding/binding-actions.js";
+import {
+    deleteBindingAtIndex,
+    ensureBindingAcl,
+    fixOverPrivilegedBindingAcl,
+} from "../../../components/dialogs/binding/binding-actions.js";
+import type { BindingEntryStruct } from "../../../components/dialogs/binding/model.js";
 import { showNodeBindingDialog } from "../../../components/dialogs/binding/show-node-binding-dialog.js";
 import { nodeIdKey } from "../../../util/access-control.js";
 import { handleAsync } from "../../../util/async-handler.js";
@@ -25,6 +30,7 @@ const CLUSTER_ID = 30;
 @customElement("binding-cluster-commands")
 class BindingClusterCommands extends BaseClusterCommands {
     private _unsubscribe?: () => void;
+    private _loadedKey = "";
     @state() private _busy = false;
 
     override updated(changed: Map<string, unknown>) {
@@ -32,11 +38,41 @@ class BindingClusterCommands extends BaseClusterCommands {
         if (changed.has("client") && this.client && !this._unsubscribe) {
             this._unsubscribe = this.client.addEventListener("nodes_changed", () => this.requestUpdate());
         }
+        void this._ensureLoaded();
     }
 
     override disconnectedCallback() {
         super.disconnectedCallback();
         this._unsubscribe?.();
+    }
+
+    /** Read the (fabric-scoped) binding attribute and each target's ACL into the cache on open. */
+    private async _ensureLoaded() {
+        if (!this.client || !this.node || this.endpoint === undefined) return;
+        const key = `${nodeIdKey(this.node.node_id)}/${this.endpoint}`;
+        if (this._loadedKey === key) return;
+        this._loadedKey = key;
+        try {
+            await this._readInto(this.node.node_id, `${this.endpoint}/30/0`);
+            const targets = new Set(
+                readBindings(this.node, this.endpoint)
+                    .map(b => (b.node != null ? nodeIdKey(b.node) : undefined))
+                    .filter((k): k is string => k !== undefined),
+            );
+            for (const k of targets) {
+                const id = this.client.nodes[k]?.node_id;
+                if (id != null) await this._readInto(id, "0/31/0");
+            }
+            this.requestUpdate();
+        } catch (err) {
+            console.error("Failed to load binding/ACL data", err);
+        }
+    }
+
+    private async _readInto(nodeId: number | bigint, path: string) {
+        const res = await this.client.readAttribute(nodeId, path);
+        const node = this.client.nodes[nodeIdKey(nodeId)];
+        if (node) for (const [k, v] of Object.entries(res)) node.attributes[k] = v;
     }
 
     private _clusterName(id: number | undefined): string {
@@ -53,6 +89,17 @@ class BindingClusterCommands extends BaseClusterCommands {
         await showNodeBindingDialog(this.node, this.endpoint);
     }
 
+    private async _run(action: () => Promise<void>, failTitle: string) {
+        this._busy = true;
+        try {
+            await action();
+        } catch (err) {
+            await showAlertDialog({ title: failTitle, text: err instanceof Error ? err.message : String(err) });
+        } finally {
+            this._busy = false;
+        }
+    }
+
     private async _delete(index: number) {
         const confirmed = await showPromptDialog({
             title: "Remove binding",
@@ -60,20 +107,36 @@ class BindingClusterCommands extends BaseClusterCommands {
             confirmText: "Remove",
         });
         if (!confirmed) return;
-        this._busy = true;
-        try {
-            await deleteBindingAtIndex(
-                this.client,
-                this.node,
-                this.endpoint,
-                index,
-                this.client.serverInfo?.fabric_index,
-            );
-        } catch (err) {
-            await showAlertDialog({ title: "Delete failed", text: err instanceof Error ? err.message : String(err) });
-        } finally {
-            this._busy = false;
-        }
+        await this._run(
+            () =>
+                deleteBindingAtIndex(
+                    this.client,
+                    this.node,
+                    this.endpoint,
+                    index,
+                    this.client.serverInfo?.fabric_index,
+                ),
+            "Delete failed",
+        );
+    }
+
+    private async _fixAcl(b: BindingEntryStruct, mode: "missing" | "overPrivileged") {
+        if (b.node == null || b.endpoint == null) return;
+        const fabricIndex = this.client.serverInfo?.fabric_index;
+        await this._run(
+            () =>
+                mode === "missing"
+                    ? ensureBindingAcl(this.client, this.node.node_id, b.node!, b.endpoint!, b.cluster, fabricIndex)
+                    : fixOverPrivilegedBindingAcl(
+                          this.client,
+                          this.node.node_id,
+                          b.node!,
+                          b.endpoint!,
+                          b.cluster,
+                          fabricIndex,
+                      ),
+            "Fix failed",
+        );
     }
 
     override render() {
@@ -82,7 +145,7 @@ class BindingClusterCommands extends BaseClusterCommands {
         const fabricIndex = this.client.serverInfo?.fabric_index;
 
         return html`
-            <details class="command-panel" open>
+            <details class="command-panel">
                 <summary>Bindings (${bindings.length})</summary>
                 <div class="command-content">
                     ${bindings.length === 0
@@ -111,16 +174,10 @@ class BindingClusterCommands extends BaseClusterCommands {
         `;
     }
 
-    private _row(b: ReturnType<typeof readBindings>[number], index: number, fabricIndex?: number) {
+    private _row(b: BindingEntryStruct, index: number, fabricIndex?: number): TemplateResult {
         const target = this._targetNode(b.node);
         const aclState: ReverseAclState =
             b.node == null ? "cannotVerify" : reverseAclState(this.node.node_id, b, target, fabricIndex).state;
-        const aclChip =
-            aclState === "present"
-                ? html`<span class="chip ok">ACL present</span>`
-                : aclState === "missing"
-                  ? html`<span class="chip warn">ACL missing on target</span>`
-                  : html`<span class="chip mut">can't verify</span>`;
         const name = b.group != null ? `Group ${b.group}` : target ? target.nodeLabel || "Unknown" : "Unknown node";
         const endpointText =
             b.endpoint == null
@@ -131,7 +188,7 @@ class BindingClusterCommands extends BaseClusterCommands {
         return html`
             <tr>
                 <td>
-                    <span class="chip"
+                    <span class="ident"
                         ><b>${name}</b>${b.node != null
                             ? html` · <span class="nid">${b.node.toString()}</span>`
                             : nothing}</span
@@ -139,8 +196,8 @@ class BindingClusterCommands extends BaseClusterCommands {
                 </td>
                 <td>${endpointText}</td>
                 <td>${this._clusterName(b.cluster)}</td>
-                <td>${aclChip}</td>
-                <td>
+                <td>${this._aclCell(b, aclState)}</td>
+                <td class="actions">
                     <md-outlined-button
                         class="danger"
                         ?disabled=${this._busy || !this.node.available}
@@ -150,6 +207,22 @@ class BindingClusterCommands extends BaseClusterCommands {
                     </md-outlined-button>
                 </td>
             </tr>
+        `;
+    }
+
+    private _aclCell(b: BindingEntryStruct, state: ReverseAclState): TemplateResult {
+        if (state === "present") return html`<span class="status ok">ACL present</span>`;
+        if (state === "cannotVerify") return html`<span class="status mut">can't verify</span>`;
+        const label = state === "missing" ? "ACL missing" : "ACL > Operate";
+        const fixLabel = state === "missing" ? "Add ACL" : "→ Operate";
+        return html`
+            <span class="status warn">${label}</span>
+            <md-outlined-button
+                class="fix"
+                ?disabled=${this._busy || !this.node.available}
+                @click=${handleAsync(() => this._fixAcl(b, state))}
+                >${fixLabel}</md-outlined-button
+            >
         `;
     }
 
@@ -172,34 +245,34 @@ class BindingClusterCommands extends BaseClusterCommands {
             .bt td {
                 padding: 10px;
                 border-bottom: 1px solid var(--md-sys-color-outline-variant);
-                vertical-align: top;
+                vertical-align: middle;
             }
             .empty {
                 opacity: 0.6;
                 padding: 8px 0 12px;
             }
-            .chip {
-                display: inline-block;
-                padding: 3px 9px;
-                border-radius: 6px;
-                margin: 2px 4px 2px 0;
-                font-size: 12px;
-                background: var(--md-sys-color-surface-container-high);
-                color: var(--md-sys-color-on-surface);
+            .ident .nid {
+                font-weight: 600;
             }
-            .chip.ok {
-                background: var(--md-sys-color-tertiary-container);
-                color: var(--md-sys-color-on-tertiary-container);
+            .status {
+                font-size: inherit;
             }
-            .chip.warn {
-                background: var(--md-sys-color-error-container);
-                color: var(--md-sys-color-on-error-container);
+            .status.ok {
+                color: var(--md-sys-color-primary);
             }
-            .chip.mut {
+            .status.warn {
+                color: var(--md-sys-color-error);
+                margin-right: 8px;
+            }
+            .status.mut {
                 opacity: 0.6;
             }
-            .nid {
-                font-weight: 600;
+            .actions {
+                text-align: right;
+                white-space: nowrap;
+            }
+            md-outlined-button.fix {
+                --md-outlined-button-container-height: 28px;
             }
             md-outlined-button.danger {
                 --md-outlined-button-label-text-color: var(--md-sys-color-error);

--- a/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
@@ -1,0 +1,212 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import "@material/web/button/outlined-button";
+import { mdiTrashCan } from "@mdi/js";
+import { css, html, nothing, type CSSResultGroup } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import "../../../components/ha-svg-icon.js";
+import { clusters } from "../../../client/models/descriptions.js";
+import { showAlertDialog, showPromptDialog } from "../../../components/dialog-box/show-dialog-box.js";
+import { deleteBindingAtIndex } from "../../../components/dialogs/binding/binding-actions.js";
+import { showNodeBindingDialog } from "../../../components/dialogs/binding/show-node-binding-dialog.js";
+import { nodeIdKey } from "../../../util/access-control.js";
+import { handleAsync } from "../../../util/async-handler.js";
+import { readBindings, reverseAclState, type ReverseAclState } from "../../../util/binding.js";
+import { getEndpointDeviceTypes } from "../../matter-endpoint-view.js";
+import { BaseClusterCommands } from "../base-cluster-commands.js";
+import { registerClusterCommands } from "../registry.js";
+
+const CLUSTER_ID = 30;
+
+@customElement("binding-cluster-commands")
+class BindingClusterCommands extends BaseClusterCommands {
+    private _unsubscribe?: () => void;
+    @state() private _busy = false;
+
+    override updated(changed: Map<string, unknown>) {
+        super.updated(changed);
+        if (changed.has("client") && this.client && !this._unsubscribe) {
+            this._unsubscribe = this.client.addEventListener("nodes_changed", () => this.requestUpdate());
+        }
+    }
+
+    override disconnectedCallback() {
+        super.disconnectedCallback();
+        this._unsubscribe?.();
+    }
+
+    private _clusterName(id: number | undefined): string {
+        if (id == null) return "All clusters";
+        return `${clusters[id]?.label ?? "Cluster"} (0x${id.toString(16).padStart(2, "0").toUpperCase()})`;
+    }
+
+    private _targetNode(nodeId: number | bigint | undefined) {
+        if (nodeId == null) return undefined;
+        return this.client.nodes[nodeIdKey(nodeId)];
+    }
+
+    private async _openAdd() {
+        await showNodeBindingDialog(this.node, this.endpoint);
+    }
+
+    private async _delete(index: number) {
+        const confirmed = await showPromptDialog({
+            title: "Remove binding",
+            text: "Remove this binding and clean up the matching access control entry on the target node?",
+            confirmText: "Remove",
+        });
+        if (!confirmed) return;
+        this._busy = true;
+        try {
+            await deleteBindingAtIndex(this.client, this.node, this.endpoint, index);
+        } catch (err) {
+            await showAlertDialog({ title: "Delete failed", text: err instanceof Error ? err.message : String(err) });
+        } finally {
+            this._busy = false;
+        }
+    }
+
+    override render() {
+        if (!this.node || this.cluster !== CLUSTER_ID) return nothing;
+        const bindings = readBindings(this.node, this.endpoint);
+        const fabricIndex = this.client.serverInfo?.fabric_index;
+
+        return html`
+            <details class="command-panel" open>
+                <summary>Bindings (${bindings.length})</summary>
+                <div class="command-content">
+                    ${bindings.length === 0
+                        ? html`<div class="empty">No bindings on this endpoint.</div>`
+                        : html`<table class="bt">
+                              <thead>
+                                  <tr>
+                                      <th>Target node</th>
+                                      <th>Endpoint</th>
+                                      <th>Cluster</th>
+                                      <th>ACL on target</th>
+                                      <th></th>
+                                  </tr>
+                              </thead>
+                              <tbody>
+                                  ${bindings.map((b, i) => this._row(b, i, fabricIndex))}
+                              </tbody>
+                          </table>`}
+                    <md-outlined-button
+                        ?disabled=${this._busy || !this.node.available}
+                        @click=${handleAsync(() => this._openAdd())}
+                        >Add binding</md-outlined-button
+                    >
+                </div>
+            </details>
+        `;
+    }
+
+    private _row(b: ReturnType<typeof readBindings>[number], index: number, fabricIndex?: number) {
+        const target = this._targetNode(b.node);
+        const aclState: ReverseAclState =
+            b.node == null ? "cannotVerify" : reverseAclState(this.node.node_id, b, target, fabricIndex).state;
+        const aclChip =
+            aclState === "present"
+                ? html`<span class="chip ok">ACL present</span>`
+                : aclState === "missing"
+                  ? html`<span class="chip warn">ACL missing on target</span>`
+                  : html`<span class="chip mut">can't verify</span>`;
+        const name = b.group != null ? `Group ${b.group}` : target ? target.nodeLabel || "Unknown" : "Unknown node";
+        const endpointText =
+            b.endpoint == null
+                ? "—"
+                : target && getEndpointDeviceTypes(target, b.endpoint)[0]
+                  ? `EP ${b.endpoint} · ${getEndpointDeviceTypes(target, b.endpoint)[0].label}`
+                  : `EP ${b.endpoint}`;
+        return html`
+            <tr>
+                <td>
+                    <span class="chip"
+                        ><b>${name}</b>${b.node != null
+                            ? html` · <span class="nid">${b.node.toString()}</span>`
+                            : nothing}</span
+                    >
+                </td>
+                <td>${endpointText}</td>
+                <td>${this._clusterName(b.cluster)}</td>
+                <td>${aclChip}</td>
+                <td>
+                    <md-outlined-button
+                        class="danger"
+                        ?disabled=${this._busy || !this.node.available}
+                        @click=${handleAsync(() => this._delete(index))}
+                    >
+                        <ha-svg-icon .path=${mdiTrashCan} slot="icon"></ha-svg-icon>delete
+                    </md-outlined-button>
+                </td>
+            </tr>
+        `;
+    }
+
+    static override styles: CSSResultGroup = [
+        BaseClusterCommands.styles,
+        css`
+            .bt {
+                width: 100%;
+                border-collapse: collapse;
+                margin-bottom: 12px;
+            }
+            .bt th {
+                text-align: left;
+                font-size: 11px;
+                text-transform: uppercase;
+                opacity: 0.6;
+                padding: 8px 10px;
+                border-bottom: 1px solid var(--md-sys-color-outline-variant);
+            }
+            .bt td {
+                padding: 10px;
+                border-bottom: 1px solid var(--md-sys-color-outline-variant);
+                vertical-align: top;
+            }
+            .empty {
+                opacity: 0.6;
+                padding: 8px 0 12px;
+            }
+            .chip {
+                display: inline-block;
+                padding: 3px 9px;
+                border-radius: 6px;
+                margin: 2px 4px 2px 0;
+                font-size: 12px;
+                background: var(--md-sys-color-surface-container-high);
+                color: var(--md-sys-color-on-surface);
+            }
+            .chip.ok {
+                background: var(--md-sys-color-tertiary-container);
+                color: var(--md-sys-color-on-tertiary-container);
+            }
+            .chip.warn {
+                background: var(--md-sys-color-error-container);
+                color: var(--md-sys-color-on-error-container);
+            }
+            .chip.mut {
+                opacity: 0.6;
+            }
+            .nid {
+                font-weight: 600;
+            }
+            md-outlined-button.danger {
+                --md-outlined-button-label-text-color: var(--md-sys-color-error);
+                --md-outlined-button-outline-color: var(--md-sys-color-error);
+            }
+        `,
+    ];
+}
+
+registerClusterCommands(CLUSTER_ID, "binding-cluster-commands");
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "binding-cluster-commands": BindingClusterCommands;
+    }
+}

--- a/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
@@ -22,6 +22,7 @@ import { nodeIdKey } from "../../../util/access-control.js";
 import { handleAsync } from "../../../util/async-handler.js";
 import { readBindings, reverseAclState, type ReverseAclState } from "../../../util/binding.js";
 import { getEndpointDeviceTypes } from "../../../util/endpoints.js";
+import { getDeviceName } from "../../../util/node-name.js";
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
 
@@ -159,7 +160,7 @@ class BindingClusterCommands extends BaseClusterCommands {
         const target = this._targetNode(b.node);
         const aclState: ReverseAclState =
             b.node == null ? "cannotVerify" : reverseAclState(this.node.node_id, b, target).state;
-        const name = b.group != null ? `Group ${b.group}` : target ? target.nodeLabel || "Unknown" : "Unknown node";
+        const name = b.group != null ? `Group ${b.group}` : target ? getDeviceName(target) : "Unknown node";
         const endpointText =
             b.endpoint == null
                 ? "—"

--- a/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
@@ -21,7 +21,7 @@ import { showNodeBindingDialog } from "../../../components/dialogs/binding/show-
 import { nodeIdKey } from "../../../util/access-control.js";
 import { handleAsync } from "../../../util/async-handler.js";
 import { readBindings, reverseAclState, type ReverseAclState } from "../../../util/binding.js";
-import { getEndpointDeviceTypes } from "../../matter-endpoint-view.js";
+import { getEndpointDeviceTypes } from "../../../util/endpoints.js";
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
 
@@ -195,7 +195,7 @@ class BindingClusterCommands extends BaseClusterCommands {
         if (state === "present") return html`<span class="status ok">ACL present</span>`;
         if (state === "cannotVerify") return html`<span class="status mut">can't verify</span>`;
         const label = state === "missing" ? "ACL missing" : "ACL > Operate";
-        const fixLabel = state === "missing" ? "Add ACL" : "→ Operate";
+        const fixLabel = state === "missing" ? "Fix ACL" : "Fix → Operate";
         return html`
             <span class="status warn">${label}</span>
             <md-outlined-button

--- a/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
@@ -68,6 +68,7 @@ class BindingClusterCommands extends BaseClusterCommands {
             );
             this.requestUpdate();
         } catch (err) {
+            this._loadedKey = ""; // allow retry on the next update after a transient failure
             console.error("Failed to load binding/ACL data", err);
         }
     }
@@ -163,12 +164,9 @@ class BindingClusterCommands extends BaseClusterCommands {
         const aclState: ReverseAclState =
             b.node == null ? "cannotVerify" : reverseAclState(this.node.node_id, b, target).state;
         const name = b.group != null ? `Group ${b.group}` : target ? getDeviceName(target) : "Unknown node";
+        const deviceType = b.endpoint != null && target ? getEndpointDeviceTypes(target, b.endpoint)[0] : undefined;
         const endpointText =
-            b.endpoint == null
-                ? "—"
-                : target && getEndpointDeviceTypes(target, b.endpoint)[0]
-                  ? `EP ${b.endpoint} · ${getEndpointDeviceTypes(target, b.endpoint)[0].label}`
-                  : `EP ${b.endpoint}`;
+            b.endpoint == null ? "—" : deviceType ? `EP ${b.endpoint} · ${deviceType.label}` : `EP ${b.endpoint}`;
         return html`
             <tr>
                 <td>

--- a/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
@@ -107,34 +107,16 @@ class BindingClusterCommands extends BaseClusterCommands {
             confirmText: "Remove",
         });
         if (!confirmed) return;
-        await this._run(
-            () =>
-                deleteBindingAtIndex(
-                    this.client,
-                    this.node,
-                    this.endpoint,
-                    index,
-                    this.client.serverInfo?.fabric_index,
-                ),
-            "Delete failed",
-        );
+        await this._run(() => deleteBindingAtIndex(this.client, this.node, this.endpoint, index), "Delete failed");
     }
 
     private async _fixAcl(b: BindingEntryStruct, mode: "missing" | "overPrivileged") {
         if (b.node == null || b.endpoint == null) return;
-        const fabricIndex = this.client.serverInfo?.fabric_index;
         await this._run(
             () =>
                 mode === "missing"
-                    ? ensureBindingAcl(this.client, this.node.node_id, b.node!, b.endpoint!, b.cluster, fabricIndex)
-                    : fixOverPrivilegedBindingAcl(
-                          this.client,
-                          this.node.node_id,
-                          b.node!,
-                          b.endpoint!,
-                          b.cluster,
-                          fabricIndex,
-                      ),
+                    ? ensureBindingAcl(this.client, this.node.node_id, b.node!, b.endpoint!, b.cluster)
+                    : fixOverPrivilegedBindingAcl(this.client, this.node.node_id, b.node!, b.endpoint!, b.cluster),
             "Fix failed",
         );
     }
@@ -142,7 +124,6 @@ class BindingClusterCommands extends BaseClusterCommands {
     override render() {
         if (!this.node || this.cluster !== CLUSTER_ID) return nothing;
         const bindings = readBindings(this.node, this.endpoint);
-        const fabricIndex = this.client.serverInfo?.fabric_index;
 
         return html`
             <details class="command-panel">
@@ -161,7 +142,7 @@ class BindingClusterCommands extends BaseClusterCommands {
                                   </tr>
                               </thead>
                               <tbody>
-                                  ${bindings.map((b, i) => this._row(b, i, fabricIndex))}
+                                  ${bindings.map((b, i) => this._row(b, i))}
                               </tbody>
                           </table>`}
                     <md-outlined-button
@@ -174,10 +155,10 @@ class BindingClusterCommands extends BaseClusterCommands {
         `;
     }
 
-    private _row(b: BindingEntryStruct, index: number, fabricIndex?: number): TemplateResult {
+    private _row(b: BindingEntryStruct, index: number): TemplateResult {
         const target = this._targetNode(b.node);
         const aclState: ReverseAclState =
-            b.node == null ? "cannotVerify" : reverseAclState(this.node.node_id, b, target, fabricIndex).state;
+            b.node == null ? "cannotVerify" : reverseAclState(this.node.node_id, b, target).state;
         const name = b.group != null ? `Group ${b.group}` : target ? target.nodeLabel || "Unknown" : "Unknown node";
         const endpointText =
             b.endpoint == null

--- a/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
@@ -54,7 +54,7 @@ class BindingClusterCommands extends BaseClusterCommands {
         if (this._loadedKey === key) return;
         this._loadedKey = key;
         try {
-            await this._readInto(this.node.node_id, `${this.endpoint}/30/0`);
+            await this._readInto(this.node.node_id, [`${this.endpoint}/30/0`, "0/62/5"]);
             const targets = new Set(
                 readBindings(this.node, this.endpoint)
                     .map(b => (b.node != null ? nodeIdKey(b.node) : undefined))
@@ -62,7 +62,7 @@ class BindingClusterCommands extends BaseClusterCommands {
             );
             for (const k of targets) {
                 const target = this.client.nodes[k];
-                if (target?.available) await this._readInto(target.node_id, "0/31/0");
+                if (target?.available) await this._readInto(target.node_id, ["0/31/0", "0/62/5"]);
             }
             this.requestUpdate();
         } catch (err) {
@@ -70,7 +70,7 @@ class BindingClusterCommands extends BaseClusterCommands {
         }
     }
 
-    private async _readInto(nodeId: number | bigint, path: string) {
+    private async _readInto(nodeId: number | bigint, path: string | string[]) {
         const res = await this.client.readAttribute(nodeId, path);
         const node = this.client.nodes[nodeIdKey(nodeId)];
         if (node) for (const [k, v] of Object.entries(res)) node.attributes[k] = v;

--- a/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
@@ -62,7 +62,13 @@ class BindingClusterCommands extends BaseClusterCommands {
         if (!confirmed) return;
         this._busy = true;
         try {
-            await deleteBindingAtIndex(this.client, this.node, this.endpoint, index);
+            await deleteBindingAtIndex(
+                this.client,
+                this.node,
+                this.endpoint,
+                index,
+                this.client.serverInfo?.fabric_index,
+            );
         } catch (err) {
             await showAlertDialog({ title: "Delete failed", text: err instanceof Error ? err.message : String(err) });
         } finally {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
@@ -48,7 +48,7 @@ class BindingClusterCommands extends BaseClusterCommands {
 
     /** Read the (fabric-scoped) binding attribute and each target's ACL into the cache on open. */
     private async _ensureLoaded() {
-        if (!this.client || !this.node || this.endpoint === undefined) return;
+        if (!this.client || !this.node || !this.node.available || this.endpoint === undefined) return;
         const key = `${nodeIdKey(this.node.node_id)}/${this.endpoint}`;
         if (this._loadedKey === key) return;
         this._loadedKey = key;
@@ -60,8 +60,8 @@ class BindingClusterCommands extends BaseClusterCommands {
                     .filter((k): k is string => k !== undefined),
             );
             for (const k of targets) {
-                const id = this.client.nodes[k]?.node_id;
-                if (id != null) await this._readInto(id, "0/31/0");
+                const target = this.client.nodes[k];
+                if (target?.available) await this._readInto(target.node_id, "0/31/0");
             }
             this.requestUpdate();
         } catch (err) {

--- a/packages/dashboard/src/pages/cluster-commands/index.ts
+++ b/packages/dashboard/src/pages/cluster-commands/index.ts
@@ -16,6 +16,7 @@ export { getClusterCommandsTag, hasClusterCommands, registerClusterCommands } fr
 export { BaseClusterCommands } from "./base-cluster-commands.js";
 
 // Cluster command components (auto-register on import)
+import "./clusters/access-control-commands.js";
 import "./clusters/avsum-commands.js";
 import "./clusters/basic-information-commands.js";
 import "./clusters/binding-commands.js";

--- a/packages/dashboard/src/pages/cluster-commands/index.ts
+++ b/packages/dashboard/src/pages/cluster-commands/index.ts
@@ -18,6 +18,7 @@ export { BaseClusterCommands } from "./base-cluster-commands.js";
 // Cluster command components (auto-register on import)
 import "./clusters/avsum-commands.js";
 import "./clusters/basic-information-commands.js";
+import "./clusters/binding-commands.js";
 import "./clusters/chime-commands.js";
 import "./clusters/level-control-commands.js";
 import "./clusters/on-off-commands.js";

--- a/packages/dashboard/src/pages/components/node-details.ts
+++ b/packages/dashboard/src/pages/components/node-details.ts
@@ -13,13 +13,13 @@ import "@material/web/list/list";
 import "@material/web/list/list-item";
 import { consume } from "@lit/context";
 import { MatterClient, MatterNode, UpdateSource } from "@matter-server/ws-client";
-import { mdiChatProcessing, mdiLink, mdiPencil, mdiShareVariant, mdiTrashCan, mdiUpdate, mdiVideo } from "@mdi/js";
+import { mdiChatProcessing, mdiPencil, mdiShareVariant, mdiTrashCan, mdiUpdate, mdiVideo } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { clientContext, tickContext } from "../../client/client-context.js";
 import { DeviceType } from "../../client/models/descriptions.js";
 import { showAlertDialog, showPromptDialog } from "../../components/dialog-box/show-dialog-box.js";
-import { showNodeBindingDialog } from "../../components/dialogs/binding/show-node-binding-dialog.js";
+import "../cluster-commands/clusters/binding-commands.js";
 import { showNodeLabelDialog } from "../../components/dialogs/node-label-dialog/show-node-label-dialog.js";
 import { handleAsync } from "../../util/async-handler.js";
 import "../../components/ha-svg-icon";
@@ -79,7 +79,7 @@ export class NodeDetails extends LitElement {
     protected override render() {
         if (!this.node) return html``;
 
-        const bindings = this.node.attributes[this.endpoint + "/30/0"];
+        const hasBindingCluster = Object.keys(this.node.attributes).some(k => k.startsWith(`${this.endpoint}/30/`));
         const deviceTypeIds = getEndpointDeviceTypes(this.node, this.endpoint).map(d => d.id);
         const isCamera = deviceTypeIds.includes(0x0142) || deviceTypeIds.includes(0x0143);
 
@@ -159,15 +159,6 @@ export class NodeDetails extends LitElement {
                                   </md-outlined-button>
                               `
                             : nothing}
-                        ${bindings
-                            ? html`
-                                  <md-outlined-button @click=${handleAsync(() => this._binding())}>
-                                      Binding
-                                      <ha-svg-icon slot="icon" .path=${mdiLink}></ha-svg-icon>
-                                  </md-outlined-button>
-                              `
-                            : nothing}
-
                         <md-outlined-button @click=${handleAsync(() => this._openCommissioningWindow())}
                             >Share<ha-svg-icon slot="icon" .path=${mdiShareVariant}></ha-svg-icon
                         ></md-outlined-button>
@@ -177,6 +168,15 @@ export class NodeDetails extends LitElement {
                     </div>
                 </md-list-item>
             </md-list>
+            ${hasBindingCluster
+                ? html`<div style="margin: 8px 16px;">
+                      <binding-cluster-commands
+                          .node=${this.node}
+                          .endpoint=${this.endpoint}
+                          .cluster=${30}
+                      ></binding-cluster-commands>
+                  </div>`
+                : nothing}
         `;
     }
 
@@ -228,14 +228,6 @@ export class NodeDetails extends LitElement {
                 title: "Failed to remove node",
                 text: err.message,
             });
-        }
-    }
-
-    private async _binding() {
-        try {
-            showNodeBindingDialog(this.node!, this.endpoint);
-        } catch (err: unknown) {
-            console.error("Binding error:", err);
         }
     }
 

--- a/packages/dashboard/src/pages/components/node-details.ts
+++ b/packages/dashboard/src/pages/components/node-details.ts
@@ -19,13 +19,12 @@ import { customElement, property, state } from "lit/decorators.js";
 import { clientContext, tickContext } from "../../client/client-context.js";
 import { DeviceType } from "../../client/models/descriptions.js";
 import { showAlertDialog, showPromptDialog } from "../../components/dialog-box/show-dialog-box.js";
-import "../cluster-commands/clusters/binding-commands.js";
 import { showNodeLabelDialog } from "../../components/dialogs/node-label-dialog/show-node-label-dialog.js";
 import { handleAsync } from "../../util/async-handler.js";
 import "../../components/ha-svg-icon";
 import "../camera-overlay.js";
 import { getDeviceIcon } from "../../util/device-icons.js";
-import { getEndpointDeviceTypes } from "../matter-endpoint-view.js";
+import { getEndpointDeviceTypes } from "../../util/endpoints.js";
 import { bindingContext } from "./context.js";
 
 /** Map updateState values to user-friendly labels */
@@ -79,7 +78,6 @@ export class NodeDetails extends LitElement {
     protected override render() {
         if (!this.node) return html``;
 
-        const hasBindingCluster = Object.keys(this.node.attributes).some(k => k.startsWith(`${this.endpoint}/30/`));
         const deviceTypeIds = getEndpointDeviceTypes(this.node, this.endpoint).map(d => d.id);
         const isCamera = deviceTypeIds.includes(0x0142) || deviceTypeIds.includes(0x0143);
 
@@ -168,15 +166,6 @@ export class NodeDetails extends LitElement {
                     </div>
                 </md-list-item>
             </md-list>
-            ${hasBindingCluster
-                ? html`<div style="margin: 8px 16px;">
-                      <binding-cluster-commands
-                          .node=${this.node}
-                          .endpoint=${this.endpoint}
-                          .cluster=${30}
-                      ></binding-cluster-commands>
-                  </div>`
-                : nothing}
         `;
     }
 

--- a/packages/dashboard/src/pages/matter-cluster-view.ts
+++ b/packages/dashboard/src/pages/matter-cluster-view.ts
@@ -351,7 +351,10 @@ class MatterClusterView extends LitElement {
 
     private _renderClusterCommands() {
         if (this.cluster === undefined) return html``;
-        if (!this.node?.available) return html``; // Don't show commands when device is offline
+        // ACL (31) and Binding (30) panels stay visible read-only for offline nodes; commands for
+        // other clusters are hidden while the device is unreachable.
+        const RENDER_WHEN_OFFLINE = new Set<number>([30, 31]);
+        if (!this.node?.available && !RENDER_WHEN_OFFLINE.has(this.cluster)) return html``;
 
         const tagName = getClusterCommandsTag(this.cluster);
         if (!tagName) return html``;

--- a/packages/dashboard/src/pages/matter-endpoint-view.ts
+++ b/packages/dashboard/src/pages/matter-endpoint-view.ts
@@ -13,12 +13,14 @@ import "@material/web/list/list-item";
 import { consume } from "@lit/context";
 import { MatterClient, MatterNode, isTestNodeId } from "@matter-server/ws-client";
 import { mdiAlertCircleOutline, mdiChevronRight } from "@mdi/js";
-import { LitElement, css, html } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { guard } from "lit/directives/guard.js";
+import "./cluster-commands/clusters/binding-commands.js";
 import { clientContext, tickContext } from "../client/client-context.js";
-import { DeviceType, clusters, device_types } from "../client/models/descriptions.js";
+import { clusters } from "../client/models/descriptions.js";
 import "../components/ha-svg-icon";
+import { getEndpointDeviceTypes } from "../util/endpoints.js";
 import { formatHex, formatNodeAddress, getEffectiveFabricIndex } from "../util/format_hex.js";
 import { notFoundStyles } from "../util/shared-styles.js";
 import { bindingContext } from "./components/context.js";
@@ -41,14 +43,7 @@ function getUniqueClusters(node: MatterNode, endpoint: number) {
     });
 }
 
-export function getEndpointDeviceTypes(node: MatterNode, endpoint: number): DeviceType[] {
-    const rawValues = node.attributes[`${endpoint}/29/0`] as Record<string, number>[] | undefined;
-    if (!rawValues) return [];
-    return rawValues.map(rawValue => {
-        const id = rawValue["0"] ?? rawValue["deviceType"];
-        return device_types[id] ?? { id: id ?? -1, label: `Unknown Device Type (${id})`, clusters: [] };
-    });
-}
+export { getEndpointDeviceTypes };
 
 @customElement("matter-endpoint-view")
 class MatterEndpointView extends LitElement {
@@ -94,6 +89,17 @@ class MatterEndpointView extends LitElement {
             <div class="container">
                 <node-details .node=${this.node}></node-details>
             </div>
+
+            <!-- Binding editor (when this endpoint has a Binding cluster) -->
+            ${getUniqueClusters(this.node, this.endpoint).includes(30)
+                ? html`<div class="container">
+                      <binding-cluster-commands
+                          .node=${this.node}
+                          .endpoint=${this.endpoint}
+                          .cluster=${30}
+                      ></binding-cluster-commands>
+                  </div>`
+                : nothing}
 
             <!-- Endpoint clusters listing -->
             <div class="container">

--- a/packages/dashboard/src/pages/matter-node-view.ts
+++ b/packages/dashboard/src/pages/matter-node-view.ts
@@ -18,11 +18,11 @@ import { guard } from "lit/directives/guard.js";
 import { clientContext, tickContext } from "../client/client-context.js";
 import "../components/ha-svg-icon";
 import { getDeviceIcon, getEndpointIcon } from "../util/device-icons.js";
+import { getEndpointDeviceTypes } from "../util/endpoints.js";
 import { formatNodeAddress, getEffectiveFabricIndex } from "../util/format_hex.js";
-import { notFoundStyles, reducedMotionStyles } from "../util/shared-styles.js";
 import "./components/header";
 import "./components/node-details";
-import { getEndpointDeviceTypes } from "./matter-endpoint-view.js";
+import { notFoundStyles, reducedMotionStyles } from "../util/shared-styles.js";
 import { getNetworkType } from "./network/network-utils.js";
 
 declare global {

--- a/packages/dashboard/src/pages/network/network-utils.ts
+++ b/packages/dashboard/src/pages/network/network-utils.ts
@@ -707,24 +707,7 @@ export function stripMdnsHostname(hostname: string): string {
     return hostname.replace(/\.$/, "").replace(/\.local$/i, "");
 }
 
-/**
- * Gets a human-readable display name for a node.
- * Format: nodeLabel || productName (serialNumber)
- */
-export function getDeviceName(node: MatterNode): string {
-    if (node.nodeLabel) {
-        return node.nodeLabel;
-    }
-
-    const productName = node.productName || "Unknown Device";
-    const serialNumber = node.serialNumber;
-
-    if (serialNumber) {
-        return `${productName} (${serialNumber})`;
-    }
-
-    return productName;
-}
+export { getDeviceName } from "../../util/node-name.js";
 
 /**
  * Gets the human-readable name for a Thread routing role.

--- a/packages/dashboard/src/util/access-control.ts
+++ b/packages/dashboard/src/util/access-control.ts
@@ -6,7 +6,6 @@
 
 import type { MatterNode } from "@matter-server/ws-client";
 import { AccessControlEntryDataTransformer, type AccessControlEntryStruct } from "../components/dialogs/acl/model.js";
-import { readAllBindings } from "./binding.js";
 
 export enum Privilege {
     View = 1,
@@ -35,14 +34,6 @@ export const AUTH_MODE_NAMES: Record<number, string> = {
     [AuthMode.Case]: "CASE",
     [AuthMode.Group]: "Group",
 };
-
-export type RelationshipKind = "none" | "backs" | "overPrivileged";
-
-export interface RelationshipResult {
-    kind: RelationshipKind;
-    sourceNodeId?: number | bigint;
-    sourceEndpoint?: number;
-}
 
 export function nodeIdKey(id: number | bigint): string {
     return String(id);
@@ -123,27 +114,4 @@ export function isProtectedAdmin(
         entry.authMode === AuthMode.Case &&
         subjectsInclude(entry, controllerNodeId)
     );
-}
-
-export function detectBindingRelationship(
-    entry: AccessControlEntryStruct,
-    viewedNodeId: number | bigint,
-    allNodes: MatterNode[],
-): RelationshipResult {
-    if (entry.authMode !== AuthMode.Case) return { kind: "none" };
-    const viewedKey = nodeIdKey(viewedNodeId);
-
-    for (const subject of entry.subjects ?? []) {
-        const sourceKey = nodeIdKey(subject);
-        const source = allNodes.find(n => nodeIdKey(n.node_id) === sourceKey);
-        if (!source || !source.available) continue;
-        for (const { endpoint, binding } of readAllBindings(source)) {
-            if (binding.node == null) continue;
-            if (nodeIdKey(binding.node) !== viewedKey) continue;
-            if (!entryMatchesTarget(entry, binding.endpoint ?? -1, binding.cluster)) continue;
-            const kind: RelationshipKind = entry.privilege === Privilege.Administer ? "overPrivileged" : "backs";
-            return { kind, sourceNodeId: source.node_id, sourceEndpoint: endpoint };
-        }
-    }
-    return { kind: "none" };
 }

--- a/packages/dashboard/src/util/access-control.ts
+++ b/packages/dashboard/src/util/access-control.ts
@@ -48,10 +48,15 @@ export function nodeIdKey(id: number | bigint): string {
     return String(id);
 }
 
+/** Normalize a raw attribute value (array or index-keyed object, or absent) into an element array. */
+export function attributeArray(value: unknown): unknown[] {
+    if (Array.isArray(value)) return value;
+    if (value && typeof value === "object") return Object.values(value);
+    return new Array<unknown>();
+}
+
 export function readAclEntries(node: MatterNode): AccessControlEntryStruct[] {
-    const raw = node.attributes["0/31/0"] as unknown[] | undefined;
-    if (!raw) return new Array<AccessControlEntryStruct>();
-    return Object.values(raw).map(value => AccessControlEntryDataTransformer.transform(value));
+    return attributeArray(node.attributes["0/31/0"]).map(value => AccessControlEntryDataTransformer.transform(value));
 }
 
 export function entriesForFabric(

--- a/packages/dashboard/src/util/access-control.ts
+++ b/packages/dashboard/src/util/access-control.ts
@@ -72,15 +72,23 @@ export function isWholeNode(entry: AccessControlEntryStruct): boolean {
     return !entry.targets || entry.targets.length === 0;
 }
 
+/**
+ * Whether the entry grants access to (endpoint, cluster). A null target endpoint/cluster is an ACL
+ * wildcard (grants all). Cluster matching is directional: a wildcard *request* (cluster undefined,
+ * i.e. an all-clusters binding) is only covered by a wildcard ACL target — a cluster-specific grant
+ * does not cover "all clusters".
+ */
 export function entryMatchesTarget(
     entry: AccessControlEntryStruct,
     endpoint: number,
     cluster: number | undefined,
 ): boolean {
     if (isWholeNode(entry)) return true;
-    return entry.targets!.some(
-        t => t.endpoint === endpoint && (t.cluster == null || cluster == null || t.cluster === cluster),
-    );
+    return entry.targets!.some(t => {
+        const endpointMatch = t.endpoint == null || t.endpoint === endpoint;
+        const clusterMatch = cluster == null ? t.cluster == null : t.cluster == null || t.cluster === cluster;
+        return endpointMatch && clusterMatch;
+    });
 }
 
 export interface AclCapacity {

--- a/packages/dashboard/src/util/access-control.ts
+++ b/packages/dashboard/src/util/access-control.ts
@@ -58,6 +58,16 @@ export function entriesForFabric(
     return entries.filter(e => e.fabricIndex === fabricIndex);
 }
 
+/**
+ * The device-side fabric index for our controller's fabric, read from CurrentFabricIndex (0/62/5).
+ * ACL/Binding entries carry this index in their fabricIndex field — NOT the controller's own
+ * fabric-table index (serverInfo.fabric_index), which lives in a different numbering space.
+ */
+export function nodeFabricIndex(node: MatterNode): number | undefined {
+    const v = node.attributes["0/62/5"];
+    return typeof v === "number" ? v : undefined;
+}
+
 export function isWholeNode(entry: AccessControlEntryStruct): boolean {
     return !entry.targets || entry.targets.length === 0;
 }

--- a/packages/dashboard/src/util/access-control.ts
+++ b/packages/dashboard/src/util/access-control.ts
@@ -91,6 +91,18 @@ export function aclCapacity(node: MatterNode): AclCapacity {
     return { max: num("0/31/4", 0), subjectsMax: num("0/31/2", 0), targetsMax: num("0/31/3", 0) };
 }
 
+/**
+ * Stable structural identity for an ACL entry, used to re-locate it in a freshly-read list before a
+ * write (the cache copy and the fresh copy are different objects).
+ */
+export function aclEntryKey(entry: AccessControlEntryStruct): string {
+    const subjects = (entry.subjects ?? []).map(nodeIdKey).sort();
+    const targets = (entry.targets ?? [])
+        .map(t => `${t.endpoint ?? ""}:${t.cluster ?? ""}:${t.deviceType ?? ""}`)
+        .sort();
+    return JSON.stringify([entry.fabricIndex, entry.privilege, entry.authMode, subjects, targets]);
+}
+
 export function subjectsInclude(entry: AccessControlEntryStruct, nodeId: number | bigint): boolean {
     const key = nodeIdKey(nodeId);
     return (entry.subjects ?? []).some(s => nodeIdKey(s) === key);

--- a/packages/dashboard/src/util/access-control.ts
+++ b/packages/dashboard/src/util/access-control.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MatterNode } from "@matter-server/ws-client";
+import { AccessControlEntryDataTransformer, type AccessControlEntryStruct } from "../components/dialogs/acl/model.js";
+import { readAllBindings } from "./binding.js";
+
+export enum Privilege {
+    View = 1,
+    ProxyView = 2,
+    Operate = 3,
+    Manage = 4,
+    Administer = 5,
+}
+
+export enum AuthMode {
+    Pase = 1,
+    Case = 2,
+    Group = 3,
+}
+
+export const PRIVILEGE_NAMES: Record<number, string> = {
+    [Privilege.View]: "View",
+    [Privilege.ProxyView]: "ProxyView",
+    [Privilege.Operate]: "Operate",
+    [Privilege.Manage]: "Manage",
+    [Privilege.Administer]: "Administer",
+};
+
+export const AUTH_MODE_NAMES: Record<number, string> = {
+    [AuthMode.Pase]: "PASE",
+    [AuthMode.Case]: "CASE",
+    [AuthMode.Group]: "Group",
+};
+
+export type RelationshipKind = "none" | "backs" | "overPrivileged";
+
+export interface RelationshipResult {
+    kind: RelationshipKind;
+    sourceNodeId?: number | bigint;
+    sourceEndpoint?: number;
+}
+
+export function nodeIdKey(id: number | bigint): string {
+    return String(id);
+}
+
+export function readAclEntries(node: MatterNode): AccessControlEntryStruct[] {
+    const raw = node.attributes["0/31/0"] as unknown[] | undefined;
+    if (!raw) return new Array<AccessControlEntryStruct>();
+    return Object.values(raw).map(value => AccessControlEntryDataTransformer.transform(value));
+}
+
+export function entriesForFabric(
+    entries: AccessControlEntryStruct[],
+    fabricIndex: number | undefined,
+): AccessControlEntryStruct[] {
+    if (fabricIndex === undefined) return entries;
+    return entries.filter(e => e.fabricIndex === fabricIndex);
+}
+
+export function isWholeNode(entry: AccessControlEntryStruct): boolean {
+    return !entry.targets || entry.targets.length === 0;
+}
+
+export function entryMatchesTarget(
+    entry: AccessControlEntryStruct,
+    endpoint: number,
+    cluster: number | undefined,
+): boolean {
+    if (isWholeNode(entry)) return true;
+    return entry.targets!.some(
+        t => t.endpoint === endpoint && (t.cluster == null || cluster == null || t.cluster === cluster),
+    );
+}
+
+export interface AclCapacity {
+    max: number;
+    subjectsMax: number;
+    targetsMax: number;
+}
+
+export function aclCapacity(node: MatterNode): AclCapacity {
+    const num = (key: string, fallback: number) => {
+        const v = node.attributes[key];
+        return typeof v === "number" ? v : fallback;
+    };
+    return { max: num("0/31/4", 0), subjectsMax: num("0/31/2", 0), targetsMax: num("0/31/3", 0) };
+}
+
+export function subjectsInclude(entry: AccessControlEntryStruct, nodeId: number | bigint): boolean {
+    const key = nodeIdKey(nodeId);
+    return (entry.subjects ?? []).some(s => nodeIdKey(s) === key);
+}
+
+export function isProtectedAdmin(
+    entry: AccessControlEntryStruct,
+    controllerNodeId: number | bigint | undefined,
+): boolean {
+    if (controllerNodeId === undefined) return false;
+    return (
+        entry.privilege === Privilege.Administer &&
+        entry.authMode === AuthMode.Case &&
+        subjectsInclude(entry, controllerNodeId)
+    );
+}
+
+export function detectBindingRelationship(
+    entry: AccessControlEntryStruct,
+    viewedNodeId: number | bigint,
+    allNodes: MatterNode[],
+): RelationshipResult {
+    if (entry.authMode !== AuthMode.Case) return { kind: "none" };
+    const viewedKey = nodeIdKey(viewedNodeId);
+
+    for (const subject of entry.subjects ?? []) {
+        const sourceKey = nodeIdKey(subject);
+        const source = allNodes.find(n => nodeIdKey(n.node_id) === sourceKey);
+        if (!source || !source.available) continue;
+        for (const { endpoint, binding } of readAllBindings(source)) {
+            if (binding.node == null) continue;
+            if (nodeIdKey(binding.node) !== viewedKey) continue;
+            if (!entryMatchesTarget(entry, binding.endpoint ?? -1, binding.cluster)) continue;
+            const kind: RelationshipKind = entry.privilege === Privilege.Administer ? "overPrivileged" : "backs";
+            return { kind, sourceNodeId: source.node_id, sourceEndpoint: endpoint };
+        }
+    }
+    return { kind: "none" };
+}

--- a/packages/dashboard/src/util/binding.ts
+++ b/packages/dashboard/src/util/binding.ts
@@ -14,6 +14,7 @@ import {
     entriesForFabric,
     entryMatchesTarget,
     isWholeNode,
+    nodeFabricIndex,
     nodeIdKey,
     readAclEntries,
     subjectsInclude,
@@ -98,10 +99,9 @@ export function reverseAclState(
     sourceNodeId: number | bigint,
     binding: BindingEntryStruct,
     targetNode: MatterNode | undefined,
-    fabricIndex?: number,
 ): ReverseAclResult {
     if (!targetNode || !targetNode.available) return { state: "cannotVerify" };
-    const matching = entriesForFabric(readAclEntries(targetNode), fabricIndex).filter(
+    const matching = entriesForFabric(readAclEntries(targetNode), nodeFabricIndex(targetNode)).filter(
         e =>
             e.authMode === AuthMode.Case &&
             subjectsInclude(e, sourceNodeId) &&
@@ -157,12 +157,8 @@ export interface AddBindingCapacity {
  * A new binding consumes a target ACL slot only when no existing our-fabric Operate+ entry for the
  * source can absorb it — mirrors the merge behavior the writer implements.
  */
-export function targetAclCapacityForBinding(
-    targetNode: MatterNode,
-    sourceNodeId: number | bigint,
-    fabricIndex?: number,
-): AddBindingCapacity {
-    const entries = entriesForFabric(readAclEntries(targetNode), fabricIndex);
+export function targetAclCapacityForBinding(targetNode: MatterNode, sourceNodeId: number | bigint): AddBindingCapacity {
+    const entries = entriesForFabric(readAclEntries(targetNode), nodeFabricIndex(targetNode));
     const targetsMaxRaw = targetNode.attributes["0/31/3"];
     const targetsMax = typeof targetsMaxRaw === "number" && targetsMaxRaw > 0 ? targetsMaxRaw : Number.MAX_SAFE_INTEGER;
     const reusable = entries.some(

--- a/packages/dashboard/src/util/binding.ts
+++ b/packages/dashboard/src/util/binding.ts
@@ -158,7 +158,11 @@ export interface AddBindingCapacity {
  * source can absorb it — mirrors the merge behavior the writer implements.
  */
 export function targetAclCapacityForBinding(targetNode: MatterNode, sourceNodeId: number | bigint): AddBindingCapacity {
-    const entries = entriesForFabric(readAclEntries(targetNode), nodeFabricIndex(targetNode));
+    const fabricIndex = nodeFabricIndex(targetNode);
+    // Advisory pre-check only. If CurrentFabricIndex isn't cached for this target yet, don't block:
+    // the write path (ensureBindingAcl → freshOurAcl) reads 0/62/5 fresh and fails cleanly if absent.
+    if (fabricIndex === undefined) return { canAdd: true };
+    const entries = entriesForFabric(readAclEntries(targetNode), fabricIndex);
     const targetsMaxRaw = targetNode.attributes["0/31/3"];
     const targetsMax = typeof targetsMaxRaw === "number" && targetsMaxRaw > 0 ? targetsMaxRaw : Number.MAX_SAFE_INTEGER;
     const reusable = entries.some(

--- a/packages/dashboard/src/util/binding.ts
+++ b/packages/dashboard/src/util/binding.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MatterNode } from "@matter-server/ws-client";
+import { BindingEntryDataTransformer, type BindingEntryStruct } from "../components/dialogs/binding/model.js";
+import {
+    AuthMode,
+    Privilege,
+    entriesForFabric,
+    entryMatchesTarget,
+    readAclEntries,
+    subjectsInclude,
+} from "./access-control.js";
+
+const BINDING_KEY_RE = /^(\d+)\/30\/0$/;
+
+export function readBindings(node: MatterNode, endpoint: number): BindingEntryStruct[] {
+    const raw = node.attributes[`${endpoint}/30/0`] as unknown[] | undefined;
+    if (!raw) return new Array<BindingEntryStruct>();
+    return Object.values(raw).map(value => BindingEntryDataTransformer.transform(value));
+}
+
+export interface EndpointBinding {
+    endpoint: number;
+    binding: BindingEntryStruct;
+}
+
+export function readAllBindings(node: MatterNode): EndpointBinding[] {
+    const result = new Array<EndpointBinding>();
+    for (const key of Object.keys(node.attributes)) {
+        const m = BINDING_KEY_RE.exec(key);
+        if (!m) continue;
+        const endpoint = Number(m[1]);
+        const raw = node.attributes[key] as unknown[] | undefined;
+        if (!raw) continue;
+        for (const value of Object.values(raw)) {
+            result.push({ endpoint, binding: BindingEntryDataTransformer.transform(value) });
+        }
+    }
+    return result;
+}
+
+function numberList(node: MatterNode, key: string): number[] {
+    const raw = node.attributes[key];
+    if (!Array.isArray(raw)) return new Array<number>();
+    return raw.map(v => Number(v));
+}
+
+export function targetServerClusters(node: MatterNode, endpoint: number): number[] {
+    return numberList(node, `${endpoint}/29/1`);
+}
+
+export function sourceClientClusters(node: MatterNode, endpoint: number): number[] {
+    return numberList(node, `${endpoint}/29/2`);
+}
+
+export interface BindableClusters {
+    bindable: number[];
+    otherTarget: number[];
+}
+
+export function bindableClusters(
+    source: MatterNode,
+    sourceEndpoint: number,
+    target: MatterNode,
+    targetEndpoint: number,
+): BindableClusters {
+    const client = new Set(sourceClientClusters(source, sourceEndpoint));
+    const server = targetServerClusters(target, targetEndpoint);
+    const bindable = new Array<number>();
+    const otherTarget = new Array<number>();
+    for (const c of server) {
+        if (client.has(c)) bindable.push(c);
+        else otherTarget.push(c);
+    }
+    return { bindable, otherTarget };
+}
+
+export type ReverseAclState = "present" | "missing" | "cannotVerify";
+
+export interface ReverseAclResult {
+    state: ReverseAclState;
+}
+
+export function reverseAclState(
+    sourceNodeId: number | bigint,
+    binding: BindingEntryStruct,
+    targetNode: MatterNode | undefined,
+    fabricIndex?: number,
+): ReverseAclResult {
+    if (!targetNode || !targetNode.available) return { state: "cannotVerify" };
+    const entries = entriesForFabric(readAclEntries(targetNode), fabricIndex);
+    const found = entries.some(
+        e =>
+            e.authMode === AuthMode.Case &&
+            e.privilege >= Privilege.Operate &&
+            subjectsInclude(e, sourceNodeId) &&
+            entryMatchesTarget(e, binding.endpoint ?? -1, binding.cluster),
+    );
+    return { state: found ? "present" : "missing" };
+}
+
+export interface AddBindingCapacity {
+    canAdd: boolean;
+    reason?: string;
+}
+
+/**
+ * A new binding consumes a target ACL slot only when no existing our-fabric Operate+ entry for the
+ * source can absorb it — mirrors the merge behavior the writer implements.
+ */
+export function targetAclCapacityForBinding(
+    targetNode: MatterNode,
+    sourceNodeId: number | bigint,
+    fabricIndex?: number,
+): AddBindingCapacity {
+    const entries = entriesForFabric(readAclEntries(targetNode), fabricIndex);
+    const reusable = entries.some(
+        e => e.authMode === AuthMode.Case && e.privilege >= Privilege.Operate && subjectsInclude(e, sourceNodeId),
+    );
+    if (reusable) return { canAdd: true };
+    const maxRaw = targetNode.attributes["0/31/4"];
+    const max = typeof maxRaw === "number" ? maxRaw : 0;
+    if (max > 0 && entries.length >= max) {
+        return { canAdd: false, reason: "Target node's access control list is full." };
+    }
+    return { canAdd: true };
+}

--- a/packages/dashboard/src/util/binding.ts
+++ b/packages/dashboard/src/util/binding.ts
@@ -5,6 +5,7 @@
  */
 
 import type { MatterNode } from "@matter-server/ws-client";
+import type { AccessControlEntryStruct } from "../components/dialogs/acl/model.js";
 import { BindingEntryDataTransformer, type BindingEntryStruct } from "../components/dialogs/binding/model.js";
 import {
     AuthMode,
@@ -13,6 +14,7 @@ import {
     entriesForFabric,
     entryMatchesTarget,
     isWholeNode,
+    nodeIdKey,
     readAclEntries,
     subjectsInclude,
 } from "./access-control.js";
@@ -79,12 +81,19 @@ export function bindableClusters(
     return { bindable, otherTarget };
 }
 
-export type ReverseAclState = "present" | "missing" | "cannotVerify";
+export type ReverseAclState = "present" | "missing" | "overPrivileged" | "cannotVerify";
 
 export interface ReverseAclResult {
     state: ReverseAclState;
 }
 
+/**
+ * Whether the target node's ACL grants the source the access this binding needs:
+ *  - present:        a matching CASE entry at Operate exists
+ *  - overPrivileged: the only matching grant is above Operate (Manage/Administer)
+ *  - missing:        no matching grant (or only below Operate)
+ *  - cannotVerify:   target node not known / offline
+ */
 export function reverseAclState(
     sourceNodeId: number | bigint,
     binding: BindingEntryStruct,
@@ -92,15 +101,51 @@ export function reverseAclState(
     fabricIndex?: number,
 ): ReverseAclResult {
     if (!targetNode || !targetNode.available) return { state: "cannotVerify" };
-    const entries = entriesForFabric(readAclEntries(targetNode), fabricIndex);
-    const found = entries.some(
+    const matching = entriesForFabric(readAclEntries(targetNode), fabricIndex).filter(
         e =>
             e.authMode === AuthMode.Case &&
-            e.privilege >= Privilege.Operate &&
             subjectsInclude(e, sourceNodeId) &&
             entryMatchesTarget(e, binding.endpoint ?? -1, binding.cluster),
     );
-    return { state: found ? "present" : "missing" };
+    const granting = matching.filter(e => e.privilege >= Privilege.Operate);
+    if (granting.length === 0) return { state: "missing" };
+    if (granting.some(e => e.privilege === Privilege.Operate)) return { state: "present" };
+    return { state: "overPrivileged" };
+}
+
+export type RelationshipKind = "none" | "backs" | "overPrivileged";
+
+export interface RelationshipResult {
+    kind: RelationshipKind;
+    sourceNodeId?: number | bigint;
+    sourceEndpoint?: number;
+}
+
+/**
+ * Whether an ACL entry on the viewed node backs a real binding from one of its subjects. Grants
+ * above Operate are flagged over-privileged (Operate is sufficient for a binding).
+ */
+export function detectBindingRelationship(
+    entry: AccessControlEntryStruct,
+    viewedNodeId: number | bigint,
+    allNodes: MatterNode[],
+): RelationshipResult {
+    if (entry.authMode !== AuthMode.Case) return { kind: "none" };
+    const viewedKey = nodeIdKey(viewedNodeId);
+
+    for (const subject of entry.subjects ?? []) {
+        const sourceKey = nodeIdKey(subject);
+        const source = allNodes.find(n => nodeIdKey(n.node_id) === sourceKey);
+        if (!source || !source.available) continue;
+        for (const { endpoint, binding } of readAllBindings(source)) {
+            if (binding.node == null) continue;
+            if (nodeIdKey(binding.node) !== viewedKey) continue;
+            if (!entryMatchesTarget(entry, binding.endpoint ?? -1, binding.cluster)) continue;
+            const kind: RelationshipKind = entry.privilege > Privilege.Operate ? "overPrivileged" : "backs";
+            return { kind, sourceNodeId: source.node_id, sourceEndpoint: endpoint };
+        }
+    }
+    return { kind: "none" };
 }
 
 export interface AddBindingCapacity {

--- a/packages/dashboard/src/util/binding.ts
+++ b/packages/dashboard/src/util/binding.ts
@@ -9,6 +9,7 @@ import { BindingEntryDataTransformer, type BindingEntryStruct } from "../compone
 import {
     AuthMode,
     Privilege,
+    attributeArray,
     entriesForFabric,
     entryMatchesTarget,
     readAclEntries,
@@ -18,9 +19,9 @@ import {
 const BINDING_KEY_RE = /^(\d+)\/30\/0$/;
 
 export function readBindings(node: MatterNode, endpoint: number): BindingEntryStruct[] {
-    const raw = node.attributes[`${endpoint}/30/0`] as unknown[] | undefined;
-    if (!raw) return new Array<BindingEntryStruct>();
-    return Object.values(raw).map(value => BindingEntryDataTransformer.transform(value));
+    return attributeArray(node.attributes[`${endpoint}/30/0`]).map(value =>
+        BindingEntryDataTransformer.transform(value),
+    );
 }
 
 export interface EndpointBinding {
@@ -34,9 +35,7 @@ export function readAllBindings(node: MatterNode): EndpointBinding[] {
         const m = BINDING_KEY_RE.exec(key);
         if (!m) continue;
         const endpoint = Number(m[1]);
-        const raw = node.attributes[key] as unknown[] | undefined;
-        if (!raw) continue;
-        for (const value of Object.values(raw)) {
+        for (const value of attributeArray(node.attributes[key])) {
             result.push({ endpoint, binding: BindingEntryDataTransformer.transform(value) });
         }
     }

--- a/packages/dashboard/src/util/binding.ts
+++ b/packages/dashboard/src/util/binding.ts
@@ -12,6 +12,7 @@ import {
     attributeArray,
     entriesForFabric,
     entryMatchesTarget,
+    isWholeNode,
     readAclEntries,
     subjectsInclude,
 } from "./access-control.js";
@@ -117,8 +118,14 @@ export function targetAclCapacityForBinding(
     fabricIndex?: number,
 ): AddBindingCapacity {
     const entries = entriesForFabric(readAclEntries(targetNode), fabricIndex);
+    const targetsMaxRaw = targetNode.attributes["0/31/3"];
+    const targetsMax = typeof targetsMaxRaw === "number" && targetsMaxRaw > 0 ? targetsMaxRaw : Number.MAX_SAFE_INTEGER;
     const reusable = entries.some(
-        e => e.authMode === AuthMode.Case && e.privilege >= Privilege.Operate && subjectsInclude(e, sourceNodeId),
+        e =>
+            e.authMode === AuthMode.Case &&
+            e.privilege >= Privilege.Operate &&
+            subjectsInclude(e, sourceNodeId) &&
+            (isWholeNode(e) || (e.targets?.length ?? 0) < targetsMax),
     );
     if (reusable) return { canAdd: true };
     const maxRaw = targetNode.attributes["0/31/4"];

--- a/packages/dashboard/src/util/endpoints.ts
+++ b/packages/dashboard/src/util/endpoints.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MatterNode } from "@matter-server/ws-client";
+import { type DeviceType, device_types } from "../client/models/descriptions.js";
+
+export function getEndpointDeviceTypes(node: MatterNode, endpoint: number): DeviceType[] {
+    const rawValues = node.attributes[`${endpoint}/29/0`] as Record<string, number>[] | undefined;
+    if (!rawValues) return new Array<DeviceType>();
+    return rawValues.map(rawValue => {
+        const id = rawValue["0"] ?? rawValue["deviceType"];
+        return device_types[id] ?? { id: id ?? -1, label: `Unknown Device Type (${id})`, clusters: [] };
+    });
+}

--- a/packages/dashboard/src/util/node-name.ts
+++ b/packages/dashboard/src/util/node-name.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MatterNode } from "@matter-server/ws-client";
+
+/**
+ * Human-readable display name for a node: nodeLabel, else productName (serialNumber), else a
+ * generic fallback. Shared so node pickers and tables name devices consistently.
+ */
+export function getDeviceName(node: MatterNode): string {
+    if (node.nodeLabel) return node.nodeLabel;
+    const productName = node.productName || "Unknown Device";
+    const serialNumber = node.serialNumber;
+    return serialNumber ? `${productName} (${serialNumber})` : productName;
+}

--- a/packages/dashboard/test/AccessControlUtilTest.ts
+++ b/packages/dashboard/test/AccessControlUtilTest.ts
@@ -60,6 +60,13 @@ describe("access-control util", () => {
         expect(isWholeNode(entries[0])).to.equal(true);
     });
 
+    it("treats null target fields as wildcard (undefined), not 0", () => {
+        const n = node({ "0/31/0": [{ "1": 3, "2": 2, "3": [1], "4": [{ "0": 6, "1": null }], "254": 1 }] });
+        const target = readAclEntries(n)[0].targets![0];
+        expect(target.cluster).to.equal(6);
+        expect(target.endpoint).to.equal(undefined);
+    });
+
     it("entriesForFabric filters by fabricIndex", () => {
         const all = [entry({ fabricIndex: 1 }), entry({ subjects: [2], fabricIndex: 2 })];
         expect(entriesForFabric(all, 1)).to.have.length(1);

--- a/packages/dashboard/test/AccessControlUtilTest.ts
+++ b/packages/dashboard/test/AccessControlUtilTest.ts
@@ -10,7 +10,6 @@ import {
     Privilege,
     aclCapacity,
     aclEntryKey,
-    detectBindingRelationship,
     entriesForFabric,
     entryMatchesTarget,
     isProtectedAdmin,
@@ -18,6 +17,7 @@ import {
     nodeIdKey,
     readAclEntries,
 } from "../src/util/access-control.js";
+import { detectBindingRelationship } from "../src/util/binding.js";
 
 function node(
     attributes: Record<string, unknown>,

--- a/packages/dashboard/test/AccessControlUtilTest.ts
+++ b/packages/dashboard/test/AccessControlUtilTest.ts
@@ -80,7 +80,9 @@ describe("access-control util", () => {
     });
 
     it("isProtectedAdmin flags the controller's admin entry across number/bigint", () => {
-        expect(isProtectedAdmin(entry({ privilege: Privilege.Administer, subjects: [112233n] }), 112233)).to.equal(true);
+        expect(isProtectedAdmin(entry({ privilege: Privilege.Administer, subjects: [112233n] }), 112233)).to.equal(
+            true,
+        );
         expect(isProtectedAdmin(entry({ privilege: Privilege.Operate, subjects: [112233] }), 112233)).to.equal(false);
         expect(isProtectedAdmin(entry({ privilege: Privilege.Administer, subjects: [112233n] }), undefined)).to.equal(
             false,
@@ -113,5 +115,16 @@ describe("access-control util", () => {
         expect(detectBindingRelationship(admin, viewed, all).kind).to.equal("overPrivileged");
         const unrelated = entry({ subjects: [555], targets: [{ endpoint: 1, cluster: 6, deviceType: undefined }] });
         expect(detectBindingRelationship(unrelated, viewed, all).kind).to.equal("none");
+    });
+
+    it("detectBindingRelationship ignores an offline source node", () => {
+        const viewed = 2588119612;
+        const source = node({ "1/30/0": [{ "1": viewed, "3": 1, "4": 6 }] }, { node_id: 976328453, available: false });
+        const operate = entry({
+            privilege: Privilege.Operate,
+            subjects: [976328453],
+            targets: [{ endpoint: 1, cluster: 6, deviceType: undefined }],
+        });
+        expect(detectBindingRelationship(operate, viewed, [source]).kind).to.equal("none");
     });
 });

--- a/packages/dashboard/test/AccessControlUtilTest.ts
+++ b/packages/dashboard/test/AccessControlUtilTest.ts
@@ -9,6 +9,7 @@ import type { AccessControlEntryStruct } from "../src/components/dialogs/acl/mod
 import {
     Privilege,
     aclCapacity,
+    aclEntryKey,
     detectBindingRelationship,
     entriesForFabric,
     entryMatchesTarget,
@@ -84,6 +85,14 @@ describe("access-control util", () => {
         expect(isProtectedAdmin(entry({ privilege: Privilege.Administer, subjects: [112233n] }), undefined)).to.equal(
             false,
         );
+    });
+
+    it("aclEntryKey is stable across number/bigint subjects and target order", () => {
+        const a = entry({ subjects: [112233], targets: [{ endpoint: 1, cluster: 6, deviceType: undefined }] });
+        const b = entry({ subjects: [112233n], targets: [{ endpoint: 1, cluster: 6, deviceType: undefined }] });
+        expect(aclEntryKey(a)).to.equal(aclEntryKey(b));
+        const c = entry({ subjects: [112233], targets: undefined });
+        expect(aclEntryKey(a)).to.not.equal(aclEntryKey(c));
     });
 
     it("detectBindingRelationship marks backs / overPrivileged / none", () => {

--- a/packages/dashboard/test/AccessControlUtilTest.ts
+++ b/packages/dashboard/test/AccessControlUtilTest.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MatterNode, type MatterNodeData } from "@matter-server/ws-client";
+import type { AccessControlEntryStruct } from "../src/components/dialogs/acl/model.js";
+import {
+    Privilege,
+    aclCapacity,
+    detectBindingRelationship,
+    entriesForFabric,
+    entryMatchesTarget,
+    isProtectedAdmin,
+    isWholeNode,
+    nodeIdKey,
+    readAclEntries,
+} from "../src/util/access-control.js";
+
+function node(
+    attributes: Record<string, unknown>,
+    opts: { node_id?: number | bigint; available?: boolean } = {},
+): MatterNode {
+    const data: MatterNodeData = {
+        node_id: opts.node_id ?? 1,
+        date_commissioned: "",
+        last_interview: "",
+        interview_version: 1,
+        available: opts.available ?? true,
+        is_bridge: false,
+        attributes,
+        attribute_subscriptions: [],
+    };
+    return new MatterNode(data);
+}
+
+function entry(p: Partial<AccessControlEntryStruct>): AccessControlEntryStruct {
+    return {
+        privilege: Privilege.Operate,
+        authMode: 2,
+        subjects: [1],
+        targets: undefined,
+        fabricIndex: 1,
+        ...p,
+    };
+}
+
+describe("access-control util", () => {
+    it("nodeIdKey normalizes number and bigint to the same string", () => {
+        expect(nodeIdKey(112233)).to.equal(nodeIdKey(112233n));
+    });
+
+    it("readAclEntries parses the raw acl attribute", () => {
+        const n = node({ "0/31/0": [{ "1": 5, "2": 2, "3": [112233], "4": undefined, "254": 1 }] });
+        const entries = readAclEntries(n);
+        expect(entries).to.have.length(1);
+        expect(entries[0].privilege).to.equal(Privilege.Administer);
+        expect(isWholeNode(entries[0])).to.equal(true);
+    });
+
+    it("entriesForFabric filters by fabricIndex", () => {
+        const all = [entry({ fabricIndex: 1 }), entry({ subjects: [2], fabricIndex: 2 })];
+        expect(entriesForFabric(all, 1)).to.have.length(1);
+        expect(entriesForFabric(all, undefined)).to.have.length(2);
+    });
+
+    it("entryMatchesTarget matches whole-node and endpoint/cluster", () => {
+        expect(entryMatchesTarget(entry({ targets: undefined }), 1, 6)).to.equal(true);
+        const scoped = entry({ targets: [{ endpoint: 1, cluster: 6, deviceType: undefined }] });
+        expect(entryMatchesTarget(scoped, 1, 6)).to.equal(true);
+        expect(entryMatchesTarget(scoped, 2, 6)).to.equal(false);
+        expect(entryMatchesTarget(scoped, 1, 8)).to.equal(false);
+    });
+
+    it("aclCapacity reads the limit attributes", () => {
+        const n = node({ "0/31/4": 4, "0/31/2": 4, "0/31/3": 3 });
+        expect(aclCapacity(n)).to.deep.equal({ max: 4, subjectsMax: 4, targetsMax: 3 });
+    });
+
+    it("isProtectedAdmin flags the controller's admin entry across number/bigint", () => {
+        expect(isProtectedAdmin(entry({ privilege: Privilege.Administer, subjects: [112233n] }), 112233)).to.equal(true);
+        expect(isProtectedAdmin(entry({ privilege: Privilege.Operate, subjects: [112233] }), 112233)).to.equal(false);
+        expect(isProtectedAdmin(entry({ privilege: Privilege.Administer, subjects: [112233n] }), undefined)).to.equal(
+            false,
+        );
+    });
+
+    it("detectBindingRelationship marks backs / overPrivileged / none", () => {
+        const viewed = 2588119612;
+        const source = node({ "1/30/0": [{ "1": viewed, "3": 1, "4": 6 }] }, { node_id: 976328453 });
+        const all = [source];
+        const operate = entry({
+            privilege: Privilege.Operate,
+            subjects: [976328453],
+            targets: [{ endpoint: 1, cluster: 6, deviceType: undefined }],
+        });
+        expect(detectBindingRelationship(operate, viewed, all).kind).to.equal("backs");
+        const admin = entry({
+            privilege: Privilege.Administer,
+            subjects: [976328453],
+            targets: [{ endpoint: 1, cluster: 6, deviceType: undefined }],
+        });
+        expect(detectBindingRelationship(admin, viewed, all).kind).to.equal("overPrivileged");
+        const unrelated = entry({ subjects: [555], targets: [{ endpoint: 1, cluster: 6, deviceType: undefined }] });
+        expect(detectBindingRelationship(unrelated, viewed, all).kind).to.equal("none");
+    });
+});

--- a/packages/dashboard/test/AccessControlUtilTest.ts
+++ b/packages/dashboard/test/AccessControlUtilTest.ts
@@ -81,6 +81,20 @@ describe("access-control util", () => {
         expect(entryMatchesTarget(scoped, 1, 8)).to.equal(false);
     });
 
+    it("entryMatchesTarget handles wildcard endpoint and directional cluster matching", () => {
+        // Wildcard endpoint (null) on the ACL target grants all endpoints.
+        const wildEp = entry({ targets: [{ endpoint: undefined, cluster: 6, deviceType: undefined }] });
+        expect(entryMatchesTarget(wildEp, 5, 6)).to.equal(true);
+        // Wildcard cluster (null) on the ACL target grants all clusters on that endpoint.
+        const wildCl = entry({ targets: [{ endpoint: 1, cluster: undefined, deviceType: undefined }] });
+        expect(entryMatchesTarget(wildCl, 1, 6)).to.equal(true);
+        // An all-clusters request (cluster undefined) is NOT covered by a cluster-specific grant.
+        const specific = entry({ targets: [{ endpoint: 1, cluster: 6, deviceType: undefined }] });
+        expect(entryMatchesTarget(specific, 1, undefined)).to.equal(false);
+        // ...but IS covered by a wildcard-cluster grant.
+        expect(entryMatchesTarget(wildCl, 1, undefined)).to.equal(true);
+    });
+
     it("aclCapacity reads the limit attributes", () => {
         const n = node({ "0/31/4": 4, "0/31/2": 4, "0/31/3": 3 });
         expect(aclCapacity(n)).to.deep.equal({ max: 4, subjectsMax: 4, targetsMax: 3 });

--- a/packages/dashboard/test/BindingUtilTest.ts
+++ b/packages/dashboard/test/BindingUtilTest.ts
@@ -42,6 +42,14 @@ describe("binding util", () => {
         expect(all.map(b => b.endpoint).sort()).to.deep.equal([1, 2]);
     });
 
+    it("treats null binding fields as unset, not 0", () => {
+        const n = node({ "1/30/0": [{ "1": 5, "3": 1, "4": null }] });
+        const [b] = readBindings(n, 1);
+        expect(b.node).to.equal(5);
+        expect(b.endpoint).to.equal(1);
+        expect(b.cluster).to.equal(undefined);
+    });
+
     it("source/target cluster lists read Descriptor ClientList/ServerList", () => {
         const n = node({ "1/29/1": [6, 8, 29], "1/29/2": [6, 768] });
         expect(targetServerClusters(n, 1)).to.deep.equal([6, 8, 29]);

--- a/packages/dashboard/test/BindingUtilTest.ts
+++ b/packages/dashboard/test/BindingUtilTest.ts
@@ -56,25 +56,39 @@ describe("binding util", () => {
         expect(result.otherTarget).to.deep.equal([8]);
     });
 
-    it("reverseAclState returns present/missing/cannotVerify", () => {
-        const target = node({ "0/31/0": [{ "1": 3, "2": 2, "3": [1], "4": [{ "0": 6, "1": 1 }], "254": 1 }] }, 2);
+    it("reverseAclState returns present/missing/overPrivileged/cannotVerify", () => {
+        const target = node(
+            { "0/62/5": 1, "0/31/0": [{ "1": 3, "2": 2, "3": [1], "4": [{ "0": 6, "1": 1 }], "254": 1 }] },
+            2,
+        );
         expect(reverseAclState(1, binding({ cluster: 6 }), target).state).to.equal("present");
         expect(reverseAclState(1, binding({ cluster: 8 }), target).state).to.equal("missing");
         expect(reverseAclState(1, binding({ cluster: 8 }), undefined).state).to.equal("cannotVerify");
-    });
-
-    it("targetAclCapacityForBinding gates on fabric-scoped count and reusable room", () => {
-        // Our fabric (1) is full (max 1) with a non-reusable entry (different subject) → cannot add.
-        const full = node({ "0/31/4": 1, "0/31/0": [{ "1": 3, "2": 2, "3": [9], "4": undefined, "254": 1 }] }, 2);
-        expect(targetAclCapacityForBinding(full, 1, 1).canAdd).to.equal(false);
-        // A foreign-fabric entry does not consume our per-fabric quota → can still add.
-        const foreignOnly = node(
-            { "0/31/4": 1, "0/31/0": [{ "1": 3, "2": 2, "3": [9], "4": undefined, "254": 2 }] },
+        const overTarget = node(
+            { "0/62/5": 1, "0/31/0": [{ "1": 5, "2": 2, "3": [1], "4": [{ "0": 6, "1": 1 }], "254": 1 }] },
             2,
         );
-        expect(targetAclCapacityForBinding(foreignOnly, 1, 1).canAdd).to.equal(true);
+        expect(reverseAclState(1, binding({ cluster: 6 }), overTarget).state).to.equal("overPrivileged");
+    });
+
+    it("targetAclCapacityForBinding gates on the node's CurrentFabricIndex (0/62/5) and reusable room", () => {
+        // Our fabric index on the device is 1. Full (max 1) with a non-reusable entry → cannot add.
+        const full = node(
+            { "0/62/5": 1, "0/31/4": 1, "0/31/0": [{ "1": 3, "2": 2, "3": [9], "4": undefined, "254": 1 }] },
+            2,
+        );
+        expect(targetAclCapacityForBinding(full, 1).canAdd).to.equal(false);
+        // The only entry belongs to another fabric (254=2 ≠ our 0/62/5=1) → doesn't count → can add.
+        const foreignOnly = node(
+            { "0/62/5": 1, "0/31/4": 1, "0/31/0": [{ "1": 3, "2": 2, "3": [9], "4": undefined, "254": 2 }] },
+            2,
+        );
+        expect(targetAclCapacityForBinding(foreignOnly, 1).canAdd).to.equal(true);
         // Our fabric already has a whole-node Operate entry for the source → reusable, can add.
-        const reusable = node({ "0/31/4": 1, "0/31/0": [{ "1": 3, "2": 2, "3": [1], "4": undefined, "254": 1 }] }, 2);
-        expect(targetAclCapacityForBinding(reusable, 1, 1).canAdd).to.equal(true);
+        const reusable = node(
+            { "0/62/5": 1, "0/31/4": 1, "0/31/0": [{ "1": 3, "2": 2, "3": [1], "4": undefined, "254": 1 }] },
+            2,
+        );
+        expect(targetAclCapacityForBinding(reusable, 1).canAdd).to.equal(true);
     });
 });

--- a/packages/dashboard/test/BindingUtilTest.ts
+++ b/packages/dashboard/test/BindingUtilTest.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MatterNode, type MatterNodeData } from "@matter-server/ws-client";
+import type { BindingEntryStruct } from "../src/components/dialogs/binding/model.js";
+import {
+    bindableClusters,
+    readAllBindings,
+    readBindings,
+    reverseAclState,
+    sourceClientClusters,
+    targetServerClusters,
+} from "../src/util/binding.js";
+
+function node(attributes: Record<string, unknown>, node_id: number | bigint = 1): MatterNode {
+    const data: MatterNodeData = {
+        node_id,
+        date_commissioned: "",
+        last_interview: "",
+        interview_version: 1,
+        available: true,
+        is_bridge: false,
+        attributes,
+        attribute_subscriptions: [],
+    };
+    return new MatterNode(data);
+}
+
+function binding(p: Partial<BindingEntryStruct>): BindingEntryStruct {
+    return { node: 2, group: undefined, endpoint: 1, cluster: 6, fabricIndex: 1, ...p };
+}
+
+describe("binding util", () => {
+    it("readBindings / readAllBindings parse the binding attribute", () => {
+        const n = node({ "1/30/0": [{ "1": 5, "3": 1, "4": 6 }], "2/30/0": [{ "1": 9, "3": 1 }] });
+        expect(readBindings(n, 1)).to.have.length(1);
+        const all = readAllBindings(n);
+        expect(all.map(b => b.endpoint).sort()).to.deep.equal([1, 2]);
+    });
+
+    it("source/target cluster lists read Descriptor ClientList/ServerList", () => {
+        const n = node({ "1/29/1": [6, 8, 29], "1/29/2": [6, 768] });
+        expect(targetServerClusters(n, 1)).to.deep.equal([6, 8, 29]);
+        expect(sourceClientClusters(n, 1)).to.deep.equal([6, 768]);
+    });
+
+    it("bindableClusters splits intersection vs other-target", () => {
+        const source = node({ "1/29/2": [6, 768] }, 1);
+        const target = node({ "1/29/1": [6, 8, 768] }, 2);
+        const result = bindableClusters(source, 1, target, 1);
+        expect(result.bindable.sort()).to.deep.equal([6, 768]);
+        expect(result.otherTarget).to.deep.equal([8]);
+    });
+
+    it("reverseAclState returns present/missing/cannotVerify", () => {
+        const target = node({ "0/31/0": [{ "1": 3, "2": 2, "3": [1], "4": [{ "0": 6, "1": 1 }], "254": 1 }] }, 2);
+        expect(reverseAclState(1, binding({ cluster: 6 }), target).state).to.equal("present");
+        expect(reverseAclState(1, binding({ cluster: 8 }), target).state).to.equal("missing");
+        expect(reverseAclState(1, binding({ cluster: 8 }), undefined).state).to.equal("cannotVerify");
+    });
+});

--- a/packages/dashboard/test/BindingUtilTest.ts
+++ b/packages/dashboard/test/BindingUtilTest.ts
@@ -98,5 +98,8 @@ describe("binding util", () => {
             2,
         );
         expect(targetAclCapacityForBinding(reusable, 1).canAdd).to.equal(true);
+        // CurrentFabricIndex not cached → advisory gate does not block (write path validates).
+        const noFabric = node({ "0/31/4": 1, "0/31/0": [{ "1": 3, "2": 2, "3": [9], "4": undefined, "254": 1 }] }, 2);
+        expect(targetAclCapacityForBinding(noFabric, 1).canAdd).to.equal(true);
     });
 });

--- a/packages/dashboard/test/BindingUtilTest.ts
+++ b/packages/dashboard/test/BindingUtilTest.ts
@@ -12,6 +12,7 @@ import {
     readBindings,
     reverseAclState,
     sourceClientClusters,
+    targetAclCapacityForBinding,
     targetServerClusters,
 } from "../src/util/binding.js";
 
@@ -60,5 +61,20 @@ describe("binding util", () => {
         expect(reverseAclState(1, binding({ cluster: 6 }), target).state).to.equal("present");
         expect(reverseAclState(1, binding({ cluster: 8 }), target).state).to.equal("missing");
         expect(reverseAclState(1, binding({ cluster: 8 }), undefined).state).to.equal("cannotVerify");
+    });
+
+    it("targetAclCapacityForBinding gates on fabric-scoped count and reusable room", () => {
+        // Our fabric (1) is full (max 1) with a non-reusable entry (different subject) → cannot add.
+        const full = node({ "0/31/4": 1, "0/31/0": [{ "1": 3, "2": 2, "3": [9], "4": undefined, "254": 1 }] }, 2);
+        expect(targetAclCapacityForBinding(full, 1, 1).canAdd).to.equal(false);
+        // A foreign-fabric entry does not consume our per-fabric quota → can still add.
+        const foreignOnly = node(
+            { "0/31/4": 1, "0/31/0": [{ "1": 3, "2": 2, "3": [9], "4": undefined, "254": 2 }] },
+            2,
+        );
+        expect(targetAclCapacityForBinding(foreignOnly, 1, 1).canAdd).to.equal(true);
+        // Our fabric already has a whole-node Operate entry for the source → reusable, can add.
+        const reusable = node({ "0/31/4": 1, "0/31/0": [{ "1": 3, "2": 2, "3": [1], "4": undefined, "254": 1 }] }, 2);
+        expect(targetAclCapacityForBinding(reusable, 1, 1).canAdd).to.equal(true);
     });
 });

--- a/packages/dashboard/test/SmokeTest.ts
+++ b/packages/dashboard/test/SmokeTest.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+describe("dashboard test harness", () => {
+    it("runs", () => {
+        expect(1 + 1).to.equal(2);
+    });
+});

--- a/packages/dashboard/test/tsconfig.json
+++ b/packages/dashboard/test/tsconfig.json
@@ -1,0 +1,23 @@
+// Managed by nacho-build.  Nacho will update references automatically but otherwise preserves your edits.
+// Use `nacho-build configure` to overwrite with defaults.
+{
+    "extends": "../../../tsc/tsconfig.test.json",
+    "compilerOptions": {
+        "types": [
+            "node",
+            "mocha",
+            "@matter/testing"
+        ]
+    },
+    "references": [
+        {
+            "path": "../../custom-clusters/src"
+        },
+        {
+            "path": "../../ws-client/src"
+        },
+        {
+            "path": "../src"
+        }
+    ]
+}

--- a/packages/dashboard/tsconfig.json
+++ b/packages/dashboard/tsconfig.json
@@ -1,5 +1,5 @@
 {
     "compilerOptions": { "composite": true },
     "files": [],
-    "references": [{ "path": "src" }]
+    "references": [{ "path": "src" }, { "path": "test" }]
 }

--- a/packages/matter-server/package.json
+++ b/packages/matter-server/package.json
@@ -53,7 +53,7 @@
         "@matter/nodejs": "0.17.3",
         "@matter/testing": "0.17.3",
         "@types/express": "^5.0.6",
-        "@types/node": "^25.9.1"
+        "@types/node": "^25.9.3"
     },
     "engines": {
         "node": ">=22.13.0"

--- a/packages/matter-server/package.json
+++ b/packages/matter-server/package.json
@@ -44,14 +44,14 @@
         "@matter-server/custom-clusters": "*",
         "@matter-server/dashboard": "*",
         "@matter-server/ws-controller": "*",
-        "@matter/main": "0.17.3-alpha.0-20260614-888c310c5",
+        "@matter/main": "0.17.3",
         "commander": "^15.0.0",
         "express": "^5.2.1"
     },
     "devDependencies": {
         "@matter-server/ws-client": "*",
-        "@matter/nodejs": "0.17.3-alpha.0-20260614-888c310c5",
-        "@matter/testing": "0.17.3-alpha.0-20260614-888c310c5",
+        "@matter/nodejs": "0.17.3",
+        "@matter/testing": "0.17.3",
         "@types/express": "^5.0.6",
         "@types/node": "^25.9.1"
     },

--- a/packages/matter-server/package.json
+++ b/packages/matter-server/package.json
@@ -44,14 +44,14 @@
         "@matter-server/custom-clusters": "*",
         "@matter-server/dashboard": "*",
         "@matter-server/ws-controller": "*",
-        "@matter/main": "0.17.2",
+        "@matter/main": "0.17.3-alpha.0-20260614-888c310c5",
         "commander": "^15.0.0",
         "express": "^5.2.1"
     },
     "devDependencies": {
         "@matter-server/ws-client": "*",
-        "@matter/nodejs": "0.17.2",
-        "@matter/testing": "0.17.2",
+        "@matter/nodejs": "0.17.3-alpha.0-20260614-888c310c5",
+        "@matter/testing": "0.17.3-alpha.0-20260614-888c310c5",
         "@types/express": "^5.0.6",
         "@types/node": "^25.9.1"
     },

--- a/packages/matter-server/src/MatterServer.ts
+++ b/packages/matter-server/src/MatterServer.ts
@@ -24,7 +24,7 @@ import {
     WebSocketControllerHandler,
 } from "@matter-server/ws-controller";
 import { Ble } from "@matter/main/protocol";
-import { getCliOptions, type LogLevel as CliLogLevel } from "./cli.js";
+import { getCliOptions, getOriginalArgv, type LogLevel as CliLogLevel } from "./cli.js";
 import { LegacyDataWriter, loadLegacyData, type LegacyData } from "./converter/index.js";
 import { createFileLogger } from "./file-logger.js";
 import { initializeOta } from "./ota.js";
@@ -67,7 +67,7 @@ Logger.level = mapLogLevel(cliOptions.logLevel);
 const logger = Logger.get("MatterServer");
 
 // Log command line arguments at startup for debugging
-logger.info(`Command line: ${process.argv.slice(2).join(" ") || "(no arguments)"}`);
+logger.info(`Command line: ${getOriginalArgv().join(" ") || "(no arguments)"}`);
 
 const env = Environment.default;
 

--- a/packages/matter-server/src/cli.ts
+++ b/packages/matter-server/src/cli.ts
@@ -276,10 +276,21 @@ export function parseCliArgs(argv?: string[]): CliOptions {
 
 // Export parsed options as singleton for use across modules
 let cliOptions: CliOptions | undefined;
+let originalArgv: string[] = [];
 
 export function getCliOptions(): CliOptions {
     if (!cliOptions) {
+        originalArgv = process.argv.slice(2);
         cliOptions = parseCliArgs();
     }
     return cliOptions;
+}
+
+/**
+ * Command-line arguments as passed to the process, captured before
+ * {@link pre-init} strips `process.argv` to keep matter.js from re-interpreting
+ * our flags as its own environment variables.
+ */
+export function getOriginalArgv(): string[] {
+    return originalArgv;
 }

--- a/packages/matter-server/src/pre-init.ts
+++ b/packages/matter-server/src/pre-init.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// cli.ts has no matter.js imports, so parsing here stays before matter.js loads.
+import { getCliOptions } from "./cli.js";
+
 // Apply server storage defaults before matter.js loads. matter.js's
 // NodeJsEnvironment runs at import time and installs `storage.driver = "file"`
 // from `config.storageDriver` as a baseline before overlaying process.env, so
@@ -14,3 +17,11 @@
 
 process.env.MATTER_STORAGE_DRIVER ??= "wal";
 process.env.MATTER_STORAGE_BLOBDRIVER ??= "dir";
+
+// matter.js's NodeJsEnvironment also parses process.argv at import time,
+// splitting any `--a-b-c` flag into the env var `a.b.c` (so `--log-level debug`
+// becomes `log.level = true`, crashing the logger). We translate every CLI
+// option to matter.js env vars ourselves, so parse now and strip argv to keep
+// matter.js from re-interpreting our flags.
+getCliOptions();
+process.argv = process.argv.slice(0, 2);

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -41,7 +41,7 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@matter/testing": "0.17.2",
+        "@matter/testing": "0.17.3-alpha.0-20260614-888c310c5",
         "@types/node": "^25.9.1",
         "@types/ws": "^8.18.1",
         "ws": "^8.21.0"

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -41,7 +41,7 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "@matter/testing": "0.17.3-alpha.0-20260614-888c310c5",
+        "@matter/testing": "0.17.3",
         "@types/node": "^25.9.1",
         "@types/ws": "^8.18.1",
         "ws": "^8.21.0"

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -42,7 +42,7 @@
     "dependencies": {},
     "devDependencies": {
         "@matter/testing": "0.17.3",
-        "@types/node": "^25.9.1",
+        "@types/node": "^25.9.3",
         "@types/ws": "^8.18.1",
         "ws": "^8.21.0"
     },

--- a/packages/ws-client/src/models/model.ts
+++ b/packages/ws-client/src/models/model.ts
@@ -382,6 +382,8 @@ export interface ServerInfoMessage {
     bluetooth_enabled: boolean;
     /** True when BLE proxy mode is enabled (server exposes `/ble` WebSocket endpoint for a remote proxy client). Note: Only available with OHF Matter Server, not Python Matter Server. */
     ble_proxy_enabled?: boolean;
+    /** The controller's own operational (CASE) node id. Note: Only available with OHF Matter Server, not Python Matter Server. */
+    controller_node_id?: number | bigint;
 }
 
 /** WebSocket event types and their data payloads */

--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -42,8 +42,8 @@
     "dependencies": {
         "@matter-server/ws-client": "*",
         "@matter/dcl-data": ">=2026.6.9",
-        "@matter/main": "0.17.3-alpha.0-20260614-888c310c5",
-        "@project-chip/matter.js": "0.17.3-alpha.0-20260614-888c310c5",
+        "@matter/main": "0.17.3",
+        "@project-chip/matter.js": "0.17.3",
         "ws": "^8.21.0"
     },
     "devDependencies": {
@@ -51,7 +51,7 @@
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.3-alpha.0-20260614-888c310c5",
+        "@matter/nodejs-ble": "0.17.3",
         "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
     },
     "engines": {

--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -41,13 +41,13 @@
     },
     "dependencies": {
         "@matter-server/ws-client": "*",
-        "@matter/dcl-data": ">=2026.6.9",
+        "@matter/dcl-data": ">=2026.6.16",
         "@matter/main": "0.17.3",
         "@project-chip/matter.js": "0.17.3",
         "ws": "^8.21.0"
     },
     "devDependencies": {
-        "@types/node": "^25.9.1",
+        "@types/node": "^25.9.3",
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {

--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -42,8 +42,8 @@
     "dependencies": {
         "@matter-server/ws-client": "*",
         "@matter/dcl-data": ">=2026.6.9",
-        "@matter/main": "0.17.2",
-        "@project-chip/matter.js": "0.17.2",
+        "@matter/main": "0.17.3-alpha.0-20260614-888c310c5",
+        "@project-chip/matter.js": "0.17.3-alpha.0-20260614-888c310c5",
         "ws": "^8.21.0"
     },
     "devDependencies": {
@@ -51,7 +51,7 @@
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.2",
+        "@matter/nodejs-ble": "0.17.3-alpha.0-20260614-888c310c5",
         "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
     },
     "engines": {

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -631,6 +631,7 @@ export class WebSocketControllerHandler implements WebServerHandler {
             thread_credentials_set: !!this.#config.threadDataset,
             bluetooth_enabled: this.#commandHandler.bleEnabled,
             ble_proxy_enabled: this.#commandHandler.bleProxyEnabled,
+            controller_node_id: this.#commandHandler.getCommissionerNodeId(),
         };
     }
 


### PR DESCRIPTION
## Summary

Adds two cluster-special-part editors to the dashboard plus a matter.js upgrade and a CLI adjustment.

### Access Control (0x1F) editor
- Collapsible panel on the cluster page showing the `acl` attribute as a readable table: colour-coded privilege, auth mode, subjects resolved to device name + decimal id (+ dim hex), target chips, and an ACL↔Binding **relationship** column.
- Detects **over-privileged binding ACLs** (granting >Operate where Operate suffices — the old binding-ACL bug) and offers a one-click **Fix → Operate** (+ a "Fix all" banner when several).
- Add (modal) and per-entry delete with a security confirm. The controller's own admin entry is **protected** (🔒, non-deletable) via a new `server_info.controller_node_id`.
- Capacity-gated add (respects `AccessControlEntriesPerFabric` / subjects / targets limits).

### Binding (0x1E) editor
- Inline panel on the **endpoint page** with a resolved table (target node/endpoint/cluster names) and a reverse **ACL-on-target** check (present / missing / >Operate / can't verify), each with a **Fix** action.
- Add dialog: node-id-first searchable picker (still accepts raw ids), dependent endpoint select, and a two-group cluster picker (bindable intersection / all / other-target ⚠ / custom).
- Replaces the old modal-only binding button.

### Correctness highlights
- All ACL/binding reads **and writes** are scoped by the device's `CurrentFabricIndex` (`0/62/5`), not the controller's `fabric_index` — avoids dropping our admin entry from display and from read-modify-write payloads (lockout risk).
- node-id comparisons normalised via `String(id)` (number-vs-bigint safe); whole-node ACL entries handled; read-modify-write reads fresh; dedup on add; reads skipped when the node is offline.

### Other
- **matter.js → 0.17.3** (off the alpha): Nuki SmartLock attestation cert fix; thread message retransmission timings applied to commands.
- **CLI**: ensure Matter-Server CLI options don't interfere with matter.js.

### Tests
- New `util/access-control` + `util/binding` unit suites (fabric scoping, relationship/over-privilege detection, capacity, number/bigint). Full suite green (248/248); lint + format clean; no circular deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)