### PR TITLE
fix(webrtc): source session streams from request and render separate track streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This page shows a detailed overview of the changes between versions without the 
 ## **WORK IN PROGRESS**
 
 - Fix: Ensure that WebSocket backpressure keeps the send window full instead of draining one frame at a time, avoiding initial-sync stalls behind a high-latency proxy (e.g. Home Assistant ingress) that could drop the dashboard connection
+- Fix: Optimize TBR address and data handling
+- Fix: Update WebRTC and Camera-related logic and respect separate Audio/Video streams in Dashboard
+- Fix: Update matter.js to the latest 0.17.5 nightly
+    - Limit OTA/BDX block size to UDP max payload size
 
 ## 1.2.1 (2026-07-09)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "packages/matter-server"
             ],
             "devDependencies": {
-                "@matter/testing": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/testing": "0.17.5-alpha.0-20260710-82b39217b",
                 "@nacho-iot/js-tools": "^0.1.7",
                 "@types/mocha": "^10.0.10",
                 "glob": "^13.0.6",
@@ -2928,86 +2928,86 @@
             "link": true
         },
         "node_modules/@matter/dcl-data": {
-            "version": "2026.7.7",
-            "resolved": "https://registry.npmjs.org/@matter/dcl-data/-/dcl-data-2026.7.7.tgz",
-            "integrity": "sha512-dia5fh1DLNW0YrM2TfvCkWJ7n4d8uc5giqAXLgioEkLGftDeMRHmGECF57cvmsu5TP10yQbdipkDkvSGfLkBUg==",
+            "version": "2026.7.10",
+            "resolved": "https://registry.npmjs.org/@matter/dcl-data/-/dcl-data-2026.7.10.tgz",
+            "integrity": "sha512-lMPOZasXdIR3FUiM5yRlNV3PygJNpr4ZTSVCkRU0TiLpjBNz4wB6E14pjoLqdeedpiKhC+b4iMwfP4/T9rfVyg==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@matter/general": {
-            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
-            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
-            "integrity": "sha512-NIUZzASG2FitKQzwWFSKgXYqIcb+nZKgjQ8O9zai6elfWnvk/X34N3buioSUf32uRPUxLMVseG2pWHEgo2p12w==",
+            "version": "0.17.5-alpha.0-20260710-82b39217b",
+            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.5-alpha.0-20260710-82b39217b.tgz",
+            "integrity": "sha512-lRGy0pfJ1rXrQVTekVa7nEuWOzh8zj/t+HZNqt3XlqwCy/tk1EhiQyiAqhFGrIyhL8AMf1neTVWcDII0jHycBg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/curves": "^2.2.0"
             }
         },
         "node_modules/@matter/main": {
-            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
-            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
-            "integrity": "sha512-lW9aUHnrwkDDMMDMMMbIKbmcnAQY3tmcV5e8FyrEjUkxpnLBIfWwhq+VF3OEM7U1CQB25RawX98Pxy+Vbwys9Q==",
+            "version": "0.17.5-alpha.0-20260710-82b39217b",
+            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.5-alpha.0-20260710-82b39217b.tgz",
+            "integrity": "sha512-dCBduKBzd+iFdoSmREdFP77naVKifK358j9Yf0hVrBSHQijvsKJCSp80CA0hDCjhcOjDdj4I0RfPXDnGfBJkRQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/model": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/node": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/protocol": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/types": "0.17.5-alpha.0-20260709-e6f78aaf7"
+                "@matter/general": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/model": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/node": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/protocol": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/types": "0.17.5-alpha.0-20260710-82b39217b"
             },
             "optionalDependencies": {
-                "@matter/nodejs": "0.17.5-alpha.0-20260709-e6f78aaf7"
+                "@matter/nodejs": "0.17.5-alpha.0-20260710-82b39217b"
             }
         },
         "node_modules/@matter/model": {
-            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
-            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
-            "integrity": "sha512-HipiOYo82w+1hxE3nTNmEWQ/3G2PILrpObcUf9TMOCX/33f53pMpg7H+BnWB3NBIAePLUVmRBzjCbwMrBB+Ebw==",
+            "version": "0.17.5-alpha.0-20260710-82b39217b",
+            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.5-alpha.0-20260710-82b39217b.tgz",
+            "integrity": "sha512-Uk5IU/vrBmE6h/SOPfMq9W5hXzDy+sIFF3q5RL+uyRfm4vey/1o3VMogZ1nuc2dok3Dk1TI71WDMBhGpX3C6tQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7"
+                "@matter/general": "0.17.5-alpha.0-20260710-82b39217b"
             }
         },
         "node_modules/@matter/node": {
-            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
-            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
-            "integrity": "sha512-jRYfFxaqoy8twp8665UK6Km/bfaaK2J77jUkZpIlMB6eIIFXQ8wezYRaRmwfCP0RI7S7AqC7BpXmqUg0V6UByw==",
+            "version": "0.17.5-alpha.0-20260710-82b39217b",
+            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.5-alpha.0-20260710-82b39217b.tgz",
+            "integrity": "sha512-73RjpuecdhyFmP7Dzw8Vs/8jhL1AS4vOaKtFMHFfaHrZgZakXmpqkostKVAMTSVKKFTYyLRTQ0GNRtCUdwFpLA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/model": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/protocol": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/types": "0.17.5-alpha.0-20260709-e6f78aaf7"
+                "@matter/general": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/model": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/protocol": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/types": "0.17.5-alpha.0-20260710-82b39217b"
             }
         },
         "node_modules/@matter/nodejs": {
-            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
-            "integrity": "sha512-tll1XDMWgSLTm4YO459AREvbFmD5z5CsqthYtThjZ4NL3D9jA5Aut6OtHj8rj+N4Bja80L8n6Cg6QfkTv4zUug==",
+            "version": "0.17.5-alpha.0-20260710-82b39217b",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.5-alpha.0-20260710-82b39217b.tgz",
+            "integrity": "sha512-BAGGSPsSpaUE60ZqIt57V2Xul13/teTrXwtIOlrxm819L0QGI/WDrRmgU+FbQzt/Mazj2+nXQad8hysA606Hhg==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/node": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/protocol": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/types": "0.17.5-alpha.0-20260709-e6f78aaf7"
+                "@matter/general": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/node": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/protocol": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/types": "0.17.5-alpha.0-20260710-82b39217b"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
             }
         },
         "node_modules/@matter/nodejs-ble": {
-            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
-            "integrity": "sha512-3+8zBOyre3VB5lAeZGuqmc/PA13FP8g9zP6zmDJISsTmspNmQjWUiaTkNEFMN1111jv8Ee+0cWvrBDe0wuY4vA==",
+            "version": "0.17.5-alpha.0-20260710-82b39217b",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.5-alpha.0-20260710-82b39217b.tgz",
+            "integrity": "sha512-iK3kv/zoOPpEiHwJL+X0GwNA6ZohreS8aXiEpv2lLXytNYYBEpicTvUeZyRbVGD2Q2JVwHcQAiaxf3JRo3HN5Q==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/protocol": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/types": "0.17.5-alpha.0-20260709-e6f78aaf7"
+                "@matter/general": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/protocol": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/types": "0.17.5-alpha.0-20260710-82b39217b"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -3018,20 +3018,20 @@
             }
         },
         "node_modules/@matter/protocol": {
-            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
-            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
-            "integrity": "sha512-2iwEg+nb0Mz6mpw46pFvBAQZFWI4eZhKuRIH+y4cui49sGTu1LmBkWrtGgx6BokBjSy2LQAq4z2A1tRIoOPSPQ==",
+            "version": "0.17.5-alpha.0-20260710-82b39217b",
+            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.5-alpha.0-20260710-82b39217b.tgz",
+            "integrity": "sha512-S4MiRjHi0dc50NGHp9h+m4A93/C92khO1l489X7tTFBLcoM0OVw+IXgcR8pqQkMR1J97g9MB6MAOskf/yVOn9A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/model": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/types": "0.17.5-alpha.0-20260709-e6f78aaf7"
+                "@matter/general": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/model": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/types": "0.17.5-alpha.0-20260710-82b39217b"
             }
         },
         "node_modules/@matter/testing": {
-            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
-            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
-            "integrity": "sha512-MC06saucu13q+5/xdANv3O00V3Vs8XlPA2mGKb/PYu4jPhWI8SqqVd1n5a0WHXEcuuP7JXx2bXFYinj5UJrY4A==",
+            "version": "0.17.5-alpha.0-20260710-82b39217b",
+            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.5-alpha.0-20260710-82b39217b.tgz",
+            "integrity": "sha512-YweMli2EGy52fFxT7fN76tQnnAA5mf4fvEJpsfqVxelkx7bW46zdAm5LJSHMRhS49+GTyPlBqp2K6Z2FCq/ZbA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3056,24 +3056,24 @@
             }
         },
         "node_modules/@matter/thread-br-client": {
-            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
-            "resolved": "https://registry.npmjs.org/@matter/thread-br-client/-/thread-br-client-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
-            "integrity": "sha512-TysTCnFWeA265rQsfG+VbUyv13P1AaIB6dCEIfg1lOiOZ3xAEw+0ZX+z3LQOuVWyCebn64eMmAeQNuNKWbhdYQ==",
+            "version": "0.17.5-alpha.0-20260710-82b39217b",
+            "resolved": "https://registry.npmjs.org/@matter/thread-br-client/-/thread-br-client-0.17.5-alpha.0-20260710-82b39217b.tgz",
+            "integrity": "sha512-9/mEJgUhzrAY/cjqnqtz1vWZBZAzmQ2x+A55pQEncTRl7BoXWxET31+GOcbmFwb8UlQ3zZVtGlicGfzLe7VQ9A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/protocol": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/general": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/protocol": "0.17.5-alpha.0-20260710-82b39217b",
                 "@noble/curves": "^2.2.0"
             }
         },
         "node_modules/@matter/types": {
-            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
-            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
-            "integrity": "sha512-p/La7kX11WnDDkjhp9QQLzePN12xJzq8NMWp6o+aTsqe1b054RU+94kVTQiZG4gtqWw280g8rOi6jaZcTPMOgw==",
+            "version": "0.17.5-alpha.0-20260710-82b39217b",
+            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.5-alpha.0-20260710-82b39217b.tgz",
+            "integrity": "sha512-Jb7bImifV5os1yG/L85AoAUQ1xTkhsVOlXEN8m/tWYkbwoKA9jBAj2wKF2S/FNT+qbxbrpeVzZ6GdWFlpEgIig==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/model": "0.17.5-alpha.0-20260709-e6f78aaf7"
+                "@matter/general": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/model": "0.17.5-alpha.0-20260710-82b39217b"
             }
         },
         "node_modules/@mdi/js": {
@@ -3984,16 +3984,16 @@
             }
         },
         "node_modules/@project-chip/matter.js": {
-            "version": "0.17.5-alpha.0-20260709-e6f78aaf7",
-            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.5-alpha.0-20260709-e6f78aaf7.tgz",
-            "integrity": "sha512-8bpvQ4IqBrCkLzEI8eNKsSIvpkNo92j3/n2SHEw7jlECjaTDrsWjIZEEzuUANiduQ92dritr+K03sCebfh0eeg==",
+            "version": "0.17.5-alpha.0-20260710-82b39217b",
+            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.5-alpha.0-20260710-82b39217b.tgz",
+            "integrity": "sha512-99L5Iu3n1jChLqVUAsXQ6OkcB2q/GCRxmL6AR188AahnF28Ph9QIKGcyxRl3Qu5snKoVYbaZixnL8zDXRe9kdQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/model": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/node": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/protocol": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/types": "0.17.5-alpha.0-20260709-e6f78aaf7"
+                "@matter/general": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/model": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/node": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/protocol": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/types": "0.17.5-alpha.0-20260710-82b39217b"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -11288,7 +11288,7 @@
             "version": "0.0.0-git",
             "dependencies": {
                 "@matter-server/ws-controller": "*",
-                "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/main": "0.17.5-alpha.0-20260710-82b39217b",
                 "ws": "^8.21.0"
             },
             "devDependencies": {
@@ -11299,7 +11299,7 @@
                 "node": ">=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/nodejs-ble": "0.17.5-alpha.0-20260710-82b39217b",
                 "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
             }
         },
