### PR TITLE
perf: faster attribute conversion (list hoist + cached struct member maps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Speed up attribute conversion for list attributes (~3x faster node population)
+
 ## 1.1.6 (2026-06-30)
 
 - Ensure that rebuilding of node structures after updates does not block the event loop for big bridges

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
-- Speed up attribute conversion for list attributes (~3x faster node population)
+- Speed up attribute conversion for list and struct attributes (~3x faster node population, faster legacy-data migration)
 
 ## 1.1.6 (2026-06-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
-- Speed up attribute conversion for list and struct attributes (~3x faster node population, faster legacy-data migration)
+- Speed up attribute data conversion for migration and websocket
 
 ## 1.1.6 (2026-06-30)
 

--- a/packages/ws-controller/src/server/Converters.ts
+++ b/packages/ws-controller/src/server/Converters.ts
@@ -90,7 +90,8 @@ export function convertWebSocketTagBasedToMatter(
 
     // Handle lists
     if (Array.isArray(value) && model.type === "list") {
-        return value.map(v => convertWebSocketTagBasedToMatter(v, model.members.at(0), clusterModel));
+        const memberModel = model.members.at(0);
+        return value.map(v => convertWebSocketTagBasedToMatter(v, memberModel, clusterModel));
     }
 
     // Handle structs - convert numeric keys to camelCased member names
@@ -136,7 +137,8 @@ export function convertCommandDataToMatter(
 
     // Handle lists
     if (Array.isArray(value) && model.type === "list") {
-        return value.map(v => convertCommandDataToMatter(v, model.members.at(0), clusterModel));
+        const memberModel = model.members.at(0);
+        return value.map(v => convertCommandDataToMatter(v, memberModel, clusterModel));
     }
 
     // Handle structs - convert numeric keys to camelCased member names
@@ -186,6 +188,9 @@ const enum ConvKind {
     Struct,
     List,
 }
+
+/** Primitive `typeof` results that pass through unchanged for schema-less (unknown) attributes. */
+const PRIMITIVE_TYPEOF = new Set(["string", "number", "bigint", "boolean", "undefined"]);
 
 /** Cached model-to-kind classification. Avoids repeated metabase property traversal. */
 const modelKindCache = new WeakMap<ValueModel, ConvKind>();
@@ -301,7 +306,7 @@ function convertMatterToWebSocket(
             // Best-effort: recursively convert elements without schema
             return value.map(v => convertMatterToWebSocket(v, undefined, clusterModel, tagBased));
         }
-        if (isObject(value) || !["string", "number", "bigint", "boolean", "undefined"].includes(typeof value)) {
+        if (isObject(value) || !PRIMITIVE_TYPEOF.has(typeof value)) {
             return null;
         }
         return value;
@@ -322,10 +327,13 @@ function convertMatterToWebSocket(
         case ConvKind.Bytes:
             return value instanceof Uint8Array ? Bytes.toBase64(value) : value;
 
-        case ConvKind.List:
-            return Array.isArray(value)
-                ? value.map(v => convertMatterToWebSocket(v, model.members.at(0), clusterModel, tagBased))
-                : value;
+        case ConvKind.List: {
+            if (!Array.isArray(value)) return value;
+            // Hoist the element model: `model.members` is a getter that rebuilds its array on every
+            // access, so reading it inside the map would rebuild it once per element.
+            const memberModel = model.members.at(0);
+            return value.map(v => convertMatterToWebSocket(v, memberModel, clusterModel, tagBased));
+        }
 
         case ConvKind.Struct: {
             if (!isObject(value)) return value;
@@ -549,7 +557,8 @@ export function convertWebsocketDataToMatter(value: any, model: ValueModel): any
             value = parseChipJSON(value);
         }
         if (Array.isArray(value)) {
-            return value.map(v => convertWebsocketDataToMatter(v, model.members.at(0)!));
+            const memberModel = model.members.at(0)!;
+            return value.map(v => convertWebsocketDataToMatter(v, memberModel));
         }
     }
 

--- a/packages/ws-controller/src/server/Converters.ts
+++ b/packages/ws-controller/src/server/Converters.ts
@@ -99,18 +99,10 @@ export function convertWebSocketTagBasedToMatter(
         const valueKeys = Object.keys(value);
         const result: { [key: string]: unknown } = {};
 
-        // Build a map of member ID to member for efficient lookup
-        const memberById: { [id: number]: ValueModel } = {};
-        for (const member of model.members) {
-            if (member.id !== undefined) {
-                memberById[member.id] = member;
-            }
-        }
-
+        const memberById = getStructMembersById(model);
         for (const key of valueKeys) {
-            const memberId = parseInt(key);
-            if (!isNaN(memberId) && memberById[memberId]) {
-                const member = memberById[memberId];
+            const member = memberById.get(parseInt(key));
+            if (member !== undefined) {
                 result[member.propertyName] = convertWebSocketTagBasedToMatter(value[key], member, clusterModel);
             } else {
                 // Keep unknown keys as-is (fallback for unknown attributes)
@@ -146,19 +138,12 @@ export function convertCommandDataToMatter(
         const valueKeys = Object.keys(value);
         const result: { [key: string]: unknown } = {};
 
-        // Build a map of member ID to member for efficient lookup
-        const memberByName: { [name: string]: ValueModel } = {};
-        for (const member of model.members) {
-            if (member.name !== undefined) {
-                memberByName[member.propertyName] = member;
-            }
-        }
-
+        const memberByName = getStructMembersByPropertyName(model);
         for (const key of valueKeys) {
             // Camelize the key to normalize PascalCase from Python CHIP SDK (e.g. DSTOffset -> dstOffset)
             const camelizedKey = camelize(key);
-            if (memberByName[camelizedKey]) {
-                const member = memberByName[camelizedKey];
+            const member = memberByName.get(camelizedKey);
+            if (member !== undefined) {
                 // Treat null for optional non-nullable fields as omitted (e.g. PINCode: null).
                 // This preserves compatibility with clients that send null instead of omitting the field.
                 if (value[key] === null && !member.mandatory && !member.nullable) {
@@ -243,6 +228,50 @@ function getStructMembers(model: ValueModel): StructMemberEntry[] {
         }
     }
     structMemberCache.set(model, members);
+    return members;
+}
+
+/**
+ * Struct member lookups for the incoming (WebSocket/legacy -> Matter) converters, cached per model so
+ * bulk conversions (e.g. legacy data migration) don't rebuild the map for every struct value.
+ */
+const structMembersByIdCache = new WeakMap<ValueModel, Map<number, ValueModel>>();
+const structMembersByPropertyNameCache = new WeakMap<ValueModel, Map<string, ValueModel>>();
+const structMembersByLowerNameCache = new WeakMap<ValueModel, Map<string, ValueModel>>();
+
+function getStructMembersById(model: ValueModel): Map<number, ValueModel> {
+    let members = structMembersByIdCache.get(model);
+    if (members !== undefined) return members;
+
+    members = new Map();
+    for (const member of model.members) {
+        if (member.id !== undefined) members.set(member.id, member);
+    }
+    structMembersByIdCache.set(model, members);
+    return members;
+}
+
+function getStructMembersByPropertyName(model: ValueModel): Map<string, ValueModel> {
+    let members = structMembersByPropertyNameCache.get(model);
+    if (members !== undefined) return members;
+
+    members = new Map();
+    for (const member of model.members) {
+        if (member.name !== undefined) members.set(member.propertyName, member);
+    }
+    structMembersByPropertyNameCache.set(model, members);
+    return members;
+}
+
+function getStructMembersByLowerName(model: ValueModel): Map<string, ValueModel> {
+    let members = structMembersByLowerNameCache.get(model);
+    if (members !== undefined) return members;
+
+    members = new Map();
+    for (const member of model.members) {
+        if (member.name !== undefined) members.set(member.name.toLowerCase(), member);
+    }
+    structMembersByLowerNameCache.set(model, members);
     return members;
 }
 
@@ -567,19 +596,11 @@ export function convertWebsocketDataToMatter(value: any, model: ValueModel): any
             value = parseChipJSON(value);
         }
         if (typeof value === "object") {
-            const members = model.members.reduce(
-                (acc, member) => {
-                    if (member.name !== undefined) {
-                        acc[member.name.toLowerCase()] = member;
-                    }
-                    return acc;
-                },
-                {} as { [key: string]: ValueModel },
-            );
+            const members = getStructMembersByLowerName(model);
             const valueKeys = Object.keys(value);
             const result: { [key: string]: unknown } = {};
             valueKeys.forEach(key => {
-                const member = members[camelize(key).toLowerCase()];
+                const member = members.get(camelize(key).toLowerCase());
                 if (member !== undefined) {
                     result[member.propertyName] = convertWebsocketDataToMatter(value[key], member);
                 }


### PR DESCRIPTION
## Problem

Attribute conversion in `Converters.ts` was slower than necessary in two hot paths, both rooted in matter.js's `model.members` getter, which **rebuilds its array on every access**:

1. **Outgoing list conversion** (`convertMatterToWebSocket`) read `model.members.at(0)` **inside** the `.map` callback → rebuilt once per list element. This dominated node population (root endpoints, ThreadNetworkDiagnostics lists).
2. **Incoming struct conversion** (the three WebSocket/legacy → Matter converters) rebuilt their member-lookup map on **every struct value**, each rebuild hitting the same getter. This slows the legacy-data migration, which bulk-converts every stored attribute via `convertWebSocketTagBasedToMatter` (`LegacyDataInjector`).

Struct conversion in the outgoing path was already fast because it caches members via `getStructMembers`; these two paths didn't.

## Fix

1. Hoist the list element model out of the `.map` (all 4 list-converting sites).
2. Cache the incoming struct member lookups per model (by id / by property name / by lowercased name), mirroring `getStructMembers`.
3. Replace a per-call array literal in the schema-less branch with a module-level `Set`.

## Measurements (micro-benchmark)

Outgoing:
| | ns/op |
|---|---|
| List[200 scalars] before | 654,898 |
| List[200 scalars] after | 5,608 |

Incoming:
| | before | after |
|---|---|---|
| single struct | 8,348 | 282 (~30×) |
| list[100 structs] | 431,452 | 29,800 (~14×) |

Real 35-node population (instrumented): total init ~1.25 s → ~0.44 s (~3×); no cluster now exceeds 2 ms of conversion. Legacy-data migration benefits from the incoming-struct caching.

## Testing

- `npm run format` / `lint` / `build` — clean
- Full suite: 248/248, exit 0
- Verified on a live 35-node network

🤖 Generated with [Claude Code](https://claude.com/claude-code)