### PR TITLE
fix(ws-controller): serve REST-only diagnostics for undialable Thread BRs

### DIFF
--- a/packages/dashboard/src/pages/network/network-details.ts
+++ b/packages/dashboard/src/pages/network/network-details.ts
@@ -923,10 +923,14 @@ export class NetworkDetails extends LitElement {
             <md-divider></md-divider>
             <div class="section">
                 ${heading}${errorBanner}
-                <div class="info-row">
-                    <span class="label">Source:</span>
-                    <span class="value">${batch.source}</span>
-                </div>
+                ${batch.source !== "none"
+                    ? html`
+                          <div class="info-row">
+                              <span class="label">Source:</span>
+                              <span class="value">${batch.source}</span>
+                          </div>
+                      `
+                    : nothing}
                 <div class="info-row">
                     <span class="label">Updated:</span>
                     <span class="value">${collected}</span>

--- a/packages/ws-client/src/models/model.ts
+++ b/packages/ws-client/src/models/model.ts
@@ -198,8 +198,12 @@ export interface ThreadDiagnosticsBatch {
     networkName: string;
     /** Epoch ms when the batch was assembled. */
     collectedAt: number;
-    /** Which transport produced it: MeshCoP (CoAP/DTLS) or the OTBR REST API. */
-    source: "meshcop" | "otbr-rest";
+    /**
+     * Which transport produced it: MeshCoP (CoAP/DTLS) or the OTBR REST API.
+     * `"none"` when no transport was attempted (e.g. a terminal `border_router_unreachable`
+     * or `no_credentials` partial).
+     */
+    source: "meshcop" | "otbr-rest" | "none";
     nodes: ThreadDiagnosticsNode[];
     /** Set when the snapshot is partial or the query could not complete; see {@link ThreadDiagnosticsPartialReason}. */
     partialReason?: ThreadDiagnosticsPartialReason;

--- a/packages/ws-controller/src/controller/ThreadDiagnosticsService.ts
+++ b/packages/ws-controller/src/controller/ThreadDiagnosticsService.ts
@@ -44,7 +44,8 @@ export interface ThreadDiagnosticsBatch {
     networkName: string;
     /** Epoch ms when the batch was assembled. */
     collectedAt: number;
-    source: "meshcop" | "otbr-rest";
+    /** Transport that produced the batch; `"none"` when no transport was attempted (terminal partials). */
+    source: "meshcop" | "otbr-rest" | "none";
     nodes: ReadonlyArray<DiagnosticResponse>;
     partialReason?: ThreadDiagnosticsPartialReason;
 }
@@ -135,6 +136,7 @@ export class ThreadDiagnosticsService {
     readonly #cache = new Map<string, ThreadDiagnosticsBatch>();
     readonly #restCaps = new Map<string, OtbrRestCapability>();
     readonly #streamsInFlight = new Map<string, InFlightStream>();
+    readonly #keyLocks = new Map<string, Promise<void>>();
     readonly #probesInFlight = new Map<string, Promise<void>>();
     readonly #probeAttempted = new Set<string>();
     readonly #cacheTtlMs: number;
@@ -269,7 +271,7 @@ export class ThreadDiagnosticsService {
         if (br === undefined) {
             logger.info(`selectBr returned none xp=${xp} candidates=${matchingBrs.length}`);
             const networkName = matchingBrs[0].networkName ?? this.#cache.get(key)?.networkName ?? "";
-            return this.#publish(this.#partial(key, networkName, "border_router_unreachable"));
+            return this.#fetchRestOnly(key, networkName, matchingBrs, extPanIdBytes, force);
         }
 
         const networkName = br.networkName ?? this.#cache.get(key)?.networkName ?? "";
@@ -300,15 +302,99 @@ export class ThreadDiagnosticsService {
         // stop()'s snapshot has already passed over (it would outlive teardown).
         if (this.#stopped) return undefined;
 
-        if (force) {
-            const existing = this.#streamsInFlight.get(key);
-            if (existing !== undefined) {
-                logger.debug(`force=true canceling in-flight stream xp=${xp}`);
-                await existing.cancel();
+        return this.#cancelAndStart(key, networkName, ranked, extPanIdBytes, force);
+    }
+
+    /**
+     * Diagnostics path for a network whose every BR is undialable (`rankBrs` returned none). MeshCoP
+     * is impossible without a dialable address, but the OTBR REST API needs only the extPanId + a
+     * registered `baseUrl`. Probe for a REST capability (a no-op for an address-less BR, but a cap
+     * cached from an earlier `added`-event probe still counts) and, if one can serve diagnostics,
+     * stream REST-only. Only when no usable cap exists is the network truly `border_router_unreachable`.
+     */
+    async #fetchRestOnly(
+        key: string,
+        networkName: string,
+        matchingBrs: BorderRouterEntry[],
+        extPanIdBytes: Uint8Array,
+        force: boolean,
+    ): Promise<ThreadDiagnosticsBatch | undefined> {
+        const xp = key.toUpperCase();
+
+        if (this.#restCaps.get(key) === undefined) {
+            await this.#probeBrForRest(matchingBrs[0], { force });
+            if (!force) {
+                const joined = this.#streamsInFlight.get(key);
+                if (joined !== undefined) {
+                    logger.debug(`join in-flight stream (rest-only post-probe) xp=${xp}`);
+                    return joined.firstBatch;
+                }
             }
         }
 
-        return this.#startStream(key, networkName, ranked, extPanIdBytes).firstBatch;
+        if (this.#stopped) return undefined;
+
+        const cap = this.#restCaps.get(key);
+        if (cap === undefined || cap.diagnosticsApi === "none") {
+            return this.#publish(this.#partial(key, networkName, "border_router_unreachable"));
+        }
+
+        logger.info(`BRs undialable, using REST-only diagnostics xp=${xp} baseUrl=${cap.baseUrl}`);
+        return this.#cancelAndStart(key, networkName, matchingBrs, extPanIdBytes, force, { restOnly: true });
+    }
+
+    /**
+     * Serialize the cancel-old-then-start-new critical section per network. `#launchStream` registers
+     * the stream synchronously, but a `force` refresh must `await existing.cancel()` first — two
+     * concurrent callers would otherwise each read the same in-flight stream, cancel it, and register a
+     * replacement, leaving two live streams and a `#streamsInFlight` entry that the first stream's
+     * teardown later deletes out from under the second. The per-key lock makes the section atomic;
+     * `firstBatch` is awaited by the caller outside the lock so joiners are not blocked for a window.
+     */
+    async #cancelAndStart(
+        key: string,
+        networkName: string,
+        brs: BorderRouterEntry[],
+        extPanIdBytes: Uint8Array,
+        force: boolean,
+        opts?: { restOnly?: boolean },
+    ): Promise<ThreadDiagnosticsBatch | undefined> {
+        const xp = key.toUpperCase();
+        const stream = await this.#serialize(key, async () => {
+            // A concurrent caller may have registered a stream while we waited on the lock. A
+            // non-force fetch joins it; a force fetch cancels it and starts fresh.
+            const existing = this.#streamsInFlight.get(key);
+            if (existing !== undefined) {
+                if (!force) {
+                    logger.debug(`join in-flight stream (serialized) xp=${xp}`);
+                    return existing;
+                }
+                logger.debug(`force=true canceling in-flight stream xp=${xp}`);
+                await existing.cancel();
+            }
+            if (this.#stopped) return undefined;
+            return this.#startStream(key, networkName, brs, extPanIdBytes, opts);
+        });
+        return stream?.firstBatch;
+    }
+
+    /**
+     * Run `fn` after any previously queued work for `key` has settled, so per-key critical sections
+     * never overlap. The lock entry is dropped once no further work is chained behind it.
+     */
+    async #serialize<T>(key: string, fn: () => Promise<T>): Promise<T> {
+        const prev = this.#keyLocks.get(key) ?? Promise.resolve();
+        const run = prev.then(fn, fn);
+        const tail = run.then(
+            () => {},
+            () => {},
+        );
+        this.#keyLocks.set(key, tail);
+        try {
+            return await run;
+        } finally {
+            if (this.#keyLocks.get(key) === tail) this.#keyLocks.delete(key);
+        }
     }
 
     #startStream(
@@ -316,8 +402,10 @@ export class ThreadDiagnosticsService {
         networkName: string,
         brs: BorderRouterEntry[],
         extPanIdBytes: Uint8Array,
+        opts?: { restOnly?: boolean },
     ): InFlightStream {
         const xp = extPanIdHex.toUpperCase();
+        const restOnly = opts?.restOnly === true;
         const restCap = this.#restCaps.get(extPanIdHex);
         const creds = this.#opts.credentials.getCredentials(extPanIdBytes);
 
@@ -335,7 +423,9 @@ export class ThreadDiagnosticsService {
             };
         }
 
-        return this.#launchStream(extPanIdHex, networkName, () => this.#acquireHybrid(xp, brs, restCap, creds));
+        return this.#launchStream(extPanIdHex, networkName, () =>
+            this.#acquireHybrid(xp, brs, restCap, creds, restOnly),
+        );
     }
 
     /**
@@ -343,19 +433,24 @@ export class ThreadDiagnosticsService {
      * exist the MeshCoP transport is connected up front (DTLS handshake, BR-fallback) so the sync
      * `selectSource` factory can hand back the ready source; REST is stateless. If the MeshCoP
      * connect fails but a REST capability exists, degrade to REST-only by hiding the credentials from
-     * `selectSource` rather than failing the whole fetch.
+     * `selectSource` rather than failing the whole fetch. When `restOnly` is set the credentials are
+     * hidden up front — every BR is undialable, so a MeshCoP connect would only fail before the same
+     * REST degrade; skip it entirely.
      */
     async #acquireHybrid(
         xp: string,
         brs: BorderRouterEntry[],
         restCap: OtbrRestCapability | undefined,
         creds: ThreadNetworkCredentials | undefined,
+        restOnly = false,
     ): Promise<MeshcopSourceHandle> {
         // A "none" cap can't serve diagnostics, so it is not a viable REST fallback for a DTLS failure.
         const restUsable = restCap !== undefined && restCap.diagnosticsApi !== "none";
         let meshHandle: MeshcopSourceHandle | undefined;
         let credentials: Pick<ThreadCredentialsRegistry, "getCredentials"> = this.#opts.credentials;
-        if (creds !== undefined) {
+        if (restOnly) {
+            credentials = { getCredentials: () => undefined };
+        } else if (creds !== undefined) {
             try {
                 meshHandle = await this.#acquireMeshcopWithFallback(xp, creds, brs);
             } catch (err) {
@@ -663,13 +758,13 @@ export class ThreadDiagnosticsService {
         networkName: string,
         partialReason: ThreadDiagnosticsPartialReason,
     ): ThreadDiagnosticsBatch {
-        return this.#partialOf(extPanIdHex, networkName, "meshcop", partialReason);
+        return this.#partialOf(extPanIdHex, networkName, "none", partialReason);
     }
 
     #partialOf(
         extPanIdHex: string,
         networkName: string,
-        source: "meshcop" | "otbr-rest",
+        source: "meshcop" | "otbr-rest" | "none",
         partialReason: ThreadDiagnosticsPartialReason,
     ): ThreadDiagnosticsBatch {
         return {

--- a/packages/ws-controller/src/controller/ThreadDiagnosticsService.ts
+++ b/packages/ws-controller/src/controller/ThreadDiagnosticsService.ts
@@ -269,7 +269,7 @@ export class ThreadDiagnosticsService {
         const ranked = rankBrs(matchingBrs);
         const br = ranked[0];
         if (br === undefined) {
-            logger.info(`selectBr returned none xp=${xp} candidates=${matchingBrs.length}`);
+            logger.info(`rankBrs returned none (no dialable BR addresses) xp=${xp} candidates=${matchingBrs.length}`);
             const networkName = matchingBrs[0].networkName ?? this.#cache.get(key)?.networkName ?? "";
             return this.#fetchRestOnly(key, networkName, matchingBrs, extPanIdBytes, force);
         }

--- a/packages/ws-controller/test/ThreadDiagnosticsServiceTest.ts
+++ b/packages/ws-controller/test/ThreadDiagnosticsServiceTest.ts
@@ -332,7 +332,80 @@ describe("ThreadDiagnosticsService", () => {
 
         const batch = await service.getOrFetch(EXT_PAN_HEX_LOWER);
         expect(batch?.partialReason).to.equal("border_router_unreachable");
+        expect(batch?.source).to.equal("none");
         expect(batch?.nodes).to.deep.equal([]);
+    });
+
+    it("uses REST for an undialable BR (empty addresses) when a cap is registered", async () => {
+        // rankBrs drops address-less BRs (correct for MeshCoP dialing), but REST needs only the
+        // extPanId + a registered baseUrl. The service must consult the REST cap instead of giving
+        // up with border_router_unreachable.
+        let restCalls = 0;
+        let meshcopCalls = 0;
+        const service = new ThreadDiagnosticsService({
+            ...FAST_TIMING,
+            borderRouters: brRegistryFrom(brsListing([makeBr({ addresses: [] })])),
+            credentials: credsRegistryFrom(credsLookup(new Map())),
+            makeRestSource: () => {
+                restCalls += 1;
+                return syncRestSource([SAMPLE_NODE]);
+            },
+            makeMeshcopSource: async () => {
+                meshcopCalls += 1;
+                return meshcopHandle(syncMeshcopSource([]));
+            },
+        });
+        service.registerRestCapability(EXT_PAN_HEX_LOWER, makeCap());
+
+        const batch = await service.getOrFetch(EXT_PAN_HEX_LOWER);
+        expect(batch?.source).to.equal("otbr-rest");
+        expect(batch?.nodes).to.have.lengthOf(1);
+        expect(restCalls).to.equal(1);
+        expect(meshcopCalls).to.equal(0);
+    });
+
+    it("uses REST-only for an undialable BR even when credentials exist (skips MeshCoP)", async () => {
+        // An undialable BR cannot be MeshCoP-dialed even with credentials, so the service must not
+        // attempt a MeshCoP connect that is guaranteed to fail — it goes straight to REST.
+        let meshcopCalls = 0;
+        const service = new ThreadDiagnosticsService({
+            ...FAST_TIMING,
+            borderRouters: brRegistryFrom(brsListing([makeBr({ addresses: [] })])),
+            credentials: credsRegistryFrom(credsLookup(new Map([[EXT_PAN_HEX_LOWER, makeCreds()]]))),
+            makeRestSource: () => syncRestSource([SAMPLE_NODE]),
+            makeMeshcopSource: async () => {
+                meshcopCalls += 1;
+                return meshcopHandle(syncMeshcopSource([SAMPLE_NODE]));
+            },
+        });
+        service.registerRestCapability(EXT_PAN_HEX_LOWER, makeCap());
+
+        const batch = await service.getOrFetch(EXT_PAN_HEX_LOWER);
+        expect(batch?.source).to.equal("otbr-rest");
+        expect(batch?.nodes).to.have.lengthOf(1);
+        expect(meshcopCalls).to.equal(0);
+    });
+
+    it("yields border_router_unreachable with source 'none' when the only BR is undialable and no REST cap exists", async () => {
+        let probeCalls = 0;
+        const service = new ThreadDiagnosticsService({
+            ...FAST_TIMING,
+            borderRouters: brRegistryFrom(brsListing([makeBr({ addresses: [] })])),
+            credentials: credsRegistryFrom(credsLookup(new Map([[EXT_PAN_HEX_LOWER, makeCreds()]]))),
+            makeRestSource: () => syncRestSource([]),
+            makeMeshcopSource: async () => meshcopHandle(syncMeshcopSource([])),
+            probeRest: async () => {
+                probeCalls += 1;
+                return makeCap();
+            },
+        });
+
+        const batch = await service.getOrFetch(EXT_PAN_HEX_LOWER);
+        expect(batch?.partialReason).to.equal("border_router_unreachable");
+        expect(batch?.source).to.equal("none");
+        expect(batch?.nodes).to.deep.equal([]);
+        // No dialable address to probe → the network probe never runs.
+        expect(probeCalls).to.equal(0);
     });
 
     it("yields no_credentials when BRs match but neither creds nor REST cap exist", async () => {
@@ -346,7 +419,7 @@ describe("ThreadDiagnosticsService", () => {
 
         const batch = await service.getOrFetch(EXT_PAN_HEX_LOWER);
         expect(batch?.partialReason).to.equal("no_credentials");
-        expect(batch?.source).to.equal("meshcop");
+        expect(batch?.source).to.equal("none");
     });
 
     it("uses REST for a capability-only network (no credentials)", async () => {
@@ -550,6 +623,52 @@ describe("ThreadDiagnosticsService", () => {
         ]);
 
         expect(maxActive).to.equal(2);
+    });
+
+    it("serializes concurrent force refreshes for the same network (never two live streams at once)", async () => {
+        let active = 0;
+        let maxActive = 0;
+        const service = new ThreadDiagnosticsService({
+            windowMs: 10_000,
+            firstBatchMs: 5,
+            debounceMs: 5,
+            borderRouters: brRegistryFrom(brsListing([makeBr()])),
+            credentials: credsRegistryFrom(credsLookup(new Map([[EXT_PAN_HEX_LOWER, makeCreds()]]))),
+            makeRestSource: () => syncRestSource([]),
+            probeRest: async () => null,
+            makeMeshcopSource: async () => {
+                active += 1;
+                maxActive = Math.max(maxActive, active);
+                return meshcopHandle(
+                    {
+                        kind: "meshcop",
+                        canQuery: () => true,
+                        queryUnicast: async () => ({ unknown: [] }),
+                        queryMulticast: () => scriptedHandle({ nodes: [SAMPLE_NODE], keepOpen: true }),
+                        resetCounters: async () => {},
+                    },
+                    () => {
+                        active -= 1;
+                    },
+                );
+            },
+        });
+
+        // Seed an in-flight stream S0 that lingers on the 10s window.
+        await service.getOrFetch(EXT_PAN_HEX_LOWER);
+        expect(active).to.equal(1);
+
+        // Two simultaneous force refreshes for the same xp must serialize their cancel→start:
+        // if both read the same in-flight stream, cancel it, then each register a replacement, two
+        // live streams overlap and #streamsInFlight is corrupted.
+        await Promise.all([
+            service.getOrFetch(EXT_PAN_HEX_LOWER, { force: true }),
+            service.getOrFetch(EXT_PAN_HEX_LOWER, { force: true }),
+        ]);
+
+        expect(maxActive).to.equal(1);
+
+        await service.stop();
     });
 
     it("maps a CommissionerRejectedError to petition_rejected and still closes the handle", async () => {


### PR DESCRIPTION
## Problem

A Thread Border Router with a working, registered OTBR REST endpoint reported **"Diagnostics unavailable: Border Router not reachable" (Source: meshcop)** in the dashboard, and REST diagnostics never ran.

Root cause: `ThreadDiagnosticsService.getOrFetch` gates the whole fetch on `rankBrs`/`selectBr`. `rankBrs` correctly drops BRs without a dialable (non-link-local) address — required for MeshCoP, which must dial an IP. But when the ranked list is empty the service returned `border_router_unreachable` **without ever consulting the registered REST capability**, even though REST needs only the extPanId + a registered `baseUrl`, not a dialable address. The `source: meshcop` label was a hardcoded default; MeshCoP was never attempted.

(Observed against a real BR whose mDNS entry had `addresses: []` at diagnostics time despite a probed IPv4 REST endpoint. The address-wipe itself is a separate upstream `@matter/thread-br-client` issue — asymmetric empty-guard between `#parseAndUpsert` and `#onTargetChanged` in `BorderRouterRegistry` — tracked separately; this PR is the consumer-side resilience.)

## Changes

- **REST-only path** (`#fetchRestOnly`): when no BR is dialable but a usable REST cap is cached, stream diagnostics over REST instead of dead-ending at unreachable. Only when no usable cap exists is the network truly `border_router_unreachable`.
- **`restOnly` threading** (`#startStream` → `#acquireHybrid`): hides credentials up front so MeshCoP is skipped entirely — every BR is undialable, so a MeshCoP connect would only fail before the same REST degrade the existing DTLS-failure path already relies on. Avoids noisy `meshcop connect FAIL` warns + wasted dials.
- **Honest source label**: terminal no-transport partials (`border_router_unreachable`, `no_credentials`) now report `source: "none"` instead of a misleading `"meshcop"`. Wire type widened (`"meshcop" | "otbr-rest" | "none"`); the dashboard hides the Source row when `"none"`. In-stream failures still carry the real transport (`meshcop`/`otbr-rest`).
- **Concurrent-`force` race fix** (pre-existing): two simultaneous `getOrFetch(force:true)` for one xp could each cancel the same in-flight stream and register a replacement, leaving two live streams and a `#streamsInFlight` entry the first stream's teardown later deletes out from under the second. A per-xp `#serialize` lock makes the cancel-then-start section atomic across both call sites; `firstBatch` is awaited outside the lock so joiners aren't blocked for a window.

## Tests

TDD (red → green). Added:
- REST-only reachable BR (empty addresses, cap present) → `otbr-rest` batch, MeshCoP not called.
- REST-only with credentials present → MeshCoP skipped.
- undialable BR + no usable cap → `border_router_unreachable` with `source: "none"`.
- `no_credentials` / no-BR-match → `source: "none"`.
- concurrent `force` refreshes → never two live streams at once.

## Verification

`npm run format` / `lint` / `build` clean. Full suite green — ws-controller 198/198, full 251/251 including live-mDNS integration tests. Two independent adversarial reviews (multi-caller fan-out, cross-method coupling, state-across-await, teardown/leaks) — no surviving defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)