### PR TITLE
fix(ws-controller): five robustness fixes — guarded observer/build/cache throws, observer-group cleanup, time-sync cooldown, unhandled-rejection hardening

### DIFF
--- a/packages/ws-controller/src/controller/AttributeDataCache.ts
+++ b/packages/ws-controller/src/controller/AttributeDataCache.ts
@@ -73,17 +73,39 @@ export class AttributeDataCache {
      */
     updateAttribute(nodeId: NodeId, data: DecodedAttributeReportValue<any>): void {
         const { endpointId, clusterId, attributeId } = data.path;
+        const path = buildAttributePath(endpointId, clusterId, attributeId);
 
         const clusterData = ClusterMap[clusterId];
-        const convertedValue = convertMatterToWebSocketTagBased(
-            data.value,
-            clusterData?.attributes[attributeId],
-            clusterData?.model,
-        );
+        let convertedValue: unknown;
+        try {
+            convertedValue = convertMatterToWebSocketTagBased(
+                data.value,
+                clusterData?.attributes[attributeId],
+                clusterData?.model,
+            );
+        } catch (error) {
+            // Unlike #collectAttributes below (which runs inside #runPopulate's own catch-all), this
+            // path has no safety net: it is invoked directly from the node's attributeChanged
+            // observer, so a rethrow here would escape into the event dispatch and could abort
+            // delivery of every other pending update for this node. A single malformed value must
+            // never take that down, so always log and skip — regardless of error type, unlike the
+            // MatterError-only tolerance below.
+            if (error instanceof MatterError) {
+                logger.debug(
+                    `Ignoring attribute update ${path} for node ${formatNodeId(nodeId)} because of`,
+                    Diagnostic.errorMessage(error),
+                );
+            } else {
+                logger.warn(
+                    `Ignoring attribute update ${path} for node ${formatNodeId(nodeId)}: converter threw`,
+                    error,
+                );
+            }
+            return;
+        }
         if (convertedValue === undefined) {
             return;
         }
-        const path = buildAttributePath(endpointId, clusterId, attributeId);
         const inFlight = this.#inFlight.get(nodeId);
         const attributes = this.#cache.get(nodeId);
 

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -528,7 +528,11 @@ export class ControllerCommandHandler {
         const node = await this.#controller.getNode(nodeId);
         const attributeCache = this.#nodes.attributeCache;
 
-        // Per-node ObserverGroup so all subscriptions are cleaned up on decommission
+        // Per-node ObserverGroup so all subscriptions are cleaned up on decommission. A node can be
+        // registered more than once for the same id (e.g. a re-commission after removal without an
+        // intervening decommission event) — close any stale group first so its listeners don't keep
+        // firing alongside the new one and double-emit downstream events.
+        this.#nodeObservers.get(nodeId)?.close();
         const nodeObservers = new ObserverGroup();
         this.#nodeObservers.set(nodeId, nodeObservers);
 

--- a/packages/ws-controller/src/controller/TimeSyncManager.ts
+++ b/packages/ws-controller/src/controller/TimeSyncManager.ts
@@ -35,10 +35,16 @@ export const TIME_FAILURE_EVENT_ID = 0x03;
 // Periodic resync interval: 24 hours
 const RESYNC_INTERVAL = Hours(24);
 
-// Minimum spacing between trigger-driven (reconnect / timeFailure) syncs for one peer.
-// The periodic path already caps its own cadence; this stops a flapping node or a device
-// repeatedly emitting timeFailure from storming setUtcTime commands.
+// Minimum spacing between trigger-driven (reconnect / timeFailure) syncs for one peer, applied after
+// a *successful* attempt. The periodic path already caps its own cadence; this stops a flapping node
+// or a device repeatedly emitting timeFailure from storming setUtcTime commands once time is known-good.
 const TRIGGER_SYNC_COOLDOWN = Hours(24);
+
+// Spacing applied instead of TRIGGER_SYNC_COOLDOWN after a *failed* attempt. A transient failure
+// (the node briefly unreachable, a dropped interaction) must not lock a node out of correction for a
+// full day; a short backoff lets the next reconnect or timeFailure retry soon while still preventing
+// an immediate resend storm.
+const TRIGGER_SYNC_FAILURE_BACKOFF = Minutes(5);
 
 export interface TimeSyncConnector {
     syncTime(peer: PeerAddress): Promise<void>;
@@ -84,8 +90,10 @@ export class TimeSyncManager extends NodeProcessor {
     readonly #connector: TimeSyncConnector;
     // Tracks in-flight immediate syncs per node to prevent parallel syncs
     #inFlightSyncs = new PeerAddressMap<Promise<void>>();
-    // Last trigger-driven sync attempt per node, used to enforce TRIGGER_SYNC_COOLDOWN
-    #lastTriggerSyncMs = new PeerAddressMap<number>();
+    // Next time (ms since epoch) a trigger-driven sync may run for one peer. Pushed out by
+    // TRIGGER_SYNC_COOLDOWN on a successful attempt, or by the shorter TRIGGER_SYNC_FAILURE_BACKOFF on
+    // a failed one — see #syncNode.
+    #nextTriggerSyncMs = new PeerAddressMap<number>();
     // True after the first periodic resync cycle, enabling immediate syncs on reconnect
     #startupComplete = false;
 
@@ -126,7 +134,7 @@ export class TimeSyncManager extends NodeProcessor {
      * Unregister a node from time sync tracking.
      */
     unregisterNode(peer: PeerAddress): void {
-        this.#lastTriggerSyncMs.delete(peer);
+        this.#nextTriggerSyncMs.delete(peer);
         if (this.unregisterPeer(peer)) {
             logger.info(`Unregistered node ${formatNodeId(peer)} from time synchronization`);
         }
@@ -142,18 +150,24 @@ export class TimeSyncManager extends NodeProcessor {
             logger.debug(`Time sync already in progress for node ${formatNodeId(peer)}, skipping`);
             return;
         }
-        const lastSync = this.#lastTriggerSyncMs.get(peer);
-        if (lastSync !== undefined && Time.nowMs - lastSync < TRIGGER_SYNC_COOLDOWN) {
-            logger.debug(
-                `Time sync for node ${formatNodeId(peer)} skipped, within ${Duration.format(TRIGGER_SYNC_COOLDOWN)} cooldown`,
-            );
+        const nextAllowed = this.#nextTriggerSyncMs.get(peer);
+        if (nextAllowed !== undefined && Time.nowMs < nextAllowed) {
+            logger.debug(`Time sync for node ${formatNodeId(peer)} skipped, still within trigger-sync backoff`);
             return;
         }
-        this.#lastTriggerSyncMs.set(peer, Time.nowMs);
+        // The cooldown is set from the *outcome* below, not here: a successful sync earns the long
+        // 24h cooldown (time is now known-good), while a failed attempt only earns a short backoff so
+        // a transient failure doesn't lock the node out of correction for a full day.
         const promise = this.#connector
             .syncTime(peer)
-            .then(() => logger.info(`Synced time on node ${formatNodeId(peer)}`))
-            .catch(error => logSyncFailure("", peer, error))
+            .then(() => {
+                this.#nextTriggerSyncMs.set(peer, Time.nowMs + TRIGGER_SYNC_COOLDOWN);
+                logger.info(`Synced time on node ${formatNodeId(peer)}`);
+            })
+            .catch(error => {
+                this.#nextTriggerSyncMs.set(peer, Time.nowMs + TRIGGER_SYNC_FAILURE_BACKOFF);
+                logSyncFailure("", peer, error);
+            })
             .finally(() => {
                 this.#inFlightSyncs.delete(peer);
             });
@@ -169,7 +183,7 @@ export class TimeSyncManager extends NodeProcessor {
         await super.stop();
         await Promise.allSettled(this.#inFlightSyncs.values());
         this.#inFlightSyncs.clear();
-        this.#lastTriggerSyncMs.clear();
+        this.#nextTriggerSyncMs.clear();
         logger.info("Time sync manager stopped");
     }
 

--- a/packages/ws-controller/src/controller/TimeSyncManager.ts
+++ b/packages/ws-controller/src/controller/TimeSyncManager.ts
@@ -52,8 +52,12 @@ export interface TimeSyncConnector {
 }
 
 /** TimeNotAccepted means the node keeps a time source it prefers — expected, not an error. */
+function isTimeNotAccepted(error: unknown): boolean {
+    return error instanceof StatusResponseError && error.clusterCode === TimeSynchronization.StatusCode.TimeNotAccepted;
+}
+
 function logSyncFailure(prefix: string, peer: PeerAddress, error: unknown) {
-    if (error instanceof StatusResponseError && error.clusterCode === TimeSynchronization.StatusCode.TimeNotAccepted) {
+    if (isTimeNotAccepted(error)) {
         logger.info(`${prefix}Node ${formatNodeId(peer)} declined the provided time`);
         return;
     }
@@ -165,7 +169,11 @@ export class TimeSyncManager extends NodeProcessor {
                 logger.info(`Synced time on node ${formatNodeId(peer)}`);
             })
             .catch(error => {
-                this.#nextTriggerSyncMs.set(peer, Time.nowMs + TRIGGER_SYNC_FAILURE_BACKOFF);
+                // A TimeNotAccepted refusal is deliberate and persistent — the node keeps
+                // its preferred time source. Give it the full cooldown; only transient
+                // failures earn the short retry backoff.
+                const spacing = isTimeNotAccepted(error) ? TRIGGER_SYNC_COOLDOWN : TRIGGER_SYNC_FAILURE_BACKOFF;
+                this.#nextTriggerSyncMs.set(peer, Time.nowMs + spacing);
                 logSyncFailure("", peer, error);
             })
             .finally(() => {

--- a/packages/ws-controller/src/server/WebSocketConnection.ts
+++ b/packages/ws-controller/src/server/WebSocketConnection.ts
@@ -145,7 +145,17 @@ export class WebSocketConnection {
     sendCoalescable(key: string, build: () => string | undefined): void {
         if (this.#disposed) return;
         if (this.#mode === "direct") {
-            const frame = build();
+            // A throwing builder (e.g. a converter fed a poisoned value) must not escape into the
+            // caller — that caller is typically an event observer shared across connections, and an
+            // uncaught throw there would abort delivery to every other connection. Treat it like an
+            // undefined frame: log it and skip the send, mirroring the queued-path guard below.
+            let frame: string | undefined;
+            try {
+                frame = build();
+            } catch (err) {
+                logger.error(`[${this.#connId}] failed to build coalescable frame; dropping it`, err);
+                return;
+            }
             if (frame !== undefined) this.#directSend(frame);
             return;
         }

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -344,74 +344,96 @@ export class WebSocketControllerHandler implements WebServerHandler {
             // Register all event listeners using ObserverGroup for easy cleanup
             observers.on(this.#commandHandler.events.attributeChanged, (nodeId, data) => {
                 if (this.#closed || this.#shuttingDown || !listening) return;
-                const { endpointId, clusterId, attributeId } = data.path;
-                const pathStr = `${endpointId}/${clusterId}/${attributeId}`;
-                // `data` is emitter-owned; snapshot the value before deferring. Coalesce latest-wins
-                // per (node, path) and convert lazily so a superseded value is never converted.
-                const rawValue = data.value;
-                connection.sendCoalescable(`attr:${nodeId}/${pathStr}`, () => {
-                    const clusterData = ClusterMap[clusterId];
-                    const value = convertMatterToWebSocketTagBased(
-                        rawValue,
-                        clusterData?.attributes[attributeId],
-                        clusterData?.model,
+                // This observer is shared across every connection; an uncaught throw here (e.g. a
+                // converter fed a poisoned attribute value) would abort the emit and starve the
+                // remaining observers — and the remaining connections — of this and all following
+                // events. Isolate per connection: log and move on, mirroring the guarded
+                // thread-diagnostics observer below.
+                try {
+                    const { endpointId, clusterId, attributeId } = data.path;
+                    const pathStr = `${endpointId}/${clusterId}/${attributeId}`;
+                    // `data` is emitter-owned; snapshot the value before deferring. Coalesce latest-wins
+                    // per (node, path) and convert lazily so a superseded value is never converted.
+                    const rawValue = data.value;
+                    connection.sendCoalescable(`attr:${nodeId}/${pathStr}`, () => {
+                        const clusterData = ClusterMap[clusterId];
+                        const value = convertMatterToWebSocketTagBased(
+                            rawValue,
+                            clusterData?.attributes[attributeId],
+                            clusterData?.model,
+                        );
+                        logger.debug(
+                            `[${connId}] Sending attribute_updated event for Node ${this.#commandHandler.formatNode(nodeId)}`,
+                            pathStr,
+                            value,
+                        );
+                        return toBigIntAwareJson({ event: "attribute_updated", data: [nodeId, pathStr, value] });
+                    });
+                } catch (err) {
+                    logger.error(
+                        `[${connId}] Failed to handle attributeChanged event for Node ${this.#commandHandler.formatNode(nodeId)}`,
+                        err,
                     );
-                    logger.debug(
-                        `[${connId}] Sending attribute_updated event for Node ${this.#commandHandler.formatNode(nodeId)}`,
-                        pathStr,
-                        value,
-                    );
-                    return toBigIntAwareJson({ event: "attribute_updated", data: [nodeId, pathStr, value] });
-                });
+                }
             });
 
             observers.on(this.#commandHandler.events.eventChanged, (nodeId, data) => {
                 if (this.#closed || this.#shuttingDown || !listening) return;
-                const { path, events } = data;
-                const { endpointId, clusterId, eventId } = path;
-                const clusterData = ClusterMap[clusterId];
+                // Same isolation rationale as attributeChanged above: this observer is shared across
+                // every connection, so a throw while converting one connection's event data must not
+                // starve the others.
+                try {
+                    const { path, events } = data;
+                    const { endpointId, clusterId, eventId } = path;
+                    const clusterData = ClusterMap[clusterId];
 
-                for (const event of events) {
-                    let timestamp: number | bigint;
-                    let timestampType: number;
+                    for (const event of events) {
+                        let timestamp: number | bigint;
+                        let timestampType: number;
 
-                    if (event.epochTimestamp !== undefined) {
-                        timestamp = event.epochTimestamp;
-                        timestampType = 1; // Epoch
-                    } else if (event.systemTimestamp !== undefined) {
-                        timestamp = event.systemTimestamp;
-                        timestampType = 0; // System
-                    } else {
-                        timestamp = Date.now();
-                        timestampType = 2; // POSIX (fallback)
+                        if (event.epochTimestamp !== undefined) {
+                            timestamp = event.epochTimestamp;
+                            timestampType = 1; // Epoch
+                        } else if (event.systemTimestamp !== undefined) {
+                            timestamp = event.systemTimestamp;
+                            timestampType = 0; // System
+                        } else {
+                            timestamp = Date.now();
+                            timestampType = 2; // POSIX (fallback)
+                        }
+
+                        const eventModel = clusterData?.events[eventId];
+                        const convertedData =
+                            event.data !== undefined
+                                ? convertMatterToWebSocketNameBased(event.data, eventModel, clusterData?.model)
+                                : null;
+
+                        const nodeEvent: MatterNodeEvent = {
+                            node_id: nodeId,
+                            endpoint_id: endpointId,
+                            cluster_id: clusterId,
+                            event_id: eventId,
+                            event_number: event.eventNumber,
+                            priority: event.priority,
+                            timestamp,
+                            timestamp_type: timestampType,
+                            data: convertedData,
+                        };
+
+                        // Store event in the history buffer
+                        this.#addEventToHistory(nodeEvent);
+
+                        logger.debug(
+                            `[${connId}] Sending node_event for Node ${this.#commandHandler.formatNode(nodeId)}`,
+                            nodeEvent,
+                        );
+                        connection.sendOrdered(toBigIntAwareJson({ event: "node_event", data: nodeEvent }));
                     }
-
-                    const eventModel = clusterData?.events[eventId];
-                    const convertedData =
-                        event.data !== undefined
-                            ? convertMatterToWebSocketNameBased(event.data, eventModel, clusterData?.model)
-                            : null;
-
-                    const nodeEvent: MatterNodeEvent = {
-                        node_id: nodeId,
-                        endpoint_id: endpointId,
-                        cluster_id: clusterId,
-                        event_id: eventId,
-                        event_number: event.eventNumber,
-                        priority: event.priority,
-                        timestamp,
-                        timestamp_type: timestampType,
-                        data: convertedData,
-                    };
-
-                    // Store event in the history buffer
-                    this.#addEventToHistory(nodeEvent);
-
-                    logger.debug(
-                        `[${connId}] Sending node_event for Node ${this.#commandHandler.formatNode(nodeId)}`,
-                        nodeEvent,
+                } catch (err) {
+                    logger.error(
+                        `[${connId}] Failed to handle eventChanged event for Node ${this.#commandHandler.formatNode(nodeId)}`,
+                        err,
                     );
-                    connection.sendOrdered(toBigIntAwareJson({ event: "node_event", data: nodeEvent }));
                 }
             });
 

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -547,22 +547,35 @@ export class WebSocketControllerHandler implements WebServerHandler {
             ws.on(
                 "message",
                 data =>
-                    void this.#handleWebSocketRequest(connId, connection, data.toString()).then(
-                        ({ response, enableListeners, wantsThreadDiagnostics: requested, wantsWebRtc: reqWebRtc }) => {
-                            if (this.#closed) return;
-                            if (enableListeners) {
-                                listening = true;
-                            }
-                            if (requested) {
-                                wantsThreadDiagnostics = true;
-                            }
-                            if (reqWebRtc) {
-                                wantsWebRtc = true;
-                            }
-                            connection.sendReliable(toBigIntAwareJson(response));
-                        },
-                        err => logger.error(`[${connId}] WebSocket request error`, err),
-                    ),
+                    // `.then(onFulfilled).catch(handler)` rather than the two-argument
+                    // `.then(onFulfilled, onRejected)`: the two-argument form only catches a rejection
+                    // of #handleWebSocketRequest itself, not a throw raised by onFulfilled — and
+                    // onFulfilled's serialization (toBigIntAwareJson) can throw on a pathological
+                    // response after the command already resolved successfully. Chaining .catch()
+                    // after .then() covers both, instead of leaking that throw as an unhandled
+                    // rejection.
+                    void this.#handleWebSocketRequest(connId, connection, data.toString())
+                        .then(
+                            ({
+                                response,
+                                enableListeners,
+                                wantsThreadDiagnostics: requested,
+                                wantsWebRtc: reqWebRtc,
+                            }) => {
+                                if (this.#closed) return;
+                                if (enableListeners) {
+                                    listening = true;
+                                }
+                                if (requested) {
+                                    wantsThreadDiagnostics = true;
+                                }
+                                if (reqWebRtc) {
+                                    wantsWebRtc = true;
+                                }
+                                connection.sendReliable(toBigIntAwareJson(response));
+                            },
+                        )
+                        .catch(err => logger.error(`[${connId}] WebSocket request error`, err)),
             );
 
             ws.on("close", onClose);
@@ -571,13 +584,14 @@ export class WebSocketControllerHandler implements WebServerHandler {
                 onClose();
             });
 
-            this.#getServerInfo().then(
-                response => {
+            // Same rationale as above: .catch() after .then() so a throw while serializing the
+            // server-info response is caught instead of leaking as an unhandled rejection.
+            this.#getServerInfo()
+                .then(response => {
                     logger.debug(`[${connId}] Sending server info`);
                     connection.sendReliable(toBigIntAwareJson(response));
-                },
-                err => logger.error(`[${connId}] WebSocket handshake error`, err),
-            );
+                })
+                .catch(err => logger.error(`[${connId}] WebSocket handshake error`, err));
         });
 
         // Initialize all nodes (populates attribute caches) and start connecting them.

--- a/packages/ws-controller/test/AttributeDataCacheTest.ts
+++ b/packages/ws-controller/test/AttributeDataCacheTest.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NodeId } from "@matter/main";
+import type { DecodedAttributeReportValue } from "@project-chip/matter.js/cluster";
+import type { PairedNode } from "@project-chip/matter.js/device";
+import { AttributeDataCache } from "../src/controller/AttributeDataCache.js";
+import { ClusterMap } from "../src/model/ModelMapper.js";
+import { buildAttributePath } from "../src/server/Converters.js";
+
+const NODE_ID = NodeId(1);
+
+// WindowCovering.ConfigStatus (attribute 7) is a real bitmap-typed attribute. Setting one of its bit
+// fields to a string makes the real converter throw ("Invalid bitmap value") — this exercises the
+// guard against the actual conversion code path instead of an injected fake.
+const WINDOW_COVERING_CLUSTER_ID = 258;
+const CONFIG_STATUS_ATTRIBUTE_ID = 7;
+const ENDPOINT_ID = 0;
+const PATH = buildAttributePath(ENDPOINT_ID, WINDOW_COVERING_CLUSTER_ID, CONFIG_STATUS_ATTRIBUTE_ID);
+
+function attributeReport(value: unknown): DecodedAttributeReportValue<any> {
+    return {
+        path: {
+            endpointId: ENDPOINT_ID,
+            clusterId: WINDOW_COVERING_CLUSTER_ID,
+            attributeId: CONFIG_STATUS_ATTRIBUTE_ID,
+            attributeName: "ConfigStatus",
+        },
+        version: 1,
+        value,
+    } as DecodedAttributeReportValue<any>;
+}
+
+/** Minimal PairedNode stand-in: no endpoints, so #collectAttributes seeds an empty cached snapshot. */
+function makeFakeNode(nodeId: NodeId): PairedNode {
+    return {
+        nodeId,
+        initialized: true,
+        node: {
+            lifecycle: { isCommissioned: true, isReady: true },
+            endpoints: [],
+        },
+    } as unknown as PairedNode;
+}
+
+describe("AttributeDataCache", () => {
+    it("sanity: WindowCovering.ConfigStatus is wired up as a real bitmap attribute", () => {
+        const entry = ClusterMap[WINDOW_COVERING_CLUSTER_ID];
+        expect(entry).to.not.equal(undefined);
+        expect(entry?.attributes[CONFIG_STATUS_ATTRIBUTE_ID]?.name).to.equal("ConfigStatus");
+    });
+
+    describe("updateAttribute", () => {
+        it("does not throw when the converter rejects the value, and leaves the cache unchanged", async () => {
+            const cache = new AttributeDataCache();
+            await cache.add(makeFakeNode(NODE_ID));
+            expect(cache.has(NODE_ID)).to.equal(true);
+            const before = { ...cache.get(NODE_ID) };
+
+            expect(() => cache.updateAttribute(NODE_ID, attributeReport({ operational: "poison" }))).to.not.throw();
+
+            expect(cache.get(NODE_ID)).to.deep.equal(before);
+        });
+
+        it("still applies a subsequent good update after a rejected one", async () => {
+            const cache = new AttributeDataCache();
+            await cache.add(makeFakeNode(NODE_ID));
+
+            cache.updateAttribute(NODE_ID, attributeReport({ operational: "poison" })); // rejected, ignored
+            cache.updateAttribute(NODE_ID, attributeReport({})); // no bit set -> valid, converts to 0
+
+            expect(cache.get(NODE_ID)?.[PATH]).to.equal(0);
+        });
+    });
+});

--- a/packages/ws-controller/test/TimeSyncManagerTest.ts
+++ b/packages/ws-controller/test/TimeSyncManagerTest.ts
@@ -33,6 +33,8 @@ class StubConnector implements TimeSyncConnector {
     readonly syncCalls: PeerAddress[] = [];
     private readonly _connected = new PeerAddressSet();
     slowSync = false;
+    /** When true, the next syncTime() call rejects instead of succeeding (auto-resets after firing). */
+    failNext = false;
     readonly syncResolvers: Array<() => void> = [];
 
     setConnected(peer: PeerAddress): void {
@@ -48,6 +50,10 @@ class StubConnector implements TimeSyncConnector {
             await new Promise<void>(resolve => this.syncResolvers.push(resolve));
         }
         this.syncCalls.push(peer);
+        if (this.failNext) {
+            this.failNext = false;
+            throw new Error("simulated sync failure");
+        }
     }
 
     resolveAll(): void {
@@ -255,6 +261,50 @@ describe("TimeSyncManager", () => {
             expect(connector.syncCalls.length).to.equal(1);
 
             await MockTime.advance(ONE_DAY_MS); // periodic still resyncs despite recent trigger sync
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.equal(2);
+        });
+    });
+
+    describe("trigger sync cooldown after a failed attempt", () => {
+        beforeEach(() => {
+            manager.registerNode(PEER_1, makeTimeSyncAttrs());
+            manager.completeStartup();
+            connector.setConnected(PEER_1);
+        });
+
+        it("retries a failed trigger sync after the short backoff, well before the 24h cooldown would allow it", async () => {
+            connector.failNext = true;
+            manager.syncNode(PEER_1);
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.equal(1);
+
+            manager.syncNode(PEER_1); // immediately after — still backed off, dropped
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.equal(1);
+
+            await MockTime.advance(6 * ONE_MINUTE_MS); // past the 5-min failure backoff
+            await MockTime.yield3();
+
+            manager.syncNode(PEER_1); // backoff elapsed — retries
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.equal(2);
+        });
+
+        it("still cools down for the full 24h after a successful sync (not shortened by an earlier failure)", async () => {
+            connector.failNext = true;
+            manager.syncNode(PEER_1); // fails, short backoff set
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.equal(1);
+
+            await MockTime.advance(6 * ONE_MINUTE_MS); // backoff elapsed
+            await MockTime.yield3();
+
+            manager.syncNode(PEER_1); // retry succeeds — full 24h cooldown now applies
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.equal(2);
+
+            manager.syncNode(PEER_1); // well within the new 24h cooldown — dropped
             await MockTime.yield3();
             expect(connector.syncCalls.length).to.equal(2);
         });

--- a/packages/ws-controller/test/TimeSyncManagerTest.ts
+++ b/packages/ws-controller/test/TimeSyncManagerTest.ts
@@ -5,7 +5,9 @@
  */
 
 import { FabricIndex, NodeId } from "@matter/main";
+import { TimeSynchronization } from "@matter/main/clusters";
 import { PeerAddress, PeerAddressSet } from "@matter/main/protocol";
+import { Status, StatusResponseError } from "@matter/main/types";
 import {
     dstOffsetListMaxSize,
     hasTimeSyncCluster,
@@ -35,6 +37,8 @@ class StubConnector implements TimeSyncConnector {
     slowSync = false;
     /** When true, the next syncTime() call rejects instead of succeeding (auto-resets after firing). */
     failNext = false;
+    /** When set, the next syncTime() call rejects with this specific error (auto-resets after firing). */
+    failNextWith: Error | undefined = undefined;
     readonly syncResolvers: Array<() => void> = [];
 
     setConnected(peer: PeerAddress): void {
@@ -53,6 +57,11 @@ class StubConnector implements TimeSyncConnector {
         if (this.failNext) {
             this.failNext = false;
             throw new Error("simulated sync failure");
+        }
+        if (this.failNextWith !== undefined) {
+            const error = this.failNextWith;
+            this.failNextWith = undefined;
+            throw error;
         }
     }
 
@@ -289,6 +298,33 @@ describe("TimeSyncManager", () => {
             manager.syncNode(PEER_1); // backoff elapsed — retries
             await MockTime.yield3();
             expect(connector.syncCalls.length).to.equal(2);
+        });
+
+        it("applies the full 24h cooldown to a TimeNotAccepted refusal, not the short backoff", async () => {
+            // TimeNotAccepted is a deliberate, persistent refusal — the node prefers its
+            // existing time source. Retrying every 5 minutes would storm a non-retryable
+            // response; it must earn the same long cooldown as a success.
+            connector.failNextWith = new StatusResponseError(
+                "Time not accepted",
+                Status.Failure,
+                TimeSynchronization.StatusCode.TimeNotAccepted,
+            );
+            manager.syncNode(PEER_1);
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.equal(1);
+
+            await MockTime.advance(6 * ONE_MINUTE_MS); // past the 5-min failure backoff
+            manager.syncNode(PEER_1); // must be dropped — the long cooldown applies
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.equal(1);
+
+            await MockTime.advance(ONE_DAY_MS); // periodic resync may fire in here (no trigger cooldown)
+            await MockTime.yield3();
+            const afterResync = connector.syncCalls.length;
+
+            manager.syncNode(PEER_1); // cooldown elapsed — allowed again
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.equal(afterResync + 1);
         });
 
         it("still cools down for the full 24h after a successful sync (not shortened by an earlier failure)", async () => {

--- a/packages/ws-controller/test/WebSocketConnectionTest.ts
+++ b/packages/ws-controller/test/WebSocketConnectionTest.ts
@@ -102,6 +102,21 @@ describe("WebSocketConnection", () => {
 
             expect(conn.mode).to.equal("queued");
         });
+
+        it("skips a coalescable whose builder throws, without crashing the connection", () => {
+            const socket = new FakeSocket();
+            const conn = makeConn(socket);
+
+            expect(() =>
+                conn.sendCoalescable("boom", () => {
+                    throw new Error("build failed");
+                }),
+            ).to.not.throw();
+
+            // The connection must still be usable for the next frame.
+            conn.sendReliable("after");
+            expect(socket.sent).to.deep.equal(["after"]);
+        });
     });
 
     describe("dynamic high-water", () => {

--- a/packages/ws-controller/test/WebSocketObserverGuardTest.ts
+++ b/packages/ws-controller/test/WebSocketObserverGuardTest.ts
@@ -1,0 +1,329 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression tests for the observer guards in WebSocketControllerHandler's shared
+ * attributeChanged/eventChanged observers (and the direct-mode build guard in
+ * WebSocketConnection beneath them).
+ *
+ * Those observers are registered once per connection on command-handler observables shared by
+ * every open connection. Before the guards, a throw inside one connection's observer body — a
+ * converter rejecting a poisoned value, or the connection's own send path failing — escaped into
+ * `Observable.emit`, aborting the emit and starving every observer registered after it: other
+ * connections silently stopped receiving that event and, for the same emit, everything behind it.
+ *
+ * These tests drive a real WebSocketControllerHandler over a real `ws` client/server pair with TWO
+ * client connections (same harness shape as WsBackpressureReproTest.ts / the serialization test)
+ * and prove the guards' core guarantee: (1) no throw escapes the emit, (2) the other connection is
+ * still fed, (3) subsequent clean emits are delivered normally.
+ */
+
+import { Environment, FabricId, MockStorageService, NodeId, Observable } from "@matter/main";
+import { AttributeId, ClusterId, EndpointNumber, EventId, EventNumber, Priority } from "@matter/main/types";
+import type { DecodedAttributeReportValue, DecodedEventReportValue } from "@project-chip/matter.js/cluster";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { WebSocket, WebSocketServer } from "ws";
+import type { MatterController } from "../src/controller/MatterController.js";
+import { ConfigStorage } from "../src/server/ConfigStorage.js";
+import { WebSocketControllerHandler } from "../src/server/WebSocketControllerHandler.js";
+
+const NODE_ID = NodeId(1);
+
+// WindowCovering.ConfigStatus (attribute 7) is a real bitmap-typed attribute; a bit field set to a
+// string makes the real converter throw ("Invalid bitmap value") — same poison as
+// AttributeDataCacheTest.ts. For attributeChanged the conversion runs inside the lazy frame build.
+const WINDOW_COVERING_CLUSTER_ID = ClusterId(258);
+const CONFIG_STATUS_ATTRIBUTE_ID = AttributeId(7);
+
+// BooleanStateConfiguration.AlarmsStateChanged (event 0) carries bitmap-typed fields; a poisoned
+// bit field makes the real converter throw *directly in the eventChanged observer body* (event
+// conversion is not deferred into a lazy build), exercising the handler-level guard specifically.
+const BOOLEAN_STATE_CONFIGURATION_CLUSTER_ID = ClusterId(128);
+const ALARMS_STATE_CHANGED_EVENT_ID = EventId(0);
+
+function attributeReport(endpointId: number, value: unknown): DecodedAttributeReportValue<unknown> {
+    return {
+        path: {
+            endpointId: EndpointNumber(endpointId),
+            clusterId: WINDOW_COVERING_CLUSTER_ID,
+            attributeId: CONFIG_STATUS_ATTRIBUTE_ID,
+            attributeName: "configStatus",
+        },
+        version: 1,
+        value,
+    };
+}
+
+function alarmsEventReport(data: unknown): DecodedEventReportValue<unknown> {
+    return {
+        path: {
+            endpointId: EndpointNumber(1),
+            clusterId: BOOLEAN_STATE_CONFIGURATION_CLUSTER_ID,
+            eventId: ALARMS_STATE_CHANGED_EVENT_ID,
+            eventName: "alarmsStateChanged",
+        },
+        events: [
+            {
+                eventNumber: EventNumber(1n),
+                priority: Priority.Info,
+                systemTimestamp: Date.now(),
+                data,
+            },
+        ],
+    };
+}
+
+/**
+ * Minimal stand-in for `ControllerCommandHandler` exposing only the surface
+ * `WebSocketControllerHandler.register()`/`start_listening` touch (see WsBackpressureReproTest.ts
+ * for the rationale on the cast-based fake — the real class needs a live CommissioningController).
+ */
+function createFakeCommandHandler() {
+    return {
+        events: {
+            attributeChanged: new Observable<[nodeId: NodeId, data: DecodedAttributeReportValue<unknown>]>(),
+            eventChanged: new Observable<[nodeId: NodeId, data: DecodedEventReportValue<unknown>]>(),
+            nodeAdded: new Observable(),
+            nodeStateChanged: new Observable(),
+            nodeAvailabilityChanged: new Observable(),
+            nodeStructureChanged: new Observable(),
+            nodeDecommissioned: new Observable(),
+            nodeEndpointAdded: new Observable(),
+            nodeEndpointRemoved: new Observable(),
+            webRtcCallback: new Observable(),
+        },
+        getNodeIds: () => new Array<NodeId>(),
+        hasNode: () => false,
+        formatNode: (nodeId: NodeId) => `test-node-${nodeId}`,
+        bleEnabled: false,
+        bleProxyEnabled: false,
+        getCommissionerNodeId: () => NodeId(112233),
+        start: async () => {},
+        getCommissionerFabricData: async () => ({
+            fabricId: FabricId(1),
+            compressedFabricId: 1n,
+            fabricIndex: 1,
+        }),
+        initializeNodes: async () => {},
+    };
+}
+
+async function createHarness() {
+    const env = new Environment("test");
+    new MockStorageService(env);
+    const config = await ConfigStorage.create(env);
+
+    const fakeCommandHandler = createFakeCommandHandler();
+    const fakeController = {
+        commandHandler: fakeCommandHandler,
+        threadDiagnostics: { events: { batchUpdated: new Observable() } },
+    } as unknown as MatterController;
+
+    const handler = new WebSocketControllerHandler(fakeController, config, "observer-guard-test");
+
+    const httpServer = createServer();
+    await new Promise<void>((resolve, reject) => {
+        httpServer.once("error", reject);
+        httpServer.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    await handler.register(httpServer);
+
+    return { env, config, fakeCommandHandler, handler, httpServer };
+}
+
+/** Captures server-side `ws.WebSocket` instances in connect order (same tap as WsBackpressureReproTest.ts). */
+function captureServerSocket() {
+    const captured = new Array<WebSocket>();
+    const originalEmit = WebSocketServer.prototype.emit;
+    WebSocketServer.prototype.emit = function (this: WebSocketServer, event: string, ...args: unknown[]) {
+        if (event === "connection") {
+            captured.push(args[0] as WebSocket);
+        }
+        return (originalEmit as (...a: unknown[]) => boolean).apply(this, [event, ...args]);
+    } as typeof WebSocketServer.prototype.emit;
+
+    return {
+        get(index: number): WebSocket {
+            const socket = captured[index];
+            if (!socket) throw new Error(`No server-side connection captured at index ${index}`);
+            return socket;
+        },
+        restore: () => {
+            WebSocketServer.prototype.emit = originalEmit;
+        },
+    };
+}
+
+type WsMessage = Record<string, unknown>;
+
+/** Same buffering helper as WsBackpressureReproTest.ts: never misses a message that arrives early. */
+function createMessageBuffer(ws: WebSocket) {
+    const backlog = new Array<WsMessage>();
+    const waiters = new Array<{ predicate: (msg: WsMessage) => boolean; resolve: (msg: WsMessage) => void }>();
+
+    ws.on("message", data => {
+        const msg = JSON.parse(data.toString()) as WsMessage;
+        const index = waiters.findIndex(w => w.predicate(msg));
+        if (index >= 0) {
+            waiters.splice(index, 1)[0].resolve(msg);
+        } else {
+            backlog.push(msg);
+        }
+    });
+
+    return {
+        wait(predicate: (msg: WsMessage) => boolean, timeoutMs = 5000): Promise<WsMessage> {
+            const index = backlog.findIndex(predicate);
+            if (index >= 0) {
+                return Promise.resolve(backlog.splice(index, 1)[0]);
+            }
+            return new Promise((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    const waiterIndex = waiters.findIndex(w => w.resolve === resolveAndClear);
+                    if (waiterIndex >= 0) waiters.splice(waiterIndex, 1);
+                    reject(new Error("Timed out waiting for message"));
+                }, timeoutMs);
+                const resolveAndClear = (msg: WsMessage) => {
+                    clearTimeout(timer);
+                    resolve(msg);
+                };
+                waiters.push({ predicate, resolve: resolveAndClear });
+            });
+        },
+    };
+}
+
+/** Predicate for an attribute_updated frame for a given "endpoint/cluster/attribute" path. */
+function attributeUpdatedFor(path: string) {
+    return (msg: WsMessage) =>
+        msg.event === "attribute_updated" && Array.isArray(msg.data) && (msg.data as unknown[])[1] === path;
+}
+
+function nodeEventForCluster(clusterId: number) {
+    return (msg: WsMessage) =>
+        msg.event === "node_event" && (msg.data as { cluster_id?: number } | undefined)?.cluster_id === clusterId;
+}
+
+describe("WebSocketControllerHandler observer guards", () => {
+    let harness: Awaited<ReturnType<typeof createHarness>>;
+    let capture: ReturnType<typeof captureServerSocket>;
+    let clientA: WebSocket;
+    let clientB: WebSocket;
+    let messagesA: ReturnType<typeof createMessageBuffer>;
+    let messagesB: ReturnType<typeof createMessageBuffer>;
+
+    async function connectListeningClient(tag: string) {
+        const address = harness.httpServer.address() as AddressInfo;
+        const client = new WebSocket(`ws://127.0.0.1:${address.port}/ws`);
+        client.on("error", () => undefined);
+        const messages = createMessageBuffer(client);
+        await once(client, "open");
+        await messages.wait(msg => "sdk_version" in msg); // initial server_info
+        client.send(JSON.stringify({ message_id: tag, command: "start_listening", args: {} }));
+        await messages.wait(msg => msg.message_id === tag);
+        return { client, messages };
+    }
+
+    beforeEach(async () => {
+        harness = await createHarness();
+        capture = captureServerSocket();
+        // Connect A fully before B so A's observers are registered first on the shared observables:
+        // pre-guard, a throw in A's observer is exactly what starved B (registered after A) mid-emit.
+        ({ client: clientA, messages: messagesA } = await connectListeningClient("startA"));
+        ({ client: clientB, messages: messagesB } = await connectListeningClient("startB"));
+    });
+
+    afterEach(async () => {
+        capture?.restore();
+        for (const client of [clientA, clientB]) {
+            if (client && (client.readyState === WebSocket.OPEN || client.readyState === WebSocket.CONNECTING)) {
+                client.terminate();
+            }
+        }
+        await harness?.handler.unregister().catch(() => undefined);
+        if (harness) {
+            await new Promise<void>(resolve => harness.httpServer.close(() => resolve()));
+            await harness.config.close();
+        }
+    });
+
+    it("keeps the other connection fed within the same emit when one connection's send path throws (attributeChanged)", async () => {
+        // Break connection A's send path only: its server-side socket throws synchronously on send,
+        // standing in for any unexpected per-connection failure while building/sending the frame.
+        // The conversion itself succeeds, so the throw surfaces in A's observer body — exactly what
+        // the handler-level guard must contain so B's observer (registered after A) still runs.
+        const serverSocketA = capture.get(0);
+        const originalSend = serverSocketA.send.bind(serverSocketA);
+        (serverSocketA as { send: unknown }).send = () => {
+            throw new Error("simulated synchronous send failure");
+        };
+
+        // (1) The throw from A's send path must not escape the emit.
+        expect(() =>
+            harness.fakeCommandHandler.events.attributeChanged.emit(NODE_ID, attributeReport(1, {})),
+        ).to.not.throw();
+
+        // (2) B, registered after A on the same observable, still receives its update for that emit.
+        const received = await messagesB.wait(attributeUpdatedFor("1/258/7"));
+        expect((received.data as unknown[])[2]).to.equal(0); // {} converts to bitmap 0
+
+        // (3) With A's send path healed, a subsequent clean emit is delivered normally to BOTH —
+        // proving A's connection survived its own failure rather than being wedged or dropped.
+        (serverSocketA as { send: unknown }).send = originalSend;
+        expect(() =>
+            harness.fakeCommandHandler.events.attributeChanged.emit(NODE_ID, attributeReport(2, {})),
+        ).to.not.throw();
+        await messagesA.wait(attributeUpdatedFor("2/258/7"));
+        await messagesB.wait(attributeUpdatedFor("2/258/7"));
+    });
+
+    it("contains a poisoned event conversion so the emit completes and clean events still flow (eventChanged)", async () => {
+        // The bitmap conversion throws in the observer body for every connection (the poisoned value
+        // is shared), so pre-guard the FIRST observer's throw aborted the emit itself.
+        expect(() =>
+            harness.fakeCommandHandler.events.eventChanged.emit(
+                NODE_ID,
+                alarmsEventReport({ alarmsActive: { visual: "poison" } }),
+            ),
+        ).to.not.throw();
+
+        // A subsequent clean event is delivered normally to both connections.
+        expect(() =>
+            harness.fakeCommandHandler.events.eventChanged.emit(
+                NODE_ID,
+                alarmsEventReport({ alarmsActive: { visual: true }, alarmsSuppressed: {} }),
+            ),
+        ).to.not.throw();
+        const [eventA, eventB] = await Promise.all([
+            messagesA.wait(nodeEventForCluster(128)),
+            messagesB.wait(nodeEventForCluster(128)),
+        ]);
+        expect((eventA.data as { data: unknown }).data).to.deep.equal({ alarmsActive: 1, alarmsSuppressed: 0 });
+        expect((eventB.data as { data: unknown }).data).to.deep.equal({ alarmsActive: 1, alarmsSuppressed: 0 });
+    });
+
+    it("contains a poisoned attribute value so the emit completes and clean updates still flow (attributeChanged)", async () => {
+        // For attributeChanged the conversion runs inside the lazy frame build, so in direct mode
+        // this exercises the connection-level build guard beneath the observer guard — the layered
+        // behavior end-to-end: the poisoned update is dropped per connection, the emit completes.
+        expect(() =>
+            harness.fakeCommandHandler.events.attributeChanged.emit(
+                NODE_ID,
+                attributeReport(1, { operational: "poison" }),
+            ),
+        ).to.not.throw();
+
+        // A subsequent clean update is delivered normally to both connections.
+        expect(() =>
+            harness.fakeCommandHandler.events.attributeChanged.emit(NODE_ID, attributeReport(2, {})),
+        ).to.not.throw();
+        await messagesA.wait(attributeUpdatedFor("2/258/7"));
+        await messagesB.wait(attributeUpdatedFor("2/258/7"));
+    });
+});

--- a/packages/ws-controller/test/WebSocketRequestSerializationTest.ts
+++ b/packages/ws-controller/test/WebSocketRequestSerializationTest.ts
@@ -1,0 +1,184 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression test for the unhandled-rejection hazard in WebSocketControllerHandler's per-message
+ * response path: `#handleWebSocketRequest(...).then(onFulfilled, onRejected)` only catches a
+ * rejection of the *original* promise, not an exception thrown by `onFulfilled` itself. A throw while
+ * serializing the response — `toBigIntAwareJson` on a pathological value such as a circular result —
+ * happens inside `onFulfilled`, after `#handleWebSocketRequest` has already resolved successfully, so
+ * it escaped as an unhandled rejection instead of being caught. `.then(onFulfilled).catch(handler)`
+ * fixes that: chaining `.catch()` after `.then()` also covers a throw raised by the fulfillment
+ * handler, unlike the two-argument `.then(a, b)` form.
+ *
+ * This drives a real WebSocketControllerHandler over a real `ws` client/server pair (same harness
+ * shape as WsBackpressureReproTest.ts) with a minimal stand-in for ControllerCommandHandler, since the
+ * real class requires a live CommissioningController.
+ */
+
+import { Environment, FabricId, MockStorageService, NodeId, Observable } from "@matter/main";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { WebSocket } from "ws";
+import type { MatterController } from "../src/controller/MatterController.js";
+import { ConfigStorage } from "../src/server/ConfigStorage.js";
+import { WebSocketControllerHandler } from "../src/server/WebSocketControllerHandler.js";
+
+/**
+ * Minimal stand-in for `ControllerCommandHandler` exposing only the surface
+ * `WebSocketControllerHandler.register()`/command dispatch touch (see WsBackpressureReproTest.ts for
+ * the fuller rationale on why a cast-based fake is used instead of the real class).
+ */
+function createFakeCommandHandler(pingNode: () => unknown) {
+    return {
+        events: {
+            attributeChanged: new Observable(),
+            eventChanged: new Observable(),
+            nodeAdded: new Observable(),
+            nodeStateChanged: new Observable(),
+            nodeAvailabilityChanged: new Observable(),
+            nodeStructureChanged: new Observable(),
+            nodeDecommissioned: new Observable(),
+            nodeEndpointAdded: new Observable(),
+            nodeEndpointRemoved: new Observable(),
+            webRtcCallback: new Observable(),
+        },
+        getNodeIds: () => new Array<NodeId>(),
+        hasNode: () => false,
+        formatNode: (nodeId: NodeId) => `test-node-${nodeId}`,
+        bleEnabled: false,
+        bleProxyEnabled: false,
+        getCommissionerNodeId: () => NodeId(112233),
+        start: async () => {},
+        getCommissionerFabricData: async () => ({
+            fabricId: FabricId(1),
+            compressedFabricId: 1n,
+            fabricIndex: 1,
+        }),
+        initializeNodes: async () => {},
+        // Backs the `ping_node` command driven below.
+        pingNode: async () => pingNode(),
+    };
+}
+
+async function createHarness(pingNode: () => unknown) {
+    const env = new Environment("test");
+    new MockStorageService(env);
+    const config = await ConfigStorage.create(env);
+
+    const fakeCommandHandler = createFakeCommandHandler(pingNode);
+    // register() subscribes to the controller-level thread-diagnostics observable; supply just that.
+    const fakeController = {
+        commandHandler: fakeCommandHandler,
+        threadDiagnostics: { events: { batchUpdated: new Observable() } },
+    } as unknown as MatterController;
+
+    const handler = new WebSocketControllerHandler(fakeController, config, "fix5-repro-test");
+
+    const httpServer = createServer();
+    await new Promise<void>((resolve, reject) => {
+        httpServer.once("error", reject);
+        httpServer.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    await handler.register(httpServer);
+
+    return { env, config, handler, httpServer };
+}
+
+type WsMessage = Record<string, unknown>;
+
+/** Same buffering helper as WsBackpressureReproTest.ts: never misses a message that arrives early. */
+function createMessageBuffer(ws: WebSocket) {
+    const backlog = new Array<WsMessage>();
+    const waiters = new Array<{ predicate: (msg: WsMessage) => boolean; resolve: (msg: WsMessage) => void }>();
+
+    ws.on("message", data => {
+        const msg = JSON.parse(data.toString()) as WsMessage;
+        const index = waiters.findIndex(w => w.predicate(msg));
+        if (index >= 0) {
+            waiters.splice(index, 1)[0].resolve(msg);
+        } else {
+            backlog.push(msg);
+        }
+    });
+
+    return {
+        wait(predicate: (msg: WsMessage) => boolean, timeoutMs = 5000): Promise<WsMessage> {
+            const index = backlog.findIndex(predicate);
+            if (index >= 0) {
+                return Promise.resolve(backlog.splice(index, 1)[0]);
+            }
+            return new Promise((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    const waiterIndex = waiters.findIndex(w => w.resolve === resolveAndClear);
+                    if (waiterIndex >= 0) waiters.splice(waiterIndex, 1);
+                    reject(new Error("Timed out waiting for message"));
+                }, timeoutMs);
+                const resolveAndClear = (msg: WsMessage) => {
+                    clearTimeout(timer);
+                    resolve(msg);
+                };
+                waiters.push({ predicate, resolve: resolveAndClear });
+            });
+        },
+    };
+}
+
+describe("WebSocketControllerHandler message response path", () => {
+    it("does not leak an unhandled rejection when the response fails to serialize, and keeps serving the connection", async () => {
+        // A circular result: JSON.stringify (inside toBigIntAwareJson) throws on this. That throw
+        // happens in the *fulfillment* handler of `#handleWebSocketRequest(...).then(...)` — the
+        // command handler itself resolves successfully with this value; only the later serialization
+        // step chokes on it, so #handleWebSocketRequest's own internal try/catch never sees it.
+        const poisoned: Record<string, unknown> = { attempts: 1 };
+        poisoned.self = poisoned;
+
+        const harness = await createHarness(() => poisoned);
+        const unhandledRejections: unknown[] = [];
+        const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
+        process.on("unhandledRejection", onUnhandledRejection);
+
+        let client: WebSocket | undefined;
+        try {
+            const address = harness.httpServer.address() as AddressInfo;
+            client = new WebSocket(`ws://127.0.0.1:${address.port}/ws`);
+            const messages = createMessageBuffer(client);
+            await once(client, "open");
+            await messages.wait(msg => "sdk_version" in msg); // initial server_info
+
+            // This request's response can never be serialized, so no frame is ever sent for it —
+            // the point under test is what happens to the *promise*, not the wire reply.
+            client.send(JSON.stringify({ message_id: "poison", command: "ping_node", args: { node_id: 1 } }));
+
+            // Let the message handler's promise chain fully settle before checking for a leaked
+            // unhandled rejection (Node surfaces "unhandledRejection" a tick or two after the throw).
+            await new Promise(resolve => setImmediate(resolve));
+            await new Promise(resolve => setImmediate(resolve));
+            await new Promise(resolve => setImmediate(resolve));
+
+            // Proof the connection (and process) survived: an unrelated, well-formed request on the
+            // SAME connection still gets served normally right after.
+            client.send(JSON.stringify({ message_id: "after", command: "server_info", args: {} }));
+            const response = await messages.wait(msg => msg.message_id === "after");
+            expect(response.result).to.not.equal(undefined);
+        } finally {
+            process.off("unhandledRejection", onUnhandledRejection);
+            if (client && (client.readyState === WebSocket.OPEN || client.readyState === WebSocket.CONNECTING)) {
+                client.terminate();
+            }
+            await harness.handler.unregister().catch(() => undefined);
+            await new Promise<void>(resolve => harness.httpServer.close(() => resolve()));
+            await harness.config.close();
+        }
+
+        expect(
+            unhandledRejections,
+            "toBigIntAwareJson throwing during serialization leaked as an unhandled promise rejection instead of being caught",
+        ).to.deep.equal([]);
+    });
+});


### PR DESCRIPTION
Companion to #843 (frozen-state forensics). Five independent fixes, one commit each, every one with a regression test (or a stated-reason exemption in the commit body):

1. **Guard direct-mode frame `build()` + `attributeChanged`/`eventChanged` observers** — a device-data-dependent converter throw (`Invalid bitmap value`, `BigInt` RangeError) escaped synchronously through `Observable.emit` into PairedNode's report dispatch, aborting delivery of the remaining attributes in the batch and starving other connections' observers (mode-dependent, intermittent frozen states). Includes a differential two-connection regression test proving one connection's throw no longer starves the other in the same emit.
2. **Guard `AttributeDataCache.updateAttribute`** — same throw family in the cache layer; the identical conversion in `#collectAttributes` was already guarded. (Note: the guard catches plain `Error` too — `Invalid bitmap value` is not a `MatterError`, so `MatterError.accept` alone would rethrow it.)
3. **Close the stale per-node ObserverGroup before replacing it in `#registerNode`** — re-registration would double-register every node observer.
4. **Time-sync trigger cooldown only on success** — the 24 h cooldown was stamped *before* the attempt, so one transient failure locked out reactive re-sync for a day; failures now get a 5-minute retry backoff instead.
5. **`.then(onFulfilled, onRejected)` → `.then().catch()`** in the WS response path — a throw during response serialization became an unhandled rejection (process exit on modern Node); regression test captures the real `unhandledRejection` pre-fix.

All commits cherry-pick cleanly onto current `main` (25f3097); suite green (239/239). Happy to split into separate PRs if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019cYKQfvTvuyjeWR2q73VJy