@@ -11307,7 +11307,7 @@
             "name": "@matter-server/custom-clusters",
             "version": "0.0.0-git",
             "dependencies": {
-                "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7"
+                "@matter/main": "0.17.5-alpha.0-20260710-82b39217b"
             },
             "engines": {
                 "node": ">=22.13.0"
@@ -11329,7 +11329,7 @@
             },
             "devDependencies": {
                 "@babel/preset-env": "^8.0.2",
-                "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/main": "0.17.5-alpha.0-20260710-82b39217b",
                 "@rollup/plugin-babel": "^7.1.0",
                 "@rollup/plugin-commonjs": "^29.0.3",
                 "@rollup/plugin-json": "^6.1.0",
@@ -11601,14 +11601,14 @@
                 "@matter-server/custom-clusters": "*",
                 "@matter-server/dashboard": "*",
                 "@matter-server/ws-controller": "*",
-                "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/main": "0.17.5-alpha.0-20260710-82b39217b",
                 "commander": "^15.0.0",
                 "express": "^5.2.1"
             },
             "devDependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/nodejs": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/testing": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/nodejs": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/testing": "0.17.5-alpha.0-20260710-82b39217b",
                 "@types/express": "^5.0.6",
                 "@types/node": "^26.1.1"
             },
@@ -11630,10 +11630,10 @@
             "version": "0.0.0-git",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/thread-br-client": "0.17.5-alpha.0-20260709-e6f78aaf7"
