### PR TITLE
refactor(ws-client): tidy topology follow-ups from #829 review

### DIFF
--- a/packages/dashboard/src/pages/network/network-utils.ts
+++ b/packages/dashboard/src/pages/network/network-utils.ts
@@ -5,7 +5,7 @@
  */
 
 import type { MatterNode, SignalLevel, ThreadConnection, ThreadEdgePair } from "@matter-server/ws-client";
-import { getEdgeSignalScore, getThreadExtendedAddressHex } from "@matter-server/ws-client";
+import { getEdgeSignalScore, getSignalLevelFromLqi, getThreadExtendedAddressHex } from "@matter-server/ws-client";
 import { getCssVar } from "../../util/shared-styles.js";
 
 // The network topology data model + derivation moved to @matter-server/ws-client so
@@ -86,7 +86,7 @@ export function signalLevelToColor(level: SignalLevel): string {
  * 0 = grey (no link), 1 = red, 2 = orange, 3 = green.
  */
 export function getSignalColorFromLqi(lqi: number): string {
-    return signalLevelToColor(lqi <= 0 ? "none" : lqi > 2 ? "strong" : lqi > 1 ? "medium" : "weak");
+    return signalLevelToColor(getSignalLevelFromLqi(lqi));
 }
 
 /**

--- a/packages/ws-client/src/topology/topology-types.ts
+++ b/packages/ws-client/src/topology/topology-types.ts
@@ -9,13 +9,13 @@ import type { BorderRouterEntry, MatterNodeData } from "../models/model.js";
 /**
  * Minimal structural view of a node required to derive network topology.
  *
- * The derivation only ever reads `node_id`, `available` and the flat `attributes`
+ * The derivation only ever reads `node_id` and the flat `attributes`
  * map, so it accepts this narrow shape rather than the full {@link MatterNode}
  * class. Both the client-side `MatterNode` and any server-side node record that
  * exposes these fields satisfy it, which lets the topology pipeline run in the
  * browser (dashboard) and in Node (server) without a shared node class.
  */
-export type TopologySourceNode = Pick<MatterNodeData, "node_id" | "available" | "attributes">;
+export type TopologySourceNode = Pick<MatterNodeData, "node_id" | "attributes">;
 
 /**
  * Network type detected from NetworkCommissioning cluster feature map.
@@ -76,7 +76,7 @@ export interface ThreadNeighbor {
     fullThreadDevice: boolean;
     /** Whether this is a full network data device */
     fullNetworkData: boolean;
-    /** Whether the link is established */
+    /** Whether the neighbor is a child of this node */
     isChild: boolean;
 }
 

--- a/packages/ws-client/src/topology/topology-utils.ts
+++ b/packages/ws-client/src/topology/topology-utils.ts
@@ -165,7 +165,9 @@ export function getThreadExtendedPanId(node: TopologySourceNode): bigint | undef
  * - Field 4: HardwareAddress (base64 encoded EUI-64)
  * - Field 7: Type (4 = Thread)
  *
