### PR TITLE
chore: update matter.js and use Timestamp.toMicroseconds for TimeSync epoch-us

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -225,8 +225,6 @@ jobs:
               env:
                   PRERELEASE: ${{ contains(steps.version.outputs.result, '-') }}
               run: |
-                  npm install -g npm@latest
-
                   if [[ "$PRERELEASE" == "true" ]]; then
                     npm publish --workspaces --tag dev
                   else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ This page shows a detailed overview of the changes between versions without the 
 - Enhancement: WebSocket sends now apply per-connection backpressure — a slow or stalled client coalesces attribute/node updates and drops stale events instead of buffering without limit, preventing unbounded memory growth (OOM) under high event volume
 - Enhancement: Update matter.js to the latest 0.17.5 nightly
     - Adds support for Matter 1.6.0
+    - Adds support for ICD (SIT and LIT) devices
     - Fixes an invoke-issue where parallel multi-endpoint invokes were working but errors returned on WebSocket
     - Optimizes subscription reporting intervals
-    - Ensures changed node structures are send via WebSocket directly after Re-Subscribe and not delayed
+    - Ensures changed node structures are sent via WebSocket directly after re-subscribe and not delayed
 - Adjustment: `webrtc_callback` events are now delivered only to the connection that issued the `send_webrtc_provider_command` for that camera session, instead of being broadcast to every connected client
 - Fix: Ensures that the Python-Client does not crash anymore on unknown events from newer Server versions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "packages/matter-server"
             ],
             "devDependencies": {
-                "@matter/testing": "0.17.5-alpha.0-20260708-18923cc56",
+                "@matter/testing": "0.17.5-alpha.0-20260709-e6f78aaf7",
                 "@nacho-iot/js-tools": "^0.1.7",
                 "@types/mocha": "^10.0.10",
                 "glob": "^13.0.6",
@@ -41,9 +41,9 @@
             }
         },
         "node_modules/@babel/code-frame/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -105,9 +105,9 @@
             }
         },
         "node_modules/@babel/core/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -116,14 +116,14 @@
             }
         },
         "node_modules/@babel/core/node_modules/@babel/parser": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
-            "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+            "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/types": "^8.0.0"
+                "@babel/types": "^8.0.4"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -133,15 +133,15 @@
             }
         },
         "node_modules/@babel/core/node_modules/@babel/types": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-            "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+            "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^8.0.0",
-                "@babel/helper-validator-identifier": "^8.0.0"
+                "@babel/helper-validator-identifier": "^8.0.4"
             },
             "engines": {
                 "node": "^22.18.0 || >=24.11.0"
@@ -176,9 +176,9 @@
             }
         },
         "node_modules/@babel/generator/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -186,13 +186,13 @@
             }
         },
         "node_modules/@babel/generator/node_modules/@babel/parser": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
-            "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+            "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^8.0.0"
+                "@babel/types": "^8.0.4"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -202,14 +202,14 @@
             }
         },
         "node_modules/@babel/generator/node_modules/@babel/types": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-            "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+            "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^8.0.0",
-                "@babel/helper-validator-identifier": "^8.0.0"
+                "@babel/helper-validator-identifier": "^8.0.4"
             },
             "engines": {
                 "node": "^22.18.0 || >=24.11.0"
@@ -239,9 +239,9 @@
             }
         },
         "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -249,14 +249,14 @@
             }
         },
         "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-            "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+            "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^8.0.0",
-                "@babel/helper-validator-identifier": "^8.0.0"
+                "@babel/helper-validator-identifier": "^8.0.4"
             },
             "engines": {
                 "node": "^22.18.0 || >=24.11.0"
@@ -372,9 +372,9 @@
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -382,14 +382,14 @@
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/types": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-            "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+            "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^8.0.0",
-                "@babel/helper-validator-identifier": "^8.0.0"
+                "@babel/helper-validator-identifier": "^8.0.4"
             },
             "engines": {
                 "node": "^22.18.0 || >=24.11.0"
@@ -420,9 +420,9 @@
             }
         },
         "node_modules/@babel/helper-module-imports/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -430,14 +430,14 @@
             }
         },
         "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-            "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+            "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^8.0.0",
