### PR TITLE
feat: tri-state ICD badge, clearer LIT wording, versioned update dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This page shows a detailed overview of the changes between versions without the 
 - Feature: Adds WiFi and Thread credential management and allows to store multiple entries. Commissioning can pick which stored network to use
 - Feature: Adds ICD (Intermittently Connected Device) management including a "Power & Sleep (ICD)" dashboard panel. Requires devices with Matter 1.4+ for LIT management.
 - Feature: Allows defining the default fabric label to use as CLI/ENV-option which then blocks changing via the WebSocket API
-- Feature: Adds automatic time synchronization for devices that support it, pushing UTC time (and time zone / DST for capable nodes). Enable it with the `--enable-time-sync` CLI option (env `ENABLE_TIME_SYNC`) when the host has a reliable, synced time source
+- Feature: Adds automatic time synchronization for devices that support it, pushing host time (UTC and time zone / DST). Enable it with the `--enable-time-sync` CLI option (env `ENABLE_TIME_SYNC`) when the host has a reliable, synced time source. Runs first 30-60 minutes after start, then every 24h.
 - Enhancement: When one WebSocket connection defines a fabric label then other connections are blocked from changing that as long as the defining connection is still active
 - Enhancement: Introduced WS schema 12 which supports the above features — see [WebSocket API schema changelog](docs/websocket-api-schema-changelog.md).
 - Enhancement: New `--disable-thread-diagnostics` CLI flag (env `DISABLE_THREAD_DIAGNOSTICS`) turns off the entire Thread Border Router subsystem (discovery, probing, diagnostics) for plain Matter-controller deployments. Matter-over-Thread commissioning is unaffected