+                "@matter/thread-br-client": "0.17.5-alpha.0-20260710-82b39217b"
             },
             "devDependencies": {
-                "@matter/testing": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/testing": "0.17.5-alpha.0-20260710-82b39217b",
                 "@types/node": "^26.1.1",
                 "@types/ws": "^8.18.1",
                 "ws": "^8.21.0"
@@ -11647,10 +11647,10 @@
             "version": "0.0.0-git",
             "dependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/dcl-data": ">=2026.7.7",
-                "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@matter/thread-br-client": "0.17.5-alpha.0-20260709-e6f78aaf7",
-                "@project-chip/matter.js": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/dcl-data": ">=2026.7.10",
+                "@matter/main": "0.17.5-alpha.0-20260710-82b39217b",
+                "@matter/thread-br-client": "0.17.5-alpha.0-20260710-82b39217b",
+                "@project-chip/matter.js": "0.17.5-alpha.0-20260710-82b39217b",
                 "ws": "^8.21.0"
             },
             "devDependencies": {
@@ -11661,7 +11661,7 @@
                 "node": ">=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.5-alpha.0-20260709-e6f78aaf7",
+                "@matter/nodejs-ble": "0.17.5-alpha.0-20260710-82b39217b",
                 "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
             }
         }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "python-ble-proxy:run": "cd python_ble_proxy && { [ -x .venv/bin/matter-ble-proxy ] || (python3 -m venv .venv && .venv/bin/pip install -e .); } && .venv/bin/matter-ble-proxy"
     },
     "devDependencies": {
-        "@matter/testing": "0.17.5-alpha.0-20260709-e6f78aaf7",
+        "@matter/testing": "0.17.5-alpha.0-20260710-82b39217b",
         "@nacho-iot/js-tools": "^0.1.7",
         "@types/mocha": "^10.0.10",
         "glob": "^13.0.6",

--- a/packages/ble-proxy/package.json
+++ b/packages/ble-proxy/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@matter-server/ws-controller": "*",
-        "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
+        "@matter/main": "0.17.5-alpha.0-20260710-82b39217b",
         "ws": "^8.21.0"
     },
     "devDependencies": {
@@ -38,7 +38,7 @@
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.5-alpha.0-20260709-e6f78aaf7",
+        "@matter/nodejs-ble": "0.17.5-alpha.0-20260710-82b39217b",
         "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
     },
     "engines": {

--- a/packages/custom-clusters/package.json
+++ b/packages/custom-clusters/package.json
@@ -39,7 +39,7 @@
         "build-clean": "nacho-build --clean"
     },
     "dependencies": {
-        "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7"
+        "@matter/main": "0.17.5-alpha.0-20260710-82b39217b"
     },
     "engines": {
         "node": ">=22.13.0"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -42,7 +42,7 @@
     },
     "devDependencies": {
         "@babel/preset-env": "^8.0.2",
-        "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
+        "@matter/main": "0.17.5-alpha.0-20260710-82b39217b",
         "@rollup/plugin-babel": "^7.1.0",
         "@rollup/plugin-commonjs": "^29.0.3",
         "@rollup/plugin-json": "^6.1.0",

--- a/packages/dashboard/src/components/webrtc-stream-view.ts
+++ b/packages/dashboard/src/components/webrtc-stream-view.ts
@@ -291,11 +291,15 @@ export class WebRtcStreamView extends LitElement {
                     console.warn("[webrtc-stream-view] ontrack fired but <video> query is null");
                     return;
                 }
-                const stream = ev.streams[0];
-                if (!stream) return;
-                // Both video and audio ontracks reference the same bundled MediaStream.
-                // Reassigning srcObject to a stream that's already attached can reset
-                // playback in Firefox, so only set when the reference actually changes.
+                // Cameras may put each track in its own MediaStream (distinct msid, e.g. Aqara's
+                // AqaraVideoStream/AqaraAudioStream), so ev.streams[0] differs per track. Assigning it
+                // to srcObject directly lets the audio track's stream clobber the video track's.
+                // Aggregate every received track into one element-owned MediaStream instead.
+                const existing = video.srcObject instanceof MediaStream ? video.srcObject : null;
+                const stream = existing ?? new MediaStream();
+                if (!stream.getTracks().includes(ev.track)) {
+                    stream.addTrack(ev.track);
+                }
                 if (video.srcObject !== stream) {
                     video.srcObject = stream;
                 }

--- a/packages/matter-server/package.json
+++ b/packages/matter-server/package.json
@@ -44,14 +44,14 @@
         "@matter-server/custom-clusters": "*",
         "@matter-server/dashboard": "*",
         "@matter-server/ws-controller": "*",
-        "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
+        "@matter/main": "0.17.5-alpha.0-20260710-82b39217b",
         "commander": "^15.0.0",
         "express": "^5.2.1"
     },
     "devDependencies": {
         "@matter-server/ws-client": "*",
-        "@matter/nodejs": "0.17.5-alpha.0-20260709-e6f78aaf7",
-        "@matter/testing": "0.17.5-alpha.0-20260709-e6f78aaf7",
+        "@matter/nodejs": "0.17.5-alpha.0-20260710-82b39217b",
+        "@matter/testing": "0.17.5-alpha.0-20260710-82b39217b",
         "@types/express": "^5.0.6",
         "@types/node": "^26.1.1"
     },

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -40,10 +40,10 @@
         "build-clean": "nacho-build --clean"
     },
     "dependencies": {
-        "@matter/thread-br-client": "0.17.5-alpha.0-20260709-e6f78aaf7"
+        "@matter/thread-br-client": "0.17.5-alpha.0-20260710-82b39217b"
     },
     "devDependencies": {
-        "@matter/testing": "0.17.5-alpha.0-20260709-e6f78aaf7",
+        "@matter/testing": "0.17.5-alpha.0-20260710-82b39217b",
         "@types/node": "^26.1.1",
         "@types/ws": "^8.18.1",
         "ws": "^8.21.0"

--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -41,10 +41,10 @@
     },
     "dependencies": {
         "@matter-server/ws-client": "*",
-        "@matter/dcl-data": ">=2026.7.7",
-        "@matter/main": "0.17.5-alpha.0-20260709-e6f78aaf7",
-        "@matter/thread-br-client": "0.17.5-alpha.0-20260709-e6f78aaf7",
-        "@project-chip/matter.js": "0.17.5-alpha.0-20260709-e6f78aaf7",
+        "@matter/dcl-data": ">=2026.7.10",
+        "@matter/main": "0.17.5-alpha.0-20260710-82b39217b",
+        "@matter/thread-br-client": "0.17.5-alpha.0-20260710-82b39217b",
+        "@project-chip/matter.js": "0.17.5-alpha.0-20260710-82b39217b",
         "ws": "^8.21.0"
     },
     "devDependencies": {
@@ -52,7 +52,7 @@
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.5-alpha.0-20260709-e6f78aaf7",
+        "@matter/nodejs-ble": "0.17.5-alpha.0-20260710-82b39217b",
         "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
     },
     "engines": {

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -107,6 +107,7 @@ import { Nodes } from "./Nodes.js";
 import { pushNodeTime, TimeSyncInvokers } from "./timeSyncCommands.js";
 import { TIME_FAILURE_EVENT_ID, TIME_SYNC_CLUSTER_ID, TimeSyncManager } from "./TimeSyncManager.js";
 import { attachWebRtcCallbackBridge } from "./WebRtcCallbackBridge.js";
+import { isTrackableWebRtcSession, resolveWebRtcSessionStreams } from "./webRtcSessionStreams.js";
 
 const logger = Logger.get("ControllerCommandHandler");
 
@@ -390,15 +391,60 @@ export class ControllerCommandHandler {
             );
         }
 
