### PR TITLE
Self-bindings (no ACL) + skip node_updated for NodeLabel-only changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Enhancement: Do not send node_updated event when only NodeLabel changes
+
 ## 1.1.0 (2026-06-17)
 
 - Enhancement: Revamped the experimental Binding overview and editor in Dashboard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This page shows a detailed overview of the changes between versions without the 
 ## **WORK IN PROGRESS**
 
 - Enhancement: Do not send node_updated event when only NodeLabel changes
+- Enhancement: Detect Self-Bindings (Node-to-same-Node-Binding) and prevent ACL creation for these cases and show in UI
 
 ## 1.1.0 (2026-06-17)
 

--- a/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
+++ b/packages/dashboard/src/components/dialogs/binding/binding-actions.ts
@@ -82,6 +82,9 @@ export async function ensureBindingAcl(
     targetEndpoint: number,
     cluster: number | undefined,
 ): Promise<void> {
+    // A self-binding (source == target) needs no ACL — a node always has access to itself.
+    if (nodeIdKey(targetNodeId) === nodeIdKey(sourceNodeId)) return;
+
     const acl = await freshOurAcl(client, targetNodeId);
 
     const alreadyGranted = acl.some(
@@ -176,6 +179,8 @@ export async function deleteBindingAtIndex(
     await client.setNodeBinding(sourceNode.node_id, sourceEndpoint, updated.map(toBindingTarget));
 
     if (removed.node == null || removed.endpoint == null) return;
+    // A self-binding never created an ACL entry, so there is nothing to clean up.
+    if (nodeIdKey(removed.node) === nodeIdKey(sourceNode.node_id)) return;
     const targetEndpoint = removed.endpoint;
     const removedCluster = removed.cluster;
     try {

--- a/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
+++ b/packages/dashboard/src/components/dialogs/binding/node-binding-dialog.ts
@@ -47,13 +47,13 @@ export class NodeBindingDialog extends LitElement {
     @state() private _busy = false;
 
     private _knownNodes(): MatterNode[] {
-        return Object.values(this.client.nodes)
-            .filter(n => nodeIdKey(n.node_id) !== nodeIdKey(this.node!.node_id))
-            .sort((a, b) => {
-                const x = BigInt(a.node_id);
-                const y = BigInt(b.node_id);
-                return x < y ? -1 : x > y ? 1 : 0;
-            });
+        // Includes the source node itself — a self-binding (e.g. switch → light on the same node)
+        // is valid and needs no ACL.
+        return Object.values(this.client.nodes).sort((a, b) => {
+            const x = BigInt(a.node_id);
+            const y = BigInt(b.node_id);
+            return x < y ? -1 : x > y ? 1 : 0;
+        });
     }
 
     private _resolveTarget(): MatterNode | undefined {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
@@ -193,6 +193,7 @@ class BindingClusterCommands extends BaseClusterCommands {
     }
 
     private _aclCell(b: BindingEntryStruct, state: ReverseAclState): TemplateResult {
+        if (state === "self") return html`<span class="status mut">self — no ACL needed</span>`;
         if (state === "present") return html`<span class="status ok">ACL present</span>`;
         if (state === "cannotVerify") return html`<span class="status mut">can't verify</span>`;
         const label = state === "missing" ? "ACL missing" : "ACL > Operate";

--- a/packages/dashboard/src/util/binding.ts
+++ b/packages/dashboard/src/util/binding.ts
@@ -82,7 +82,7 @@ export function bindableClusters(
     return { bindable, otherTarget };
 }
 
-export type ReverseAclState = "present" | "missing" | "overPrivileged" | "cannotVerify";
+export type ReverseAclState = "present" | "missing" | "overPrivileged" | "cannotVerify" | "self";
 
 export interface ReverseAclResult {
     state: ReverseAclState;
@@ -90,6 +90,7 @@ export interface ReverseAclResult {
 
 /**
  * Whether the target node's ACL grants the source the access this binding needs:
+ *  - self:           target is the source node itself — no ACL needed
  *  - present:        a matching CASE entry at Operate exists
  *  - overPrivileged: the only matching grant is above Operate (Manage/Administer)
  *  - missing:        no matching grant (or only below Operate)
@@ -100,6 +101,7 @@ export function reverseAclState(
     binding: BindingEntryStruct,
     targetNode: MatterNode | undefined,
 ): ReverseAclResult {
+    if (binding.node != null && nodeIdKey(binding.node) === nodeIdKey(sourceNodeId)) return { state: "self" };
     if (!targetNode || !targetNode.available) return { state: "cannotVerify" };
     const matching = entriesForFabric(readAclEntries(targetNode), nodeFabricIndex(targetNode)).filter(
         e =>
@@ -158,6 +160,8 @@ export interface AddBindingCapacity {
  * source can absorb it — mirrors the merge behavior the writer implements.
  */
 export function targetAclCapacityForBinding(targetNode: MatterNode, sourceNodeId: number | bigint): AddBindingCapacity {
+    // A self-binding (target is the source node) needs no ACL entry, so no capacity is consumed.
+    if (nodeIdKey(targetNode.node_id) === nodeIdKey(sourceNodeId)) return { canAdd: true };
     const fabricIndex = nodeFabricIndex(targetNode);
     // Advisory pre-check only. If CurrentFabricIndex isn't cached for this target yet, don't block:
     // the write path (ensureBindingAcl → freshOurAcl) reads 0/62/5 fresh and fails cleanly if absent.

--- a/packages/dashboard/test/BindingUtilTest.ts
+++ b/packages/dashboard/test/BindingUtilTest.ts
@@ -77,6 +77,13 @@ describe("binding util", () => {
             2,
         );
         expect(reverseAclState(1, binding({ cluster: 6 }), overTarget).state).to.equal("overPrivileged");
+        // Self-binding (binding target == source) needs no ACL.
+        expect(reverseAclState(7, binding({ node: 7 }), node({}, 7)).state).to.equal("self");
+    });
+
+    it("targetAclCapacityForBinding treats a self-binding as free (no ACL needed)", () => {
+        const self = node({ "0/62/5": 1, "0/31/4": 1, "0/31/0": [{ "1": 5, "2": 2, "3": [99], "254": 1 }] }, 7);
+        expect(targetAclCapacityForBinding(self, 7).canAdd).to.equal(true);
     });
 
     it("targetAclCapacityForBinding gates on the node's CurrentFabricIndex (0/62/5) and reusable room", () => {

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -105,13 +105,6 @@ const logger = Logger.get("ControllerCommandHandler");
 const RECONNECT_TIMEOUT = Minutes(3);
 
 /**
- * Cluster IDs whose attribute changes should trigger a full node_updated broadcast.
- * BasicInformation (0x28) covers firmware version, product name, etc.
- * BridgedDeviceBasicInformation (0x39) covers the same for bridged child nodes.
- */
-const FULL_UPDATE_CLUSTER_IDS = new Set<ClusterId>([BasicInformation.id, BridgedDeviceBasicInformation.id]);
-
-/**
  * Determine the Matter specification version from cached attributes.
  * Uses SpecificationVersion attribute (0/40/21) if available, otherwise
  * estimates from DataModelRevision attribute (0/40/0).
@@ -399,7 +392,11 @@ export class ControllerCommandHandler {
         node.events.attributeChanged.on(data => {
             attributeCache.updateAttribute(nodeId, data);
             this.events.attributeChanged.emit(nodeId, data);
-            if (FULL_UPDATE_CLUSTER_IDS.has(data.path.clusterId)) {
+            if (
+                (data.path.clusterId === BasicInformation.id ||
+                    data.path.clusterId === BridgedDeviceBasicInformation.id) &&
+                data.path.attributeId !== BasicInformation.attributes.nodeLabel.id
+            ) {
                 basicInfoChangedInBatch = true;
             }
         });

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -1257,9 +1257,35 @@ export class ControllerCommandHandler {
             fabricIndex,
         }));
 
-        logger.info("Setting ACL entries", aclEntries);
+        // A node always has access to itself, so an ACL entry naming the node's own id as a subject
+        // (a "self-ACL") is meaningless. Strip such subjects (and drop entries left with none) rather
+        // than write them to the device, but still report success to the caller.
+        const nodeKey = nodeId.toString();
+        let selfRemoved = false;
+        const filteredEntries = aclEntries
+            .map(entry => {
+                if (!entry.subjects) return entry;
+                const subjects = entry.subjects.filter(s => s.toString() !== nodeKey);
+                if (subjects.length === entry.subjects.length) return entry;
+                selfRemoved = true;
+                return subjects.length > 0 ? { ...entry, subjects } : undefined;
+            })
+            .filter((entry): entry is AccessControl.AccessControlEntry => entry !== undefined);
+        if (selfRemoved) {
+            logger.warn(
+                `ACL for node ${nodeId} named the node's own id as a subject (self-ACL); a node always has access to itself, so those subjects are not written to the device. Reporting success.`,
+            );
+        }
 
-        const { status } = await this.#writeAttribute(nodeId, EndpointNumber(0), AccessControl.id, "acl", aclEntries);
+        logger.info("Setting ACL entries", filteredEntries);
+
+        const { status } = await this.#writeAttribute(
+            nodeId,
+            EndpointNumber(0),
+            AccessControl.id,
+            "acl",
+            filteredEntries,
+        );
         return [
             {
                 path: { endpoint_id: 0, cluster_id: AccessControl.id, attribute_id: 0 },


### PR DESCRIPTION
Follow-up to #757 (already merged).

## Self-bindings (no ACL)
A node binding to itself (target node == source node, e.g. a switch endpoint → a light endpoint on the same node) is valid and needs no ACL grant — a node always has access to itself.

- **Dashboard**: skip creating a self-ACL when adding such a binding; skip ACL cleanup on delete; report the binding's ACL-on-target as **"self — no ACL needed"** (not "missing", no fix button); allow selecting the own node in the binding picker; treat the capacity gate as free for self.
- **Server** (`ControllerCommandHandler.setAclEntry`): defensively strips any self-subject (the node's own id) from an ACL write rather than writing it to the device, logs a warning, and still reports success.

## Skip node_updated for NodeLabel-only changes
`ControllerCommandHandler` no longer triggers a full `node_updated` broadcast when only the BasicInformation `NodeLabel` attribute changed.

## Tests
Added unit tests for the `self` reverse-ACL state and the self-binding capacity gate. Full suite green (248/248); lint + format clean; no circular deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)