--- a/packages/dashboard/src/pages/cluster-commands/clusters/icd-management-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/icd-management-commands.ts
@@ -259,16 +259,18 @@ export class IcdManagementClusterCommands extends BaseClusterCommands {
                                 reconnecting can also take up to <b>${this._idleText}</b>.
                             </li>
                             <li>
-                                <b>Every</b> ecosystem this device is paired with must support Battery Saver Mode
-                                (Matter "ICD LIT"), otherwise the device will appear offline or unresponsive there.
+                                <b>Every</b> ecosystem (e.g. Apple, Google) this device is paired with must support
+                                Battery Saver Mode (called Matter LIT (Long Idle Time) ICD), otherwise the device will
+                                appear offline or unresponsive there.
                             </li>
                         </ul>
                     </div>
                 </label>
             </div>
             <p class="info-banner">
-                Every ecosystem this device is paired with must support Battery Saver Mode (Matter "ICD LIT"). You can
-                switch back to Standard Mode later as long as no other ecosystem is registered for it.
+                Every ecosystem (e.g. Apple, Google) this device is paired with must support Battery Saver Mode (called
+                Matter LIT (Long Idle Time) ICD). You can switch back to Standard Mode later as long as no other
+                ecosystem is registered for it.
                 ${!single && !this._registered
                     ? html` This device is already paired with <b>${this._commissionedFabrics - 1}</b> other
                           ecosystem(s).`
@@ -316,11 +318,12 @@ export class IcdManagementClusterCommands extends BaseClusterCommands {
             <p>
                 <b>Important:</b>
                 ${single
-                    ? html`every ecosystem you pair this device with later must support Battery Saver Mode (Matter ICD
-                      "LIT"). In an ecosystem without support the device will appear offline or unresponsive.`
+                    ? html`every ecosystem (e.g. Apple, Google) you pair this device with later must support Battery
+                      Saver Mode (called Matter LIT (Long Idle Time) ICD). In an ecosystem without support the device
+                      will appear offline or unresponsive.`
                     : html`this device is already paired with <b>${this._commissionedFabrics - 1}</b> other
-                          ecosystem(s). All of them must support Battery Saver Mode (Matter ICD "LIT"), otherwise the
-                          device will appear offline or unresponsive in those ecosystems.`}
+                          ecosystem(s). All of them must support Battery Saver Mode (called Matter LIT (Long Idle Time)
+                          ICD), otherwise the device will appear offline or unresponsive in those ecosystems.`}
             </p>
             <p>
                 You can switch back to Standard Mode later as long as no other ecosystem is registered for Battery Saver

--- a/packages/dashboard/src/pages/components/node-details.ts
+++ b/packages/dashboard/src/pages/components/node-details.ts
@@ -25,7 +25,7 @@ import "../../components/ha-svg-icon";
 import "../camera-overlay.js";
 import { getDeviceIcon } from "../../util/device-icons.js";
 import { getEndpointDeviceTypes } from "../../util/endpoints.js";
-import { ICD_CLUSTER_ID, isLitIcd, litOfflineHint } from "../../util/icd.js";
+import { ICD_CLUSTER_ID, icdBadge } from "../../util/icd.js";
 import { bindingContext } from "./context.js";
 
 /** Map updateState values to user-friendly labels */
@@ -81,6 +81,7 @@ export class NodeDetails extends LitElement {
 
         const deviceTypeIds = getEndpointDeviceTypes(this.node, this.endpoint).map(d => d.id);
         const isCamera = deviceTypeIds.includes(0x0142) || deviceTypeIds.includes(0x0143);
+        const badge = icdBadge(this.node.attributes, this.node.available);
 
         return html`
             <md-list>
@@ -99,16 +100,15 @@ export class NodeDetails extends LitElement {
                                   </md-icon-button>
                               `
                             : nothing}
-                        ${this.node.available
-                            ? nothing
-                            : html` <span class="status">OFFLINE</span>${isLitIcd(this.node.attributes)
-                                      ? html`<a
-                                            class="status icd-badge"
-                                            href="#node/${this.node.node_id}/0/${ICD_CLUSTER_ID}"
-                                            title=${litOfflineHint(this.node.attributes)}
-                                            >ICD</a
-                                        >`
-                                      : nothing}`}
+                        ${this.node.available ? nothing : html` <span class="status">OFFLINE</span>`}
+                        ${badge
+                            ? html`<a
+                                  class="icd-badge icd-${badge.state}"
+                                  href="#node/${this.node.node_id}/0/${ICD_CLUSTER_ID}"
+                                  title=${badge.hint}
+                                  >ICD</a
+                              >`
+                            : nothing}
                     </div>
                 </md-list-item>
                 <md-list-item>
@@ -377,9 +377,26 @@ export class NodeDetails extends LitElement {
         .icd-badge {
             margin-left: 4px;
             padding: 0 4px;
-            border: 1px solid var(--danger-color);
+            border: 1px solid;
             border-radius: 4px;
+            font-weight: bold;
+            font-size: 0.8em;
             text-decoration: none;
+        }
+
+        .icd-badge.icd-offline {
+            color: var(--danger-color);
+            border-color: var(--danger-color);
+        }
+
+        .icd-badge.icd-lit {
+            color: var(--success-color);
+            border-color: var(--success-color);
+        }
+
+        .icd-badge.icd-sit {
+            color: var(--text-color);
+            border-color: var(--text-color);
         }
     `;
 }

--- a/packages/dashboard/src/pages/components/node-details.ts
+++ b/packages/dashboard/src/pages/components/node-details.ts
@@ -242,6 +242,14 @@ export class NodeDetails extends LitElement {
         }
     }
 
+    /** "1.5 (1234)" from SoftwareVersionString (0/40/10) + SoftwareVersion (0/40/9); manufacturers mix these up, so show both. */
+    private _formatSoftwareVersion(): string {
+        const versionString = this.node?.attributes["0/40/10"];
+        const versionNumber = this.node?.attributes["0/40/9"];
+        const str = typeof versionString === "string" && versionString !== "" ? versionString : "unknown";
+        return typeof versionNumber === "number" ? `${str} (${versionNumber})` : str;
+    }
+
     private async _searchUpdate() {
         const nodeUpdate = await this.client.checkNodeUpdate(this.node!.node_id);
         if (!nodeUpdate) {
@@ -274,8 +282,9 @@ export class NodeDetails extends LitElement {
                           `
                         : nothing}
                     <p>
+                        Current version: <b>${this._formatSoftwareVersion()}</b><br />
                         Do you want to update this node to version
-                        <b>${nodeUpdate.software_version_string}</b>?
+                        <b>${nodeUpdate.software_version_string} (${nodeUpdate.software_version})</b>?
                     </p>
                     <p>
                         Note that updating firmware is at your own risk and may cause the device to malfunction or needs

--- a/packages/dashboard/src/pages/matter-server-view.ts
+++ b/packages/dashboard/src/pages/matter-server-view.ts
@@ -17,7 +17,7 @@ import { clientContext, tickContext } from "../client/client-context.js";
 import "../components/ha-svg-icon";
 import { getDeviceIcon } from "../util/device-icons.js";
 import { formatNodeAddress } from "../util/format_hex.js";
-import { ICD_CLUSTER_ID, isLitIcd, litOfflineHint } from "../util/icd.js";
+import { ICD_CLUSTER_ID, icdBadge } from "../util/icd.js";
 import "./components/footer";
 import "./components/header";
 import type { ActiveView } from "./components/header.js";
@@ -85,6 +85,7 @@ class MatterServerView extends LitElement {
                         </div>
                     </md-list-item>
                     ${nodes.map(([_id, node]) => {
+                        const badge = icdBadge(node.attributes, node.available);
                         return html`
                             <md-list-item type="link" href=${`#node/${node.node_id}`}>
                                 <ha-svg-icon
@@ -103,17 +104,16 @@ class MatterServerView extends LitElement {
                                             node.node_id,
                                         )})</span
                                     >
-                                    ${node.available
-                                        ? ""
-                                        : html` <span class="status">OFFLINE</span>${isLitIcd(node.attributes)
-                                                  ? html`<a
-                                                        class="status icd-badge"
-                                                        href="#node/${node.node_id}/0/${ICD_CLUSTER_ID}"
-                                                        title=${litOfflineHint(node.attributes)}
-                                                        @click=${(e: Event) => e.stopPropagation()}
-                                                        >ICD</a
-                                                    >`
-                                                  : ""}`}
+                                    ${node.available ? "" : html` <span class="status">OFFLINE</span>`}
+                                    ${badge
+                                        ? html`<a
+                                              class="icd-badge icd-${badge.state}"
+                                              href="#node/${node.node_id}/0/${ICD_CLUSTER_ID}"
+                                              title=${badge.hint}
+                                              @click=${(e: Event) => e.stopPropagation()}
+                                              >ICD</a
+                                          >`
+                                        : ""}
                                 </div>
                                 <div slot="supporting-text">
                                     ${node.nodeLabel ? `${node.nodeLabel} | ` : nothing} ${node.vendorName} |
@@ -170,9 +170,26 @@ class MatterServerView extends LitElement {
         .icd-badge {
             margin-left: 4px;
             padding: 0 4px;
-            border: 1px solid var(--danger-color);
+            border: 1px solid;
             border-radius: 4px;
+            font-weight: bold;
+            font-size: 0.8em;
             text-decoration: none;
+        }
+
+        .icd-badge.icd-offline {
+            color: var(--danger-color);
+            border-color: var(--danger-color);
+        }
+
+        .icd-badge.icd-lit {
+            color: var(--success-color);
+            border-color: var(--success-color);
+        }
+
+        .icd-badge.icd-sit {
+            color: var(--text-color);
+            border-color: var(--text-color);
         }
 
         .hex-id {

--- a/packages/dashboard/src/util/icd.ts
+++ b/packages/dashboard/src/util/icd.ts
@@ -100,15 +100,6 @@ export function icdInfo(attributes: Record<string, unknown>): IcdInfo {
     };
 }
 
-/**
- * Badge predicate: the node is an ICD currently operating in LIT mode. Requires spec >= 1.4 —
- * below that the controller does not track check-ins, so offline is not "normal sleeping".
- */
-export function isLitIcd(attributes: Record<string, unknown>): boolean {
-    const info = icdInfo(attributes);
-    return info.supported && info.operatingMode === "LIT" && litSpecVersionOk(attributes);
-}
-
 export function isRegisteredByUs(
     clients: IcdRegisteredClient[],
     controllerNodeId: number | bigint | undefined,
@@ -150,12 +141,45 @@ export function wakeInstruction(hint: number | undefined, instruction: string | 
     return { kind: "manual", text: "see the device manual" };
 }
 
-/** Tooltip for the OFFLINE "ICD" badge. */
-export function litOfflineHint(attributes: Record<string, unknown>): string {
+export interface IcdBadge {
+    state: "offline" | "lit" | "sit";
+    hint: string;
+}
+
+/**
+ * Tri-state "ICD" badge for LIT-capable nodes (cluster present, LongIdleTimeSupport feature, spec >= 1.4 —
+ * below that the controller does not track check-ins, so offline is not "normal sleeping").
+ * Returns undefined for nodes that aren't LIT-capable, since neither SIT-only nor unsupported nodes get a badge.
+ */
+export function icdBadge(attributes: Record<string, unknown>, available: boolean): IcdBadge | undefined {
     const info = icdInfo(attributes);
-    const interval =
-        info.idleModeDuration !== undefined ? formatDuration(info.idleModeDuration) : "its check-in interval";
-    return `Battery Saver device: it sleeps between check-ins and may come back on its own (check-in interval up to ${interval}). Click for options.`;
+    if (!info.supported || !info.features.longIdleTimeSupport || !litSpecVersionOk(attributes)) return undefined;
+
+    if (info.operatingMode === "SIT") {
+        return {
+            state: "sit",
+            hint: "Supports Battery Saver Mode (called Matter LIT (Long Idle Time) ICD), currently in Standard mode. Click for options.",
+        };
+    }
+
+    if (info.operatingMode === "LIT") {
+        if (!available) {
+            const offlineInterval =
+                info.idleModeDuration !== undefined ? formatDuration(info.idleModeDuration) : "its check-in interval";
+            return {
+                state: "offline",
+                hint: `Battery Saver device: it sleeps between check-ins and may come back on its own (check-in interval up to ${offlineInterval}). Click for options.`,
+            };
+        }
+        const onlineInterval =
+            info.idleModeDuration !== undefined ? formatDuration(info.idleModeDuration) : "its idle interval";
+        return {
+            state: "lit",
+            hint: `Battery Saver Mode active (Matter LIT (Long Idle Time) ICD): the device sleeps between check-ins and reacts to commands within up to ${onlineInterval}. Click for options.`,
+        };
+    }
+
+    return undefined;
 }
 
 /** Extracts admin vendor ids from a multi-admin error `details` payload; undefined if not that shape. */

--- a/packages/dashboard/test/IcdUtilTest.ts
+++ b/packages/dashboard/test/IcdUtilTest.ts
@@ -6,10 +6,9 @@
 
 import {
     decodeRegisteredClients,
+    icdBadge,
     icdInfo,
-    isLitIcd,
     isRegisteredByUs,
-    litOfflineHint,
     litSpecVersionOk,
     otherFabricClientCount,
     parseIcdFeatures,
@@ -60,18 +59,40 @@ describe("icd util", () => {
         });
     });
 
-    describe("isLitIcd", () => {
-        it("true for operating LIT device", () => {
-            expect(isLitIcd(LIT_ATTRS)).to.equal(true);
+    describe("icdBadge", () => {
+        it("offline for an operating-LIT device that is unavailable", () => {
+            const badge = icdBadge(LIT_ATTRS, false);
+            expect(badge?.state).to.equal("offline");
+            expect(badge?.hint).to.contain("Battery Saver device");
+            expect(badge?.hint).to.contain("1 h");
         });
-        it("false for SIT device", () => {
-            expect(isLitIcd({ ...LIT_ATTRS, "0/70/8": 0 })).to.equal(false);
+        it("lit for an operating-LIT device that is available", () => {
+            const badge = icdBadge(LIT_ATTRS, true);
+            expect(badge?.state).to.equal("lit");
+            expect(badge?.hint).to.contain("Battery Saver Mode active");
+            expect(badge?.hint).to.contain("1 h");
         });
-        it("false for pre-1.4 device even when operating LIT", () => {
-            expect(isLitIcd({ ...LIT_ATTRS, "0/40/21": 0x01030000 })).to.equal(false);
+        it("lit hint falls back to 'its idle interval' when duration unknown", () => {
+            const attrs = { ...LIT_ATTRS };
+            delete attrs["0/70/0"];
+            const badge = icdBadge(attrs, true);
+            expect(badge?.hint).to.contain("its idle interval");
         });
-        it("false without ICD cluster", () => {
-            expect(isLitIcd({})).to.equal(false);
+        it("sit for an operating-SIT device, regardless of availability", () => {
+            const sitAttrs = { ...LIT_ATTRS, "0/70/8": 0 };
+            expect(icdBadge(sitAttrs, true)?.state).to.equal("sit");
+            expect(icdBadge(sitAttrs, false)?.state).to.equal("sit");
+            expect(icdBadge(sitAttrs, true)?.hint).to.contain("currently in Standard mode");
+        });
+        it("undefined without ICD cluster", () => {
+            expect(icdBadge({}, false)).to.equal(undefined);
+        });
+        it("undefined without LongIdleTimeSupport feature", () => {
+            const attrs = { ...LIT_ATTRS, "0/70/65532": 0b0011 }; // CIP | UAT, no LITS
+            expect(icdBadge(attrs, false)).to.equal(undefined);
+        });
+        it("undefined below spec 1.4", () => {
+            expect(icdBadge({ ...LIT_ATTRS, "0/40/21": 0x01030000 }, false)).to.equal(undefined);
         });
     });
 
@@ -158,12 +179,6 @@ describe("icd util", () => {
         });
         it("true above 1.4.0", () => {
             expect(litSpecVersionOk({ "0/40/21": 0x01040100 })).to.equal(true);
-        });
-    });
-
-    describe("litOfflineHint", () => {
-        it("mentions formatted interval", () => {
-            expect(litOfflineHint(LIT_ATTRS)).to.contain("1 h");
         });
     });
 

--- a/packages/ws-controller/src/controller/CustomClusterPoller.ts
+++ b/packages/ws-controller/src/controller/CustomClusterPoller.ts
@@ -10,7 +10,7 @@
  * a custom cluster without standard Matter subscription support.
  */
 
-import { Logger } from "@matter/main";
+import { asError, Diagnostic, Logger } from "@matter/main";
 import { PeerAddress, PeerAddressMap } from "@matter/main/protocol";
 import { AttributesData } from "../types/CommandHandler.js";
 import { formatNodeId } from "../util/formatNodeId.js";
@@ -190,7 +190,10 @@ export class CustomClusterPoller extends NodeProcessor {
             );
             await readPromise;
         } catch (error) {
-            logger.warn(`Failed to poll custom attributes for node ${formatNodeId(peer)}: `, error);
+            logger.warn(
+                `Failed to poll custom attributes for node ${formatNodeId(peer)}: `,
+                Diagnostic.errorMessage(asError(error)),
+            );
         } finally {
             this.#currentReadPromise = undefined;
         }

--- a/packages/ws-controller/src/controller/TimeSyncManager.ts
+++ b/packages/ws-controller/src/controller/TimeSyncManager.ts
@@ -45,10 +45,10 @@ export interface TimeSyncConnector {
     nodeConnected(peer: PeerAddress): boolean;
 }
 
-/** TimeNotAccepted means the node trusts its own time source — expected, not an error. */
+/** TimeNotAccepted means the node keeps a time source it prefers — expected, not an error. */
 function logSyncFailure(prefix: string, peer: PeerAddress, error: unknown) {
     if (error instanceof StatusResponseError && error.clusterCode === TimeSynchronization.StatusCode.TimeNotAccepted) {
-        logger.info(`${prefix}Node ${formatNodeId(peer)} declined the time (it trusts its own time source)`);
+        logger.info(`${prefix}Node ${formatNodeId(peer)} declined the provided time`);
         return;
     }
     logger.warn(`${prefix}Failed to sync time on node ${formatNodeId(peer)}:`, error);

--- a/packages/ws-controller/src/controller/TimeSyncManager.ts
+++ b/packages/ws-controller/src/controller/TimeSyncManager.ts
@@ -17,7 +17,9 @@
  */
 
 import { Duration, Hours, Logger, Minutes, Time } from "@matter/main";
+import { TimeSynchronization } from "@matter/main/clusters";
 import { PeerAddress, PeerAddressMap } from "@matter/main/protocol";
+import { StatusResponseError } from "@matter/main/types";
 import { AttributesData } from "../types/CommandHandler.js";
 import { formatNodeId } from "../util/formatNodeId.js";
 import { NodeProcessor } from "./NodeProcessor.js";
@@ -41,6 +43,15 @@ const TRIGGER_SYNC_COOLDOWN = Hours(24);
 export interface TimeSyncConnector {
     syncTime(peer: PeerAddress): Promise<void>;
     nodeConnected(peer: PeerAddress): boolean;
+}
+
+/** TimeNotAccepted means the node trusts its own time source — expected, not an error. */
+function logSyncFailure(prefix: string, peer: PeerAddress, error: unknown) {
+    if (error instanceof StatusResponseError && error.clusterCode === TimeSynchronization.StatusCode.TimeNotAccepted) {
+        logger.info(`${prefix}Node ${formatNodeId(peer)} declined the time (it trusts its own time source)`);
+        return;
+    }
+    logger.warn(`${prefix}Failed to sync time on node ${formatNodeId(peer)}:`, error);
 }
 
 /**
@@ -142,7 +153,7 @@ export class TimeSyncManager extends NodeProcessor {
         const promise = this.#connector
             .syncTime(peer)
             .then(() => logger.info(`Synced time on node ${formatNodeId(peer)}`))
-            .catch(error => logger.warn(`Failed to sync time on node ${formatNodeId(peer)}:`, error))
+            .catch(error => logSyncFailure("", peer, error))
             .finally(() => {
                 this.#inFlightSyncs.delete(peer);
             });
@@ -172,7 +183,7 @@ export class TimeSyncManager extends NodeProcessor {
         const promise = this.#connector
             .syncTime(peer)
             .then(() => logger.info(`Periodic resync: synced time on node ${formatNodeId(peer)}`))
-            .catch(error => logger.warn(`Periodic resync: failed to sync time on node ${formatNodeId(peer)}:`, error))
+            .catch(error => logSyncFailure("Periodic resync: ", peer, error))
             .finally(() => {
                 this.#inFlightSyncs.delete(peer);
             });


### PR DESCRIPTION
## Summary

Two small dashboard polish items (combined PR):

**Tri-state ICD badge** — the "ICD" badge next to node names now renders for every LIT-capable node (IcdManagement + LITS feature + Matter >= 1.4), not only for offline ones:
- red: offline in Battery Saver Mode (unchanged semantics)
- green: online and in Battery Saver Mode
- grey: supports Battery Saver Mode but currently in Standard mode
Always links to the node's ICD management page. Shown in the node list and the node header.

**Clearer ICD copy** — the generic ecosystem-support statements now read "Every ecosystem (e.g. Apple, Google) …" and the LIT parentheticals spell out "(called Matter LIT (Long Idle Time) ICD)".

**Software update dialog** — now shows the current version and the update target both as string + numeric software version ("1.5 (1234)"), since manufacturers occasionally mismatch the two.

**Time-sync log** — a node answering SetUtcTime with cluster status `TimeNotAccepted` now logs one info line ("Node X declined the provided time") instead of a warning with a stack trace — it is an expected, spec-defined answer, not an error.

## Test plan
- Dashboard unit tests 56/56 (7 new icdBadge cases: three states, non-capable/spec-gate → no badge, tooltip content)
- format / lint / build clean; full suite green apart from the documented pre-existing mDNS integration flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