-                "@babel/helper-validator-identifier": "^8.0.0"
+                "@babel/helper-validator-identifier": "^8.0.4"
             },
             "engines": {
                 "node": "^22.18.0 || >=24.11.0"
@@ -462,9 +462,9 @@
             }
         },
         "node_modules/@babel/helper-module-transforms/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -495,9 +495,9 @@
             }
         },
         "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -505,14 +505,14 @@
             }
         },
         "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/types": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-            "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+            "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^8.0.0",
-                "@babel/helper-validator-identifier": "^8.0.0"
+                "@babel/helper-validator-identifier": "^8.0.4"
             },
             "engines": {
                 "node": "^22.18.0 || >=24.11.0"
@@ -592,9 +592,9 @@
             }
         },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -602,14 +602,14 @@
             }
         },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/types": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-            "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+            "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^8.0.0",
-                "@babel/helper-validator-identifier": "^8.0.0"
+                "@babel/helper-validator-identifier": "^8.0.4"
             },
             "engines": {
                 "node": "^22.18.0 || >=24.11.0"
@@ -671,9 +671,9 @@
             }
         },
         "node_modules/@babel/helper-wrap-function/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -681,14 +681,14 @@
             }
         },
         "node_modules/@babel/helper-wrap-function/node_modules/@babel/types": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-            "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+            "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^8.0.0",
-                "@babel/helper-validator-identifier": "^8.0.0"
+                "@babel/helper-validator-identifier": "^8.0.4"
             },
             "engines": {
                 "node": "^22.18.0 || >=24.11.0"
@@ -721,9 +721,9 @@
             }
         },
         "node_modules/@babel/helpers/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -732,15 +732,15 @@
             }
         },
         "node_modules/@babel/helpers/node_modules/@babel/types": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-            "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+            "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/helper-string-parser": "^8.0.0",
-                "@babel/helper-validator-identifier": "^8.0.0"
+                "@babel/helper-validator-identifier": "^8.0.4"
             },
             "engines": {
                 "node": "^22.18.0 || >=24.11.0"
@@ -1298,9 +1298,9 @@
             }
         },
         "node_modules/@babel/plugin-transform-modules-systemjs/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1830,9 +1830,9 @@
             }
         },
         "node_modules/@babel/preset-modules/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1840,14 +1840,14 @@
             }
         },
         "node_modules/@babel/preset-modules/node_modules/@babel/types": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-            "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+            "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^8.0.0",
-                "@babel/helper-validator-identifier": "^8.0.0"
+                "@babel/helper-validator-identifier": "^8.0.4"
             },
             "engines": {
                 "node": "^22.18.0 || >=24.11.0"
@@ -1879,9 +1879,9 @@
             }
         },
         "node_modules/@babel/template/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1889,13 +1889,13 @@
             }
         },
         "node_modules/@babel/template/node_modules/@babel/parser": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
-            "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+            "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^8.0.0"
+                "@babel/types": "^8.0.4"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1905,32 +1905,32 @@
             }
         },
         "node_modules/@babel/template/node_modules/@babel/types": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-            "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+            "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^8.0.0",