- * Returns as BigInt. Only upper 48 bits should be used for matching due to JSON precision loss.
+ * Returns the full EUI-64 as BigInt. Decoded from the base64 hardware address,
+ * so it is exact and used whole for matching — the JSON number-precision caveat
+ * that applies to revived integers does not apply here.
  */
 export function getThreadExtendedAddress(node: TopologySourceNode): bigint | undefined {
     // Get NetworkInterfaces from General Diagnostics cluster (0/51/0)
@@ -329,7 +331,7 @@ export function getRoutableDestinationsCount(node: TopologySourceNode): number {
  * Calculate combined bidirectional LQI from route table entry.
  * Returns average of lqiIn and lqiOut if both are non-zero.
  */
-export function getRouteBidirectionalLqi(route: ThreadRoute): number | undefined {
+export function getRouteBidirectionalLqi(route: Pick<ThreadRoute, "lqiIn" | "lqiOut">): number | undefined {
     if (route.lqiIn > 0 && route.lqiOut > 0) {
         return Math.round((route.lqiIn + route.lqiOut) / 2);
     }
@@ -719,6 +721,13 @@ export function buildThreadEdgePairs(
     for (const node of Object.values(nodes)) {
         const fromNodeId = String(node.node_id);
         const neighbors = parseNeighborTable(node);
+        const routes = parseRouteTable(node);
+        const routeByExtAddress = new Map<bigint, ThreadRoute>();
+        for (const route of routes) {
+            if (route.linkEstablished && !routeByExtAddress.has(route.extAddress)) {
+                routeByExtAddress.set(route.extAddress, route);
+            }
+        }
 
         for (const neighbor of neighbors) {
             let toNodeId: string | undefined = extAddrMap.get(neighbor.extAddress);
@@ -743,7 +752,7 @@ export function buildThreadEdgePairs(
             if (isFromA && pair.edgeAB) continue;
             if (!isFromA && pair.edgeBA) continue;
 
-            const routeEntry = findRouteByExtAddress(node, neighbor.extAddress);
+            const routeEntry = routeByExtAddress.get(neighbor.extAddress);
             const bidirectionalLqi = routeEntry ? getRouteBidirectionalLqi(routeEntry) : undefined;
 
             const edge: ThreadConnection = {
@@ -764,7 +773,6 @@ export function buildThreadEdgePairs(
         }
 
         // Supplementary: route table entries not already covered by neighbor table
-        const routes = parseRouteTable(node);
         for (const route of routes) {
             if (!route.linkEstablished || !route.allocated) continue;
 

--- a/packages/ws-client/test/TopologyUtilsTest.ts
+++ b/packages/ws-client/test/TopologyUtilsTest.ts
@@ -25,8 +25,8 @@ import {
     parseRouteTable,
 } from "../src/index.js";
 
-function mkNode(nodeId: number, attributes: Record<string, unknown>, available = true): TopologySourceNode {
-    return { node_id: nodeId, available, attributes };
+function mkNode(nodeId: number, attributes: Record<string, unknown>): TopologySourceNode {
+    return { node_id: nodeId, attributes };
 }
 
 /** base64 of a byte array (server-side Node helper — mirrors what the wire delivers). */
@@ -165,9 +165,9 @@ describe("topology-utils", () => {
         });
 
         it("averages bidirectional LQI, falling back to the live direction", () => {
-            expect(getRouteBidirectionalLqi({ lqiIn: 3, lqiOut: 1 } as never)).to.equal(2);
-            expect(getRouteBidirectionalLqi({ lqiIn: 3, lqiOut: 0 } as never)).to.equal(3);
-            expect(getRouteBidirectionalLqi({ lqiIn: 0, lqiOut: 0 } as never)).to.equal(undefined);
+            expect(getRouteBidirectionalLqi({ lqiIn: 3, lqiOut: 1 })).to.equal(2);
+            expect(getRouteBidirectionalLqi({ lqiIn: 3, lqiOut: 0 })).to.equal(3);
+            expect(getRouteBidirectionalLqi({ lqiIn: 0, lqiOut: 0 })).to.equal(undefined);
         });
     });
 


### PR DESCRIPTION
## What

Follow-up cleanups to the topology extraction merged in #829. Non-blocking review findings deferred at merge time — addressed here. **No behavior change.**

## Changes

**From Copilot review of #829:**
- `topology-types.ts`: fix `isChild` JSDoc — was "Whether the link is established", now "Whether the neighbor is a child of this node".
- `topology-utils.ts`: correct the `getThreadExtendedAddress` comment. It claimed only the upper 48 bits are usable due to JSON precision loss, but the value is base64-decoded (exact) and matched whole — the precision caveat never applied to this path.
- `topology-utils.ts`: `buildThreadEdgePairs` no longer re-parses the entire route table per neighbor via `findRouteByExtAddress`. Parses once per node into a `Map<bigint, ThreadRoute>` (first `linkEstablished` route per extAddress — same selection as the old `.find`) and does O(1) lookups. The supplementary route-table loop reuses the same parsed array.

**Additional nits:**
- `TopologySourceNode`: dropped `available` from the `Pick` — the derivation only reads `node_id` + `attributes`. Doc updated to match. Dashboard consumers read `.available` on `MatterNode`, not on this narrowed shape, so unaffected.
- `getRouteBidirectionalLqi`: param narrowed to `Pick<ThreadRoute, "lqiIn" | "lqiOut">` (all it reads). Removes the `as never` casts from the tests.
- dashboard `getSignalColorFromLqi`: reuses the shared `getSignalLevelFromLqi` instead of reimplementing the LQI thresholds inline — one source of truth.

## Verification

- `npm run format` / `npm run lint` / `npm run build`: clean.
- `PRIMARY_INTERFACE=en0 MATTER_MDNS_NETWORKINTERFACE=en0 npm test`: 251/251 passing (integration included). topology-utils suite covered.
- Independent adversarial review of the route-map refactor: confirmed equivalent to the old `findRouteByExtAddress` for duplicate/zero/non-established extAddress cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)