### PR TITLE
refactor(ws-client): extract shared Thread/WiFi topology derivation

### DIFF
--- a/packages/dashboard/src/pages/network/network-types.ts
+++ b/packages/dashboard/src/pages/network/network-types.ts
@@ -4,219 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { BorderRouterEntry } from "@matter-server/ws-client";
+import type { NetworkType, ThreadRoutingRole } from "@matter-server/ws-client";
 
-/**
- * Network type detected from NetworkCommissioning cluster feature map.
- */
-export type NetworkType = "thread" | "wifi" | "ethernet" | "unknown";
-
-/**
- * Classification of a Thread mesh link based on LQI.
- * "none" means LQI=0 — neighbor entry exists but no recent valid frames (dead/stale link).
- */
-export type SignalLevel = "strong" | "medium" | "weak" | "none";
-
-/**
- * Thread routing role from ThreadNetworkDiagnostics cluster.
- * Attribute 0/53/1 (RoutingRole)
- */
-export enum ThreadRoutingRole {
-    Unspecified = 0,
-    Unassigned = 1,
-    SleepyEndDevice = 2,
-    EndDevice = 3,
-    REED = 4, // Router-Eligible End Device
-    Router = 5,
-    Leader = 6,
-}
-
-/**
- * Thread neighbor table entry from ThreadNetworkDiagnostics cluster.
- * Attribute 0/53/7 (NeighborTable)
- */
-export interface ThreadNeighbor {
-    /** Extended address of the neighbor (64-bit) */
-    extAddress: bigint;
-    /** Age of the entry in seconds */
-    age: number;
-    /** RLOC16 (Router Locator) */
-    rloc16: number;
-    /** Link frame counter */
-    linkFrameCounter: number;
-    /** MLE frame counter */
-    mleFrameCounter: number;
-    /**
-     * Link Quality Indicator. Spec types as uint8 (0-255), but OpenThread reports
-     * 0-3 in practice. 0 = no recent valid frames (dead/stale link).
-     */
-    lqi: number;
-    /** Average RSSI in dBm (nullable) */
-    avgRssi: number | null;
-    /** Last RSSI in dBm (nullable) */
-    lastRssi: number | null;
-    /** Frame error rate (0-255) */
-    frameErrorRate: number;
-    /** Message error rate (0-255) */
-    messageErrorRate: number;
-    /** Whether RX is on when idle */
-    rxOnWhenIdle: boolean;
-    /** Whether this is a full Thread device */
-    fullThreadDevice: boolean;
-    /** Whether this is a full network data device */
-    fullNetworkData: boolean;
-    /** Whether the link is established */
-    isChild: boolean;
-}
-
-/**
- * Thread route table entry from ThreadNetworkDiagnostics cluster.
- * Attribute 0/53/8 (RouteTable)
- */
-export interface ThreadRoute {
-    /** Extended address of the destination */
-    extAddress: bigint;
-    /** RLOC16 of the destination */
-    rloc16: number;
-    /** Router ID */
-    routerId: number;
-    /** Next hop RLOC16 */
-    nextHop: number;
-    /** Path cost */
-    pathCost: number;
-    /** LQI in (0-3 on OpenThread; 0 = no link). */
-    lqiIn: number;
-    /** LQI out (0-3 on OpenThread; 0 = no link). */
-    lqiOut: number;
-    /** Age of the route */
-    age: number;
-    /** Whether this is allocated */
-    allocated: boolean;
-    /** Whether link is established */
-    linkEstablished: boolean;
-}
-
-/**
- * Categorized devices by network type.
- * Node IDs are stored as strings to avoid BigInt precision loss.
- */
-export interface CategorizedDevices {
-    thread: string[];
-    wifi: string[];
-    ethernet: string[];
-    unknown: string[];
-}
-
-/**
- * Thread mesh connection between two nodes.
- */
-export interface ThreadConnection {
-    fromNodeId: number | string;
-    toNodeId: number | string;
-    signalColor: string;
-    signalLevel: SignalLevel;
-    lqi: number;
-    rssi: number | null;
-    /** Path cost from route table (1 = direct, higher = multi-hop). Only available for routers. */
-    pathCost?: number;
-    /** Bidirectional LQI from route table (average of lqiIn and lqiOut) */
-    bidirectionalLqi?: number;
-    /** Whether this connection was supplemented by route table data (vs neighbor table only) */
-    fromRouteTable?: boolean;
-}
-
-/**
- * A pair of Thread nodes with their directional edge data.
- * Each connected pair has 0-2 edges (one per neighbor/route table direction).
- */
-export interface ThreadEdgePair {
-    /** Canonical pair key (sorted node IDs joined by "|") */
-    pairKey: string;
-    /** First node ID (lexicographically smaller) */
-    nodeA: string;
-    /** Second node ID (lexicographically larger) */
-    nodeB: string;
-    /** Edge where nodeA reports nodeB as neighbor */
-    edgeAB?: ThreadConnection;
-    /** Edge where nodeB reports nodeA as neighbor */
-    edgeBA?: ThreadConnection;
-}
-
-/**
- * Unknown Thread device seen in neighbor tables but not commissioned.
- */
-export interface UnknownThreadDevice {
-    kind: "unknown";
-    /** Unique ID for the unknown device (prefixed with 'unknown_') */
-    id: string;
-    /** Extended address as hex string */
-    extAddressHex: string;
-    /** Extended address as BigInt */
-    extAddress: bigint;
-    /** Node IDs that see this device as a neighbor (as strings to avoid BigInt precision loss) */
-    seenBy: string[];
-    /** Whether this device appears to be a router */
-    isRouter: boolean;
-    /** Best signal strength seen */
-    bestRssi: number | null;
-    /**
-     * Extended PAN ID (16-char uppercase hex) inherited from the commissioned node that
-     * reports this neighbor. All Thread neighbors share the observing node's network.
-     */
-    extendedPanIdHex?: string;
-    /**
-     * Friendly Thread network name resolved by joining {@link extendedPanIdHex} against the
-     * Border Router registry. Some BR vendors (e.g. Apple, Aqara) use a stable border-agent
-     * ID as the MeshCoP `xa` while the actual Thread radio MAC differs, so the BR can show
-     * up as both a known BR and an "unknown" router on the same network.
-     */
-    networkName?: string;
-}
-
-/**
- * Router/leader sourced purely from diagnostics (route64) that matches no
- * commissioned Matter device, known BR, or neighbor-inferred unknown. Its
- * childTable leaves are not materialized as nodes — they surface as {@link childCount}.
- */
-export interface DiagnosticMeshNode {
-    kind: "diagnostic";
-    /** Graph id `thread_<EXTMAC>`, else `meshrloc_<extPanId>_<rloc16>`. */
-    id: string;
-    rloc16: number;
-    /** Uppercase hex Thread MAC if known. */
-    extAddressHex?: string;
-    isRouter: boolean;
-    vendorName?: string;
-    /** Number of childTable entries this router reports (shown as a label badge). */
-    childCount: number;
-    networkName: string;
-}
-
-/**
- * Thread Border Router enriched via mDNS.
- *
- * Same neighbor-table aggregate fields as UnknownThreadDevice (seenBy, isRouter, bestRssi),
- * plus all BorderRouterEntry fields (network name, vendor, addresses, etc.).
- */
-export interface KnownBorderRouter extends BorderRouterEntry {
-    kind: "br";
-    /** DOM/graph ID, formatted "br_<XAHEX>". */
-    id: string;
-    /** Convenience copy of extAddressHex as bigint, mirroring UnknownThreadDevice. */
-    extAddress: bigint;
-    /** Commissioned node IDs whose neighbor table sees this xa. */
-    seenBy: string[];
-    /** Inferred from neighbor entry. */
-    isRouter: boolean;
-    /** Best signal strength seen across observers. */
-    bestRssi: number | null;
-}
-
-/**
- * External Thread device discriminated union — either a recognized Border Router
- * or an unidentified neighbor.
- */
-export type ThreadExternalDevice = KnownBorderRouter | UnknownThreadDevice;
+// The network topology data model + derivation now lives in @matter-server/ws-client
+// so the server can reuse it. Re-exported here so existing dashboard imports of
+// "./network-types.js" keep resolving unchanged.
+export type {
+    CategorizedDevices,
+    DiagnosticMeshNode,
+    KnownBorderRouter,
+    NetworkType,
+    SignalLevel,
+    ThreadConnection,
+    ThreadEdgePair,
+    ThreadExternalDevice,
+    ThreadNeighbor,
+    ThreadRoute,
+    UnknownThreadDevice,
+    WiFiDiagnostics,
+} from "@matter-server/ws-client";
+export { ThreadRoutingRole } from "@matter-server/ws-client";
 
 /**
  * Network graph node data for vis.js.

--- a/packages/dashboard/src/pages/network/network-utils.ts
+++ b/packages/dashboard/src/pages/network/network-utils.ts
@@ -4,40 +4,54 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-    BorderRouterEntry,
-    MatterNode,
-    ThreadDiagnosticsBatch,
-    ThreadDiagnosticsNode,
-} from "@matter-server/ws-client";
+import type { MatterNode, SignalLevel, ThreadConnection, ThreadEdgePair } from "@matter-server/ws-client";
+import { getEdgeSignalScore, getThreadExtendedAddressHex } from "@matter-server/ws-client";
 import { getCssVar } from "../../util/shared-styles.js";
-import type {
-    CategorizedDevices,
-    DiagnosticMeshNode,
-    NetworkType,
-    SignalLevel,
-    ThreadConnection,
-    ThreadEdgePair,
-    ThreadExternalDevice,
-    ThreadNeighbor,
-    ThreadRoute,
-} from "./network-types.js";
 
-// NetworkCommissioning cluster feature map bits (cluster 0x31/49)
-const WIFI_FEATURE = 1 << 0; // Bit 0: WiFi Network Interface
-const THREAD_FEATURE = 1 << 1; // Bit 1: Thread Network Interface
-const ETHERNET_FEATURE = 1 << 2; // Bit 2: Ethernet Network Interface
+// The network topology data model + derivation moved to @matter-server/ws-client so
+// the server can reuse it. Re-exported here so existing dashboard imports from
+// "./network-utils.js" keep resolving unchanged. Color/theme, display-string and
+// side-panel (NodeConnection) helpers stay below — those are render concerns.
+export {
+    buildDiagnosticRloc16Map,
+    buildExtAddrMap,
+    buildMatterRloc16ByXp,
+    buildRloc16Map,
+    buildThreadEdgePairs,
+    categorizeDevices,
+    diagnosticNodeId,
+    findDiagnosticMeshNodes,
+    findRouteByExtAddress,
+    findUnknownDevices,
+    getEdgeSignalScore,
+    getNeighborTableLength,
+    getNetworkType,
+    getRoutableDestinationsCount,
+    getRouteBidirectionalLqi,
+    getSignalLevel,
+    getSignalLevelFromLqi,
+    getThreadChannel,
+    getThreadExtendedAddress,
+    getThreadExtendedAddressHex,
+    getThreadExtendedPanId,
+    getThreadRloc16,
+    getThreadRole,
+    getThreadVersion,
+    getWiFiDiagnostics,
+    makeDiagnosticRloc16Resolver,
+    makePairKey,
+    mergeDiagnosticEdges,
+    parseNeighborTable,
+    parseRouteTable,
+} from "@matter-server/ws-client";
+export type { WiFiDiagnostics } from "@matter-server/ws-client";
+
+export { getDeviceName } from "../../util/node-name.js";
 
 // WiFi RSSI thresholds (dBm). Used only for the WiFi diagnostics graph; Thread
-// neighbor/route edges are LQI-driven (see below).
+// neighbor/route edges are LQI-driven and classified in ws-client.
 const SIGNAL_STRONG_THRESHOLD = -70;
 const SIGNAL_MEDIUM_THRESHOLD = -85;
-
-// Thread LQI thresholds. Spec types LQI as uint8 (0-255), but OpenThread — the
-// dominant Thread stack — only ever reports 0-3. We classify on the 0-3 scale:
-// 3 = strong, 2 = medium, 1 = weak, 0 = no link (stale/dead neighbor entry).
-const LQI_STRONG_THRESHOLD = 2;
-const LQI_MEDIUM_THRESHOLD = 1;
 
 // Signal colors — read from CSS variables for theme awareness
 function getSignalColorStrong(): string {
@@ -53,85 +67,42 @@ function getSignalColorNone(): string {
     return getCssVar("--signal-color-none", "#9e9e9e");
 }
 
-/**
- * WiFi Diagnostics info from cluster 0x36/54.
- */
-export interface WiFiDiagnostics {
-    /** BSSID as hex string */
-    bssid: string | null;
-    /** RSSI in dBm (-120 to 0) */
-    rssi: number | null;
-    /** WiFi channel */
-    channel: number | null;
-    /** Security type */
-    securityType: number | null;
-    /** WiFi version */
-    wifiVersion: number | null;
-}
-
-/**
- * Converts a base64-encoded extended address to BigInt.
- * Extended addresses are 8 bytes (64 bits) stored as big-endian.
- * Some Matter implementations include a TLV prefix byte that we need to skip.
- */
-function base64ToBigInt(base64: string): bigint {
-    try {
-        const binary = atob(base64);
-        let result = 0n;
-
-        // If we have 9 bytes, skip the first byte (likely a TLV type prefix)
-        // EUI-64 should be exactly 8 bytes
-        const start = binary.length > 8 ? binary.length - 8 : 0;
-
-        for (let i = start; i < binary.length; i++) {
-            result = (result << 8n) | BigInt(binary.charCodeAt(i));
-        }
-        return result;
-    } catch {
-        return 0n;
+/** Map a signal level to its theme-aware color. */
+export function signalLevelToColor(level: SignalLevel): string {
+    switch (level) {
+        case "strong":
+            return getSignalColorStrong();
+        case "medium":
+            return getSignalColorMedium();
+        case "weak":
+            return getSignalColorWeak();
+        case "none":
+            return getSignalColorNone();
     }
 }
 
 /**
- * Normalizes an extended address to BigInt for comparison.
- * Handles: BigInt, base64 strings, numbers.
+ * Get signal color from an LQI value (0-3 in practice on OpenThread).
+ * 0 = grey (no link), 1 = red, 2 = orange, 3 = green.
  */
-function normalizeExtAddress(value: unknown): bigint {
-    if (typeof value === "bigint") {
-        return value;
-    }
-    if (typeof value === "string") {
-        return base64ToBigInt(value);
-    }
-    if (typeof value === "number") {
-        return BigInt(value);
-    }
-    return 0n;
+export function getSignalColorFromLqi(lqi: number): string {
+    return signalLevelToColor(lqi <= 0 ? "none" : lqi > 2 ? "strong" : lqi > 1 ? "medium" : "weak");
 }
 
 /**
- * Detects the network type from the NetworkCommissioning cluster feature map.
- * Uses attribute 0/49/65532 (FeatureMap).
+ * Gets the signal color for a given RSSI value.
  */
-export function getNetworkType(node: MatterNode): NetworkType {
-    const featureMap = node.attributes["0/49/65532"] as number | undefined;
-
-    if (featureMap === undefined) {
-        return "unknown";
+export function getSignalColorFromRssi(rssi: number | null): string {
+    if (rssi === null) {
+        return getSignalColorMedium(); // Default to medium if unknown
     }
-
-    // Check in priority order: Thread > WiFi > Ethernet
-    if (featureMap & THREAD_FEATURE) {
-        return "thread";
+    if (rssi > SIGNAL_STRONG_THRESHOLD) {
+        return getSignalColorStrong();
     }
-    if (featureMap & WIFI_FEATURE) {
-        return "wifi";
+    if (rssi > SIGNAL_MEDIUM_THRESHOLD) {
+        return getSignalColorMedium();
     }
-    if (featureMap & ETHERNET_FEATURE) {
-        return "ethernet";
-    }
-
-    return "unknown";
+    return getSignalColorWeak();
 }
 
 // NetworkCommissioning ThreadVersion (attr 0x0A) follows the Thread spec
@@ -146,15 +117,6 @@ const THREAD_VERSION_NAMES: Record<number, string> = {
 };
 
 /**
- * Thread protocol version supported by the device's Thread interface.
- * Uses NetworkCommissioning cluster (0x31/49) ThreadVersion attribute (0x0A/10).
- */
-export function getThreadVersion(node: MatterNode): number | undefined {
-    const v = node.attributes["0/49/10"];
-    return typeof v === "number" ? v : undefined;
-}
-
-/**
  * Human-readable Thread version string from the Version TLV value.
  * Unmapped TLVs render as `Thread unknown (N)` so the raw value stays
  * visible for diagnostics.
@@ -165,504 +127,78 @@ export function formatThreadVersion(tlv: number): string {
 }
 
 /**
- * Categorizes nodes by their network type.
- * Node IDs are stored as strings to avoid BigInt precision loss.
+ * Gets the human-readable name for a Thread routing role.
  */
-export function categorizeDevices(nodes: Record<string, MatterNode>): CategorizedDevices {
-    const result: CategorizedDevices = {
-        thread: [],
-        wifi: [],
-        ethernet: [],
-        unknown: [],
-    };
-
-    for (const node of Object.values(nodes)) {
-        const nodeId = String(node.node_id);
-        const networkType = getNetworkType(node);
-        result[networkType].push(nodeId);
+export function getThreadRoleName(role: number | undefined): string {
+    switch (role) {
+        case 0:
+            return "Unspecified";
+        case 1:
+            return "Unassigned";
+        case 2:
+            return "Sleepy End Device";
+        case 3:
+            return "End Device";
+        case 4:
+            return "REED";
+        case 5:
+            return "Router";
+        case 6:
+            return "Leader";
+        default:
+            return "Unknown";
     }
-
-    return result;
 }
 
 /**
- * Gets the Thread routing role for a node.
- * Uses attribute 0/53/1 (RoutingRole, nullable per Matter spec).
+ * Gets WiFi security type name.
  */
-export function getThreadRole(node: MatterNode): number | undefined {
-    const v = node.attributes["0/53/1"];
-    return typeof v === "number" ? v : undefined;
-}
-
-/**
- * Gets the Thread channel for a node.
- * Uses attribute 0/53/0 (Channel, nullable per Matter spec).
- */
-export function getThreadChannel(node: MatterNode): number | undefined {
-    const v = node.attributes["0/53/0"];
-    return typeof v === "number" ? v : undefined;
-}
-
-/**
- * Gets the Thread extended PAN ID for a node.
- * Uses attribute 0/53/4 (ExtendedPanId, nullable per Matter spec).
- *
- * The WebSocket JSON reviver only revives integers above Number.MAX_SAFE_INTEGER
- * as bigint; smaller uint64 values arrive as plain number, so accept both.
- */
-export function getThreadExtendedPanId(node: MatterNode): bigint | undefined {
-    const v = node.attributes["0/53/4"];
-    if (typeof v === "bigint") return v;
-    if (typeof v === "number" && Number.isInteger(v)) return BigInt(v);
-    return undefined;
-}
-
-/**
- * Gets the Thread extended address (EUI-64) for a node.
- *
- * Uses General Diagnostics cluster (0x0033/51) NetworkInterfaces attribute (0/51/0).
- * The NetworkInterface struct has:
- * - Field 4: HardwareAddress (base64 encoded EUI-64)
- * - Field 7: Type (4 = Thread)
- *
- * Returns as BigInt. Only upper 48 bits should be used for matching due to JSON precision loss.
- */
-export function getThreadExtendedAddress(node: MatterNode): bigint | undefined {
-    // Get NetworkInterfaces from General Diagnostics cluster (0/51/0)
-    const networkInterfaces = node.attributes["0/51/0"] as Array<Record<string, unknown>> | undefined;
-
-    if (!Array.isArray(networkInterfaces) || networkInterfaces.length === 0) {
-        return undefined;
+export function getWiFiSecurityTypeName(securityType: number | null): string {
+    switch (securityType) {
+        case 0:
+            return "Unspecified";
+        case 1:
+            return "None";
+        case 2:
+            return "WEP";
+        case 3:
+            return "WPA Personal";
+        case 4:
+            return "WPA2 Personal";
+        case 5:
+            return "WPA3 Personal";
+        default:
+            return "Unknown";
     }
+}
 
-    // Find Thread interface (type 7 field = 4) or use first with hardware address
-    const threadIface = networkInterfaces.find(i => i["7"] === 4) || networkInterfaces[0];
-
-    if (!threadIface) {
-        return undefined;
+/**
+ * Gets WiFi version name.
+ */
+export function getWiFiVersionName(version: number | null): string {
+    switch (version) {
+        case 0:
+            return "802.11a";
+        case 1:
+            return "802.11b";
+        case 2:
+            return "802.11g";
+        case 3:
+            return "802.11n";
+        case 4:
+            return "802.11ac";
+        case 5:
+            return "802.11ax";
+        case 6:
+            return "802.11ah";
+        default:
+            return "Unknown";
     }
-
-    // HardwareAddress is field 4, base64 encoded
-    const hwAddrB64 = threadIface["4"];
-
-    if (typeof hwAddrB64 !== "string" || !hwAddrB64) {
-        return undefined;
-    }
-
-    // Decode base64 to get EUI-64
-    const extAddr = base64ToBigInt(hwAddrB64);
-    return extAddr !== 0n ? extAddr : undefined;
 }
 
-/**
- * Gets the Thread extended address as a hex string for display.
- * Uses General Diagnostics NetworkInterfaces (0/51/0).
- */
-export function getThreadExtendedAddressHex(node: MatterNode): string | undefined {
-    const extAddr = getThreadExtendedAddress(node);
-    if (extAddr !== undefined) {
-        return extAddr.toString(16).padStart(16, "0").toUpperCase();
-    }
-    return undefined;
-}
-
-/**
- * Counts entries in the Thread neighbor table without normalizing each entry.
- * Use this in hot paths where only the cardinality matters; the full parse
- * does a base64 decode per entry that adds up across re-renders.
- */
-export function getNeighborTableLength(node: MatterNode): number {
-    const neighborTable = node.attributes["0/53/7"];
-    return Array.isArray(neighborTable) ? neighborTable.length : 0;
-}
-
-/**
- * Parses the Thread neighbor table from a node's attributes.
- * Attribute 0/53/7 (NeighborTable) is an array of neighbor objects.
- * The data uses numeric keys matching the Matter spec field IDs.
- */
-export function parseNeighborTable(node: MatterNode): ThreadNeighbor[] {
-    const neighborTable = node.attributes["0/53/7"];
-
-    if (!Array.isArray(neighborTable)) {
-        return [];
-    }
-
-    return neighborTable.map((entry: Record<string, unknown>) => {
-        // Field 0: extAddress - can be BigInt or base64 string
-        const rawExtAddr = entry["0"] ?? entry.extAddress;
-        const extAddress = normalizeExtAddress(rawExtAddr);
-
-        return {
-            extAddress,
-            // Field 1: age
-            age: (entry["1"] ?? entry.age ?? 0) as number,
-            // Field 2: rloc16
-            rloc16: (entry["2"] ?? entry.rloc16 ?? 0) as number,
-            // Field 3: linkFrameCounter
-            linkFrameCounter: (entry["3"] ?? entry.linkFrameCounter ?? 0) as number,
-            // Field 4: mleFrameCounter
-            mleFrameCounter: (entry["4"] ?? entry.mleFrameCounter ?? 0) as number,
-            // Field 5: lqi
-            lqi: (entry["5"] ?? entry.lqi ?? 0) as number,
-            // Field 6: averageRssi (nullable)
-            avgRssi: (entry["6"] ?? entry.averageRssi ?? null) as number | null,
-            // Field 7: lastRssi (nullable)
-            lastRssi: (entry["7"] ?? entry.lastRssi ?? null) as number | null,
-            // Field 8: frameErrorRate
-            frameErrorRate: (entry["8"] ?? entry.frameErrorRate ?? 0) as number,
-            // Field 9: messageErrorRate
-            messageErrorRate: (entry["9"] ?? entry.messageErrorRate ?? 0) as number,
-            // Field 10: rxOnWhenIdle
-            rxOnWhenIdle: (entry["10"] ?? entry.rxOnWhenIdle ?? false) as boolean,
-            // Field 11: fullThreadDevice
-            fullThreadDevice: (entry["11"] ?? entry.fullThreadDevice ?? false) as boolean,
-            // Field 12: fullNetworkData
-            fullNetworkData: (entry["12"] ?? entry.fullNetworkData ?? false) as boolean,
-            // Field 13: isChild
-            isChild: (entry["13"] ?? entry.isChild ?? false) as boolean,
-        };
-    });
-}
-
-/**
- * Parses the Thread route table from a node's attributes.
- * Attribute 0/53/8 (RouteTable) is an array of route objects.
- * The data uses numeric keys matching the Matter spec field IDs.
- */
-export function parseRouteTable(node: MatterNode): ThreadRoute[] {
-    const routeTable = node.attributes["0/53/8"];
-
-    if (!Array.isArray(routeTable)) {
-        return [];
-    }
-
-    return routeTable.map((entry: Record<string, unknown>) => {
-        // Field 0: extAddress - can be BigInt or base64 string
-        const rawExtAddr = entry["0"] ?? entry.extAddress;
-        const extAddress = normalizeExtAddress(rawExtAddr);
-
-        return {
-            extAddress,
-            // Field 1: rloc16
-            rloc16: (entry["1"] ?? entry.rloc16 ?? 0) as number,
-            // Field 2: routerId
-            routerId: (entry["2"] ?? entry.routerId ?? 0) as number,
-            // Field 3: nextHop
-            nextHop: (entry["3"] ?? entry.nextHop ?? 0) as number,
-            // Field 4: pathCost
-            pathCost: (entry["4"] ?? entry.pathCost ?? 0) as number,
-            // Field 5: lqiIn
-            lqiIn: (entry["5"] ?? entry.lqiIn ?? 0) as number,
-            // Field 6: lqiOut
-            lqiOut: (entry["6"] ?? entry.lqiOut ?? 0) as number,
-            // Field 7: age
-            age: (entry["7"] ?? entry.age ?? 0) as number,
-            // Field 8: allocated
-            allocated: (entry["8"] ?? entry.allocated ?? false) as boolean,
-            // Field 9: linkEstablished
-            linkEstablished: (entry["9"] ?? entry.linkEstablished ?? false) as boolean,
-        };
-    });
-}
-
-/**
- * Find a route table entry for a specific destination by extended address.
- * Returns the route entry if found, undefined otherwise.
- */
-export function findRouteByExtAddress(node: MatterNode, targetExtAddr: bigint): ThreadRoute | undefined {
-    const routes = parseRouteTable(node);
-    return routes.find(route => route.extAddress === targetExtAddr && route.linkEstablished);
-}
-
-/**
- * Count the number of routable destinations for a node (from route table).
- * Only counts entries where allocated=true and linkEstablished=true.
- * This is typically only meaningful for router nodes.
- */
-export function getRoutableDestinationsCount(node: MatterNode): number {
-    const routes = parseRouteTable(node);
-    return routes.filter(route => route.allocated && route.linkEstablished).length;
-}
-
-/**
- * Calculate combined bidirectional LQI from route table entry.
- * Returns average of lqiIn and lqiOut if both are non-zero.
- */
-export function getRouteBidirectionalLqi(route: ThreadRoute): number | undefined {
-    if (route.lqiIn > 0 && route.lqiOut > 0) {
-        return Math.round((route.lqiIn + route.lqiOut) / 2);
-    }
-    if (route.lqiIn > 0) return route.lqiIn;
-    if (route.lqiOut > 0) return route.lqiOut;
-    return undefined;
-}
-
-/**
- * Gets the RLOC16 (short address) for a Thread node.
- * Uses attribute 0/53/64 (Rloc16, 0x0040).
- */
-export function getThreadRloc16(node: MatterNode): number | undefined {
-    const value = node.attributes["0/53/64"];
-    if (typeof value === "number") {
-        return value;
-    }
-    return undefined;
-}
-
-/**
- * Builds a map of extended addresses (BigInt) to node IDs for Thread devices.
- * Uses General Diagnostics NetworkInterfaces (0/51/0) for the hardware address.
- * Node IDs are stored as strings to avoid BigInt precision loss.
- */
-export function buildExtAddrMap(nodes: Record<string, MatterNode>): Map<bigint, string> {
-    const extAddrMap = new Map<bigint, string>();
-
-    for (const node of Object.values(nodes)) {
-        const nodeId = String(node.node_id);
-        const extAddr = getThreadExtendedAddress(node);
-
-        if (extAddr !== undefined) {
-            extAddrMap.set(extAddr, nodeId);
-        }
-    }
-
-    return extAddrMap;
-}
-
-/**
- * Builds a map of RLOC16 (short addresses) to node IDs for Thread devices.
- * Used as fallback when ExtAddress is not available.
- * Node IDs are stored as strings to avoid BigInt precision loss.
- */
-export function buildRloc16Map(nodes: Record<string, MatterNode>): Map<number, string> {
-    const rloc16Map = new Map<number, string>();
-
-    for (const node of Object.values(nodes)) {
-        const nodeId = String(node.node_id);
-        const rloc16 = getThreadRloc16(node);
-
-        if (rloc16 !== undefined) {
-            rloc16Map.set(rloc16, nodeId);
-        }
-    }
-
-    return rloc16Map;
-}
-
-/**
- * Stable graph id for a diagnostic mesh node: prefer the globally-unique extMac,
- * else an rloc16 namespaced by extPanId (rloc16 is only unique within a network).
- */
-export function diagnosticNodeId(
-    node: Pick<ThreadDiagnosticsNode, "extMacAddress" | "rloc16">,
-    extPanIdHex: string,
-): string {
-    if (node.extMacAddress !== undefined) return `thread_${node.extMacAddress.toUpperCase()}`;
-    return `meshrloc_${extPanIdHex.toUpperCase()}_${node.rloc16 ?? "x"}`;
-}
-
-/** Resolver key joining a network's extPanId with an rloc16 (rloc16 alone is not unique across networks). */
-function diagRlocKey(extPanIdHex: string, rloc16: number): string {
-    return `${extPanIdHex.toUpperCase()}:${rloc16}`;
-}
-
-/**
- * `extPanId:rloc16` -> Matter node id, scoped per Thread network. rloc16 is only
- * unique within a network, so a global rloc16 map would mis-attach diagnostic
- * edges from one network onto a Matter device on another. Keyed via {@link diagRlocKey}.
- */
-export function buildMatterRloc16ByXp(nodes: Record<string, MatterNode>): Map<string, string> {
-    const map = new Map<string, string>();
-    for (const node of Object.values(nodes)) {
-        const rloc16 = getThreadRloc16(node);
-        const xp = getThreadExtendedPanId(node);
-        if (rloc16 === undefined || xp === undefined) continue;
-        map.set(diagRlocKey(xp.toString(16).padStart(16, "0"), rloc16), String(node.node_id));
-    }
-    return map;
-}
-
-/**
- * Resolve a diagnostic node to the graph node id it is actually rendered under:
- * a commissioned Matter device (by extMac), a known Border Router (`br_<xa>`), a
- * neighbor-inferred unknown, or — when it matches none — its own diagnostic id.
- * Mirrors the precedence in {@link findDiagnosticMeshNodes} so edges target the
- * same node those materialize, rather than a phantom `thread_`/`meshrloc_` id.
- */
-function diagnosticGraphNodeId(
-    node: ThreadDiagnosticsNode,
-    extPanIdHex: string,
-    matterExtAddrMap: Map<bigint, string>,
-    borderRouters: ReadonlyMap<string, BorderRouterEntry>,
-    unknownIdByExt: Map<string, string>,
-): string {
-    const up = node.extMacAddress?.toUpperCase();
-    if (up !== undefined) {
-        const matterId = matterExtAddrMap.get(BigInt(`0x${up}`));
-        if (matterId !== undefined) return matterId;
-        if (borderRouters.has(up)) return `br_${up}`;
-        const unknownId = unknownIdByExt.get(up);
-        if (unknownId !== undefined) return unknownId;
-    }
-    return diagnosticNodeId(node, extPanIdHex);
-}
-
-/**
- * `extPanId:rloc16` -> graph node id across diagnostic batches, layered UNDER the
- * Matter rloc16 map. Resolves route64/childTable references within the referencing
- * node's own network to whatever id that node is drawn as (Matter / `br_` /
- * `unknown_` / diagnostic). Keyed via {@link diagRlocKey}.
- */
-export function buildDiagnosticRloc16Map(
-    batches: ReadonlyMap<string, ThreadDiagnosticsBatch>,
-    matterRloc16ByXp: Map<string, string>,
-    matterExtAddrMap: Map<bigint, string>,
-    borderRouters: ReadonlyMap<string, BorderRouterEntry>,
-    unknownDevices: ThreadExternalDevice[],
-): Map<string, string> {
-    const unknownIdByExt = new Map<string, string>();
-    for (const d of unknownDevices) unknownIdByExt.set(d.extAddressHex.toUpperCase(), d.id);
-
-    const map = new Map<string, string>();
-    for (const batch of batches.values()) {
-        for (const node of batch.nodes) {
-            if (node.rloc16 === undefined) continue;
-            // Matter device on THIS network (by rloc16) wins.
-            if (matterRloc16ByXp.has(diagRlocKey(batch.extPanIdHex, node.rloc16))) continue;
-            map.set(
-                diagRlocKey(batch.extPanIdHex, node.rloc16),
-                diagnosticGraphNodeId(node, batch.extPanIdHex, matterExtAddrMap, borderRouters, unknownIdByExt),
-            );
-        }
-    }
-    return map;
-}
-
-/**
- * Build a per-network rloc16 resolver: a Matter device on the same Thread network
- * wins, else the diagnostic node id within the same extPanId. Returns undefined
- * when unresolved. Both lookups are keyed by `extPanId:rloc16` so identical rloc16
- * values across networks never cross-attach.
- */
-export function makeDiagnosticRloc16Resolver(
-    matterRloc16ByXp: Map<string, string>,
-    diagRloc16Map: Map<string, string>,
-): (rloc16: number, extPanIdHex: string) => string | undefined {
-    return (rloc16, extPanIdHex) =>
-        matterRloc16ByXp.get(diagRlocKey(extPanIdHex, rloc16)) ?? diagRloc16Map.get(diagRlocKey(extPanIdHex, rloc16));
-}
-
-interface ExternalAggregate {
-    extAddressHex: string;
-    extAddress: bigint;
-    seenBy: string[];
-    isRouter: boolean;
-    bestRssi: number | null;
-    /** xp of the first observing matter node; all neighbors of a Thread node share its xp. */
-    extendedPanIdHex?: string;
-}
-
-/**
- * Finds external Thread devices - addresses seen in neighbor tables that don't match
- * any commissioned device. Classifies each against the optional Border Router registry:
- * matched ones are emitted as kind:"br" with full mDNS enrichment; the rest stay as
- * kind:"unknown". Uses RLOC16 as fallback when extended address matching fails.
- */
-export function findUnknownDevices(
-    nodes: Record<string, MatterNode>,
-    extAddrMap: Map<bigint, string>,
-    rloc16Map: Map<number, string>,
-    borderRouters?: ReadonlyMap<string, BorderRouterEntry>,
-): ThreadExternalDevice[] {
-    const aggregates = new Map<string, ExternalAggregate>();
-
-    for (const node of Object.values(nodes)) {
-        const nodeId = String(node.node_id);
-        const neighbors = parseNeighborTable(node);
-        const observerXp = getThreadExtendedPanId(node);
-        const observerXpHex =
-            observerXp !== undefined ? observerXp.toString(16).padStart(16, "0").toUpperCase() : undefined;
-
-        for (const neighbor of neighbors) {
-            if (extAddrMap.has(neighbor.extAddress)) {
-                continue;
-            }
-            if (neighbor.rloc16 !== 0 && rloc16Map.has(neighbor.rloc16)) {
-                continue;
-            }
-
-            const extAddressHex = neighbor.extAddress.toString(16).padStart(16, "0").toUpperCase();
-
-            let agg = aggregates.get(extAddressHex);
-            if (agg === undefined) {
-                agg = {
-                    extAddressHex,
-                    extAddress: neighbor.extAddress,
-                    seenBy: [],
-                    isRouter: false,
-                    bestRssi: null,
-                    extendedPanIdHex: observerXpHex,
-                };
-                aggregates.set(extAddressHex, agg);
-            } else if (agg.extendedPanIdHex === undefined && observerXpHex !== undefined) {
-                agg.extendedPanIdHex = observerXpHex;
-            }
-
-            if (!agg.seenBy.includes(nodeId)) {
-                agg.seenBy.push(nodeId);
-            }
-            if (neighbor.rxOnWhenIdle) {
-                agg.isRouter = true;
-            }
-            const rssi = neighbor.avgRssi ?? neighbor.lastRssi;
-            if (rssi !== null && (agg.bestRssi === null || rssi > agg.bestRssi)) {
-                agg.bestRssi = rssi;
-            }
-        }
-    }
-
-    // Pre-compute xp → networkName from the BR registry so we can label unknowns by network.
-    const networkNameByXp = new Map<string, string>();
-    if (borderRouters !== undefined) {
-        for (const br of borderRouters.values()) {
-            if (br.extendedPanIdHex !== undefined && br.networkName !== undefined) {
-                networkNameByXp.set(br.extendedPanIdHex, br.networkName);
-            }
-        }
-    }
-
-    const out = new Array<ThreadExternalDevice>();
-    for (const agg of aggregates.values()) {
-        const br = borderRouters?.get(agg.extAddressHex);
-        if (br !== undefined) {
-            out.push({
-                kind: "br",
-                ...br,
-                id: `br_${agg.extAddressHex}`,
-                extAddressHex: agg.extAddressHex,
-                extAddress: agg.extAddress,
-                seenBy: agg.seenBy,
-                isRouter: agg.isRouter,
-                bestRssi: agg.bestRssi,
-            });
-        } else {
-            const networkName =
-                agg.extendedPanIdHex !== undefined ? networkNameByXp.get(agg.extendedPanIdHex) : undefined;
-            out.push({
-                kind: "unknown",
-                id: `unknown_${agg.extAddressHex}`,
-                extAddressHex: agg.extAddressHex,
-                extAddress: agg.extAddress,
-                seenBy: agg.seenBy,
-                isRouter: agg.isRouter,
-                bestRssi: agg.bestRssi,
-                extendedPanIdHex: agg.extendedPanIdHex,
-                networkName,
-            });
-        }
-    }
-    return out;
+/** Strips trailing dot and `.local` suffix from an mDNS hostname. */
+export function stripMdnsHostname(hostname: string): string {
+    return hostname.replace(/\.$/, "").replace(/\.local$/i, "");
 }
 
 /**
@@ -768,233 +304,6 @@ export function decodeMeshcopStateBitmap(hex: string | undefined): DecodedStateB
     };
 }
 
-/** Determine signal level from a Thread neighbor's LQI. */
-export function getSignalLevel(neighbor: ThreadNeighbor): SignalLevel {
-    return getSignalLevelFromLqi(neighbor.lqi);
-}
-
-/**
- * Map an LQI value (0-3 in practice on OpenThread) to a signal level.
- * 0 = "none" (no recent valid frames — stale/dead link).
- */
-export function getSignalLevelFromLqi(lqi: number): SignalLevel {
-    if (lqi <= 0) return "none";
-    if (lqi > LQI_STRONG_THRESHOLD) return "strong";
-    if (lqi > LQI_MEDIUM_THRESHOLD) return "medium";
-    return "weak";
-}
-
-/** Map a signal level to its theme-aware color. */
-export function signalLevelToColor(level: SignalLevel): string {
-    switch (level) {
-        case "strong":
-            return getSignalColorStrong();
-        case "medium":
-            return getSignalColorMedium();
-        case "weak":
-            return getSignalColorWeak();
-        case "none":
-            return getSignalColorNone();
-    }
-}
-
-/** Gets the signal color for a Thread neighbor based on its LQI. */
-export function getSignalColor(neighbor: ThreadNeighbor): string {
-    return getSignalColorFromLqi(neighbor.lqi);
-}
-
-/**
- * Get signal color from an LQI value (0-3 in practice on OpenThread).
- * 0 = grey (no link), 1 = red, 2 = orange, 3 = green.
- */
-export function getSignalColorFromLqi(lqi: number): string {
-    return signalLevelToColor(getSignalLevelFromLqi(lqi));
-}
-
-/** Strips trailing dot and `.local` suffix from an mDNS hostname. */
-export function stripMdnsHostname(hostname: string): string {
-    return hostname.replace(/\.$/, "").replace(/\.local$/i, "");
-}
-
-export { getDeviceName } from "../../util/node-name.js";
-
-/**
- * Gets the human-readable name for a Thread routing role.
- */
-export function getThreadRoleName(role: number | undefined): string {
-    switch (role) {
-        case 0:
-            return "Unspecified";
-        case 1:
-            return "Unassigned";
-        case 2:
-            return "Sleepy End Device";
-        case 3:
-            return "End Device";
-        case 4:
-            return "REED";
-        case 5:
-            return "Router";
-        case 6:
-            return "Leader";
-        default:
-            return "Unknown";
-    }
-}
-
-/**
- * Parses WiFi diagnostics from a node's attributes.
- * Cluster 0x36/54 - WiFi Network Diagnostics.
- */
-export function getWiFiDiagnostics(node: MatterNode): WiFiDiagnostics {
-    // BSSID is attribute 0/54/0, stored as base64
-    const bssidRaw = node.attributes["0/54/0"] as string | undefined;
-    let bssid: string | null = null;
-    if (bssidRaw) {
-        try {
-            const binary = atob(bssidRaw);
-            bssid = Array.from(binary)
-                .map(c => c.charCodeAt(0).toString(16).padStart(2, "0").toUpperCase())
-                .join(":");
-        } catch {
-            bssid = null;
-        }
-    }
-
-    // RSSI is attribute 0/54/4
-    const rssi = node.attributes["0/54/4"] as number | null | undefined;
-
-    // Channel is attribute 0/54/3
-    const channel = node.attributes["0/54/3"] as number | null | undefined;
-
-    // Security type is attribute 0/54/1
-    const securityType = node.attributes["0/54/1"] as number | null | undefined;
-
-    // WiFi version is attribute 0/54/2
-    const wifiVersion = node.attributes["0/54/2"] as number | null | undefined;
-
-    return {
-        bssid: bssid,
-        rssi: rssi ?? null,
-        channel: channel ?? null,
-        securityType: securityType ?? null,
-        wifiVersion: wifiVersion ?? null,
-    };
-}
-
-/**
- * Gets the signal color for a given RSSI value.
- */
-export function getSignalColorFromRssi(rssi: number | null): string {
-    if (rssi === null) {
-        return getSignalColorMedium(); // Default to medium if unknown
-    }
-    if (rssi > SIGNAL_STRONG_THRESHOLD) {
-        return getSignalColorStrong();
-    }
-    if (rssi > SIGNAL_MEDIUM_THRESHOLD) {
-        return getSignalColorMedium();
-    }
-    return getSignalColorWeak();
-}
-
-/**
- * Gets WiFi security type name.
- */
-export function getWiFiSecurityTypeName(securityType: number | null): string {
-    switch (securityType) {
-        case 0:
-            return "Unspecified";
-        case 1:
-            return "None";
-        case 2:
-            return "WEP";
-        case 3:
-            return "WPA Personal";
-        case 4:
-            return "WPA2 Personal";
-        case 5:
-            return "WPA3 Personal";
-        default:
-            return "Unknown";
-    }
-}
-
-/**
- * Gets WiFi version name.
- */
-export function getWiFiVersionName(version: number | null): string {
-    switch (version) {
-        case 0:
-            return "802.11a";
-        case 1:
-            return "802.11b";
-        case 2:
-            return "802.11g";
-        case 3:
-            return "802.11n";
-        case 4:
-            return "802.11ac";
-        case 5:
-            return "802.11ax";
-        case 6:
-            return "802.11ah";
-        default:
-            return "Unknown";
-    }
-}
-
-/**
- * Materialize mesh nodes that exist only in diagnostics: router records and
- * childTable children whose rloc16/extMac matches no Matter device, BR, or
- * already-found unknown. Matter/BR/unknown matches are enriched in place, not
- * duplicated.
- */
-export function findDiagnosticMeshNodes(
-    batches: ReadonlyMap<string, ThreadDiagnosticsBatch>,
-    matterRloc16ByXp: Map<string, string>,
-    matterExtAddrMap: Map<bigint, string>,
-    borderRouters: ReadonlyMap<string, BorderRouterEntry>,
-    unknownDevices: ThreadExternalDevice[],
-): DiagnosticMeshNode[] {
-    const unknownExt = new Set<string>(unknownDevices.map(d => d.extAddressHex.toUpperCase()));
-    const out = new Map<string, DiagnosticMeshNode>();
-
-    const matchesExisting = (extPanIdHex: string, rloc16: number | undefined, extHex?: string): boolean => {
-        if (rloc16 !== undefined && matterRloc16ByXp.has(diagRlocKey(extPanIdHex, rloc16))) return true;
-        if (extHex !== undefined) {
-            const up = extHex.toUpperCase();
-            if (matterExtAddrMap.has(BigInt(`0x${up}`))) return true;
-            if (borderRouters.has(up)) return true;
-            if (unknownExt.has(up)) return true;
-        }
-        return false;
-    };
-
-    for (const batch of batches.values()) {
-        for (const node of batch.nodes) {
-            // Only materialize a node for the responding router itself (a route64
-            // participant). Its childTable children are leaf end devices — surfaced
-            // as a count on the router, not as individual floating nodes — unless a
-            // child is itself a commissioned Matter device, which already has a node.
-            if (node.rloc16 === undefined) continue;
-            if (matchesExisting(batch.extPanIdHex, node.rloc16, node.extMacAddress)) continue;
-            const id = diagnosticNodeId(node, batch.extPanIdHex);
-            out.set(id, {
-                kind: "diagnostic",
-                id,
-                rloc16: node.rloc16,
-                extAddressHex: node.extMacAddress?.toUpperCase(),
-                isRouter: (node.rloc16 & 0x3ff) === 0,
-                vendorName: node.vendorName,
-                childCount: node.childTable?.length ?? 0,
-                networkName: batch.networkName,
-            });
-        }
-    }
-    return [...out.values()];
-}
-
 /**
  * Represents a connection from the perspective of a specific node.
  * Includes both neighbors this node reports AND nodes that report this node as their neighbor.
@@ -1021,220 +330,6 @@ export interface NodeConnection {
     pathCost?: number;
     /** Bidirectional LQI from route table (average of lqiIn and lqiOut) */
     bidirectionalLqi?: number;
-}
-
-/**
- * Creates a canonical pair key from two node IDs.
- * The key is always ordered so that the same pair produces the same key regardless of direction.
- */
-export function makePairKey(a: string, b: string): string {
-    return a < b ? `${a}|${b}` : `${b}|${a}`;
-}
-
-/**
- * Computes a numeric signal score for edge comparison.
- * Lower score = weaker signal (worst case).
- */
-export function getEdgeSignalScore(conn: ThreadConnection): number {
-    const levelScore =
-        conn.signalLevel === "strong"
-            ? 3000
-            : conn.signalLevel === "medium"
-              ? 2000
-              : conn.signalLevel === "weak"
-                ? 1000
-                : 0;
-    const detail = conn.rssi !== null ? conn.rssi + 200 : conn.lqi;
-    return levelScore + detail;
-}
-
-/**
- * Builds edge pairs for all Thread connections.
- * Each pair represents two connected nodes with up to 2 directional edges
- * (one from each node's neighbor/route table). No dedup is performed —
- * callers are responsible for selecting which edge to display per pair.
- */
-export function buildThreadEdgePairs(
-    nodes: Record<string, MatterNode>,
-    extAddrMap: Map<bigint, string>,
-    rloc16Map: Map<number, string>,
-    unknownDevices: ThreadExternalDevice[],
-): Map<string, ThreadEdgePair> {
-    const pairs = new Map<string, ThreadEdgePair>();
-
-    const unknownExtAddrMap = new Map<bigint, string>();
-    for (const unknown of unknownDevices) {
-        unknownExtAddrMap.set(unknown.extAddress, unknown.id);
-    }
-
-    for (const node of Object.values(nodes)) {
-        const fromNodeId = String(node.node_id);
-        const neighbors = parseNeighborTable(node);
-
-        for (const neighbor of neighbors) {
-            let toNodeId: string | undefined = extAddrMap.get(neighbor.extAddress);
-            if (toNodeId === undefined && neighbor.rloc16 !== 0) {
-                toNodeId = rloc16Map.get(neighbor.rloc16);
-            }
-            if (toNodeId === undefined) {
-                toNodeId = unknownExtAddrMap.get(neighbor.extAddress);
-            }
-            if (toNodeId === undefined || fromNodeId === toNodeId) continue;
-
-            const pairKey = makePairKey(fromNodeId, toNodeId);
-            if (!pairs.has(pairKey)) {
-                const [nodeA, nodeB] = fromNodeId < toNodeId ? [fromNodeId, toNodeId] : [toNodeId, fromNodeId];
-                pairs.set(pairKey, { pairKey, nodeA, nodeB });
-            }
-
-            const pair = pairs.get(pairKey)!;
-            const isFromA = fromNodeId === pair.nodeA;
-
-            // Neighbor table entry takes precedence — skip if already present for this direction
-            if (isFromA && pair.edgeAB) continue;
-            if (!isFromA && pair.edgeBA) continue;
-
-            const routeEntry = findRouteByExtAddress(node, neighbor.extAddress);
-            const bidirectionalLqi = routeEntry ? getRouteBidirectionalLqi(routeEntry) : undefined;
-
-            const edge: ThreadConnection = {
-                fromNodeId,
-                toNodeId,
-                signalColor: getSignalColor(neighbor),
-                signalLevel: getSignalLevel(neighbor),
-                lqi: neighbor.lqi,
-                rssi: neighbor.avgRssi ?? neighbor.lastRssi,
-                pathCost: routeEntry?.pathCost,
-                bidirectionalLqi,
-            };
-
-            if (isFromA) {
-                pair.edgeAB = edge;
-            } else {
-                pair.edgeBA = edge;
-            }
-        }
-
-        // Supplementary: route table entries not already covered by neighbor table
-        const routes = parseRouteTable(node);
-        for (const route of routes) {
-            if (!route.linkEstablished || !route.allocated) continue;
-
-            let toNodeId: string | undefined = extAddrMap.get(route.extAddress);
-            if (toNodeId === undefined && route.rloc16 !== 0) {
-                toNodeId = rloc16Map.get(route.rloc16);
-            }
-            if (toNodeId === undefined) {
-                toNodeId = unknownExtAddrMap.get(route.extAddress);
-            }
-            if (toNodeId === undefined || toNodeId === fromNodeId) continue;
-
-            const pairKey = makePairKey(fromNodeId, toNodeId);
-            if (!pairs.has(pairKey)) {
-                const [nodeA, nodeB] = fromNodeId < toNodeId ? [fromNodeId, toNodeId] : [toNodeId, fromNodeId];
-                pairs.set(pairKey, { pairKey, nodeA, nodeB });
-            }
-
-            const pair = pairs.get(pairKey)!;
-            const isFromA = fromNodeId === pair.nodeA;
-
-            // Only add from route table if no neighbor table edge for this direction
-            if (isFromA && pair.edgeAB) continue;
-            if (!isFromA && pair.edgeBA) continue;
-
-            const bidirectionalLqi = getRouteBidirectionalLqi(route);
-            // No bidirectional LQI = both lqiIn and lqiOut are 0 → treat as no-link.
-            const signalLevel: SignalLevel =
-                bidirectionalLqi !== undefined ? getSignalLevelFromLqi(bidirectionalLqi) : "none";
-
-            const edge: ThreadConnection = {
-                fromNodeId,
-                toNodeId,
-                signalColor: signalLevelToColor(signalLevel),
-                signalLevel,
-                lqi: bidirectionalLqi ?? 0,
-                rssi: null,
-                pathCost: route.pathCost,
-                bidirectionalLqi,
-                fromRouteTable: true,
-            };
-
-            if (isFromA) {
-                pair.edgeAB = edge;
-            } else {
-                pair.edgeBA = edge;
-            }
-        }
-    }
-
-    return pairs;
-}
-
-/**
- * Merge route64 (router<->router) and childTable (router->child) edges from
- * diagnostics into an existing edge-pair map. Resolves references to graph node
- * ids via `resolveRloc16`; unresolved references are dropped (no phantom nodes).
- * Existing edges (Matter-sourced) take precedence per direction.
- */
-export function mergeDiagnosticEdges(
-    pairs: Map<string, ThreadEdgePair>,
-    batches: ReadonlyMap<string, ThreadDiagnosticsBatch>,
-    resolveRloc16: (rloc16: number, extPanIdHex: string) => string | undefined,
-): void {
-    const addEdge = (fromNodeId: string, toNodeId: string, lqi: number, pathCost?: number): void => {
-        if (fromNodeId === toNodeId) return;
-        const pairKey = makePairKey(fromNodeId, toNodeId);
-        let pair = pairs.get(pairKey);
-        if (pair === undefined) {
-            const [nodeA, nodeB] = fromNodeId < toNodeId ? [fromNodeId, toNodeId] : [toNodeId, fromNodeId];
-            pair = { pairKey, nodeA, nodeB };
-            pairs.set(pairKey, pair);
-        }
-        const isFromA = fromNodeId === pair.nodeA;
-        if (isFromA && pair.edgeAB) return; // existing (Matter) edge wins
-        if (!isFromA && pair.edgeBA) return;
-        const signalLevel = getSignalLevelFromLqi(lqi);
-        const edge: ThreadConnection = {
-            fromNodeId,
-            toNodeId,
-            signalColor: signalLevelToColor(signalLevel),
-            signalLevel,
-            lqi,
-            rssi: null,
-            pathCost,
-            fromRouteTable: true,
-        };
-        if (isFromA) pair.edgeAB = edge;
-        else pair.edgeBA = edge;
-    };
-
-    for (const batch of batches.values()) {
-        for (const node of batch.nodes) {
-            if (node.rloc16 === undefined) continue;
-            const xp = batch.extPanIdHex;
-            const fromId = resolveRloc16(node.rloc16, xp) ?? diagnosticNodeId(node, xp);
-            const routerId = (node.rloc16 >> 10) & 0x3f;
-            if (node.route64 !== undefined) {
-                for (const e of node.route64.entries) {
-                    if (e.routerId === routerId) continue;
-                    const toId = resolveRloc16((e.routerId << 10) & 0xffff, xp);
-                    if (toId === undefined) continue;
-                    addEdge(fromId, toId, e.linkQualityIn, e.routeCost);
-                }
-            }
-            if (node.childTable !== undefined) {
-                for (const child of node.childTable) {
-                    const childRloc16 = ((routerId << 10) | child.childId) & 0xffff;
-                    // Only link children that are themselves a real graph node (a
-                    // commissioned Matter device). Non-Matter leaves are a count on
-                    // the parent, not floating nodes — so don't invent an edge.
-                    const toId = resolveRloc16(childRloc16, xp);
-                    if (toId === undefined) continue;
-                    addEdge(fromId, toId, child.incomingLinkQuality);
-                }
-            }
-        }
-    }
 }
 
 /**
@@ -1354,7 +449,7 @@ export function getNodeConnectionsFromPairs(
             connectedNodeId: remoteId,
             connectedNode: remoteNode,
             extAddressHex,
-            signalColor: winner.conn.signalColor,
+            signalColor: signalLevelToColor(winner.conn.signalLevel),
             signalLevel: winner.conn.signalLevel,
             lqi: winner.conn.lqi,
             rssi: winner.conn.rssi,

--- a/packages/dashboard/src/pages/network/thread-graph.ts
+++ b/packages/dashboard/src/pages/network/thread-graph.ts
@@ -37,6 +37,7 @@ import {
     getThreadExtendedAddressHex,
     getThreadRole,
     mergeDiagnosticEdges,
+    signalLevelToColor,
     stripMdnsHostname,
 } from "./network-utils.js";
 
@@ -574,11 +575,12 @@ export class ThreadGraph extends BaseNetworkGraph {
                     }
                 }
 
+                const edgeColor = signalLevelToColor(conn.signalLevel);
                 const visEdge: NetworkGraphEdge = {
                     id: edgeId,
                     from: fromId,
                     to: toId,
-                    color: { color: conn.signalColor, highlight: conn.signalColor },
+                    color: { color: edgeColor, highlight: edgeColor },
                     width: 2,
                     title: tooltip,
                     dashes: isInferredEdge || hasOfflineEndpoint,

--- a/packages/ws-client/src/index.ts
+++ b/packages/ws-client/src/index.ts
@@ -23,3 +23,7 @@ export * from "./json-utils.js";
 // Export models
 export * from "./models/model.js";
 export * from "./models/node.js";
+
+// Export network topology derivation (shared by dashboard + server)
+export * from "./topology/topology-types.js";
+export * from "./topology/topology-utils.js";

--- a/packages/ws-client/src/topology/topology-types.ts
+++ b/packages/ws-client/src/topology/topology-types.ts
@@ -1,0 +1,249 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { BorderRouterEntry, MatterNodeData } from "../models/model.js";
+
+/**
+ * Minimal structural view of a node required to derive network topology.
+ *
+ * The derivation only ever reads `node_id`, `available` and the flat `attributes`
+ * map, so it accepts this narrow shape rather than the full {@link MatterNode}
+ * class. Both the client-side `MatterNode` and any server-side node record that
+ * exposes these fields satisfy it, which lets the topology pipeline run in the
+ * browser (dashboard) and in Node (server) without a shared node class.
+ */
+export type TopologySourceNode = Pick<MatterNodeData, "node_id" | "available" | "attributes">;
+
+/**
+ * Network type detected from NetworkCommissioning cluster feature map.
+ */
+export type NetworkType = "thread" | "wifi" | "ethernet" | "unknown";
+
+/**
+ * Classification of a Thread mesh link based on LQI.
+ * "none" means LQI=0 — neighbor entry exists but no recent valid frames (dead/stale link).
+ */
+export type SignalLevel = "strong" | "medium" | "weak" | "none";
+
+/**
+ * Thread routing role from ThreadNetworkDiagnostics cluster.
+ * Attribute 0/53/1 (RoutingRole)
+ */
+export enum ThreadRoutingRole {
+    Unspecified = 0,
+    Unassigned = 1,
+    SleepyEndDevice = 2,
+    EndDevice = 3,
+    REED = 4, // Router-Eligible End Device
+    Router = 5,
+    Leader = 6,
+}
+
+/**
+ * Thread neighbor table entry from ThreadNetworkDiagnostics cluster.
+ * Attribute 0/53/7 (NeighborTable)
+ */
+export interface ThreadNeighbor {
+    /** Extended address of the neighbor (64-bit) */
+    extAddress: bigint;
+    /** Age of the entry in seconds */
+    age: number;
+    /** RLOC16 (Router Locator) */
+    rloc16: number;
+    /** Link frame counter */
+    linkFrameCounter: number;
+    /** MLE frame counter */
+    mleFrameCounter: number;
+    /**
+     * Link Quality Indicator. Spec types as uint8 (0-255), but OpenThread reports
+     * 0-3 in practice. 0 = no recent valid frames (dead/stale link).
+     */
+    lqi: number;
+    /** Average RSSI in dBm (nullable) */
+    avgRssi: number | null;
+    /** Last RSSI in dBm (nullable) */
+    lastRssi: number | null;
+    /** Frame error rate (0-255) */
+    frameErrorRate: number;
+    /** Message error rate (0-255) */
+    messageErrorRate: number;
+    /** Whether RX is on when idle */
+    rxOnWhenIdle: boolean;
+    /** Whether this is a full Thread device */
+    fullThreadDevice: boolean;
+    /** Whether this is a full network data device */
+    fullNetworkData: boolean;
+    /** Whether the link is established */
+    isChild: boolean;
+}
+
+/**
+ * Thread route table entry from ThreadNetworkDiagnostics cluster.
+ * Attribute 0/53/8 (RouteTable)
+ */
+export interface ThreadRoute {
+    /** Extended address of the destination */
+    extAddress: bigint;
+    /** RLOC16 of the destination */
+    rloc16: number;
+    /** Router ID */
+    routerId: number;
+    /** Next hop RLOC16 */
+    nextHop: number;
+    /** Path cost */
+    pathCost: number;
+    /** LQI in (0-3 on OpenThread; 0 = no link). */
+    lqiIn: number;
+    /** LQI out (0-3 on OpenThread; 0 = no link). */
+    lqiOut: number;
+    /** Age of the route */
+    age: number;
+    /** Whether this is allocated */
+    allocated: boolean;
+    /** Whether link is established */
+    linkEstablished: boolean;
+}
+
+/**
+ * WiFi Diagnostics info from cluster 0x36/54.
+ */
+export interface WiFiDiagnostics {
+    /** BSSID as hex string */
+    bssid: string | null;
+    /** RSSI in dBm (-120 to 0) */
+    rssi: number | null;
+    /** WiFi channel */
+    channel: number | null;
+    /** Security type */
+    securityType: number | null;
+    /** WiFi version */
+    wifiVersion: number | null;
+}
+
+/**
+ * Categorized devices by network type.
+ * Node IDs are stored as strings to avoid BigInt precision loss.
+ */
+export interface CategorizedDevices {
+    thread: string[];
+    wifi: string[];
+    ethernet: string[];
+    unknown: string[];
+}
+
+/**
+ * Thread mesh connection between two nodes.
+ *
+ * Intentionally carries no color: color is a render concern derived from
+ * {@link signalLevel} by the consumer, keeping this model DOM/theme-free so the
+ * topology pipeline can run server-side.
+ */
+export interface ThreadConnection {
+    fromNodeId: number | string;
+    toNodeId: number | string;
+    signalLevel: SignalLevel;
+    lqi: number;
+    rssi: number | null;
+    /** Path cost from route table (1 = direct, higher = multi-hop). Only available for routers. */
+    pathCost?: number;
+    /** Bidirectional LQI from route table (average of lqiIn and lqiOut) */
+    bidirectionalLqi?: number;
+    /** Whether this connection was supplemented by route table data (vs neighbor table only) */
+    fromRouteTable?: boolean;
+}
+
+/**
+ * A pair of Thread nodes with their directional edge data.
+ * Each connected pair has 0-2 edges (one per neighbor/route table direction).
+ */
+export interface ThreadEdgePair {
+    /** Canonical pair key (sorted node IDs joined by "|") */
+    pairKey: string;
+    /** First node ID (lexicographically smaller) */
+    nodeA: string;
+    /** Second node ID (lexicographically larger) */
+    nodeB: string;
+    /** Edge where nodeA reports nodeB as neighbor */
+    edgeAB?: ThreadConnection;
+    /** Edge where nodeB reports nodeA as neighbor */
+    edgeBA?: ThreadConnection;
+}
+
+/**
+ * Unknown Thread device seen in neighbor tables but not commissioned.
+ */
+export interface UnknownThreadDevice {
+    kind: "unknown";
+    /** Unique ID for the unknown device (prefixed with 'unknown_') */
+    id: string;
+    /** Extended address as hex string */
+    extAddressHex: string;
+    /** Extended address as BigInt */
+    extAddress: bigint;
+    /** Node IDs that see this device as a neighbor (as strings to avoid BigInt precision loss) */
+    seenBy: string[];
+    /** Whether this device appears to be a router */
+    isRouter: boolean;
+    /** Best signal strength seen */
+    bestRssi: number | null;
+    /**
+     * Extended PAN ID (16-char uppercase hex) inherited from the commissioned node that
+     * reports this neighbor. All Thread neighbors share the observing node's network.
+     */
+    extendedPanIdHex?: string;
+    /**
+     * Friendly Thread network name resolved by joining {@link extendedPanIdHex} against the
+     * Border Router registry. Some BR vendors (e.g. Apple, Aqara) use a stable border-agent
+     * ID as the MeshCoP `xa` while the actual Thread radio MAC differs, so the BR can show
+     * up as both a known BR and an "unknown" router on the same network.
+     */
+    networkName?: string;
+}
+
+/**
+ * Router/leader sourced purely from diagnostics (route64) that matches no
+ * commissioned Matter device, known BR, or neighbor-inferred unknown. Its
+ * childTable leaves are not materialized as nodes — they surface as {@link childCount}.
+ */
+export interface DiagnosticMeshNode {
+    kind: "diagnostic";
+    /** Graph id `thread_<EXTMAC>`, else `meshrloc_<extPanId>_<rloc16>`. */
+    id: string;
+    rloc16: number;
+    /** Uppercase hex Thread MAC if known. */
+    extAddressHex?: string;
+    isRouter: boolean;
+    vendorName?: string;
+    /** Number of childTable entries this router reports (shown as a label badge). */
+    childCount: number;
+    networkName: string;
+}
+
+/**
+ * Thread Border Router enriched via mDNS.
+ *
+ * Same neighbor-table aggregate fields as UnknownThreadDevice (seenBy, isRouter, bestRssi),
+ * plus all BorderRouterEntry fields (network name, vendor, addresses, etc.).
+ */
+export interface KnownBorderRouter extends BorderRouterEntry {
+    kind: "br";
+    /** DOM/graph ID, formatted "br_<XAHEX>". */
+    id: string;
+    /** Convenience copy of extAddressHex as bigint, mirroring UnknownThreadDevice. */
+    extAddress: bigint;
+    /** Commissioned node IDs whose neighbor table sees this xa. */
+    seenBy: string[];
+    /** Inferred from neighbor entry. */
+    isRouter: boolean;
+    /** Best signal strength seen across observers. */
+    bestRssi: number | null;
+}
+
+/**
+ * External Thread device discriminated union — either a recognized Border Router
+ * or an unidentified neighbor.
+ */
+export type ThreadExternalDevice = KnownBorderRouter | UnknownThreadDevice;

--- a/packages/ws-client/src/topology/topology-utils.ts
+++ b/packages/ws-client/src/topology/topology-utils.ts
@@ -1,0 +1,924 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { BorderRouterEntry, ThreadDiagnosticsBatch, ThreadDiagnosticsNode } from "../models/model.js";
+import type {
+    CategorizedDevices,
+    DiagnosticMeshNode,
+    NetworkType,
+    SignalLevel,
+    ThreadConnection,
+    ThreadEdgePair,
+    ThreadExternalDevice,
+    ThreadNeighbor,
+    ThreadRoute,
+    TopologySourceNode,
+    WiFiDiagnostics,
+} from "./topology-types.js";
+
+// NetworkCommissioning cluster feature map bits (cluster 0x31/49)
+const WIFI_FEATURE = 1 << 0; // Bit 0: WiFi Network Interface
+const THREAD_FEATURE = 1 << 1; // Bit 1: Thread Network Interface
+const ETHERNET_FEATURE = 1 << 2; // Bit 2: Ethernet Network Interface
+
+// Thread LQI thresholds. Spec types LQI as uint8 (0-255), but OpenThread — the
+// dominant Thread stack — only ever reports 0-3. We classify on the 0-3 scale:
+// 3 = strong, 2 = medium, 1 = weak, 0 = no link (stale/dead neighbor entry).
+const LQI_STRONG_THRESHOLD = 2;
+const LQI_MEDIUM_THRESHOLD = 1;
+
+/**
+ * Converts a base64-encoded extended address to BigInt.
+ * Extended addresses are 8 bytes (64 bits) stored as big-endian.
+ * Some Matter implementations include a TLV prefix byte that we need to skip.
+ */
+function base64ToBigInt(base64: string): bigint {
+    try {
+        const binary = atob(base64);
+        let result = 0n;
+
+        // If we have 9 bytes, skip the first byte (likely a TLV type prefix)
+        // EUI-64 should be exactly 8 bytes
+        const start = binary.length > 8 ? binary.length - 8 : 0;
+
+        for (let i = start; i < binary.length; i++) {
+            result = (result << 8n) | BigInt(binary.charCodeAt(i));
+        }
+        return result;
+    } catch {
+        return 0n;
+    }
+}
+
+/**
+ * Normalizes an extended address to BigInt for comparison.
+ * Handles: BigInt, base64 strings, numbers.
+ */
+function normalizeExtAddress(value: unknown): bigint {
+    if (typeof value === "bigint") {
+        return value;
+    }
+    if (typeof value === "string") {
+        return base64ToBigInt(value);
+    }
+    if (typeof value === "number") {
+        return BigInt(value);
+    }
+    return 0n;
+}
+
+/**
+ * Detects the network type from the NetworkCommissioning cluster feature map.
+ * Uses attribute 0/49/65532 (FeatureMap).
+ */
+export function getNetworkType(node: TopologySourceNode): NetworkType {
+    const featureMap = node.attributes["0/49/65532"] as number | undefined;
+
+    if (featureMap === undefined) {
+        return "unknown";
+    }
+
+    // Check in priority order: Thread > WiFi > Ethernet
+    if (featureMap & THREAD_FEATURE) {
+        return "thread";
+    }
+    if (featureMap & WIFI_FEATURE) {
+        return "wifi";
+    }
+    if (featureMap & ETHERNET_FEATURE) {
+        return "ethernet";
+    }
+
+    return "unknown";
+}
+
+/**
+ * Thread protocol version supported by the device's Thread interface.
+ * Uses NetworkCommissioning cluster (0x31/49) ThreadVersion attribute (0x0A/10).
+ */
+export function getThreadVersion(node: TopologySourceNode): number | undefined {
+    const v = node.attributes["0/49/10"];
+    return typeof v === "number" ? v : undefined;
+}
+
+/**
+ * Categorizes nodes by their network type.
+ * Node IDs are stored as strings to avoid BigInt precision loss.
+ */
+export function categorizeDevices(nodes: Record<string, TopologySourceNode>): CategorizedDevices {
+    const result: CategorizedDevices = {
+        thread: [],
+        wifi: [],
+        ethernet: [],
+        unknown: [],
+    };
+
+    for (const node of Object.values(nodes)) {
+        const nodeId = String(node.node_id);
+        const networkType = getNetworkType(node);
+        result[networkType].push(nodeId);
+    }
+
+    return result;
+}
+
+/**
+ * Gets the Thread routing role for a node.
+ * Uses attribute 0/53/1 (RoutingRole, nullable per Matter spec).
+ */
+export function getThreadRole(node: TopologySourceNode): number | undefined {
+    const v = node.attributes["0/53/1"];
+    return typeof v === "number" ? v : undefined;
+}
+
+/**
+ * Gets the Thread channel for a node.
+ * Uses attribute 0/53/0 (Channel, nullable per Matter spec).
+ */
+export function getThreadChannel(node: TopologySourceNode): number | undefined {
+    const v = node.attributes["0/53/0"];
+    return typeof v === "number" ? v : undefined;
+}
+
+/**
+ * Gets the Thread extended PAN ID for a node.
+ * Uses attribute 0/53/4 (ExtendedPanId, nullable per Matter spec).
+ *
+ * The WebSocket JSON reviver only revives integers above Number.MAX_SAFE_INTEGER
+ * as bigint; smaller uint64 values arrive as plain number, so accept both.
+ */
+export function getThreadExtendedPanId(node: TopologySourceNode): bigint | undefined {
+    const v = node.attributes["0/53/4"];
+    if (typeof v === "bigint") return v;
+    if (typeof v === "number" && Number.isInteger(v)) return BigInt(v);
+    return undefined;
+}
+
+/**
+ * Gets the Thread extended address (EUI-64) for a node.
+ *
+ * Uses General Diagnostics cluster (0x0033/51) NetworkInterfaces attribute (0/51/0).
+ * The NetworkInterface struct has:
+ * - Field 4: HardwareAddress (base64 encoded EUI-64)
+ * - Field 7: Type (4 = Thread)
+ *
+ * Returns as BigInt. Only upper 48 bits should be used for matching due to JSON precision loss.
+ */
+export function getThreadExtendedAddress(node: TopologySourceNode): bigint | undefined {
+    // Get NetworkInterfaces from General Diagnostics cluster (0/51/0)
+    const networkInterfaces = node.attributes["0/51/0"] as Array<Record<string, unknown>> | undefined;
+
+    if (!Array.isArray(networkInterfaces) || networkInterfaces.length === 0) {
+        return undefined;
+    }
+
+    // Find Thread interface (type 7 field = 4) or use first with hardware address
+    const threadIface = networkInterfaces.find(i => i["7"] === 4) || networkInterfaces[0];
+
+    if (!threadIface) {
+        return undefined;
+    }
+
+    // HardwareAddress is field 4, base64 encoded
+    const hwAddrB64 = threadIface["4"];
+
+    if (typeof hwAddrB64 !== "string" || !hwAddrB64) {
+        return undefined;
+    }
+
+    // Decode base64 to get EUI-64
+    const extAddr = base64ToBigInt(hwAddrB64);
+    return extAddr !== 0n ? extAddr : undefined;
+}
+
+/**
+ * Gets the Thread extended address as a hex string for display.
+ * Uses General Diagnostics NetworkInterfaces (0/51/0).
+ */
+export function getThreadExtendedAddressHex(node: TopologySourceNode): string | undefined {
+    const extAddr = getThreadExtendedAddress(node);
+    if (extAddr !== undefined) {
+        return extAddr.toString(16).padStart(16, "0").toUpperCase();
+    }
+    return undefined;
+}
+
+/**
+ * Counts entries in the Thread neighbor table without normalizing each entry.
+ * Use this in hot paths where only the cardinality matters; the full parse
+ * does a base64 decode per entry that adds up across re-renders.
+ */
+export function getNeighborTableLength(node: TopologySourceNode): number {
+    const neighborTable = node.attributes["0/53/7"];
+    return Array.isArray(neighborTable) ? neighborTable.length : 0;
+}
+
+/**
+ * Parses the Thread neighbor table from a node's attributes.
+ * Attribute 0/53/7 (NeighborTable) is an array of neighbor objects.
+ * The data uses numeric keys matching the Matter spec field IDs.
+ */
+export function parseNeighborTable(node: TopologySourceNode): ThreadNeighbor[] {
+    const neighborTable = node.attributes["0/53/7"];
+
+    if (!Array.isArray(neighborTable)) {
+        return [];
+    }
+
+    return neighborTable.map((entry: Record<string, unknown>) => {
+        // Field 0: extAddress - can be BigInt or base64 string
+        const rawExtAddr = entry["0"] ?? entry.extAddress;
+        const extAddress = normalizeExtAddress(rawExtAddr);
+
+        return {
+            extAddress,
+            // Field 1: age
+            age: (entry["1"] ?? entry.age ?? 0) as number,
+            // Field 2: rloc16
+            rloc16: (entry["2"] ?? entry.rloc16 ?? 0) as number,
+            // Field 3: linkFrameCounter
+            linkFrameCounter: (entry["3"] ?? entry.linkFrameCounter ?? 0) as number,
+            // Field 4: mleFrameCounter
+            mleFrameCounter: (entry["4"] ?? entry.mleFrameCounter ?? 0) as number,
+            // Field 5: lqi
+            lqi: (entry["5"] ?? entry.lqi ?? 0) as number,
+            // Field 6: averageRssi (nullable)
+            avgRssi: (entry["6"] ?? entry.averageRssi ?? null) as number | null,
+            // Field 7: lastRssi (nullable)
+            lastRssi: (entry["7"] ?? entry.lastRssi ?? null) as number | null,
+            // Field 8: frameErrorRate
+            frameErrorRate: (entry["8"] ?? entry.frameErrorRate ?? 0) as number,
+            // Field 9: messageErrorRate
+            messageErrorRate: (entry["9"] ?? entry.messageErrorRate ?? 0) as number,
+            // Field 10: rxOnWhenIdle
+            rxOnWhenIdle: (entry["10"] ?? entry.rxOnWhenIdle ?? false) as boolean,
+            // Field 11: fullThreadDevice
+            fullThreadDevice: (entry["11"] ?? entry.fullThreadDevice ?? false) as boolean,
+            // Field 12: fullNetworkData
+            fullNetworkData: (entry["12"] ?? entry.fullNetworkData ?? false) as boolean,
+            // Field 13: isChild
+            isChild: (entry["13"] ?? entry.isChild ?? false) as boolean,
+        };
+    });
+}
+
+/**
+ * Parses the Thread route table from a node's attributes.
+ * Attribute 0/53/8 (RouteTable) is an array of route objects.
+ * The data uses numeric keys matching the Matter spec field IDs.
+ */
+export function parseRouteTable(node: TopologySourceNode): ThreadRoute[] {
+    const routeTable = node.attributes["0/53/8"];
+
+    if (!Array.isArray(routeTable)) {
+        return [];
+    }
+
+    return routeTable.map((entry: Record<string, unknown>) => {
+        // Field 0: extAddress - can be BigInt or base64 string
+        const rawExtAddr = entry["0"] ?? entry.extAddress;
+        const extAddress = normalizeExtAddress(rawExtAddr);
+
+        return {
+            extAddress,
+            // Field 1: rloc16
+            rloc16: (entry["1"] ?? entry.rloc16 ?? 0) as number,
+            // Field 2: routerId
+            routerId: (entry["2"] ?? entry.routerId ?? 0) as number,
+            // Field 3: nextHop
+            nextHop: (entry["3"] ?? entry.nextHop ?? 0) as number,
+            // Field 4: pathCost
+            pathCost: (entry["4"] ?? entry.pathCost ?? 0) as number,
+            // Field 5: lqiIn
+            lqiIn: (entry["5"] ?? entry.lqiIn ?? 0) as number,
+            // Field 6: lqiOut
+            lqiOut: (entry["6"] ?? entry.lqiOut ?? 0) as number,
+            // Field 7: age
+            age: (entry["7"] ?? entry.age ?? 0) as number,
+            // Field 8: allocated
+            allocated: (entry["8"] ?? entry.allocated ?? false) as boolean,
+            // Field 9: linkEstablished
+            linkEstablished: (entry["9"] ?? entry.linkEstablished ?? false) as boolean,
+        };
+    });
+}
+
+/**
+ * Find a route table entry for a specific destination by extended address.
+ * Returns the route entry if found, undefined otherwise.
+ */
+export function findRouteByExtAddress(node: TopologySourceNode, targetExtAddr: bigint): ThreadRoute | undefined {
+    const routes = parseRouteTable(node);
+    return routes.find(route => route.extAddress === targetExtAddr && route.linkEstablished);
+}
+
+/**
+ * Count the number of routable destinations for a node (from route table).
+ * Only counts entries where allocated=true and linkEstablished=true.
+ * This is typically only meaningful for router nodes.
+ */
+export function getRoutableDestinationsCount(node: TopologySourceNode): number {
+    const routes = parseRouteTable(node);
+    return routes.filter(route => route.allocated && route.linkEstablished).length;
+}
+
+/**
+ * Calculate combined bidirectional LQI from route table entry.
+ * Returns average of lqiIn and lqiOut if both are non-zero.
+ */
+export function getRouteBidirectionalLqi(route: ThreadRoute): number | undefined {
+    if (route.lqiIn > 0 && route.lqiOut > 0) {
+        return Math.round((route.lqiIn + route.lqiOut) / 2);
+    }
+    if (route.lqiIn > 0) return route.lqiIn;
+    if (route.lqiOut > 0) return route.lqiOut;
+    return undefined;
+}
+
+/**
+ * Gets the RLOC16 (short address) for a Thread node.
+ * Uses attribute 0/53/64 (Rloc16, 0x0040).
+ */
+export function getThreadRloc16(node: TopologySourceNode): number | undefined {
+    const value = node.attributes["0/53/64"];
+    if (typeof value === "number") {
+        return value;
+    }
+    return undefined;
+}
+
+/**
+ * Builds a map of extended addresses (BigInt) to node IDs for Thread devices.
+ * Uses General Diagnostics NetworkInterfaces (0/51/0) for the hardware address.
+ * Node IDs are stored as strings to avoid BigInt precision loss.
+ */
+export function buildExtAddrMap(nodes: Record<string, TopologySourceNode>): Map<bigint, string> {
+    const extAddrMap = new Map<bigint, string>();
+
+    for (const node of Object.values(nodes)) {
+        const nodeId = String(node.node_id);
+        const extAddr = getThreadExtendedAddress(node);
+
+        if (extAddr !== undefined) {
+            extAddrMap.set(extAddr, nodeId);
+        }
+    }
+
+    return extAddrMap;
+}
+
+/**
+ * Builds a map of RLOC16 (short addresses) to node IDs for Thread devices.
+ * Used as fallback when ExtAddress is not available.
+ * Node IDs are stored as strings to avoid BigInt precision loss.
+ */
+export function buildRloc16Map(nodes: Record<string, TopologySourceNode>): Map<number, string> {
+    const rloc16Map = new Map<number, string>();
+
+    for (const node of Object.values(nodes)) {
+        const nodeId = String(node.node_id);
+        const rloc16 = getThreadRloc16(node);
+
+        if (rloc16 !== undefined) {
+            rloc16Map.set(rloc16, nodeId);
+        }
+    }
+
+    return rloc16Map;
+}
+
+/**
+ * Stable graph id for a diagnostic mesh node: prefer the globally-unique extMac,
+ * else an rloc16 namespaced by extPanId (rloc16 is only unique within a network).
+ */
+export function diagnosticNodeId(
+    node: Pick<ThreadDiagnosticsNode, "extMacAddress" | "rloc16">,
+    extPanIdHex: string,
+): string {
+    if (node.extMacAddress !== undefined) return `thread_${node.extMacAddress.toUpperCase()}`;
+    return `meshrloc_${extPanIdHex.toUpperCase()}_${node.rloc16 ?? "x"}`;
+}
+
+/** Resolver key joining a network's extPanId with an rloc16 (rloc16 alone is not unique across networks). */
+function diagRlocKey(extPanIdHex: string, rloc16: number): string {
+    return `${extPanIdHex.toUpperCase()}:${rloc16}`;
+}
+
+/**
+ * `extPanId:rloc16` -> Matter node id, scoped per Thread network. rloc16 is only
+ * unique within a network, so a global rloc16 map would mis-attach diagnostic
+ * edges from one network onto a Matter device on another. Keyed via {@link diagRlocKey}.
+ */
+export function buildMatterRloc16ByXp(nodes: Record<string, TopologySourceNode>): Map<string, string> {
+    const map = new Map<string, string>();
+    for (const node of Object.values(nodes)) {
+        const rloc16 = getThreadRloc16(node);
+        const xp = getThreadExtendedPanId(node);
+        if (rloc16 === undefined || xp === undefined) continue;
+        map.set(diagRlocKey(xp.toString(16).padStart(16, "0"), rloc16), String(node.node_id));
+    }
+    return map;
+}
+
+/**
+ * Resolve a diagnostic node to the graph node id it is actually rendered under:
+ * a commissioned Matter device (by extMac), a known Border Router (`br_<xa>`), a
+ * neighbor-inferred unknown, or — when it matches none — its own diagnostic id.
+ * Mirrors the precedence in {@link findDiagnosticMeshNodes} so edges target the
+ * same node those materialize, rather than a phantom `thread_`/`meshrloc_` id.
+ */
+function diagnosticGraphNodeId(
+    node: ThreadDiagnosticsNode,
+    extPanIdHex: string,
+    matterExtAddrMap: Map<bigint, string>,
+    borderRouters: ReadonlyMap<string, BorderRouterEntry>,
+    unknownIdByExt: Map<string, string>,
+): string {
+    const up = node.extMacAddress?.toUpperCase();
+    if (up !== undefined) {
+        const matterId = matterExtAddrMap.get(BigInt(`0x${up}`));
+        if (matterId !== undefined) return matterId;
+        if (borderRouters.has(up)) return `br_${up}`;
+        const unknownId = unknownIdByExt.get(up);
+        if (unknownId !== undefined) return unknownId;
+    }
+    return diagnosticNodeId(node, extPanIdHex);
+}
+
+/**
+ * `extPanId:rloc16` -> graph node id across diagnostic batches, layered UNDER the
+ * Matter rloc16 map. Resolves route64/childTable references within the referencing
+ * node's own network to whatever id that node is drawn as (Matter / `br_` /
+ * `unknown_` / diagnostic). Keyed via {@link diagRlocKey}.
+ */
+export function buildDiagnosticRloc16Map(
+    batches: ReadonlyMap<string, ThreadDiagnosticsBatch>,
+    matterRloc16ByXp: Map<string, string>,
+    matterExtAddrMap: Map<bigint, string>,
+    borderRouters: ReadonlyMap<string, BorderRouterEntry>,
+    unknownDevices: ThreadExternalDevice[],
+): Map<string, string> {
+    const unknownIdByExt = new Map<string, string>();
+    for (const d of unknownDevices) unknownIdByExt.set(d.extAddressHex.toUpperCase(), d.id);
+
+    const map = new Map<string, string>();
+    for (const batch of batches.values()) {
+        for (const node of batch.nodes) {
+            if (node.rloc16 === undefined) continue;
+            // Matter device on THIS network (by rloc16) wins.
+            if (matterRloc16ByXp.has(diagRlocKey(batch.extPanIdHex, node.rloc16))) continue;
+            map.set(
+                diagRlocKey(batch.extPanIdHex, node.rloc16),
+                diagnosticGraphNodeId(node, batch.extPanIdHex, matterExtAddrMap, borderRouters, unknownIdByExt),
+            );
+        }
+    }
+    return map;
+}
+
+/**
+ * Build a per-network rloc16 resolver: a Matter device on the same Thread network
+ * wins, else the diagnostic node id within the same extPanId. Returns undefined
+ * when unresolved. Both lookups are keyed by `extPanId:rloc16` so identical rloc16
+ * values across networks never cross-attach.
+ */
+export function makeDiagnosticRloc16Resolver(
+    matterRloc16ByXp: Map<string, string>,
+    diagRloc16Map: Map<string, string>,
+): (rloc16: number, extPanIdHex: string) => string | undefined {
+    return (rloc16, extPanIdHex) =>
+        matterRloc16ByXp.get(diagRlocKey(extPanIdHex, rloc16)) ?? diagRloc16Map.get(diagRlocKey(extPanIdHex, rloc16));
+}
+
+interface ExternalAggregate {
+    extAddressHex: string;
+    extAddress: bigint;
+    seenBy: string[];
+    isRouter: boolean;
+    bestRssi: number | null;
+    /** xp of the first observing matter node; all neighbors of a Thread node share its xp. */
+    extendedPanIdHex?: string;
+}
+
+/**
+ * Finds external Thread devices - addresses seen in neighbor tables that don't match
+ * any commissioned device. Classifies each against the optional Border Router registry:
+ * matched ones are emitted as kind:"br" with full mDNS enrichment; the rest stay as
+ * kind:"unknown". Uses RLOC16 as fallback when extended address matching fails.
+ */
+export function findUnknownDevices(
+    nodes: Record<string, TopologySourceNode>,
+    extAddrMap: Map<bigint, string>,
+    rloc16Map: Map<number, string>,
+    borderRouters?: ReadonlyMap<string, BorderRouterEntry>,
+): ThreadExternalDevice[] {
+    const aggregates = new Map<string, ExternalAggregate>();
+
+    for (const node of Object.values(nodes)) {
+        const nodeId = String(node.node_id);
+        const neighbors = parseNeighborTable(node);
+        const observerXp = getThreadExtendedPanId(node);
+        const observerXpHex =
+            observerXp !== undefined ? observerXp.toString(16).padStart(16, "0").toUpperCase() : undefined;
+
+        for (const neighbor of neighbors) {
+            if (extAddrMap.has(neighbor.extAddress)) {
+                continue;
+            }
+            if (neighbor.rloc16 !== 0 && rloc16Map.has(neighbor.rloc16)) {
+                continue;
+            }
+
+            const extAddressHex = neighbor.extAddress.toString(16).padStart(16, "0").toUpperCase();
+
+            let agg = aggregates.get(extAddressHex);
+            if (agg === undefined) {
+                agg = {
+                    extAddressHex,
+                    extAddress: neighbor.extAddress,
+                    seenBy: [],
+                    isRouter: false,
+                    bestRssi: null,
+                    extendedPanIdHex: observerXpHex,
+                };
+                aggregates.set(extAddressHex, agg);
+            } else if (agg.extendedPanIdHex === undefined && observerXpHex !== undefined) {
+                agg.extendedPanIdHex = observerXpHex;
+            }
+
+            if (!agg.seenBy.includes(nodeId)) {
+                agg.seenBy.push(nodeId);
+            }
+            if (neighbor.rxOnWhenIdle) {
+                agg.isRouter = true;
+            }
+            const rssi = neighbor.avgRssi ?? neighbor.lastRssi;
+            if (rssi !== null && (agg.bestRssi === null || rssi > agg.bestRssi)) {
+                agg.bestRssi = rssi;
+            }
+        }
+    }
+
+    // Pre-compute xp → networkName from the BR registry so we can label unknowns by network.
+    const networkNameByXp = new Map<string, string>();
+    if (borderRouters !== undefined) {
+        for (const br of borderRouters.values()) {
+            if (br.extendedPanIdHex !== undefined && br.networkName !== undefined) {
+                networkNameByXp.set(br.extendedPanIdHex, br.networkName);
+            }
+        }
+    }
+
+    const out = new Array<ThreadExternalDevice>();
+    for (const agg of aggregates.values()) {
+        const br = borderRouters?.get(agg.extAddressHex);
+        if (br !== undefined) {
+            out.push({
+                kind: "br",
+                ...br,
+                id: `br_${agg.extAddressHex}`,
+                extAddressHex: agg.extAddressHex,
+                extAddress: agg.extAddress,
+                seenBy: agg.seenBy,
+                isRouter: agg.isRouter,
+                bestRssi: agg.bestRssi,
+            });
+        } else {
+            const networkName =
+                agg.extendedPanIdHex !== undefined ? networkNameByXp.get(agg.extendedPanIdHex) : undefined;
+            out.push({
+                kind: "unknown",
+                id: `unknown_${agg.extAddressHex}`,
+                extAddressHex: agg.extAddressHex,
+                extAddress: agg.extAddress,
+                seenBy: agg.seenBy,
+                isRouter: agg.isRouter,
+                bestRssi: agg.bestRssi,
+                extendedPanIdHex: agg.extendedPanIdHex,
+                networkName,
+            });
+        }
+    }
+    return out;
+}
+
+/** Determine signal level from a Thread neighbor's LQI. */
+export function getSignalLevel(neighbor: ThreadNeighbor): SignalLevel {
+    return getSignalLevelFromLqi(neighbor.lqi);
+}
+
+/**
+ * Map an LQI value (0-3 in practice on OpenThread) to a signal level.
+ * 0 = "none" (no recent valid frames — stale/dead link).
+ */
+export function getSignalLevelFromLqi(lqi: number): SignalLevel {
+    if (lqi <= 0) return "none";
+    if (lqi > LQI_STRONG_THRESHOLD) return "strong";
+    if (lqi > LQI_MEDIUM_THRESHOLD) return "medium";
+    return "weak";
+}
+
+/**
+ * Materialize mesh nodes that exist only in diagnostics: router records and
+ * childTable children whose rloc16/extMac matches no Matter device, BR, or
+ * already-found unknown. Matter/BR/unknown matches are enriched in place, not
+ * duplicated.
+ */
+export function findDiagnosticMeshNodes(
+    batches: ReadonlyMap<string, ThreadDiagnosticsBatch>,
+    matterRloc16ByXp: Map<string, string>,
+    matterExtAddrMap: Map<bigint, string>,
+    borderRouters: ReadonlyMap<string, BorderRouterEntry>,
+    unknownDevices: ThreadExternalDevice[],
+): DiagnosticMeshNode[] {
+    const unknownExt = new Set<string>(unknownDevices.map(d => d.extAddressHex.toUpperCase()));
+    const out = new Map<string, DiagnosticMeshNode>();
+
+    const matchesExisting = (extPanIdHex: string, rloc16: number | undefined, extHex?: string): boolean => {
+        if (rloc16 !== undefined && matterRloc16ByXp.has(diagRlocKey(extPanIdHex, rloc16))) return true;
+        if (extHex !== undefined) {
+            const up = extHex.toUpperCase();
+            if (matterExtAddrMap.has(BigInt(`0x${up}`))) return true;
+            if (borderRouters.has(up)) return true;
+            if (unknownExt.has(up)) return true;
+        }
+        return false;
+    };
+
+    for (const batch of batches.values()) {
+        for (const node of batch.nodes) {
+            // Only materialize a node for the responding router itself (a route64
+            // participant). Its childTable children are leaf end devices — surfaced
+            // as a count on the router, not as individual floating nodes — unless a
+            // child is itself a commissioned Matter device, which already has a node.
+            if (node.rloc16 === undefined) continue;
+            if (matchesExisting(batch.extPanIdHex, node.rloc16, node.extMacAddress)) continue;
+            const id = diagnosticNodeId(node, batch.extPanIdHex);
+            out.set(id, {
+                kind: "diagnostic",
+                id,
+                rloc16: node.rloc16,
+                extAddressHex: node.extMacAddress?.toUpperCase(),
+                isRouter: (node.rloc16 & 0x3ff) === 0,
+                vendorName: node.vendorName,
+                childCount: node.childTable?.length ?? 0,
+                networkName: batch.networkName,
+            });
+        }
+    }
+    return [...out.values()];
+}
+
+/**
+ * Creates a canonical pair key from two node IDs.
+ * The key is always ordered so that the same pair produces the same key regardless of direction.
+ */
+export function makePairKey(a: string, b: string): string {
+    return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+/**
+ * Computes a numeric signal score for edge comparison.
+ * Lower score = weaker signal (worst case).
+ */
+export function getEdgeSignalScore(conn: ThreadConnection): number {
+    const levelScore =
+        conn.signalLevel === "strong"
+            ? 3000
+            : conn.signalLevel === "medium"
+              ? 2000
+              : conn.signalLevel === "weak"
+                ? 1000
+                : 0;
+    const detail = conn.rssi !== null ? conn.rssi + 200 : conn.lqi;
+    return levelScore + detail;
+}
+
+/**
+ * Builds edge pairs for all Thread connections.
+ * Each pair represents two connected nodes with up to 2 directional edges
+ * (one from each node's neighbor/route table). No dedup is performed —
+ * callers are responsible for selecting which edge to display per pair.
+ */
+export function buildThreadEdgePairs(
+    nodes: Record<string, TopologySourceNode>,
+    extAddrMap: Map<bigint, string>,
+    rloc16Map: Map<number, string>,
+    unknownDevices: ThreadExternalDevice[],
+): Map<string, ThreadEdgePair> {
+    const pairs = new Map<string, ThreadEdgePair>();
+
+    const unknownExtAddrMap = new Map<bigint, string>();
+    for (const unknown of unknownDevices) {
+        unknownExtAddrMap.set(unknown.extAddress, unknown.id);
+    }
+
+    for (const node of Object.values(nodes)) {
+        const fromNodeId = String(node.node_id);
+        const neighbors = parseNeighborTable(node);
+
+        for (const neighbor of neighbors) {
+            let toNodeId: string | undefined = extAddrMap.get(neighbor.extAddress);
+            if (toNodeId === undefined && neighbor.rloc16 !== 0) {
+                toNodeId = rloc16Map.get(neighbor.rloc16);
+            }
+            if (toNodeId === undefined) {
+                toNodeId = unknownExtAddrMap.get(neighbor.extAddress);
+            }
+            if (toNodeId === undefined || fromNodeId === toNodeId) continue;
+
+            const pairKey = makePairKey(fromNodeId, toNodeId);
+            if (!pairs.has(pairKey)) {
+                const [nodeA, nodeB] = fromNodeId < toNodeId ? [fromNodeId, toNodeId] : [toNodeId, fromNodeId];
+                pairs.set(pairKey, { pairKey, nodeA, nodeB });
+            }
+
+            const pair = pairs.get(pairKey)!;
+            const isFromA = fromNodeId === pair.nodeA;
+
+            // Neighbor table entry takes precedence — skip if already present for this direction
+            if (isFromA && pair.edgeAB) continue;
+            if (!isFromA && pair.edgeBA) continue;
+
+            const routeEntry = findRouteByExtAddress(node, neighbor.extAddress);
+            const bidirectionalLqi = routeEntry ? getRouteBidirectionalLqi(routeEntry) : undefined;
+
+            const edge: ThreadConnection = {
+                fromNodeId,
+                toNodeId,
+                signalLevel: getSignalLevel(neighbor),
+                lqi: neighbor.lqi,
+                rssi: neighbor.avgRssi ?? neighbor.lastRssi,
+                pathCost: routeEntry?.pathCost,
+                bidirectionalLqi,
+            };
+
+            if (isFromA) {
+                pair.edgeAB = edge;
+            } else {
+                pair.edgeBA = edge;
+            }
+        }
+
+        // Supplementary: route table entries not already covered by neighbor table
+        const routes = parseRouteTable(node);
+        for (const route of routes) {
+            if (!route.linkEstablished || !route.allocated) continue;
+
+            let toNodeId: string | undefined = extAddrMap.get(route.extAddress);
+            if (toNodeId === undefined && route.rloc16 !== 0) {
+                toNodeId = rloc16Map.get(route.rloc16);
+            }
+            if (toNodeId === undefined) {
+                toNodeId = unknownExtAddrMap.get(route.extAddress);
+            }
+            if (toNodeId === undefined || toNodeId === fromNodeId) continue;
+
+            const pairKey = makePairKey(fromNodeId, toNodeId);
+            if (!pairs.has(pairKey)) {
+                const [nodeA, nodeB] = fromNodeId < toNodeId ? [fromNodeId, toNodeId] : [toNodeId, fromNodeId];
+                pairs.set(pairKey, { pairKey, nodeA, nodeB });
+            }
+
+            const pair = pairs.get(pairKey)!;
+            const isFromA = fromNodeId === pair.nodeA;
+
+            // Only add from route table if no neighbor table edge for this direction
+            if (isFromA && pair.edgeAB) continue;
+            if (!isFromA && pair.edgeBA) continue;
+
+            const bidirectionalLqi = getRouteBidirectionalLqi(route);
+            // No bidirectional LQI = both lqiIn and lqiOut are 0 → treat as no-link.
+            const signalLevel: SignalLevel =
+                bidirectionalLqi !== undefined ? getSignalLevelFromLqi(bidirectionalLqi) : "none";
+
+            const edge: ThreadConnection = {
+                fromNodeId,
+                toNodeId,
+                signalLevel,
+                lqi: bidirectionalLqi ?? 0,
+                rssi: null,
+                pathCost: route.pathCost,
+                bidirectionalLqi,
+                fromRouteTable: true,
+            };
+
+            if (isFromA) {
+                pair.edgeAB = edge;
+            } else {
+                pair.edgeBA = edge;
+            }
+        }
+    }
+
+    return pairs;
+}
+
+/**
+ * Merge route64 (router<->router) and childTable (router->child) edges from
+ * diagnostics into an existing edge-pair map. Resolves references to graph node
+ * ids via `resolveRloc16`; unresolved references are dropped (no phantom nodes).
+ * Existing edges (Matter-sourced) take precedence per direction.
+ */
+export function mergeDiagnosticEdges(
+    pairs: Map<string, ThreadEdgePair>,
+    batches: ReadonlyMap<string, ThreadDiagnosticsBatch>,
+    resolveRloc16: (rloc16: number, extPanIdHex: string) => string | undefined,
+): void {
+    const addEdge = (fromNodeId: string, toNodeId: string, lqi: number, pathCost?: number): void => {
+        if (fromNodeId === toNodeId) return;
+        const pairKey = makePairKey(fromNodeId, toNodeId);
+        let pair = pairs.get(pairKey);
+        if (pair === undefined) {
+            const [nodeA, nodeB] = fromNodeId < toNodeId ? [fromNodeId, toNodeId] : [toNodeId, fromNodeId];
+            pair = { pairKey, nodeA, nodeB };
+            pairs.set(pairKey, pair);
+        }
+        const isFromA = fromNodeId === pair.nodeA;
+        if (isFromA && pair.edgeAB) return; // existing (Matter) edge wins
+        if (!isFromA && pair.edgeBA) return;
+        const signalLevel = getSignalLevelFromLqi(lqi);
+        const edge: ThreadConnection = {
+            fromNodeId,
+            toNodeId,
+            signalLevel,
+            lqi,
+            rssi: null,
+            pathCost,
+            fromRouteTable: true,
+        };
+        if (isFromA) pair.edgeAB = edge;
+        else pair.edgeBA = edge;
+    };
+
+    for (const batch of batches.values()) {
+        for (const node of batch.nodes) {
+            if (node.rloc16 === undefined) continue;
+            const xp = batch.extPanIdHex;
+            const fromId = resolveRloc16(node.rloc16, xp) ?? diagnosticNodeId(node, xp);
+            const routerId = (node.rloc16 >> 10) & 0x3f;
+            if (node.route64 !== undefined) {
+                for (const e of node.route64.entries) {
+                    if (e.routerId === routerId) continue;
+                    const toId = resolveRloc16((e.routerId << 10) & 0xffff, xp);
+                    if (toId === undefined) continue;
+                    addEdge(fromId, toId, e.linkQualityIn, e.routeCost);
+                }
+            }
+            if (node.childTable !== undefined) {
+                for (const child of node.childTable) {
+                    const childRloc16 = ((routerId << 10) | child.childId) & 0xffff;
+                    // Only link children that are themselves a real graph node (a
+                    // commissioned Matter device). Non-Matter leaves are a count on
+                    // the parent, not floating nodes — so don't invent an edge.
+                    const toId = resolveRloc16(childRloc16, xp);
+                    if (toId === undefined) continue;
+                    addEdge(fromId, toId, child.incomingLinkQuality);
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Parses WiFi diagnostics from a node's attributes.
+ * Cluster 0x36/54 - WiFi Network Diagnostics.
+ */
+export function getWiFiDiagnostics(node: TopologySourceNode): WiFiDiagnostics {
+    // BSSID is attribute 0/54/0, stored as base64
+    const bssidRaw = node.attributes["0/54/0"] as string | undefined;
+    let bssid: string | null = null;
+    if (bssidRaw) {
+        try {
+            const binary = atob(bssidRaw);
+            bssid = Array.from(binary)
+                .map(c => c.charCodeAt(0).toString(16).padStart(2, "0").toUpperCase())
+                .join(":");
+        } catch {
+            bssid = null;
+        }
+    }
+
+    // RSSI is attribute 0/54/4
+    const rssi = node.attributes["0/54/4"] as number | null | undefined;
+
+    // Channel is attribute 0/54/3
+    const channel = node.attributes["0/54/3"] as number | null | undefined;
+
+    // Security type is attribute 0/54/1
+    const securityType = node.attributes["0/54/1"] as number | null | undefined;
+
+    // WiFi version is attribute 0/54/2
+    const wifiVersion = node.attributes["0/54/2"] as number | null | undefined;
+
+    return {
+        bssid: bssid,
+        rssi: rssi ?? null,
+        channel: channel ?? null,
+        securityType: securityType ?? null,
+        wifiVersion: wifiVersion ?? null,
+    };
+}

--- a/packages/ws-client/test/TopologyUtilsTest.ts
+++ b/packages/ws-client/test/TopologyUtilsTest.ts
@@ -1,0 +1,362 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { BorderRouterEntry, ThreadDiagnosticsBatch, ThreadEdgePair, TopologySourceNode } from "../src/index.js";
+import {
+    buildExtAddrMap,
+    buildMatterRloc16ByXp,
+    buildRloc16Map,
+    buildThreadEdgePairs,
+    categorizeDevices,
+    findUnknownDevices,
+    getEdgeSignalScore,
+    getNetworkType,
+    getRouteBidirectionalLqi,
+    getSignalLevel,
+    getSignalLevelFromLqi,
+    getWiFiDiagnostics,
+    makeDiagnosticRloc16Resolver,
+    makePairKey,
+    mergeDiagnosticEdges,
+    parseNeighborTable,
+    parseRouteTable,
+} from "../src/index.js";
+
+function mkNode(nodeId: number, attributes: Record<string, unknown>, available = true): TopologySourceNode {
+    return { node_id: nodeId, available, attributes };
+}
+
+/** base64 of a byte array (server-side Node helper — mirrors what the wire delivers). */
+function b64(bytes: number[]): string {
+    return Buffer.from(bytes).toString("base64");
+}
+
+// 0xAABBCCDDEEFF0011 as its constituent bytes + expected values.
+const EXT_BYTES = [0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11];
+const EXT_HEX = "AABBCCDDEEFF0011";
+const EXT_BIGINT = 0xaabbccddeeff0011n;
+
+describe("topology-utils", () => {
+    describe("getNetworkType", () => {
+        it("returns unknown when the feature map is absent", () => {
+            expect(getNetworkType(mkNode(1, {}))).to.equal("unknown");
+        });
+
+        it("classifies thread / wifi / ethernet from the feature map bits", () => {
+            expect(getNetworkType(mkNode(1, { "0/49/65532": 1 << 1 }))).to.equal("thread");
+            expect(getNetworkType(mkNode(1, { "0/49/65532": 1 << 0 }))).to.equal("wifi");
+            expect(getNetworkType(mkNode(1, { "0/49/65532": 1 << 2 }))).to.equal("ethernet");
+        });
+
+        it("prefers thread when multiple interface bits are set", () => {
+            expect(getNetworkType(mkNode(1, { "0/49/65532": (1 << 0) | (1 << 1) }))).to.equal("thread");
+        });
+    });
+
+    describe("getSignalLevelFromLqi", () => {
+        it("maps the OpenThread 0-3 LQI scale to signal levels", () => {
+            expect(getSignalLevelFromLqi(0)).to.equal("none");
+            expect(getSignalLevelFromLqi(1)).to.equal("weak");
+            expect(getSignalLevelFromLqi(2)).to.equal("medium");
+            expect(getSignalLevelFromLqi(3)).to.equal("strong");
+        });
+
+        it("treats any value above the strong threshold as strong", () => {
+            expect(getSignalLevelFromLqi(255)).to.equal("strong");
+        });
+
+        it("getSignalLevel reads the neighbor's lqi", () => {
+            expect(
+                getSignalLevel({
+                    extAddress: 0n,
+                    age: 0,
+                    rloc16: 0,
+                    linkFrameCounter: 0,
+                    mleFrameCounter: 0,
+                    lqi: 2,
+                    avgRssi: null,
+                    lastRssi: null,
+                    frameErrorRate: 0,
+                    messageErrorRate: 0,
+                    rxOnWhenIdle: false,
+                    fullThreadDevice: false,
+                    fullNetworkData: false,
+                    isChild: false,
+                }),
+            ).to.equal("medium");
+        });
+    });
+
+    describe("getEdgeSignalScore", () => {
+        it("orders none < weak < medium < strong (weakest lowest)", () => {
+            const base = { fromNodeId: "1", toNodeId: "2", rssi: null } as const;
+            const none = getEdgeSignalScore({ ...base, signalLevel: "none", lqi: 0 });
+            const weak = getEdgeSignalScore({ ...base, signalLevel: "weak", lqi: 1 });
+            const medium = getEdgeSignalScore({ ...base, signalLevel: "medium", lqi: 2 });
+            const strong = getEdgeSignalScore({ ...base, signalLevel: "strong", lqi: 3 });
+            expect(none).to.be.lessThan(weak);
+            expect(weak).to.be.lessThan(medium);
+            expect(medium).to.be.lessThan(strong);
+        });
+    });
+
+    describe("parseNeighborTable", () => {
+        it("parses numeric-keyed TLV fields incl. base64 extended address", () => {
+            const neighbors = parseNeighborTable(
+                mkNode(1, {
+                    "0/53/7": [
+                        {
+                            "0": b64(EXT_BYTES),
+                            "1": 10,
+                            "2": 1024,
+                            "5": 3,
+                            "6": -50,
+                            "7": -48,
+                            "10": true,
+                            "13": false,
+                        },
+                    ],
+                }),
+            );
+            expect(neighbors).to.have.length(1);
+            const n = neighbors[0];
+            expect(n.extAddress).to.equal(EXT_BIGINT);
+            expect(n.age).to.equal(10);
+            expect(n.rloc16).to.equal(1024);
+            expect(n.lqi).to.equal(3);
+            expect(n.avgRssi).to.equal(-50);
+            expect(n.lastRssi).to.equal(-48);
+            expect(n.rxOnWhenIdle).to.equal(true);
+            expect(n.isChild).to.equal(false);
+        });
+
+        it("falls back to camelCase keys and applies defaults", () => {
+            const neighbors = parseNeighborTable(mkNode(1, { "0/53/7": [{ extAddress: 5n, lqi: 2 }] }));
+            expect(neighbors[0].extAddress).to.equal(5n);
+            expect(neighbors[0].lqi).to.equal(2);
+            expect(neighbors[0].rloc16).to.equal(0);
+            expect(neighbors[0].avgRssi).to.equal(null);
+        });
+
+        it("returns an empty array when the attribute is missing", () => {
+            expect(parseNeighborTable(mkNode(1, {}))).to.have.length(0);
+        });
+    });
+
+    describe("parseRouteTable / getRouteBidirectionalLqi", () => {
+        it("parses route table entries", () => {
+            const routes = parseRouteTable(
+                mkNode(1, {
+                    "0/53/8": [{ "0": 7n, "1": 2048, "2": 3, "3": 15, "4": 1, "5": 3, "6": 2, "8": true, "9": true }],
+                }),
+            );
+            expect(routes).to.have.length(1);
+            const r = routes[0];
+            expect(r.extAddress).to.equal(7n);
+            expect(r.rloc16).to.equal(2048);
+            expect(r.routerId).to.equal(3);
+            expect(r.pathCost).to.equal(1);
+            expect(r.lqiIn).to.equal(3);
+            expect(r.lqiOut).to.equal(2);
+            expect(r.linkEstablished).to.equal(true);
+        });
+
+        it("averages bidirectional LQI, falling back to the live direction", () => {
+            expect(getRouteBidirectionalLqi({ lqiIn: 3, lqiOut: 1 } as never)).to.equal(2);
+            expect(getRouteBidirectionalLqi({ lqiIn: 3, lqiOut: 0 } as never)).to.equal(3);
+            expect(getRouteBidirectionalLqi({ lqiIn: 0, lqiOut: 0 } as never)).to.equal(undefined);
+        });
+    });
+
+    describe("buildExtAddrMap / buildRloc16Map", () => {
+        it("maps extended address (from NetworkInterfaces) and rloc16 to node id", () => {
+            const nodes: Record<string, TopologySourceNode> = {
+                "1": mkNode(1, { "0/51/0": [{ "4": b64(EXT_BYTES), "7": 4 }], "0/53/64": 1024 }),
+            };
+            expect(buildExtAddrMap(nodes).get(EXT_BIGINT)).to.equal("1");
+            expect(buildRloc16Map(nodes).get(1024)).to.equal("1");
+        });
+    });
+
+    describe("buildThreadEdgePairs", () => {
+        it("merges the two directions of a link into one pair", () => {
+            const nodes: Record<string, TopologySourceNode> = {
+                "1": mkNode(1, { "0/53/64": 1024, "0/53/7": [{ "0": 0, "2": 1025, "5": 3, "6": -40 }] }),
+                "2": mkNode(2, { "0/53/64": 1025, "0/53/7": [{ "0": 0, "2": 1024, "5": 2, "6": -60 }] }),
+            };
+            const rloc16Map = buildRloc16Map(nodes);
+            const pairs = buildThreadEdgePairs(nodes, new Map(), rloc16Map, []);
+
+            expect(pairs.size).to.equal(1);
+            const pair = pairs.get("1|2")!;
+            expect(pair.edgeAB?.signalLevel).to.equal("strong");
+            expect(pair.edgeBA?.signalLevel).to.equal("medium");
+        });
+
+        it("prefers the neighbor-table entry over the route-table entry per direction", () => {
+            const nodes: Record<string, TopologySourceNode> = {
+                "1": mkNode(1, {
+                    "0/53/64": 1024,
+                    "0/53/7": [{ "0": 0, "2": 1025, "5": 3, "6": -40 }],
+                    "0/53/8": [{ "0": 0, "1": 1025, "4": 5, "5": 1, "6": 1, "8": true, "9": true }],
+                }),
+                "2": mkNode(2, { "0/53/64": 1025 }),
+            };
+            const pairs = buildThreadEdgePairs(nodes, new Map(), buildRloc16Map(nodes), []);
+            const pair = pairs.get("1|2")!;
+            // Neighbor edge (lqi 3) wins; the route-table supplement (which would set
+            // fromRouteTable) must not overwrite it.
+            expect(pair.edgeAB?.signalLevel).to.equal("strong");
+            expect(pair.edgeAB?.fromRouteTable).to.equal(undefined);
+        });
+
+        it("does not create self-edges", () => {
+            const nodes: Record<string, TopologySourceNode> = {
+                "1": mkNode(1, { "0/53/64": 1024, "0/53/7": [{ "0": 0, "2": 1024, "5": 3 }] }),
+            };
+            const pairs = buildThreadEdgePairs(nodes, new Map(), buildRloc16Map(nodes), []);
+            expect(pairs.size).to.equal(0);
+        });
+    });
+
+    describe("findUnknownDevices", () => {
+        const nodes: Record<string, TopologySourceNode> = {
+            "1": mkNode(1, {
+                "0/53/4": 0x1122334455667788n,
+                "0/53/7": [{ "0": EXT_BIGINT, "2": 61440, "5": 2, "6": -70, "10": true }],
+            }),
+        };
+
+        it("classifies an unmatched neighbor as an unknown device", () => {
+            const unknown = findUnknownDevices(nodes, new Map(), new Map(), undefined);
+            expect(unknown).to.have.length(1);
+            expect(unknown[0].kind).to.equal("unknown");
+            expect(unknown[0].id).to.equal(`unknown_${EXT_HEX}`);
+            expect(unknown[0].isRouter).to.equal(true);
+            expect(unknown[0].bestRssi).to.equal(-70);
+            expect(unknown[0].seenBy).to.deep.equal(["1"]);
+        });
+
+        it("promotes a neighbor that matches the border-router registry", () => {
+            const br: BorderRouterEntry = {
+                extAddressHex: EXT_HEX,
+                extendedPanIdHex: "1122334455667788",
+                networkName: "TestNet",
+                addresses: [],
+                sources: ["meshcop"],
+                lastSeen: 0,
+            };
+            const found = findUnknownDevices(nodes, new Map(), new Map(), new Map([[EXT_HEX, br]]));
+            expect(found).to.have.length(1);
+            expect(found[0].kind).to.equal("br");
+            expect(found[0].id).to.equal(`br_${EXT_HEX}`);
+            expect((found[0] as { networkName?: string }).networkName).to.equal("TestNet");
+        });
+    });
+
+    describe("mergeDiagnosticEdges", () => {
+        const batch: ThreadDiagnosticsBatch = {
+            extPanIdHex: "1122334455667788",
+            networkName: "TestNet",
+            collectedAt: 0,
+            source: "meshcop",
+            nodes: [
+                {
+                    rloc16: 1024, // routerId 1
+                    route64: {
+                        idSequence: 0,
+                        entries: [{ routerId: 2, linkQualityIn: 3, linkQualityOut: 3, routeCost: 1 }],
+                    },
+                },
+            ],
+        };
+        const batches = new Map([[batch.extPanIdHex, batch]]);
+        const resolve = (rloc16: number): string | undefined =>
+            rloc16 === 1024 ? "1" : rloc16 === 2048 ? "2" : undefined;
+
+        it("adds a route64 router-to-router edge", () => {
+            const pairs = new Map<string, ThreadEdgePair>();
+            mergeDiagnosticEdges(pairs, batches, resolve);
+            expect(pairs.size).to.equal(1);
+            const pair = pairs.get("1|2")!;
+            expect(pair.edgeAB?.signalLevel).to.equal("strong");
+            expect(pair.edgeAB?.fromRouteTable).to.equal(true);
+            expect(pair.edgeAB?.pathCost).to.equal(1);
+        });
+
+        it("does not overwrite an existing (Matter-sourced) edge", () => {
+            const pairs = new Map<string, ThreadEdgePair>([
+                [
+                    "1|2",
+                    {
+                        pairKey: "1|2",
+                        nodeA: "1",
+                        nodeB: "2",
+                        edgeAB: { fromNodeId: "1", toNodeId: "2", signalLevel: "weak", lqi: 1, rssi: null },
+                    },
+                ],
+            ]);
+            mergeDiagnosticEdges(pairs, batches, resolve);
+            const pair = pairs.get("1|2")!;
+            expect(pair.edgeAB?.signalLevel).to.equal("weak");
+            expect(pair.edgeAB?.fromRouteTable).to.equal(undefined);
+        });
+
+        it("drops references that resolve to nothing (no phantom nodes)", () => {
+            const pairs = new Map<string, ThreadEdgePair>();
+            mergeDiagnosticEdges(pairs, batches, (rloc16: number) => (rloc16 === 1024 ? "1" : undefined));
+            expect(pairs.size).to.equal(0);
+        });
+    });
+
+    describe("makeDiagnosticRloc16Resolver", () => {
+        it("resolves a Matter device by its per-network rloc16", () => {
+            const nodes: Record<string, TopologySourceNode> = {
+                "1": mkNode(1, { "0/53/64": 1024, "0/53/4": 0x1122334455667788n }),
+            };
+            const resolver = makeDiagnosticRloc16Resolver(buildMatterRloc16ByXp(nodes), new Map());
+            expect(resolver(1024, "1122334455667788")).to.equal("1");
+            expect(resolver(9999, "1122334455667788")).to.equal(undefined);
+        });
+    });
+
+    describe("getWiFiDiagnostics", () => {
+        it("decodes BSSID from base64 and reads rssi / channel", () => {
+            const diag = getWiFiDiagnostics(
+                mkNode(1, {
+                    "0/54/0": b64([0x11, 0x22, 0x33, 0x44, 0x55, 0x66]),
+                    "0/54/1": 4,
+                    "0/54/2": 3,
+                    "0/54/3": 6,
+                    "0/54/4": -55,
+                }),
+            );
+            expect(diag.bssid).to.equal("11:22:33:44:55:66");
+            expect(diag.rssi).to.equal(-55);
+            expect(diag.channel).to.equal(6);
+        });
+    });
+
+    describe("categorizeDevices", () => {
+        it("buckets node ids by network type", () => {
+            const result = categorizeDevices({
+                "1": mkNode(1, { "0/49/65532": 1 << 1 }),
+                "2": mkNode(2, { "0/49/65532": 1 << 0 }),
+                "3": mkNode(3, {}),
+            });
+            expect(result.thread).to.deep.equal(["1"]);
+            expect(result.wifi).to.deep.equal(["2"]);
+            expect(result.unknown).to.deep.equal(["3"]);
+        });
+    });
+
+    describe("makePairKey", () => {
+        it("produces a direction-independent canonical key", () => {
+            expect(makePairKey("2", "1")).to.equal("1|2");
+            expect(makePairKey("1", "2")).to.equal("1|2");
+        });
+    });
+});


### PR DESCRIPTION
## What

Moves the pure Thread/WiFi network-topology derivation out of the dashboard and into `@matter-server/ws-client` so it can be reused outside the browser (e.g. server-side, for a future `get_network_topology` API).

Purely a refactor — **no behaviour change to the dashboard**.

## Details

- New `ws-client/src/topology/` (`topology-types.ts`, `topology-utils.ts`): neighbor/route-table parsing, edge-pair building, unknown/border-router classification, route64/childTable merging and WiFi diagnostics.
- Derivation functions now take a structural `TopologySourceNode` (`Pick<MatterNodeData, …>`) instead of the dashboard `MatterNode` class, so the pipeline runs in Node too.
- Dropped the DOM-derived `signalColor` field from `ThreadConnection`; callers derive the colour from `signalLevel` at render time, leaving the pipeline free of theme/DOM dependencies.
- The dashboard's `network-types.ts` / `network-utils.ts` keep the render, colour and side-panel helpers and re-export the moved symbols, so existing imports are unchanged.
- Adds `TopologyUtilsTest.ts` — first direct unit coverage of the derivation pipeline.

Groundwork for exposing Matter network topology to Home Assistant (OpenHomeFoundation/roadmap#210).