-                "@babel/helper-validator-identifier": "^8.0.0"
+                "@babel/helper-validator-identifier": "^8.0.4"
             },
             "engines": {
                 "node": "^22.18.0 || >=24.11.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.0.tgz",
-            "integrity": "sha512-bxTj/W2VclGE6CctlfQOpxg8MPDzXArRqkOBePw8EHfebcjF7fETWSS3BriEECo+UiU/Yblq+xUtSImFu7cTbw==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-8.0.4.tgz",
+            "integrity": "sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^8.0.0",
                 "@babel/generator": "^8.0.0",
                 "@babel/helper-globals": "^8.0.0",
-                "@babel/parser": "^8.0.0",
+                "@babel/parser": "^8.0.4",
                 "@babel/template": "^8.0.0",
-                "@babel/types": "^8.0.0",
+                "@babel/types": "^8.0.4",
                 "obug": "^2.1.1"
             },
             "engines": {
@@ -1948,9 +1948,9 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/helper-validator-identifier": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.2.tgz",
-            "integrity": "sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+            "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1958,13 +1958,13 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/parser": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
-            "integrity": "sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+            "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^8.0.0"
+                "@babel/types": "^8.0.4"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1974,14 +1974,14 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/types": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0.tgz",
-            "integrity": "sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==",
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+            "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^8.0.0",
-                "@babel/helper-validator-identifier": "^8.0.0"
+                "@babel/helper-validator-identifier": "^8.0.4"
             },
             "engines": {
                 "node": "^22.18.0 || >=24.11.0"
@@ -2937,77 +2937,77 @@
             }
         },
         "node_modules/@matter/general": {
-            "version": "0.17.5-alpha.0-20260708-18923cc56",
-            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.5-alpha.0-20260708-18923cc56.tgz",
-            "integrity": "sha512-a10uZZ5hAYpkH2TkeByld2mUNHvEJeIZ/d56zGyB117fSwxthachsq6E5/wAfq49y9t6YTbyABkt0YLTk3ZDNA==",
+            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
+            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
+            "integrity": "sha512-NIUZzASG2FitKQzwWFSKgXYqIcb+nZKgjQ8O9zai6elfWnvk/X34N3buioSUf32uRPUxLMVseG2pWHEgo2p12w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/curves": "^2.2.0"
             }
         },
         "node_modules/@matter/main": {
-            "version": "0.17.5-alpha.0-20260708-18923cc56",
-            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.5-alpha.0-20260708-18923cc56.tgz",
-            "integrity": "sha512-2uNwaTYGAx47TJDx+4klB6iIvqBDrJsAM6Fn6oObBzghDiC/1jhDhuw3bFSnIzYGMQmk/3WWtXHpUSa4v1xAWQ==",
+            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
+            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
+            "integrity": "sha512-lW9aUHnrwkDDMMDMMMbIKbmcnAQY3tmcV5e8FyrEjUkxpnLBIfWwhq+VF3OEM7U1CQB25RawX98Pxy+Vbwys9Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/model": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/node": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/protocol": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/types": "0.17.5-alpha.0-20260708-18923cc56"
+                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/model": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/node": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/protocol": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/types": "0.17.5-alpha.0-20260709-e6f78aaf7"
             },
             "optionalDependencies": {
-                "@matter/nodejs": "0.17.5-alpha.0-20260708-18923cc56"
+                "@matter/nodejs": "0.17.5-alpha.0-20260709-e6f78aaf7"
             }
         },
         "node_modules/@matter/model": {
-            "version": "0.17.5-alpha.0-20260708-18923cc56",
-            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.5-alpha.0-20260708-18923cc56.tgz",
-            "integrity": "sha512-qlVkOIV57vxOQB38fdUBAeHXpO0kwslwFnCmeEHAGHwGEv+qQ2NMPsu20TkKtrrPTL7gkAOEXlYjS3OnmddAPA==",
+            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
+            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
+            "integrity": "sha512-HipiOYo82w+1hxE3nTNmEWQ/3G2PILrpObcUf9TMOCX/33f53pMpg7H+BnWB3NBIAePLUVmRBzjCbwMrBB+Ebw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260708-18923cc56"
+                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7"
             }
         },
         "node_modules/@matter/node": {
-            "version": "0.17.5-alpha.0-20260708-18923cc56",
-            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.5-alpha.0-20260708-18923cc56.tgz",
-            "integrity": "sha512-0iJl8L8uLH/L76Kd4/Bh9bw6W08PU3FDGh6bRiCdZIfYPqelrId/XQozU8zTz29mhWctsgO+ScaTpNKuR6eUnw==",
+            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
+            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
+            "integrity": "sha512-jRYfFxaqoy8twp8665UK6Km/bfaaK2J77jUkZpIlMB6eIIFXQ8wezYRaRmwfCP0RI7S7AqC7BpXmqUg0V6UByw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/model": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/protocol": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/types": "0.17.5-alpha.0-20260708-18923cc56"
+                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/model": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/protocol": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/types": "0.17.5-alpha.0-20260709-e6f78aaf7"
             }
         },
         "node_modules/@matter/nodejs": {
-            "version": "0.17.5-alpha.0-20260708-18923cc56",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.5-alpha.0-20260708-18923cc56.tgz",
-            "integrity": "sha512-jZ8X9fJljscvoYrbwrqgRsfpDnm2hZEQQMoj6jcIIse7BqFvgYDL8ESZ7gWRbG1dRjl7iGXUQdCQdqhxpp8aHQ==",
+            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
+            "integrity": "sha512-tll1XDMWgSLTm4YO459AREvbFmD5z5CsqthYtThjZ4NL3D9jA5Aut6OtHj8rj+N4Bja80L8n6Cg6QfkTv4zUug==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/node": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/protocol": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/types": "0.17.5-alpha.0-20260708-18923cc56"
+                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/node": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/protocol": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/types": "0.17.5-alpha.0-20260709-e6f78aaf7"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
             }
         },
         "node_modules/@matter/nodejs-ble": {
-            "version": "0.17.5-alpha.0-20260708-18923cc56",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.5-alpha.0-20260708-18923cc56.tgz",
-            "integrity": "sha512-RJxSjutvU+Yvi+3LRmrfZEYYnK3AUut9xxrhjQjy8I2lPJqiHsCWfr0em6Dsu4ejmmtQ3zTqRTqnhxcMMkJ+Tw==",
+            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
+            "integrity": "sha512-3+8zBOyre3VB5lAeZGuqmc/PA13FP8g9zP6zmDJISsTmspNmQjWUiaTkNEFMN1111jv8Ee+0cWvrBDe0wuY4vA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/protocol": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/types": "0.17.5-alpha.0-20260708-18923cc56"
+                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/protocol": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/types": "0.17.5-alpha.0-20260709-e6f78aaf7"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -3018,20 +3018,20 @@
             }
         },
         "node_modules/@matter/protocol": {
-            "version": "0.17.5-alpha.0-20260708-18923cc56",
-            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.5-alpha.0-20260708-18923cc56.tgz",
-            "integrity": "sha512-bGkfR2qEL9p2GojhbmWdIAY/kWccbG1EWImGiYZUuQe4NyyYtxYBaSqNBZwaxQL6kUmowwu9grGsdoxP4KxAfw==",
+            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
+            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
+            "integrity": "sha512-2iwEg+nb0Mz6mpw46pFvBAQZFWI4eZhKuRIH+y4cui49sGTu1LmBkWrtGgx6BokBjSy2LQAq4z2A1tRIoOPSPQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/model": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/types": "0.17.5-alpha.0-20260708-18923cc56"
+                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/model": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/types": "0.17.5-alpha.0-20260709-e6f78aaf7"
             }
         },
         "node_modules/@matter/testing": {
-            "version": "0.17.5-alpha.0-20260708-18923cc56",
-            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.5-alpha.0-20260708-18923cc56.tgz",
-            "integrity": "sha512-IeCGH6jzoZ0oOpqJCTgVQHY8g+eeSW9W0sX161rHRwQCMQU3G0Rd7Ed4zyTX9qYZf/+Bfwy00w7PXZDIdHgJ3Q==",
+            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
+            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
+            "integrity": "sha512-MC06saucu13q+5/xdANv3O00V3Vs8XlPA2mGKb/PYu4jPhWI8SqqVd1n5a0WHXEcuuP7JXx2bXFYinj5UJrY4A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3056,24 +3056,24 @@
             }
         },
         "node_modules/@matter/thread-br-client": {
-            "version": "0.17.5-alpha.0-20260708-18923cc56",
-            "resolved": "https://registry.npmjs.org/@matter/thread-br-client/-/thread-br-client-0.17.5-alpha.0-20260708-18923cc56.tgz",
-            "integrity": "sha512-efnsxU1VTI4FNCK3obx1YPoP5BwbQv2yKGMOtnbatXrm07qUlBkzdNFxAXua9LPN76dn26RNIzhSDoBokFBjPA==",
+            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
+            "resolved": "https://registry.npmjs.org/@matter/thread-br-client/-/thread-br-client-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
+            "integrity": "sha512-TysTCnFWeA265rQsfG+VbUyv13P1AaIB6dCEIfg1lOiOZ3xAEw+0ZX+z3LQOuVWyCebn64eMmAeQNuNKWbhdYQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/protocol": "0.17.5-alpha.0-20260708-18923cc56",
+                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/protocol": "0.17.5-alpha.0-20260709-e6f78aaf7",
                 "@noble/curves": "^2.2.0"
             }
         },
         "node_modules/@matter/types": {
-            "version": "0.17.5-alpha.0-20260708-18923cc56",
-            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.5-alpha.0-20260708-18923cc56.tgz",
-            "integrity": "sha512-sFGJC2QxLfYMQEtuBxewjaoROtPGde6ES76QCfuC6NC/giCGKc+Np3P+/7+BzAnHE+FiPLldm5m9SWjvr15qFA==",
+            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
+            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
+            "integrity": "sha512-p/La7kX11WnDDkjhp9QQLzePN12xJzq8NMWp6o+aTsqe1b054RU+94kVTQiZG4gtqWw280g8rOi6jaZcTPMOgw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/model": "0.17.5-alpha.0-20260708-18923cc56"
+                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/model": "0.17.5-alpha.0-20260709-e6f78aaf7"
             }
         },
         "node_modules/@mdi/js": {
@@ -3984,16 +3984,16 @@
             }
         },
         "node_modules/@project-chip/matter.js": {
-            "version": "0.17.5-alpha.0-20260708-18923cc56",
-            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.5-alpha.0-20260708-18923cc56.tgz",
-            "integrity": "sha512-TZFyo6tYRbo6fCVT5ro74IZ/WgOEALazfDohOzhuVuuemMf2lVqRF1KsuyGm5I9rzCYS3q+PpD+NMQb/TjttUw==",
+            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
+            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
+            "integrity": "sha512-8bpvQ4IqBrCkLzEI8eNKsSIvpkNo92j3/n2SHEw7jlECjaTDrsWjIZEEzuUANiduQ92dritr+K03sCebfh0eeg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/model": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/node": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/protocol": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/types": "0.17.5-alpha.0-20260708-18923cc56"
+                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/model": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/node": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/protocol": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/types": "0.17.5-alpha.0-20260709-e6f78aaf7"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -5107,9 +5107,9 @@
             "peer": true
         },
         "node_modules/@types/hast": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+            "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11288,7 +11288,7 @@
             "version": "0.0.0-git",
             "dependencies": {
                 "@matter-server/ws-controller": "*",
-                "@matter/main": "0.17.5-alpha.0-20260708-18923cc56",
+                "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
                 "ws": "^8.21.0"
             },
             "devDependencies": {
@@ -11299,7 +11299,7 @@
                 "node": ">=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.5-alpha.0-20260708-18923cc56",
+                "@matter/nodejs-ble": "0.17.5-alpha.0-20260709-e6f78aaf7",
                 "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
             }
         },