-        const streamUsage = payload.streamUsage as WebRtcTransportDefinitions.WebRtcSession["streamUsage"];
-        const metadataEnabled = (payload.metadataEnabled as boolean | undefined) ?? false;
-        const videoStreams = response.videoStreamId != null ? [response.videoStreamId] : new Array<number>();
-        const audioStreams = response.audioStreamId != null ? [response.audioStreamId] : new Array<number>();
+        const streamUsage = convertedPayload.streamUsage;
+        const metadataEnabled = convertedPayload.metadataEnabled === true;
+
+        const videoStreams = resolveWebRtcSessionStreams(
+            convertedPayload.videoStreams,
+            convertedPayload.videoStreamId,
+            response.videoStreamId,
+        );
+        const audioStreams = resolveWebRtcSessionStreams(
+            convertedPayload.audioStreams,
+            convertedPayload.audioStreamId,
+            response.audioStreamId,
+        );
+
+        // An untrackable session (no stream usage, or no stream — e.g. an auto-select/deferred
+        // SolicitOffer whose provider reports no stream id yet) cannot be stored in the requestor's
+        // CurrentSessions, so we could never route the peer's follow-up signaling for it. Rather than
+        // return a session id that will silently never deliver media, tear the just-created device
+        // session down and fail the command. Deferred/auto-select is thus unsupported for now; the
+        // dashboard never hits this (it always requests a concrete stream usage + id).
+        if (!isTrackableWebRtcSession(streamUsage, videoStreams, audioStreams)) {
+            logger.warn(
+                `Tearing down untrackable WebRTC session id=${response.webRtcSessionId} for node ${this.formatNode(
+                    nodeId,
+                )}: request lacks a stream usage or any video/audio stream, so signaling cannot be routed for it`,
+            );
+            try {
+                await this.#invokeCommand(node.node, {
+                    endpoint: endpointId,
+                    cluster: WebRtcTransportProvider,
+                    command: "endSession",
+                    fields: {
+                        webRtcSessionId: response.webRtcSessionId,
+                        reason: WebRtcTransportDefinitions.WebRtcEndReason.OutOfResources,
+                    },
+                });
+            } catch (err) {
+                logger.warn(
+                    `EndSession cleanup for untrackable WebRTC session id=${response.webRtcSessionId} failed: ${
+                        err instanceof Error ? err.message : String(err)
+                    }`,
+                );
+            }
+            throw ServerError.sdkStackError(
+                `${commandName} for node ${this.formatNode(nodeId)} produced a session with no stream usage or ` +
+                    `video/audio stream; deferred/auto-select streaming is not supported`,
+            );
+        }
+
         const session: WebRtcTransportDefinitions.WebRtcSession = {
             id: response.webRtcSessionId,
             peerNodeId: nodeId,
             peerEndpointId: endpointId,
-            streamUsage,
+            streamUsage: streamUsage as WebRtcTransportDefinitions.WebRtcSession["streamUsage"],
             metadataEnabled,
             videoStreams,
             audioStreams,
@@ -413,6 +459,17 @@ export class ControllerCommandHandler {
         });
 
         return response;
