### PR TITLE
fix: window the WebSocket backpressure drain instead of one-in-flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Fix: WebSocket backpressure now keeps the send window full instead of draining one frame at a time, so a burst is not serialized to one network round-trip per frame — this could stall initial sync behind a high-latency proxy (e.g. Home Assistant ingress) long enough to drop the dashboard connection
+
 ## 1.2.1 (2026-07-09)
 
 - Fix: Optimize WebSocket backpressure calculation so a single large payload no longer trips congestion mode on a healthy client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
-- Fix: WebSocket backpressure now keeps the send window full instead of draining one frame at a time, so a burst is not serialized to one network round-trip per frame — this could stall initial sync behind a high-latency proxy (e.g. Home Assistant ingress) long enough to drop the dashboard connection
+- Fix: Ensure that WebSocket backpressure keeps the send window full instead of draining one frame at a time, avoiding initial-sync stalls behind a high-latency proxy (e.g. Home Assistant ingress) that could drop the dashboard connection
 
 ## 1.2.1 (2026-07-09)
 

--- a/packages/ws-controller/src/server/WebSocketConnection.ts
+++ b/packages/ws-controller/src/server/WebSocketConnection.ts
@@ -59,11 +59,12 @@ const DEFAULT_WATCHDOG = Minutes(5);
  *
  * In **direct** mode every send hits the socket immediately in emit order — zero overhead for the
  * common case. When a send pushes `ws.bufferedAmount` over the high-water mark the connection flips