@@ -11307,7 +11307,7 @@
             "name": "@matter-server/custom-clusters",
             "version": "0.0.0-git",
             "dependencies": {
-                "@matter/main": "0.17.5-alpha.0-20260708-18923cc56"
+                "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7"
             },
             "engines": {
                 "node": ">=22.13.0"
@@ -11329,7 +11329,7 @@
             },
             "devDependencies": {
                 "@babel/preset-env": "^8.0.2",
-                "@matter/main": "0.17.5-alpha.0-20260708-18923cc56",
+                "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
                 "@rollup/plugin-babel": "^7.1.0",
                 "@rollup/plugin-commonjs": "^29.0.3",
                 "@rollup/plugin-json": "^6.1.0",
@@ -11601,14 +11601,14 @@
                 "@matter-server/custom-clusters": "*",
                 "@matter-server/dashboard": "*",
                 "@matter-server/ws-controller": "*",
-                "@matter/main": "0.17.5-alpha.0-20260708-18923cc56",
+                "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
                 "commander": "^15.0.0",
                 "express": "^5.2.1"
             },
             "devDependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/nodejs": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/testing": "0.17.5-alpha.0-20260708-18923cc56",
+                "@matter/nodejs": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/testing": "0.17.5-alpha.0-20260709-e6f78aaf7",
                 "@types/express": "^5.0.6",
                 "@types/node": "^26.1.1"
             },
