### PR TITLE
feat(ws-controller): bootstrap Thread credentials from REST to prefer CoAP diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Enhancement: Thread diagnostics fetch a Border Router's dataset via REST when no credentials are stored, enabling the faster MeshCoP (CoAP) transport instead of the slower REST collection
+
 ## 1.2.2 (2026-07-10)
 
 - Fix: Ensure that WebSocket backpressure keeps the send window full instead of draining one frame at a time, avoiding initial-sync stalls behind a high-latency proxy (e.g. Home Assistant ingress) that could drop the dashboard connection

--- a/packages/ws-client/src/models/model.ts
+++ b/packages/ws-client/src/models/model.ts
@@ -185,7 +185,9 @@ export type ThreadDiagnosticsPartialReason =
     /** Streaming multicast query is still active; this is a snapshot, more nodes may follow. */
     | "in_progress"
     /** Streaming multicast query is active but no responses have arrived yet. */
-    | "meshcop_no_responses_yet";
+    | "meshcop_no_responses_yet"
+    /** REST collection query is active but no responses have arrived yet. */
+    | "rest_no_responses_yet";
 
 /**
  * One Thread network's diagnostics snapshot, keyed by extended PAN ID, delivered by

--- a/packages/ws-controller/src/controller/MatterController.ts
+++ b/packages/ws-controller/src/controller/MatterController.ts
@@ -282,6 +282,13 @@ export class MatterController {
                 return new OtbrRestDiagnosticSource(new OtbrRestClient({ host, port }), cap);
             },
             makeMeshcopSource: (creds, br) => connectMeshcop({ environment: this.#env, creds, br }),
+            bootstrapCredentialsFromRest: async cap => {
+                const { host, port } = parseRestBaseUrl(cap.baseUrl);
+                const ds = await new OtbrRestClient({ host, port }).getActiveDataset();
+                if (ds === undefined) return;
+                this.#credentials.register(ds);
+                logger.info(`Registered Thread credentials from rest:${cap.baseUrl} (${formatDatasetForLog(ds)})`);
+            },
         });
     }
 

--- a/packages/ws-controller/src/controller/ThreadDiagnosticsService.ts
+++ b/packages/ws-controller/src/controller/ThreadDiagnosticsService.ts
@@ -36,7 +36,8 @@ export type ThreadDiagnosticsPartialReason =
     | "rest_protocol"
     | "timeout"
     | "in_progress"
-    | "meshcop_no_responses_yet";
+    | "meshcop_no_responses_yet"
+    | "rest_no_responses_yet";
 
 export interface ThreadDiagnosticsBatch {
     /** 16-char lowercase hex of the extPanId. Internal cache key; serializeBatch uppercases for wire. */