- * to **queued** mode: frames go into a single ordered outbox drained one-at-a-time, each next send
- * gated on the prior send's flush callback so the socket's own drain rate paces output and
- * `bufferedAmount` stays near one frame. Attribute/node-snapshot sends coalesce latest-wins per key;
- * events are FIFO and, past the cap, dropped oldest-first. A stalled in-flight send trips a watchdog
- * that closes the dead connection. The outbox empties → back to direct mode.
+ * to **queued** mode: frames drain from a single ordered outbox, kept-in-flight up to `highWater`
+ * bytes (a window, not one frame at a time) so the pipe stays full and delivery is not serialized to
+ * one round-trip per frame — which over a high-latency relay would stall a burst. Each flush callback
+ * frees window space and pulls more. Attribute/node-snapshot sends coalesce latest-wins per key;
+ * events are FIFO and, past the cap, dropped oldest-first. An in-flight send stalled beyond the
+ * watchdog closes the dead connection. The outbox empties → back to direct mode.
  */
 export class WebSocketConnection {
     readonly #ws: OutboundSocket;
@@ -78,7 +79,8 @@ export class WebSocketConnection {
 
     #mode: SendMode = "direct";
     readonly #outbox = new Map<string, OutboxEntry>();
-    #inFlight = false;
+    /** Frames sent but not yet flushed. The window is bounded by bytes (`ws.bufferedAmount`), not count. */
+    #inFlightCount = 0;
     #seq = 0;
     #disposed = false;
     #capWarned = false;
@@ -200,16 +202,19 @@ export class WebSocketConnection {
     }
 
     #drain(): void {
-        if (this.#inFlight || this.#mode !== "queued") return;
+        if (this.#mode !== "queued") return;
         if (this.#ws.readyState !== OPEN) {
             this.#outbox.clear();
             return;
         }
-        while (this.#outbox.size > 0) {
+        // Keep the pipe full: send while there is a queued frame and the in-flight bytes are still
+        // below the mark. A single frame is always allowed through when nothing is in flight, so a
+        // frame larger than the mark can't wedge the drain.
+        while (this.#outbox.size > 0 && (this.#inFlightCount === 0 || this.#ws.bufferedAmount < this.#highWater)) {
             const [key, entry] = this.#outbox.entries().next().value as [string, OutboxEntry];
             this.#outbox.delete(key);
-            // #drain runs inside the ws send-completion callback, so a throwing builder would escape
-            // as an uncaught exception. Treat a throw like an undefined frame: log it and skip on.
+            // A throwing builder would escape into the ws flush callback as an uncaught exception.
+            // Treat a throw like an undefined frame: log it and skip on.
             let frame: string | undefined;
             try {
                 frame = entry.build();
@@ -219,17 +224,15 @@ export class WebSocketConnection {
             }
             if (frame === undefined) continue;
             this.#raiseHighWater(frame);
-            this.#inFlight = true;
-            this.#watchdogTimer.start();
+            if (this.#inFlightCount === 0) this.#armWatchdog();
+            this.#inFlightCount++;
             this.#ws.send(frame, err => this.#onFlushed(err));
-            return;
         }
-        this.#exitQueued();
+        if (this.#outbox.size === 0 && this.#inFlightCount === 0) this.#exitQueued();
     }
 
     #onFlushed(err?: Error): void {
-        this.#inFlight = false;
-        this.#watchdogTimer.stop();
+        this.#inFlightCount--;
         if (this.#disposed) return;
         if (err !== undefined) {
             // A send error means the socket is dead. Dispose to release the queued closures, then
@@ -239,6 +242,10 @@ export class WebSocketConnection {
             this.#ws.terminate();
             return;
         }
+        // A flush is progress: restart the watchdog while frames remain in flight, stop it when the
+        // window empties. So it fires only when an in-flight send makes no progress for the interval.
+        if (this.#inFlightCount > 0) this.#armWatchdog();
+        else this.#watchdogTimer.stop();
         this.#drain();
     }
 
@@ -249,8 +256,14 @@ export class WebSocketConnection {
         logger.notice(`[${this.#connId}] outbound drained — leaving backpressure mode`);
     }
 
+    /** (Re)start the watchdog with a fresh interval. Explicit stop+start so a restart resets the deadline regardless of timer implementation. */
+    #armWatchdog(): void {
+        this.#watchdogTimer.stop();
+        this.#watchdogTimer.start();
+    }
+
     #onWatchdog(): void {
-        if (this.#disposed || !this.#inFlight) return;
+        if (this.#disposed || this.#inFlightCount === 0) return;
         logger.warn(`[${this.#connId}] outbound send stalled beyond watchdog — terminating dead connection`);
         // Dispose first so no further sends happen, then terminate (not a graceful close): a
         // half-open socket may never complete a graceful close, but terminate forces the "close"

--- a/packages/ws-controller/src/server/WebSocketConnection.ts
+++ b/packages/ws-controller/src/server/WebSocketConnection.ts
@@ -12,6 +12,7 @@ const logger = Logger.get("WebSocketConnection");
 export interface OutboundSocket {
     readonly bufferedAmount: number;
     readonly readyState: number;
+    /** `cb` is invoked when the frame is flushed. Like `ws`, it must fire asynchronously, not inline. */
     send(data: string, cb?: (err?: Error) => void): void;
     close(code?: number, reason?: string): void;
     terminate(): void;
@@ -81,6 +82,8 @@ export class WebSocketConnection {
     readonly #outbox = new Map<string, OutboxEntry>();
     /** Frames sent but not yet flushed. The window is bounded by bytes (`ws.bufferedAmount`), not count. */
     #inFlightCount = 0;
+    /** Guards the drain loop against re-entry, in case a flush callback ever fires inline. */
+    #draining = false;
     #seq = 0;
     #disposed = false;
     #capWarned = false;
@@ -202,31 +205,37 @@ export class WebSocketConnection {
     }
 
     #drain(): void {
-        if (this.#mode !== "queued") return;
+        if (this.#mode !== "queued" || this.#draining) return;
         if (this.#ws.readyState !== OPEN) {
             this.#outbox.clear();
             return;
         }
         // Keep the pipe full: send while there is a queued frame and the in-flight bytes are still
         // below the mark. A single frame is always allowed through when nothing is in flight, so a
-        // frame larger than the mark can't wedge the drain.
-        while (this.#outbox.size > 0 && (this.#inFlightCount === 0 || this.#ws.bufferedAmount < this.#highWater)) {
-            const [key, entry] = this.#outbox.entries().next().value as [string, OutboxEntry];
-            this.#outbox.delete(key);
-            // A throwing builder would escape into the ws flush callback as an uncaught exception.
-            // Treat a throw like an undefined frame: log it and skip on.
-            let frame: string | undefined;
-            try {
-                frame = entry.build();
-            } catch (err) {
-                logger.error(`[${this.#connId}] failed to build queued frame; dropping it`, err);
-                continue;
+        // frame larger than the mark can't wedge the drain. The #draining guard keeps an inline flush
+        // callback from re-entering the loop; the outer iteration picks up the freed window instead.
+        this.#draining = true;
+        try {
+            while (this.#outbox.size > 0 && (this.#inFlightCount === 0 || this.#ws.bufferedAmount < this.#highWater)) {
+                const [key, entry] = this.#outbox.entries().next().value as [string, OutboxEntry];
+                this.#outbox.delete(key);
+                // A throwing builder would escape into the ws flush callback as an uncaught exception.
+                // Treat a throw like an undefined frame: log it and skip on.
+                let frame: string | undefined;
+                try {
+                    frame = entry.build();
+                } catch (err) {
+                    logger.error(`[${this.#connId}] failed to build queued frame; dropping it`, err);
+                    continue;
+                }
+                if (frame === undefined) continue;
+                this.#raiseHighWater(frame);
+                if (this.#inFlightCount === 0) this.#armWatchdog();
+                this.#inFlightCount++;
+                this.#ws.send(frame, err => this.#onFlushed(err));
             }
-            if (frame === undefined) continue;
-            this.#raiseHighWater(frame);
-            if (this.#inFlightCount === 0) this.#armWatchdog();
-            this.#inFlightCount++;
-            this.#ws.send(frame, err => this.#onFlushed(err));
+        } finally {
+            this.#draining = false;
         }
         if (this.#outbox.size === 0 && this.#inFlightCount === 0) this.#exitQueued();
     }

--- a/packages/ws-controller/test/WebSocketConnectionTest.ts
+++ b/packages/ws-controller/test/WebSocketConnectionTest.ts
@@ -299,10 +299,9 @@ describe("WebSocketConnection", () => {
             expect(conn.outboxSize).to.equal(3); // {keep, e3, e4}
 
             for (let i = 0; i < 6 && socket.pendingCount > 0; i++) socket.flushOne();
-            expect(socket.sent).to.include(f(50, "keep"));
-            expect(socket.sent).to.include(f(50, "e3"));
-            expect(socket.sent).to.include(f(50, "e4"));
-            expect(socket.sent).to.not.include(f(50, "e1"));
+            // Exact sequence: the window (w1,w2) sent first, then the survivors keep,e3,e4 in order —
+            // the oldest ordered entries e1,e2 were dropped and nothing extra slipped through.
+            expect(socket.sent).to.deep.equal([f(50, "w1"), f(50, "w2"), f(50, "keep"), f(50, "e3"), f(50, "e4")]);
         });
 
         it("scales the cap with node count (nodeCount * capPerNode)", () => {

--- a/packages/ws-controller/test/WebSocketConnectionTest.ts
+++ b/packages/ws-controller/test/WebSocketConnectionTest.ts
@@ -9,10 +9,15 @@ import { OutboundSocket, WebSocketConnection } from "../src/server/WebSocketConn
 
 const OPEN = 1;
 
+/** A frame of exactly `bytes` bytes, optionally tagged (tag padded out) so it stays identifiable. */
+function f(bytes: number, tag = "x"): string {
+    return tag.padEnd(bytes, "x").slice(0, bytes);
+}
+
 /**
- * Controllable stand-in for a `ws` socket. `bufferedAmount` is set directly by the test to simulate
- * congestion; queued-mode sends carry a callback that the test releases via {@link flushOne} to step
- * the drain pump deterministically.
+ * Controllable stand-in for a `ws` socket. It tracks `bufferedAmount` from real byte lengths — sends
+ * add, {@link flushOne} (simulating the peer draining a frame) subtracts and fires that frame's send
+ * callback — so the connection's byte-windowed drain behaves as it would against a real socket.
  */
 class FakeSocket implements OutboundSocket {
     bufferedAmount = 0;
@@ -20,11 +25,13 @@ class FakeSocket implements OutboundSocket {
     terminated = false;
     readonly sent = new Array<string>();
     readonly closes = new Array<{ code?: number; reason?: string }>();
-    #pending = new Array<(err?: Error) => void>();
+    #pending = new Array<{ bytes: number; cb?: (err?: Error) => void }>();
 
     send(data: string, cb?: (err?: Error) => void): void {
         this.sent.push(data);
-        if (cb) this.#pending.push(cb);
+        const bytes = Buffer.byteLength(data);
+        this.bufferedAmount += bytes;
+        this.#pending.push({ bytes, cb });
     }
 
     close(code?: number, reason?: string): void {
@@ -37,11 +44,12 @@ class FakeSocket implements OutboundSocket {
         this.readyState = 3;
     }
 
-    /** Release the oldest held send callback, as if that frame flushed to the OS socket. */
+    /** Release the oldest in-flight frame, as if the peer drained it: shrink the buffer, fire its callback. */
     flushOne(err?: Error): void {
-        const cb = this.#pending.shift();
-        if (cb === undefined) throw new Error("no pending send callback to flush");
-        cb(err);
+        const p = this.#pending.shift();
+        if (p === undefined) throw new Error("no pending send to flush");
+        this.bufferedAmount -= p.bytes;
+        p.cb?.(err);
     }
 
     get pendingCount(): number {
@@ -49,10 +57,12 @@ class FakeSocket implements OutboundSocket {
     }
 }
 
+/** ceiling === floor so the mark is fixed at 100 and a frame over 100 bytes trips queued mode. */
 function makeConn(socket: FakeSocket, overrides: Partial<ConstructorParameters<typeof WebSocketConnection>[1]> = {}) {
     return new WebSocketConnection(socket, {
         connId: "test",
         highWaterBytes: 100,
+        highWaterCeilingBytes: 100,
         capBase: 1000,
         capPerNode: 20,
         watchdog: Millis(300_000),
@@ -61,11 +71,11 @@ function makeConn(socket: FakeSocket, overrides: Partial<ConstructorParameters<t
     });
 }
 
-/** Drive one direct send that trips the high-water mark, leaving the connection in queued mode. */
+/** Trip into queued mode with one over-the-mark frame, then flush it so the window starts empty. */
 function enterQueued(socket: FakeSocket, conn: WebSocketConnection): void {
-    socket.bufferedAmount = 200;
-    conn.sendReliable("<trigger>");
-    socket.bufferedAmount = 0;
+    conn.sendReliable(f(150, "<trigger>"));
+    socket.flushOne();
+    socket.sent.length = 0;
 }
 
 describe("WebSocketConnection", () => {
@@ -88,136 +98,110 @@ describe("WebSocketConnection", () => {
             const socket = new FakeSocket();
             const conn = makeConn(socket);
 
-            socket.bufferedAmount = 101;
-            conn.sendOrdered("a");
-
-            expect(socket.sent).to.deep.equal(["a"]);
-            expect(conn.mode).to.equal("queued");
-        });
-
-        it("does not trip on a single large frame — high-water scales to 2x the largest frame", () => {
-            const socket = new FakeSocket();
-            const conn = makeConn(socket); // 100-byte floor
-
-            const big = "x".repeat(200); // 200 bytes, well over the 100-byte floor
-            // FakeSocket.send doesn't track size, so pre-set the bufferedAmount the congestion check
-            // will read after this frame is sent.
-            socket.bufferedAmount = 200;
-            conn.sendReliable(big);
-
-            // A single legitimate large payload (e.g. the initial start_listening dump) must not be
-            // mistaken for a stalled consumer: the water mark rises to 2x its size.
-            expect(conn.mode).to.equal("direct");
-        });
-
-        it("still trips when backlog grows past 2x the largest frame (stalled consumer)", () => {
-            const socket = new FakeSocket();
-            const conn = makeConn(socket); // 100-byte floor
-
-            const big = "x".repeat(200);
-            conn.sendReliable(big); // raises high-water to 400
-            socket.bufferedAmount = 500; // backlog now exceeds 2x the largest frame
-            conn.sendReliable("y");
-
-            expect(conn.mode).to.equal("queued");
-        });
-
-        it("clamps the initial high-water to the ceiling when a floor above the ceiling is configured", () => {
-            const socket = new FakeSocket();
-            const conn = makeConn(socket, { highWaterBytes: 1000, highWaterCeilingBytes: 500 });
-
-            socket.bufferedAmount = 600; // above the ceiling, below the misconfigured floor
-            conn.sendReliable("y");
-
-            // The ceiling is an absolute cap; a floor mistakenly set above it must not raise the mark.
-            expect(conn.mode).to.equal("queued");
-        });
-
-        it("caps the dynamic high-water at the ceiling", () => {
-            const socket = new FakeSocket();
-            const conn = makeConn(socket, { highWaterBytes: 100, highWaterCeilingBytes: 1000 });
-
-            conn.sendReliable("x".repeat(800)); // 2x = 1600, but ceiling clamps to 1000
-            socket.bufferedAmount = 1100; // above the ceiling, below the un-clamped 1600
-            conn.sendReliable("y");
+            conn.sendOrdered(f(150)); // one frame over the 100-byte mark
 
             expect(conn.mode).to.equal("queued");
         });
     });
 
-    describe("queued mode", () => {
-        it("enqueues instead of sending, draining one frame per flushed callback", () => {
+    describe("dynamic high-water", () => {
+        it("does not trip on a single large frame — the mark scales to 2x the largest frame", () => {
             const socket = new FakeSocket();
-            const conn = makeConn(socket);
-            enterQueued(socket, conn);
+            const conn = makeConn(socket, { highWaterBytes: 100, highWaterCeilingBytes: 10_000 });
 
-            conn.sendOrdered("x");
-            conn.sendOrdered("y");
+            conn.sendReliable(f(200)); // mark rises to 400; bufferedAmount 200 < 400
 
-            expect(socket.sent).to.deep.equal(["<trigger>", "x"]);
-            expect(conn.outboxSize).to.equal(1);
-
-            socket.flushOne();
-            expect(socket.sent).to.deep.equal(["<trigger>", "x", "y"]);
+            expect(conn.mode).to.equal("direct");
         });
 
-        it("returns to direct mode once the outbox drains empty", () => {
+        it("still trips when backlog grows past 2x the largest frame (stalled consumer)", () => {
+            const socket = new FakeSocket();
+            const conn = makeConn(socket, { highWaterBytes: 100, highWaterCeilingBytes: 10_000 });
+
+            conn.sendReliable(f(200)); // mark → 400, direct
+            conn.sendReliable(f(200)); // bufferedAmount 400, still not > 400
+            conn.sendReliable(f(200)); // bufferedAmount 600 > 400 → trips
+
+            expect(conn.mode).to.equal("queued");
+        });
+
+        it("caps the dynamic mark at the ceiling", () => {
+            const socket = new FakeSocket();
+            const conn = makeConn(socket, { highWaterBytes: 100, highWaterCeilingBytes: 1000 });
+
+            conn.sendReliable(f(800)); // 2x = 1600, clamped to 1000; bufferedAmount 800 < 1000, direct
+            conn.sendReliable(f(300)); // bufferedAmount 1100 > 1000 → trips (proves clamp to 1000, not 1600)
+
+            expect(conn.mode).to.equal("queued");
+        });
+
+        it("clamps the initial mark to the ceiling when a floor above the ceiling is configured", () => {
+            const socket = new FakeSocket();
+            const conn = makeConn(socket, { highWaterBytes: 1000, highWaterCeilingBytes: 500 });
+
+            conn.sendReliable(f(600)); // above the 500 ceiling → trips; a floor of 1000 must not apply
+
+            expect(conn.mode).to.equal("queued");
+        });
+    });
+
+    describe("queued mode (byte-windowed drain)", () => {
+        it("keeps up to high-water bytes in flight and queues the rest", () => {
             const socket = new FakeSocket();
             const conn = makeConn(socket);
             enterQueued(socket, conn);
 
-            conn.sendOrdered("x");
+            conn.sendOrdered(f(50, "e1"));
+            conn.sendOrdered(f(50, "e2"));
+            conn.sendOrdered(f(50, "e3"));
+            conn.sendOrdered(f(50, "e4"));
+
+            // Window is 100 bytes: e1+e2 (100) are in flight, e3+e4 wait in the outbox.
+            expect(socket.sent.length).to.equal(2);
+            expect(conn.outboxSize).to.equal(2);
+
+            socket.flushOne(); // frees 50 bytes → e3 goes
+            expect(socket.sent.length).to.equal(3);
+            socket.flushOne(); // → e4 goes
+            expect(socket.sent.length).to.equal(4);
+        });
+
+        it("returns to direct mode once the outbox drains and the window empties", () => {
+            const socket = new FakeSocket();
+            const conn = makeConn(socket);
+            enterQueued(socket, conn);
+
+            conn.sendOrdered(f(50, "e1"));
             expect(conn.mode).to.equal("queued");
 
             socket.flushOne();
             expect(conn.mode).to.equal("direct");
         });
 
-        it("disposes on a send error, releasing queued frames and refusing further sends", () => {
+        it("coalesces same-key sends beyond the window to one frame, built once, keeping first position", () => {
             const socket = new FakeSocket();
             const conn = makeConn(socket);
             enterQueued(socket, conn);
 
-            conn.sendOrdered("x"); // in flight
-            conn.sendOrdered("y"); // queued behind it
-            expect(conn.outboxSize).to.equal(1);
+            conn.sendOrdered(f(50, "w1")); // fill the window
+            conn.sendOrdered(f(50, "w2"));
 
-            socket.flushOne(new Error("socket write failed"));
-
-            // A send error means the socket is dead: drop the queued closures now instead of pinning
-            // them until a close event, terminate to force that close event (so the handler removes
-            // the connection), and send nothing more.
-            expect(conn.outboxSize).to.equal(0);
-            expect(socket.terminated).to.equal(true);
-            const before = socket.sent.length;
-            conn.sendReliable("late");
-            expect(socket.sent.length).to.equal(before);
-        });
-
-        it("coalesces same-key sends to one frame, built once, keeping first position", () => {
-            const socket = new FakeSocket();
-            const conn = makeConn(socket);
-            enterQueued(socket, conn);
-
-            conn.sendOrdered("blocker"); // occupies the single in-flight slot
             let builds = 0;
-            conn.sendCoalescable("k", () => {
+            const build = () => {
                 builds++;
-                return "v-latest";
-            });
-            conn.sendCoalescable("k", () => {
-                builds++;
-                return "v-latest";
-            });
-            conn.sendOrdered("after");
+                return f(50, "kv");
+            };
+            conn.sendCoalescable("k", build);
+            conn.sendCoalescable("k", build); // coalesces onto the first
+            conn.sendOrdered(f(50, "after"));
 
             expect(conn.outboxSize).to.equal(2); // {k, after}
-            socket.flushOne(); // blocker flushed -> drains k
+            socket.flushOne(); // w1 flushed → drains k
             expect(builds).to.equal(1);
-            expect(socket.sent).to.deep.equal(["<trigger>", "blocker", "v-latest"]);
+            expect(socket.sent[socket.sent.length - 1]).to.equal(f(50, "kv"));
 
-            socket.flushOne(); // k flushed -> drains after
-            expect(socket.sent[socket.sent.length - 1]).to.equal("after");
+            socket.flushOne(); // w2 flushed → drains after
+            expect(socket.sent[socket.sent.length - 1]).to.equal(f(50, "after"));
         });
 
         it("skips a coalescable whose builder returns undefined", () => {
@@ -225,29 +209,29 @@ describe("WebSocketConnection", () => {
             const conn = makeConn(socket);
             enterQueued(socket, conn);
 
-            conn.sendOrdered("blocker");
+            conn.sendOrdered(f(50, "w1"));
+            conn.sendOrdered(f(50, "w2")); // window full
             conn.sendCoalescable("gone", () => undefined);
-            conn.sendOrdered("after");
+            conn.sendOrdered(f(50, "after"));
 
-            socket.flushOne(); // blocker -> skip gone -> send after
-            expect(socket.sent).to.deep.equal(["<trigger>", "blocker", "after"]);
+            socket.flushOne(); // w1 → skip gone → send after
+            expect(socket.sent[socket.sent.length - 1]).to.equal(f(50, "after"));
         });
 
-        it("skips a coalescable whose builder throws, without escaping the drain pump", () => {
+        it("skips a coalescable whose builder throws, without escaping the drain", () => {
             const socket = new FakeSocket();
             const conn = makeConn(socket);
             enterQueued(socket, conn);
 
-            conn.sendOrdered("blocker");
+            conn.sendOrdered(f(50, "w1"));
+            conn.sendOrdered(f(50, "w2"));
             conn.sendCoalescable("boom", () => {
                 throw new Error("build failed");
             });
-            conn.sendOrdered("after");
+            conn.sendOrdered(f(50, "after"));
 
-            // The throwing entry drains via the flushed callback; it must not propagate out of the
-            // ws send-completion callback (which would become an uncaught exception in production).
             expect(() => socket.flushOne()).to.not.throw();
-            expect(socket.sent).to.deep.equal(["<trigger>", "blocker", "after"]);
+            expect(socket.sent[socket.sent.length - 1]).to.equal(f(50, "after"));
         });
 
         it("sendReliable bypasses the queue and sends immediately even while congested", () => {
@@ -255,11 +239,33 @@ describe("WebSocketConnection", () => {
             const conn = makeConn(socket);
             enterQueued(socket, conn);
 
-            conn.sendOrdered("blocker");
-            conn.sendReliable("urgent");
+            conn.sendOrdered(f(50, "w1"));
+            conn.sendOrdered(f(50, "w2")); // window full
+            conn.sendOrdered(f(50, "queued")); // waits in outbox
+            expect(conn.outboxSize).to.equal(1);
 
-            expect(socket.sent).to.deep.equal(["<trigger>", "blocker", "urgent"]);
+            conn.sendReliable("urgent");
+            expect(socket.sent[socket.sent.length - 1]).to.equal("urgent");
+            expect(conn.outboxSize).to.equal(1); // queued frame untouched
+        });
+
+        it("disposes on a send error, releasing queued frames and refusing further sends", () => {
+            const socket = new FakeSocket();
+            const conn = makeConn(socket);
+            enterQueued(socket, conn);
+
+            conn.sendOrdered(f(50, "w1"));
+            conn.sendOrdered(f(50, "w2"));
+            conn.sendOrdered(f(50, "q1")); // queued behind the window
+            expect(conn.outboxSize).to.equal(1);
+
+            socket.flushOne(new Error("socket write failed"));
+
             expect(conn.outboxSize).to.equal(0);
+            expect(socket.terminated).to.equal(true);
+            const before = socket.sent.length;
+            conn.sendReliable("late");
+            expect(socket.sent.length).to.equal(before);
         });
     });
 
@@ -282,20 +288,21 @@ describe("WebSocketConnection", () => {
             const conn = makeConn(socket, { capBase: 3, capPerNode: 0 });
             enterQueued(socket, conn);
 
-            conn.sendOrdered("blocker"); // in flight, not in outbox
-            conn.sendCoalescable("keep", () => "keep");
-            conn.sendOrdered("e1");
-            conn.sendOrdered("e2");
-            conn.sendOrdered("e3");
-            conn.sendOrdered("e4"); // {keep,e1,e2,e3,e4} exceeds cap 3 -> oldest ordered e1,e2 dropped
+            conn.sendOrdered(f(50, "w1")); // fill window (2 frames of 50 = 100)
+            conn.sendOrdered(f(50, "w2"));
+            conn.sendCoalescable("keep", () => f(50, "keep"));
+            conn.sendOrdered(f(50, "e1"));
+            conn.sendOrdered(f(50, "e2"));
+            conn.sendOrdered(f(50, "e3"));
+            conn.sendOrdered(f(50, "e4")); // {keep,e1,e2,e3,e4} over cap 3 → drop oldest ordered e1,e2
 
             expect(conn.outboxSize).to.equal(3); // {keep, e3, e4}
 
-            for (let i = 0; i < 4 && socket.pendingCount > 0; i++) {
-                socket.flushOne();
-            }
-            // after blocker flush, survivors drain in order: keep, e3, e4 (e1/e2 dropped, keep never dropped).
-            expect(socket.sent.slice(2)).to.deep.equal(["keep", "e3", "e4"]);
+            for (let i = 0; i < 6 && socket.pendingCount > 0; i++) socket.flushOne();
+            expect(socket.sent).to.include(f(50, "keep"));
+            expect(socket.sent).to.include(f(50, "e3"));
+            expect(socket.sent).to.include(f(50, "e4"));
+            expect(socket.sent).to.not.include(f(50, "e1"));
         });
 
         it("scales the cap with node count (nodeCount * capPerNode)", () => {
@@ -303,8 +310,9 @@ describe("WebSocketConnection", () => {
             const conn = makeConn(socket, { capBase: 3, capPerNode: 20, getNodeCount: () => 10 });
             enterQueued(socket, conn);
 
-            conn.sendOrdered("blocker");
-            for (let i = 0; i < 250; i++) conn.sendOrdered(`e${i}`);
+            conn.sendOrdered(f(50, "w1"));
+            conn.sendOrdered(f(50, "w2")); // window full; the rest queue
+            for (let i = 0; i < 250; i++) conn.sendOrdered(f(50, `e${i}`));
 
             expect(conn.outboxSize).to.equal(200); // capped at max(3, 10*20)
         });
@@ -316,28 +324,44 @@ describe("WebSocketConnection", () => {
             const conn = makeConn(socket, { watchdog: Millis(300_000) });
             enterQueued(socket, conn);
 
-            conn.sendOrdered("stuck"); // in flight, callback never released
+            conn.sendOrdered(f(50, "stuck")); // in flight, callback never released
 
             expect(socket.terminated).to.equal(false);
             await MockTime.advance(Millis(300_000));
 
-            // terminate() (not a graceful close) forces the ws "close" event so the handler removes
-            // the dead connection even when a half-open socket would never emit close on its own.
             expect(socket.terminated).to.equal(true);
-            // Disposed: no further frames are queued or sent after the watchdog gives up.
             const before = socket.sent.length;
             conn.sendReliable("late");
             expect(socket.sent.length).to.equal(before);
         });
 
-        it("does not terminate when the in-flight send flushes in time", async () => {
+        it("does not terminate while in-flight sends keep flushing in time", async () => {
             const socket = new FakeSocket();
             const conn = makeConn(socket, { watchdog: Millis(300_000) });
             enterQueued(socket, conn);
 
-            conn.sendOrdered("ok");
+            conn.sendOrdered(f(50, "ok"));
             socket.flushOne();
             await MockTime.advance(Millis(300_000));
+
+            expect(socket.terminated).to.equal(false);
+        });
+
+        it("does not terminate a busy window that keeps flushing across intervals (watchdog restarts on progress)", async () => {
+            const socket = new FakeSocket();
+            const conn = makeConn(socket, { watchdog: Millis(300_000) });
+            enterQueued(socket, conn);
+
+            // Window holds 2; keep 4 more queued so every flush pulls a replacement and the window
+            // never empties (frames stay in flight throughout).
+            for (let i = 1; i <= 6; i++) conn.sendOrdered(f(50, `e${i}`));
+
+            // Advance well past the watchdog interval in total, but flush a frame each step (< interval
+            // apart), so progress keeps resetting the deadline. It must never terminate.
+            for (let step = 0; step < 4; step++) {
+                await MockTime.advance(Millis(200_000));
+                socket.flushOne();
+            }
 
             expect(socket.terminated).to.equal(false);
         });

--- a/packages/ws-controller/test/WsBackpressureLatencyReproTest.ts
+++ b/packages/ws-controller/test/WsBackpressureLatencyReproTest.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Root-cause repro + fix guard for the reported dashboard disconnect (docs/plans/ws-backpressure.md).
+ *
+ * The browser dashboard reaches the server through the Home Assistant ingress proxy, which relays
+ * WebSocket frames with a non-trivial per-frame round-trip latency L. {@link LatentSocket} models that
+ * link: a sent frame occupies `bufferedAmount` until it "arrives" one L later, at which point its
+ * flush callback fires (as a real socket's write callback does once the peer drains it).
+ *
+ * The original strictly-one-in-flight drain sent the next queued frame only after the previous frame's
+ * callback, so a burst of N frames serialized to N x L — over a latent link that stalls initial sync
+ * long enough for ingress to time out and close. The windowed drain keeps up to `highWater` bytes in
+ * flight, so a burst pipelines (bounded latency) while memory stays bounded. On a zero-latency link the
+ * two are indistinguishable, which is why the bug only surfaced through ingress.
+ */
+
+import { Millis, Time } from "@matter/main";
+import { OutboundSocket, WebSocketConnection } from "../src/server/WebSocketConnection.js";
+
+const OPEN = 1;
+const L = Millis(100); // per-frame link latency (ingress relay round-trip)
+const FRAME_BYTES = 20;
+const HIGH_WATER = 100; // window = HIGH_WATER / FRAME_BYTES = 5 frames in flight
+const WINDOW_FRAMES = HIGH_WATER / FRAME_BYTES;
+const BURST = 10;
+
+/** A frame of exactly FRAME_BYTES bytes, tagged with an index for readability. */
+function frame(i: number): string {
+    return `e${i}`.padEnd(FRAME_BYTES, "x");
+}
+
+/** A WS link where each frame occupies bufferedAmount until it arrives (and its callback fires) L later. */
+class LatentSocket implements OutboundSocket {
+    bufferedAmount = 0;
+    readyState = OPEN;
+    readonly delivered = new Array<string>();
+    #seq = 0;
+
+    send(data: string, cb?: (err?: Error) => void): void {
+        const bytes = Buffer.byteLength(data);
+        this.bufferedAmount += bytes;
+        Time.getTimer(`latent-${this.#seq++}`, L, () => {
+            this.bufferedAmount -= bytes;
+            this.delivered.push(data);
+            cb?.();
+        }).start();
+    }
+
+    close(): void {
+        this.readyState = 3;
+    }
+
+    terminate(): void {
+        this.readyState = 3;
+    }
+}
+
+describe("WS backpressure latency repro (ingress-style link)", () => {
+    beforeEach(() => MockTime.init());
+
+    it("direct mode pipelines a burst — all frames arrive after one link latency", async () => {
+        const socket = new LatentSocket();
+        const conn = new WebSocketConnection(socket, { connId: "direct", highWaterBytes: 10_000_000 });
+
+        for (let i = 1; i <= BURST; i++) conn.sendOrdered(frame(i));
+        expect(conn.mode).to.equal("direct");
+
+        await MockTime.advance(L);
+        expect(socket.delivered.length).to.equal(BURST);
+    });
+
+    it("queued mode keeps the window full — a burst pipelines instead of serializing to N x L", async () => {
+        const socket = new LatentSocket();
+        const conn = new WebSocketConnection(socket, {
+            connId: "queued",
+            highWaterBytes: HIGH_WATER,
+            highWaterCeilingBytes: HIGH_WATER,
+        });
+
+        conn.sendReliable(frame(0).padEnd(HIGH_WATER + 1, "x")); // one frame over the ceiling trips queued
+        expect(conn.mode).to.equal("queued");
+        await MockTime.advance(L); // flush the trigger
+        socket.delivered.length = 0;
+
+        for (let i = 1; i <= BURST; i++) conn.sendOrdered(frame(i));
+
+        // One window's worth is in flight at once (not a single frame), so the first latency window
+        // delivers the whole window rather than one frame. Strict one-in-flight would deliver just 1.
+        await MockTime.advance(L);
+        expect(socket.delivered.length, "frames delivered after one latency window").to.equal(WINDOW_FRAMES);
+
+        // The whole burst clears in BURST/WINDOW windows, not BURST windows.
+        await MockTime.advance(L);
+        expect(socket.delivered.length).to.equal(BURST);
+    });
+});


### PR DESCRIPTION
## Problem

Real users on large networks saw the browser dashboard connect, then drop and reconnect in a loop. Root cause traced to the per-connection backpressure feature: when a connection entered **queued** mode, the outbox drained **strictly one frame in flight** — the next frame was sent only after the previous frame's flush callback.

The dashboard reaches the server through the **Home Assistant ingress proxy** (`ws://.../api/hassio_ingress/.../ws`), which relays frames with a per-frame round-trip latency `L`. One-in-flight **serializes** that latency: a burst of N frames takes `N×L` instead of pipelining (~`L`). During initial sync (many node/attribute frames) that stretched delivery past ingress's timeout → ingress closed the socket → the dashboard's pending command rejected → reconnect loop. On localhost `L≈0`, so it was invisible — which is why it only appeared through ingress and not in local tests.

(Command responses were never the issue — `sendReliable` bypasses the queue. The stall was the *paced push stream* over the latent relay.)

## Change

Drain a **byte window** instead of one frame:

- In queued mode, keep sending queued frames while `ws.bufferedAmount < highWater`, so the pipe stays full and a burst **pipelines** (~one round-trip total) instead of `N×L`.
- In-flight tracked by count (`#inFlightCount`) rather than a boolean; in-flight bytes bounded by `highWater` + one frame, so the memory/OOM guard is unchanged.
- A single frame larger than the mark still goes through (escape hatch when nothing is in flight) — no wedge.
- The **watchdog restarts on each flush** (progress), via explicit stop+start, so a busy-but-flushing connection is never terminated while a genuinely stalled in-flight send still is.

## Tests

- New `WsBackpressureLatencyReproTest.ts` — models an ingress-style latent link with MockTime and proves a burst pipelines (direct **and** windowed deliver a window per latency step) where strict one-in-flight would deliver one frame per step.
- `WebSocketConnectionTest.ts` reworked for windowed semantics: `FakeSocket` now models `bufferedAmount` from real byte lengths; tests assert the window holds up to `highWater` bytes with the rest queued, coalescing/cap/skip/reliable-bypass/send-error all gated behind a filled window, and a watchdog restart-on-progress test (busy window flushing across intervals is not killed).

Full suite green (ws-controller 197, ws-client 73, dashboard 56, ble-proxy 34, matter-server 251); format, lint, build clean. Confirmed against the user's browser log (fix resolves the disconnect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)