+    }
+
+    /**
+     * Drop a WebRTC session from the local requestor's CurrentSessions tracking. Call when the session
+     * is ended locally (e.g. the client invokes EndSession on the provider); peer-initiated ends are
+     * already removed by the requestor's own End handler. No-op if the id is not tracked.
+     */
+    async removeTrackedWebRtcSession(webRtcSessionId: number): Promise<void> {
+        await this.#cameraControllerEndpoint().act(agent => {
+            agent.get(WebRtcTransportRequestorServer).removeSession(webRtcSessionId);
+        });
     }
 
     /**

--- a/packages/ws-controller/src/controller/webRtcSessionStreams.ts
+++ b/packages/ws-controller/src/controller/webRtcSessionStreams.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2022-2026 Matter.js Authors
+ * Copyright 2025-2026 Open Home Foundation
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/ws-controller/src/controller/webRtcSessionStreams.ts
+++ b/packages/ws-controller/src/controller/webRtcSessionStreams.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2022-2026 Matter.js Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** A stream id is a non-negative integer (matter.js VideoStreamID/AudioStreamID are uint16). */
+function isStreamId(value: unknown): value is number {
+    return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+/**
+ * Resolve the video/audio stream list stored in a WebRTCSessionStruct for one media kind.
+ *
+ * Stream membership comes from the ProvideOffer/SolicitOffer request; the response's deprecated
+ * stream-id echo exists only to report the provider's choice for a rev-1 null (auto-select) request
+ * (spec §11.5.6.4). Inputs are the raw request/response values (untyped wire data), narrowed here:
+ *
+ *   - `requestList` (rev-2): the valid ids from a non-empty list are used verbatim.
+ *   - `requestId` (rev-1): a valid id is an explicit request; `null` requests auto-selection, so the
+ *     provider's `responseId` echo is used; anything else means the request omitted this media kind.
+ */
+export function resolveWebRtcSessionStreams(
+    requestList: unknown,
+    requestId: unknown,
+    responseId: unknown,
+): number[] | undefined {
+    if (Array.isArray(requestList)) {
+        const ids = requestList.filter(isStreamId);
+        if (ids.length > 0) {
+            return ids;
+        }
+    }
+    if (isStreamId(requestId)) {
+        return [requestId];
+    }
+    if (requestId === null && isStreamId(responseId)) {
+        return [responseId];
+    }
+    return undefined;
+}
+
+/**
+ * Whether a resolved WebRTC session can be stored in the WebRTCSessionStruct.
+ *
+ * The struct requires a StreamUsage (mandatory) and at least one video or audio stream (choice "a",
+ * min 1). streamUsage is optional on the request and the stream lists may resolve to none, so a session
+ * failing this cannot be tracked and must not be written (the write would throw and orphan the session
+ * the provider already created).
+ */
+export function isTrackableWebRtcSession(
+    streamUsage: unknown,
+    videoStreams: number[] | undefined,
+    audioStreams: number[] | undefined,
+): boolean {
+    return (
+        typeof streamUsage === "number" &&
+        Number.isInteger(streamUsage) &&
+        streamUsage >= 0 &&
+        (videoStreams !== undefined || audioStreams !== undefined)
+    );
+}

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -102,13 +102,22 @@ function normalizeFabricLabel(label: string | null): string {
     return (trimmed && trimmed !== "" ? trimmed : "HomeAssistant").substring(0, 32);
 }
 
-/** Pull the numeric WebRTCSessionID out of an EndSession payload, tolerant of wire key spellings. */
+/**
+ * Pull the WebRTCSessionID out of an EndSession payload, tolerant of wire key spellings. The payload
+ * comes from {@link parseBigIntAwareJson}, so a large id arrives as a bigint; accept a non-negative
+ * integer of either type and normalize to number (session ids are well within the safe range).
+ */
 function extractWebRtcSessionId(payload: unknown): number | undefined {
     if (typeof payload !== "object" || payload === null) return undefined;
     const record = payload as Record<string, unknown>;
     for (const key of ["webRtcSessionId", "webRtcSessionID", "WebRTCSessionID"]) {
         const value = record[key];
-        if (typeof value === "number") return value;
+        if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
+            return value;
+        }
+        if (typeof value === "bigint" && value >= 0n && value <= BigInt(Number.MAX_SAFE_INTEGER)) {
+            return Number(value);
+        }
     }
     return undefined;
 }

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -102,6 +102,17 @@ function normalizeFabricLabel(label: string | null): string {
     return (trimmed && trimmed !== "" ? trimmed : "HomeAssistant").substring(0, 32);
 }
 