@@ -65,6 +66,14 @@ export interface ThreadDiagnosticsServiceOpts {
     makeMeshcopSource: (creds: ThreadNetworkCredentials, br: BorderRouterEntry) => Promise<MeshcopSourceHandle>;
     /** Sync factory — REST source has no resource lifecycle. */
     makeRestSource: (cap: OtbrRestCapability) => DiagnosticSource;
+    /**
+     * Optional bootstrap that fetches the active operational dataset from the BR's REST API and
+     * registers the derived credentials, so a dialable BR with no locally-registered credentials can
+     * still use the faster/complete MeshCoP (CoAP) transport instead of the slow REST collection.
+     * Called at most once per network (re-attempted only on a forced refresh) and only when no
+     * credentials exist yet. Best-effort — a rejection leaves the network on the REST-only path.
+     */
+    bootstrapCredentialsFromRest?: (cap: OtbrRestCapability) => Promise<void>;
     /**
      * Preferred transport when a network has BOTH a REST capability and Thread credentials.
      * Defaults to `"coap"` — the REST collection API drives one BR-managed action per node and is
@@ -139,6 +148,8 @@ export class ThreadDiagnosticsService {
     readonly #keyLocks = new Map<string, Promise<void>>();
     readonly #probesInFlight = new Map<string, Promise<void>>();
     readonly #probeAttempted = new Set<string>();
+    readonly #bootstrapsInFlight = new Map<string, Promise<void>>();
+    readonly #credentialBootstrapAttempted = new Set<string>();
     readonly #cacheTtlMs: number;
     readonly #windowMs: number;
     readonly #firstBatchMs: number;
@@ -302,7 +313,53 @@ export class ThreadDiagnosticsService {
         // stop()'s snapshot has already passed over (it would outlive teardown).
         if (this.#stopped) return undefined;
 
+        // A dialable BR with no local credentials can still bootstrap them from the BR's REST
+        // dataset, promoting this fetch from slow REST-only collection to direct MeshCoP (CoAP).
+        await this.#maybeBootstrapCredentialsFromRest(key, extPanIdBytes, force);
+        if (this.#stopped) return undefined;
+
         return this.#cancelAndStart(key, networkName, ranked, extPanIdBytes, force);
+    }
+
+    /**
+     * When a dialable BR has no locally-registered credentials but a REST capability is present,
+     * fetch the active operational dataset from the BR once and register the derived credentials so
+     * the faster/complete MeshCoP (CoAP) transport can run instead of the slow REST collection.
+     * Gated to one attempt per network (re-attempted only on a forced refresh). Best-effort: any
+     * failure (REST forbids the dataset, no PSKc, unreachable) leaves the network on REST-only.
+     */
+    async #maybeBootstrapCredentialsFromRest(key: string, extPanIdBytes: Uint8Array, force: boolean): Promise<void> {
+        const bootstrap = this.#opts.bootstrapCredentialsFromRest;
+        if (bootstrap === undefined) return;
+        if (this.#opts.credentials.getCredentials(extPanIdBytes) !== undefined) return;
+
+        // Coalesce concurrent callers (including forced refreshes) onto one dataset fetch.
+        const inFlight = this.#bootstrapsInFlight.get(key);
+        if (inFlight !== undefined) {
+            await inFlight;
+            return;
+        }
+        if (!force && this.#credentialBootstrapAttempted.has(key)) return;
+        const cap = this.#restCaps.get(key);
+        if (cap === undefined) return;
+
+        this.#credentialBootstrapAttempted.add(key);
+        const xp = key.toUpperCase();
+        const run = (async () => {
+            try {
+                await bootstrap(cap);
+                const registered = this.#opts.credentials.getCredentials(extPanIdBytes) !== undefined;
+                logger.info(`REST credential bootstrap xp=${xp} registered=${registered}`);
+            } catch (err) {
+                logger.debug(`REST credential bootstrap failed xp=${xp}: ${err}`);
+            }
+        })();
+        this.#bootstrapsInFlight.set(key, run);
+        try {
+            await run;
+        } finally {
+            this.#bootstrapsInFlight.delete(key);
+        }
     }
 
     /**
@@ -659,7 +716,12 @@ export class ThreadDiagnosticsService {
 
         const firstBatchTimer = setTimeout(() => {
             firstBatchFired = true;
-            const reason = acc.size === 0 ? "meshcop_no_responses_yet" : "in_progress";
+            const reason =
+                acc.size === 0
+                    ? sourceKind === "otbr-rest"
+                        ? "rest_no_responses_yet"
+                        : "meshcop_no_responses_yet"
+                    : "in_progress";
             logger.debug(
                 `stream firstBatch xp=${xp} acc=${acc.size} partial=${reason} t+${Date.now() - streamStart}ms`,
             );
@@ -751,6 +813,7 @@ export class ThreadDiagnosticsService {
             logger.info(`REST capability unregistered xp=${xp.toUpperCase()} (last BR for network removed)`);
         }
         this.#probeAttempted.delete(key);
+        this.#credentialBootstrapAttempted.delete(key);
     }
 
     #partial(

--- a/packages/ws-controller/test/ThreadDiagnosticsServiceTest.ts
+++ b/packages/ws-controller/test/ThreadDiagnosticsServiceTest.ts
@@ -507,6 +507,146 @@ describe("ThreadDiagnosticsService", () => {
         expect(restCalls).to.equal(0);
     });
 
+    it("bootstraps credentials from REST for a dialable BR with none, then uses MeshCoP", async () => {
+        const credsMap = new Map<string, ThreadNetworkCredentials>();
+        let meshcopCalls = 0;
+        let bootstrapCalls = 0;
+        const service = new ThreadDiagnosticsService({
+            ...FAST_TIMING,
+            borderRouters: brRegistryFrom(brsListing([makeBr({ addresses: ["fd00::1"] })])),
+            credentials: credsRegistryFrom(credsLookup(credsMap)),
+            makeRestSource: () => syncRestSource([SAMPLE_NODE]),
+            makeMeshcopSource: async () => {
+                meshcopCalls += 1;
+                return meshcopHandle(syncMeshcopSource([SAMPLE_NODE]));
+            },
+            probeRest: async () => makeCap(),
+            bootstrapCredentialsFromRest: async () => {
+                bootstrapCalls += 1;
+                credsMap.set(EXT_PAN_HEX_LOWER, makeCreds());
+            },
+        });
+
+        const batch = await service.getOrFetch(EXT_PAN_HEX_LOWER);
+        expect(bootstrapCalls).to.equal(1);
+        expect(batch?.source).to.equal("meshcop");
+        expect(meshcopCalls).to.equal(1);
+    });
+
+    it("skips REST credential bootstrap when credentials already exist", async () => {
+        let bootstrapCalls = 0;
+        const service = new ThreadDiagnosticsService({
+            ...FAST_TIMING,
+            borderRouters: brRegistryFrom(brsListing([makeBr()])),
+            credentials: credsRegistryFrom(credsLookup(new Map([[EXT_PAN_HEX_LOWER, makeCreds()]]))),
+            makeRestSource: () => syncRestSource([]),
+            makeMeshcopSource: async () => meshcopHandle(syncMeshcopSource([SAMPLE_NODE])),
+            probeRest: async () => makeCap(),
+            bootstrapCredentialsFromRest: async () => {
+                bootstrapCalls += 1;
+            },
+        });
+
+        const batch = await service.getOrFetch(EXT_PAN_HEX_LOWER);
+        expect(bootstrapCalls).to.equal(0);
+        expect(batch?.source).to.equal("meshcop");
+    });
+
+    it("falls back to REST-only when the REST credential bootstrap yields no credentials", async () => {
+        let bootstrapCalls = 0;
+        const service = new ThreadDiagnosticsService({
+            ...FAST_TIMING,
+            borderRouters: brRegistryFrom(brsListing([makeBr({ addresses: ["fd00::1"] })])),
+            credentials: credsRegistryFrom(credsLookup(new Map())),
+            makeRestSource: () => syncRestSource([SAMPLE_NODE]),
+            makeMeshcopSource: async () => meshcopHandle(syncMeshcopSource([])),
+            probeRest: async () => makeCap(),
+            bootstrapCredentialsFromRest: async () => {
+                bootstrapCalls += 1;
+            },
+        });
+
+        const batch = await service.getOrFetch(EXT_PAN_HEX_LOWER);
+        expect(bootstrapCalls).to.equal(1);
+        expect(batch?.source).to.equal("otbr-rest");
+    });
+
+    it("re-attempts the REST credential bootstrap on a forced refresh", async () => {
+        let bootstrapCalls = 0;
+        const service = new ThreadDiagnosticsService({
+            ...FAST_TIMING,
+            borderRouters: brRegistryFrom(brsListing([makeBr({ addresses: ["fd00::1"] })])),
+            credentials: credsRegistryFrom(credsLookup(new Map())),
+            makeRestSource: () => syncRestSource([SAMPLE_NODE]),
+            makeMeshcopSource: async () => meshcopHandle(syncMeshcopSource([])),
+            probeRest: async () => makeCap(),
+            bootstrapCredentialsFromRest: async () => {
+                bootstrapCalls += 1;
+            },
+        });
+
+        await service.getOrFetch(EXT_PAN_HEX_LOWER);
+        await service.getOrFetch(EXT_PAN_HEX_LOWER, { force: true });
+        expect(bootstrapCalls).to.equal(2);
+    });
+
+    it("coalesces concurrent credential bootstraps into a single dataset fetch", async () => {
+        const credsMap = new Map<string, ThreadNetworkCredentials>();
+        let bootstrapCalls = 0;
+        let releaseBootstrap!: () => void;
+        const gate = new Promise<void>(r => {
+            releaseBootstrap = r;
+        });
+        const service = new ThreadDiagnosticsService({
+            ...FAST_TIMING,
+            windowMs: 50,
+            firstBatchMs: 10,
+            borderRouters: brRegistryFrom(brsListing([makeBr({ addresses: ["fd00::1"] })])),
+            credentials: credsRegistryFrom(credsLookup(credsMap)),
+            makeRestSource: () => syncRestSource([SAMPLE_NODE]),
+            makeMeshcopSource: async () => meshcopHandle(syncMeshcopSource([SAMPLE_NODE])),
+            probeRest: async () => makeCap(),
+            bootstrapCredentialsFromRest: async () => {
+                bootstrapCalls += 1;
+                await gate;
+                credsMap.set(EXT_PAN_HEX_LOWER, makeCreds());
+            },
+        });
+
+        const p1 = service.getOrFetch(EXT_PAN_HEX_LOWER);
+        const p2 = service.getOrFetch(EXT_PAN_HEX_LOWER);
+        await new Promise(r => setTimeout(r, 5));
+        releaseBootstrap();
+        const [a, b] = await Promise.all([p1, p2]);
+        expect(bootstrapCalls).to.equal(1);
+        expect(a?.source).to.equal("meshcop");
+        expect(b?.source).to.equal("meshcop");
+    });
+
+    it("first-batch resolves with rest_no_responses_yet on a REST-only stream with no arrivals", async () => {
+        const service = new ThreadDiagnosticsService({
+            windowMs: 30,
+            firstBatchMs: 10,
+            debounceMs: 5,
+            borderRouters: brRegistryFrom(brsListing([makeBr({ addresses: [] })])),
+            credentials: credsRegistryFrom(credsLookup(new Map())),
+            makeRestSource: () => ({
+                kind: "otbr-rest",
+                canQuery: () => true,
+                queryUnicast: async () => ({ unknown: [] }),
+                queryMulticast: () => scriptedHandle({ keepOpen: true }),
+                resetCounters: async () => {},
+            }),
+            makeMeshcopSource: async () => meshcopHandle(syncMeshcopSource([])),
+        });
+        service.registerRestCapability(EXT_PAN_HEX_LOWER, makeCap());
+
+        const first = await service.getOrFetch(EXT_PAN_HEX_LOWER);
+        expect(first?.source).to.equal("otbr-rest");
+        expect(first?.partialReason).to.equal("rest_no_responses_yet");
+        expect(first?.nodes).to.have.lengthOf(0);
+    });
+
     it("concurrent fetches for the same extPanId share a single stream", async () => {
         let acquireCalls = 0;
         const service = new ThreadDiagnosticsService({


### PR DESCRIPTION
## Motivation

Field logs (BR xp=B27339BCF9CF0C75) show the OTBR REST collection diagnostics path is slow and incomplete: each collection took ~108s and returned only 3–5 of ~13 nodes, with most dashboard responses arriving empty (`nodes: []`). The BR exposes its operational dataset via REST, so we can derive credentials and use the far faster, complete MeshCoP (CoAP) transport instead.

## Changes

**Bootstrap credentials from REST (prefer CoAP).** When a dialable BR has no locally-registered Thread credentials but a REST capability is cached, `ThreadDiagnosticsService` now fetches the active operational dataset from the BR once and registers the derived credentials before selecting a transport. The subsequent fetch then uses MeshCoP (CoAP) — direct per-node `DIAG_GET`, seconds not minutes, full topology — degrading to REST-only only if the bootstrap yields nothing.

- Gated to one attempt per network (re-attempted only on a forced refresh); skipped entirely when credentials already exist.
- Concurrent/forced callers are coalesced onto a single dataset fetch (`#bootstrapsInFlight`).
- The attempt gate is cleared when the last BR for a network is removed (recovery parity with the REST-probe path).
- Best-effort: a BR that forbids the dataset, omits PSKc, or errors leaves the network on the existing REST-only path.
- `MatterController` wires it via `OtbrRestClient.getActiveDataset()` (single round-trip) + `ThreadCredentialsRegistry.register`.

**Fix mislabeled partial reason.** A REST stream with no arrivals before the first-batch deadline reported the MeshCoP-specific `meshcop_no_responses_yet`. Added `rest_no_responses_yet` and select the reason by the transport actually querying.

## Verification

- 6 new unit tests (bootstrap→MeshCoP, skip-when-creds-exist, REST-only fallback, force re-attempt, concurrent coalescing, `rest_no_responses_yet`); RED→GREEN confirmed.
- Full `ws-controller` suite: 229/229. `ws-client`: 73/73. Clean build, `format-verify`, `lint` all pass.
- No library change — all `@matter/thread-br-client` APIs already existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)