@@ -11630,10 +11630,10 @@
             "version": "0.0.0-git",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/thread-br-client": "0.17.5-alpha.0-20260708-18923cc56"
+                "@matter/thread-br-client": "0.17.5-alpha.0-20260709-e6f78aaf7"
             },
             "devDependencies": {
-                "@matter/testing": "0.17.5-alpha.0-20260708-18923cc56",
+                "@matter/testing": "0.17.5-alpha.0-20260709-e6f78aaf7",
                 "@types/node": "^26.1.1",
                 "@types/ws": "^8.18.1",
                 "ws": "^8.21.0"
@@ -11648,9 +11648,9 @@
             "dependencies": {
                 "@matter-server/ws-client": "*",
                 "@matter/dcl-data": ">=2026.7.7",
-                "@matter/main": "0.17.5-alpha.0-20260708-18923cc56",
-                "@matter/thread-br-client": "0.17.5-alpha.0-20260708-18923cc56",
-                "@project-chip/matter.js": "0.17.5-alpha.0-20260708-18923cc56",
+                "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/thread-br-client": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@project-chip/matter.js": "0.17.5-alpha.0-20260709-e6f78aaf7",
                 "ws": "^8.21.0"
             },
             "devDependencies": {
@@ -11661,7 +11661,7 @@
                 "node": ">=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.5-alpha.0-20260708-18923cc56",
+                "@matter/nodejs-ble": "0.17.5-alpha.0-20260709-e6f78aaf7",
                 "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
             }
         }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "python-ble-proxy:run": "cd python_ble_proxy && { [ -x .venv/bin/matter-ble-proxy ] || (python3 -m venv .venv && .venv/bin/pip install -e .); } && .venv/bin/matter-ble-proxy"
     },
     "devDependencies": {
-        "@matter/testing": "0.17.5-alpha.0-20260708-18923cc56",
+        "@matter/testing": "0.17.5-alpha.0-20260709-e6f78aaf7",
         "@nacho-iot/js-tools": "^0.1.7",
         "@types/mocha": "^10.0.10",
         "glob": "^13.0.6",

--- a/packages/ble-proxy/package.json
+++ b/packages/ble-proxy/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@matter-server/ws-controller": "*",
-        "@matter/main": "0.17.5-alpha.0-20260708-18923cc56",
+        "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
         "ws": "^8.21.0"
     },
     "devDependencies": {
@@ -38,7 +38,7 @@
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.5-alpha.0-20260708-18923cc56",
+        "@matter/nodejs-ble": "0.17.5-alpha.0-20260709-e6f78aaf7",
         "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
     },
     "engines": {

--- a/packages/custom-clusters/package.json
+++ b/packages/custom-clusters/package.json
@@ -39,7 +39,7 @@
         "build-clean": "nacho-build --clean"
     },
     "dependencies": {
-        "@matter/main": "0.17.5-alpha.0-20260708-18923cc56"
+        "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7"
     },
     "engines": {
         "node": ">=22.13.0"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -42,7 +42,7 @@
     },
     "devDependencies": {
         "@babel/preset-env": "^8.0.2",
-        "@matter/main": "0.17.5-alpha.0-20260708-18923cc56",
+        "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
         "@rollup/plugin-babel": "^7.1.0",
         "@rollup/plugin-commonjs": "^29.0.3",
         "@rollup/plugin-json": "^6.1.0",

--- a/packages/matter-server/package.json
+++ b/packages/matter-server/package.json
@@ -44,14 +44,14 @@
         "@matter-server/custom-clusters": "*",
         "@matter-server/dashboard": "*",
         "@matter-server/ws-controller": "*",
-        "@matter/main": "0.17.5-alpha.0-20260708-18923cc56",
+        "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
         "commander": "^15.0.0",
         "express": "^5.2.1"
     },
     "devDependencies": {
         "@matter-server/ws-client": "*",
-        "@matter/nodejs": "0.17.5-alpha.0-20260708-18923cc56",
-        "@matter/testing": "0.17.5-alpha.0-20260708-18923cc56",
+        "@matter/nodejs": "0.17.5-alpha.0-20260709-e6f78aaf7",
+        "@matter/testing": "0.17.5-alpha.0-20260709-e6f78aaf7",
         "@types/express": "^5.0.6",
         "@types/node": "^26.1.1"
     },

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -40,10 +40,10 @@
         "build-clean": "nacho-build --clean"
     },
     "dependencies": {
-        "@matter/thread-br-client": "0.17.5-alpha.0-20260708-18923cc56"
+        "@matter/thread-br-client": "0.17.5-alpha.0-20260709-e6f78aaf7"
     },
     "devDependencies": {
-        "@matter/testing": "0.17.5-alpha.0-20260708-18923cc56",
+        "@matter/testing": "0.17.5-alpha.0-20260709-e6f78aaf7",
         "@types/node": "^26.1.1",
         "@types/ws": "^8.18.1",
         "ws": "^8.21.0"

--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -42,9 +42,9 @@
     "dependencies": {
         "@matter-server/ws-client": "*",
         "@matter/dcl-data": ">=2026.7.7",
-        "@matter/main": "0.17.5-alpha.0-20260708-18923cc56",
-        "@matter/thread-br-client": "0.17.5-alpha.0-20260708-18923cc56",
-        "@project-chip/matter.js": "0.17.5-alpha.0-20260708-18923cc56",
+        "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
+        "@matter/thread-br-client": "0.17.5-alpha.0-20260709-e6f78aaf7",
+        "@project-chip/matter.js": "0.17.5-alpha.0-20260709-e6f78aaf7",
         "ws": "^8.21.0"
     },
     "devDependencies": {
@@ -52,7 +52,7 @@
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.5-alpha.0-20260708-18923cc56",
+        "@matter/nodejs-ble": "0.17.5-alpha.0-20260709-e6f78aaf7",
         "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
     },
     "engines": {

--- a/packages/ws-controller/src/controller/timeSyncCommands.ts
+++ b/packages/ws-controller/src/controller/timeSyncCommands.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Logger } from "@matter/main";
+import { Logger, Timestamp } from "@matter/main";
 import { TimeSynchronization } from "@matter/main/clusters";
 import { MATTER_EPOCH_OFFSET_US } from "@matter/main/types";
 import { AttributesData } from "../types/CommandHandler.js";
@@ -42,9 +42,8 @@ const defaultTimeZoneProvider: TimeZoneProvider = {
     dstWindows: defaultDstWindows,
 };
 
-// epoch-us fields are raw Unix-epoch microseconds; matter.js TlvEpochUs adds the Matter-epoch offset.
-function unixMsToEpochUs(ms: number): number {
-    return ms * 1000;
+function unixMsToEpochUs(ms: number): bigint {
+    return Timestamp.toMicroseconds(Timestamp(ms));
 }
 
 /**

--- a/packages/ws-controller/test/TimeSyncCommandsTest.ts
+++ b/packages/ws-controller/test/TimeSyncCommandsTest.ts
@@ -41,13 +41,13 @@ describe("pushNodeTime", () => {
         await pushNodeTime({ invokers, attributes: TZ_ATTRS, nowMs: NOW_MS, tz });
 
         expect(calls.map(c => c.command)).to.deep.equal(["setUtcTime", "setTimeZone", "setDstOffset"]);
-        expect((calls[0].fields as TimeSynchronization.SetUtcTimeRequest).utcTime).to.equal(NOW_MS * 1000);
+        expect((calls[0].fields as TimeSynchronization.SetUtcTimeRequest).utcTime).to.equal(BigInt(NOW_MS) * 1000n);
         const tzReq = calls[1].fields as TimeSynchronization.SetTimeZoneRequest;
         expect(tzReq.timeZone).to.deep.equal([
             { offset: 3600, validAt: MATTER_EPOCH_OFFSET_US, name: "Europe/Berlin" },
         ]);
         const dstReq = calls[2].fields as TimeSynchronization.SetDstOffsetRequest;
-        expect(dstReq.dstOffset).to.deep.equal([{ offset: 3600, validStarting: 1_000_000, validUntil: 2_000_000 }]);
+        expect(dstReq.dstOffset).to.deep.equal([{ offset: 3600, validStarting: 1_000_000n, validUntil: 2_000_000n }]);
     });
 
     it("emits a first-entry validAt the matter.js TlvEpochUs codec accepts", async () => {


### PR DESCRIPTION
Follow-up to the TimeSync feature (#440), now that matter.js ships a `Timestamp.toMicroseconds` helper (matter-js/matter.js#4043).

## Changes
- **deps**: bump matter.js to the `0.17.5` nightly that includes `Timestamp.toMicroseconds`.
- **refactor(ws-controller)**: replace the hand-rolled `ms * 1000` epoch-us conversion in `timeSyncCommands.ts` with `Timestamp.toMicroseconds(Timestamp(ms))`. Epoch-us command fields (`utcTime`, DST `validStarting`/`validUntil`) are now `bigint`, which the `TimeSynchronization` request types accept. Drops the local WHY comment about the `Time.nowUs`-is-milliseconds trap — the helper is self-documenting and the trap is now handled upstream.
- **ci**: drop the redundant `npm install -g npm@latest` step in `release-npm.yml`.

`MATTER_EPOCH_OFFSET_US` (for the canonical `validAt: 0` / no-DST entry) is unchanged — that's an epoch constant, not a ms→µs conversion.

## Verification
- `npm run format` / `npm run lint` / `npm run build` clean.
- `npm test -w @matter-server/ws-controller` 190/190, including the `pushNodeTime` sequencing + real-codec round-trip tests (updated to assert bigint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)