+/** Pull the numeric WebRTCSessionID out of an EndSession payload, tolerant of wire key spellings. */
+function extractWebRtcSessionId(payload: unknown): number | undefined {
+    if (typeof payload !== "object" || payload === null) return undefined;
+    const record = payload as Record<string, unknown>;
+    for (const key of ["webRtcSessionId", "webRtcSessionID", "WebRTCSessionID"]) {
+        const value = record[key];
+        if (typeof value === "number") return value;
+    }
+    return undefined;
+}
+
 /** WebSocket Server compatible with Schema version 12, minimum supported 11 */
 export class WebSocketControllerHandler implements WebServerHandler {
     #controller: MatterController;
@@ -1135,11 +1146,12 @@ export class WebSocketControllerHandler implements WebServerHandler {
             timed_request_timeout_ms: timedInteractionTimeoutMs,
         } = args;
 
+        const camelizedCommand = camelize(commandName);
         const result = await this.#handlerFor(nodeId).handleInvoke({
             nodeId: NodeId(nodeId),
             endpointId: EndpointNumber(endpointId),
             clusterId: ClusterId(clusterId),
-            commandName: camelize(commandName),
+            commandName: camelizedCommand,
             data: payload,
             timedInteractionTimeoutMs:
                 typeof timedInteractionTimeoutMs === "number" ? Millis(timedInteractionTimeoutMs) : undefined,
@@ -1148,6 +1160,20 @@ export class WebSocketControllerHandler implements WebServerHandler {
         // Test nodes return null
         if (TestNodeCommandHandler.isTestNodeId(nodeId)) {
             return null;
+        }
+
+        // The invoke above succeeded (it throws otherwise). A client-initiated EndSession on the
+        // provider ends the session on the device; drop our local tracking of it too, since the peer
+        // won't send us an End for a session we ended ourselves.
+        if (clusterId === WebRtcTransportProvider.id && camelizedCommand === "endSession") {
+            const sessionId = extractWebRtcSessionId(payload);
+            if (sessionId !== undefined) {
+                await this.#commandHandler.removeTrackedWebRtcSession(sessionId);
+            } else {
+                logger.debug(
+                    "EndSession invoked without a recognizable webRtcSessionId; local session tracking left unchanged",
+                );
+            }
         }
         const cmdResult = this.#convertCommandDataToWebSocket(ClusterId(clusterId), commandName, result);
         if (cmdResult === undefined) {

--- a/packages/ws-controller/test/WebRtcSessionStreamsTest.ts
+++ b/packages/ws-controller/test/WebRtcSessionStreamsTest.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isTrackableWebRtcSession, resolveWebRtcSessionStreams } from "../src/controller/webRtcSessionStreams.js";
+
+describe("resolveWebRtcSessionStreams", () => {
+    it("uses the requested rev-2 list verbatim", () => {
+        expect(resolveWebRtcSessionStreams([3, 5], undefined, undefined)).to.deep.equal([3, 5]);
+    });
+
+    it("prefers the requested list over the deprecated scalar echoes", () => {
+        expect(resolveWebRtcSessionStreams([3], 9, 9)).to.deep.equal([3]);
+    });
+
+    it("wraps an explicit rev-1 request id even when the response omits its echo", () => {
+        expect(resolveWebRtcSessionStreams(undefined, 3, undefined)).to.deep.equal([3]);
+    });
+
+    it("keeps the explicit request id when the response echoes a different value", () => {
+        expect(resolveWebRtcSessionStreams(undefined, 3, 7)).to.deep.equal([3]);
+    });
+
+    it("falls back to the response echo when the request asked for auto-selection", () => {
+        expect(resolveWebRtcSessionStreams(undefined, null, 7)).to.deep.equal([7]);
+    });
+
+    it("yields no stream when auto-selection is requested but the provider reports none", () => {
+        expect(resolveWebRtcSessionStreams(undefined, null, null)).to.equal(undefined);
+        expect(resolveWebRtcSessionStreams(undefined, null, undefined)).to.equal(undefined);
+    });
+
+    it("yields no stream when the media kind is absent from the request", () => {
+        expect(resolveWebRtcSessionStreams(undefined, undefined, undefined)).to.equal(undefined);
+    });
+
+    it("ignores an empty requested list and falls through to the scalar path", () => {
+        expect(resolveWebRtcSessionStreams([], 3, undefined)).to.deep.equal([3]);
+        expect(resolveWebRtcSessionStreams([], undefined, undefined)).to.equal(undefined);
+    });
+
+    it("keeps only numeric entries from a mixed request list", () => {
+        expect(resolveWebRtcSessionStreams([3, "x", null, 5], undefined, undefined)).to.deep.equal([3, 5]);
+    });
+
+    it("falls through when a request list contains no numeric entries", () => {
+        expect(resolveWebRtcSessionStreams(["x", null], 3, undefined)).to.deep.equal([3]);
+        expect(resolveWebRtcSessionStreams(["x"], undefined, undefined)).to.equal(undefined);
+    });
+
+    it("treats a non-numeric, non-null request id as an omitted media kind", () => {
+        expect(resolveWebRtcSessionStreams(undefined, "3", 7)).to.equal(undefined);
+        expect(resolveWebRtcSessionStreams(undefined, undefined, 7)).to.equal(undefined);
+    });
+
+    it("yields no stream when auto-selection is requested but the echo is non-numeric", () => {
+        expect(resolveWebRtcSessionStreams(undefined, null, "7")).to.equal(undefined);
+    });
+
+    it("rejects non-integer, negative, and NaN ids from a list", () => {
+        expect(resolveWebRtcSessionStreams([3, -1, 2.5, NaN, 5], undefined, undefined)).to.deep.equal([3, 5]);
+        expect(resolveWebRtcSessionStreams([-1, 2.5, NaN], 4, undefined)).to.deep.equal([4]);
+    });
+
+    it("treats a non-integer/negative scalar request id as an omitted media kind", () => {
+        expect(resolveWebRtcSessionStreams(undefined, 2.5, undefined)).to.equal(undefined);
+        expect(resolveWebRtcSessionStreams(undefined, -1, undefined)).to.equal(undefined);
+        expect(resolveWebRtcSessionStreams(undefined, NaN, undefined)).to.equal(undefined);
+    });
+
+    it("ignores a non-integer auto-select echo", () => {
+        expect(resolveWebRtcSessionStreams(undefined, null, 2.5)).to.equal(undefined);
+        expect(resolveWebRtcSessionStreams(undefined, null, -1)).to.equal(undefined);
+    });
+
+    it("accepts stream id 0", () => {
+        expect(resolveWebRtcSessionStreams(undefined, 0, undefined)).to.deep.equal([0]);
+    });
+});
+
+describe("isTrackableWebRtcSession", () => {
+    it("accepts a session with a numeric usage and a video stream", () => {
+        expect(isTrackableWebRtcSession(3, [3], undefined)).to.equal(true);
+    });
+
+    it("accepts a session with a numeric usage and an audio stream", () => {
+        expect(isTrackableWebRtcSession(3, undefined, [1])).to.equal(true);
+    });
+
+    it("rejects a session with no video and no audio stream", () => {
+        expect(isTrackableWebRtcSession(3, undefined, undefined)).to.equal(false);
+    });
+
+    it("rejects a session whose stream usage is missing or non-numeric", () => {
+        expect(isTrackableWebRtcSession(undefined, [3], [1])).to.equal(false);
+        expect(isTrackableWebRtcSession("3", [3], undefined)).to.equal(false);
+        expect(isTrackableWebRtcSession(null, undefined, [1])).to.equal(false);
+    });
+
+    it("rejects a session whose stream usage is non-integer or negative", () => {
+        expect(isTrackableWebRtcSession(2.5, [3], undefined)).to.equal(false);
+        expect(isTrackableWebRtcSession(-1, [3], undefined)).to.equal(false);
+        expect(isTrackableWebRtcSession(NaN, [3], undefined)).to.equal(false);
+    });
+
+    it("accepts stream usage 0", () => {
+        expect(isTrackableWebRtcSession(0, [3], undefined)).to.equal(true);
+    });
+});


### PR DESCRIPTION
## Problem

Streaming a Matter camera (Aqara G350) over WebRTC failed in two independent ways:

1. **Server** rolled back with a conformance error after the device had already created the session:
   `Validating …webRtcTransportRequestor.state.0: Conformance choice "a": Too few fields present (0 of min 1)`.
2. **Dashboard** showed a **black video** (audio worked) even though ICE connected and `chrome://webrtc-internals` confirmed 720p H264 frames decoding at 20fps.

## Root causes

- **Server:** the WebRTCSessionStruct's `videoStreams`/`audioStreams` were read from `ProvideOfferResponse`, which in cluster rev-2 carries only `webRtcSessionId` (the deprecated stream-id fields only echo a rev-1 *auto-select* choice). Both lists came out empty, violating the struct's `O.a+` choice (min 1) — and the throw happened *after* the device created the session, orphaning it. Stream membership must come from the **request**.
- **Dashboard:** the camera uses a **distinct msid per track** (`AqaraVideoStream`/`AqaraAudioStream`), so `ontrack` fires with two different `MediaStream`s. Assigning `srcObject = ev.streams[0]` per event let the audio track's stream clobber the video one → `videoWidth:0`, audio-only, black.

## Changes

**ws-controller**
- New `webRtcSessionStreams.ts`: `resolveWebRtcSessionStreams` (request-sourced, response echo only for rev-1 auto-select; validates non-negative integer ids) and `isTrackableWebRtcSession`.
- Untrackable session (no stream usage / no stream — e.g. deferred/auto-select) is torn down via `EndSession` and the command fails, instead of returning a session id that silently never delivers media.
- Client-initiated `EndSession` now drops local `currentSessions` tracking (previously only peer-initiated ends did), so it no longer grows across start/stop cycles.

**dashboard**
- `ontrack` aggregates every track into one element-owned `MediaStream`.

Also bumps matter.js to the 0.17.5 `2026-07-10` nightly.

## Testing

- New unit tests for `resolveWebRtcSessionStreams` / `isTrackableWebRtcSession` (22 cases: rev-1/rev-2, auto-select echo, absent-vs-null, mixed/invalid/NaN/negative ids, stream-usage validity).
- Full suite green; format/lint/build green.
- **Live-verified** end-to-end against a real Aqara G350 camera in both Chrome and Firefox — video + audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)