### PR TITLE
fix: concurrent camera snapshot + non-blocking startup init + reinterview navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This page shows a detailed overview of the changes between versions without the 
 ## **WORK IN PROGRESS**
 
 - Enhancement: Thread diagnostics fetch a Border Router's dataset via REST when no credentials are stored, enabling the faster MeshCoP (CoAP) transport instead of the slower REST collection
+- Fix: Update WebRTC and Camera-related logic to respect available Pixelrate and Encoders of the camera device
+- Fix: Optimize startup behavior
 
 ## 1.2.2 (2026-07-10)
 

--- a/packages/dashboard/src/components/webrtc-stream-view.ts
+++ b/packages/dashboard/src/components/webrtc-stream-view.ts
@@ -118,11 +118,10 @@ export function parseSnapshotCapabilitiesFromList(list: unknown[], preferEncoder
         };
     });
     // When preferEncoderFree (a video stream is live), restrict to encoder-free capabilities
-    // (RequiresEncodedPixels=false): with MaxConcurrentEncoders=1 (Aqara G350) the video stream
-    // holds the sole encoder, so only an encoder-free snapshot can be captured concurrently —
-    // on the G350 that is the 640×480 entry, while 1080p requires the encoder. When idle, use the
-    // full set so an idle capture can use the higher-resolution (encoder) capability. Within the
-    // chosen set, take the highest resolution.
+    // (RequiresEncodedPixels=false): a camera with MaxConcurrentEncoders=1 holds its sole encoder
+    // for the video stream, so only an encoder-free capability can be captured concurrently (often
+    // a lower resolution). When idle, use the full set so a capture can use the higher-resolution
+    // (encoder) capability. Within the chosen set, take the highest resolution.
     const encoderFree = parsed.filter(cap => !cap.requiresEncodedPixels);
     const pool = preferEncoderFree && encoderFree.length > 0 ? encoderFree : parsed;
     return pool.reduce((best, cur) =>
@@ -325,10 +324,10 @@ export class WebRtcStreamView extends LitElement {
                     console.warn("[webrtc-stream-view] ontrack fired but <video> query is null");
                     return;
                 }
-                // Cameras may put each track in its own MediaStream (distinct msid, e.g. Aqara's
-                // AqaraVideoStream/AqaraAudioStream), so ev.streams[0] differs per track. Assigning it
-                // to srcObject directly lets the audio track's stream clobber the video track's.
-                // Aggregate every received track into one element-owned MediaStream instead.
+                // Cameras may put each track in its own MediaStream (distinct msid), so
+                // ev.streams[0] differs per track. Assigning it to srcObject directly lets the audio
+                // track's stream clobber the video track's. Aggregate every received track into one
+                // element-owned MediaStream instead.
                 const existing = video.srcObject instanceof MediaStream ? video.srcObject : null;
                 const stream = existing ?? new MediaStream();
                 if (!stream.getTracks().includes(ev.track)) {
@@ -401,8 +400,8 @@ export class WebRtcStreamView extends LitElement {
                     const isResourceExhausted =
                         message.includes("Resource exhausted") || message.includes("(code 137)");
                     if (!isResourceExhausted) throw err;
-                    // Cameras with shared encoder pools (Aqara G350) refuse VideoStreamAllocate
-                    // while a snapshot stream is held — free ours and retry once.
+                    // Cameras with a shared encoder pool refuse VideoStreamAllocate while a snapshot
+                    // stream is held — free ours and retry once.
                     if (this._snapshotStreamId !== null) {
                         console.info(
                             "[webrtc-stream-view] VideoStreamAllocate ResourceExhausted; freeing snapshot stream and retrying",
@@ -827,9 +826,9 @@ export class WebRtcStreamView extends LitElement {
 
         const node = this.client.nodes[String(this.nodeId)];
 
-        // SnapshotCapabilities (attr id 10) — preferred source. Aqara G350 advertises SNP via
-        // FeatureMap bit 2 but ships an empty capabilities list, so fall back to sensible
-        // defaults (matching the resolution range our VideoStream uses) when the list is empty.
+        // SnapshotCapabilities (attr id 10) — preferred source. Some cameras advertise the SNP
+        // feature but ship an empty capabilities list, so fall back to sensible defaults when it
+        // is empty.
         // Once a video stream is allocated the sole encoder (MaxConcurrentEncoders=1) is held —
         // through the whole connecting/streaming phase, not just once "streaming" — so a concurrent
         // snapshot must use an encoder-free capability (typically a lower resolution).

--- a/packages/dashboard/src/components/webrtc-stream-view.ts
+++ b/packages/dashboard/src/components/webrtc-stream-view.ts
@@ -17,6 +17,12 @@ import { LitElement, css, html } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { clientContext } from "../client/client-context.js";
 import { asObject, pickNumber } from "../util/attribute-shapes.js";
+import {
+    pixelRate,
+    planVideoMaxFrameRate,
+    VIDEO_MIN_FRAME_RATE,
+    videoStreamFitsSnapshotBudget,
+} from "../util/camera-stream-budget.js";
 import "./ha-svg-icon.js";
 
 // Spec values from @matter/types globals/StreamUsage.ts and
@@ -29,12 +35,16 @@ const END_REASON_USER_HANGUP = 2;
 export const CAMERA_AV_STREAM_MANAGEMENT_CLUSTER_ID = 0x551;
 const WEBRTC_TRANSPORT_PROVIDER_CLUSTER_ID = 0x553;
 
-// AVSM FeatureMap bits (spec §11.2.4): WMARK=6 enables watermark overlay,
-// OSD=7 enables on-screen display. When advertised, VideoStreamAllocate and
-// SnapshotStreamAllocate REQUIRE watermarkEnabled / osdEnabled fields.
+// AVSM FeatureMap bits (spec §11.2.4): SNP=2 enables snapshot streams, WMARK=6
+// enables watermark overlay, OSD=7 enables on-screen display. When advertised,
+// VideoStreamAllocate and SnapshotStreamAllocate REQUIRE watermarkEnabled / osdEnabled fields.
+export const AVSM_FEAT_SNP = 1 << 2;
 export const AVSM_FEAT_WMARK = 1 << 6;
 export const AVSM_FEAT_OSD = 1 << 7;
 export const AVSM_FEATURE_MAP_ATTR_ID = 0xfffc;
+// MaxEncodedPixelRate (attr 0x0001): shared encoder budget in px/s that video and
+// snapshot streams draw from.
+const AVSM_MAX_ENCODED_PIXEL_RATE_ATTR_ID = 0x1;
 
 const DEFAULT_MAX_RESOLUTION = { width: 1920, height: 1080 };
 const DEFAULT_MIN_RESOLUTION = { width: 640, height: 480 };
@@ -61,19 +71,22 @@ interface SnapshotCapability {
     resolution: { width: number; height: number };
     maxFrameRate: number;
     imageCodec: number;
+    /** RequiresEncodedPixels — whether this capability draws from MaxEncodedPixelRate. */
+    requiresEncodedPixels: boolean;
 }
 
 const SNAPSHOT_DEFAULTS: SnapshotCapability = {
     resolution: { width: 1920, height: 1080 },
     maxFrameRate: 30,
     imageCodec: 0,
+    requiresEncodedPixels: true,
 };
 
-function parseSnapshotCapabilitiesFromList(list: unknown[]): SnapshotCapability {
+export function parseSnapshotCapabilitiesFromList(list: unknown[], preferEncoderFree: boolean): SnapshotCapability {
     // SnapshotCapabilitiesStruct field IDs per the Matter spec:
-    // 0=resolution (VideoResolutionStruct {0=width, 1=height}), 1=maxFrameRate, 2=imageCodec.
-    // Cached attributes are tag-based (numeric keys); read_attribute responses are name-based.
-    // Prefer the highest-resolution entry — Aqara G350 ships [VGA, 1080p] and 1080p is the useful one.
+    // 0=resolution (VideoResolutionStruct {0=width, 1=height}), 1=maxFrameRate, 2=imageCodec,
+    // 3=requiresEncodedPixels. Cached attributes are tag-based (numeric keys); read_attribute
+    // responses are name-based.
     const candidates = list.map(asObject).filter((c): c is Record<string, unknown> => c !== undefined);
     if (candidates.length === 0) return SNAPSHOT_DEFAULTS;
     const parsed = candidates.map(cap => {
@@ -82,6 +95,7 @@ function parseSnapshotCapabilitiesFromList(list: unknown[]): SnapshotCapability 
         const height = res ? pickNumber(res, "height", "1") : null;
         const maxFrameRate = pickNumber(cap, "maxFrameRate", "1");
         const imageCodec = pickNumber(cap, "imageCodec", "2");
+        const requiresEncodedPixels = cap["requiresEncodedPixels"] ?? cap["3"];
         return {
             resolution: {
                 width: width ?? SNAPSHOT_DEFAULTS.resolution.width,
@@ -89,9 +103,18 @@ function parseSnapshotCapabilitiesFromList(list: unknown[]): SnapshotCapability 
             },
             maxFrameRate: maxFrameRate ?? SNAPSHOT_DEFAULTS.maxFrameRate,
             imageCodec: imageCodec ?? SNAPSHOT_DEFAULTS.imageCodec,
+            requiresEncodedPixels: requiresEncodedPixels !== false,
         };
     });
-    return parsed.reduce((best, cur) =>
+    // When preferEncoderFree (a video stream is live), restrict to encoder-free capabilities
+    // (RequiresEncodedPixels=false): with MaxConcurrentEncoders=1 (Aqara G350) the video stream
+    // holds the sole encoder, so only an encoder-free snapshot can be captured concurrently —
+    // on the G350 that is the 640×480 entry, while 1080p requires the encoder. When idle, use the
+    // full set so an idle capture can use the higher-resolution (encoder) capability. Within the
+    // chosen set, take the highest resolution.
+    const encoderFree = parsed.filter(cap => !cap.requiresEncodedPixels);
+    const pool = preferEncoderFree && encoderFree.length > 0 ? encoderFree : parsed;
+    return pool.reduce((best, cur) =>
         cur.resolution.width * cur.resolution.height > best.resolution.width * best.resolution.height ? cur : best,
     );
 }
@@ -308,11 +331,21 @@ export class WebRtcStreamView extends LitElement {
             const minResolution = this.resolution ?? DEFAULT_MIN_RESOLUTION;
             const maxResolution = this.resolution ?? DEFAULT_MAX_RESOLUTION;
             const avsmFeatures = this._readAvsmFeatures();
+            const maxEncodedPixelRate = this._readMaxEncodedPixelRate();
+            const snapshotReservation = this._snapshotBudgetReservation();
+            // Reserving the whole MaxEncodedPixelRate (e.g. 1080p@120) starves a concurrent
+            // SnapshotStreamAllocate (ResourceExhausted); size the video rate to leave the
+            // snapshot stream room within the shared encoder budget.
+            const videoMaxFrameRate = planVideoMaxFrameRate({
+                maxEncodedPixelRate,
+                videoResolution: maxResolution,
+                snapshotReservation,
+            });
             const videoAllocPayload: Record<string, unknown> = {
                 streamUsage: STREAM_USAGE_LIVE_VIEW,
                 videoCodec: 0,
-                minFrameRate: 30,
-                maxFrameRate: 120,
+                minFrameRate: Math.min(VIDEO_MIN_FRAME_RATE, videoMaxFrameRate),
+                maxFrameRate: videoMaxFrameRate,
                 minResolution,
                 maxResolution,
                 minBitRate: 10000,
@@ -324,16 +357,21 @@ export class WebRtcStreamView extends LitElement {
 
             // Spec §11.2.1.2.1 — server SHALL reuse an existing stream that covers our
             // request. Search AllocatedVideoStreams (attr 0x000F) first to avoid even
-            // sending VideoStreamAllocate when a usable stream is already in place.
-            const reusedVideoId = this._findMatchingVideoStream({
+            // sending VideoStreamAllocate when a usable stream is already in place. Skip
+            // candidates that over-reserve the encoder budget so reuse can't reintroduce
+            // the snapshot ResourceExhausted a fresh allocation avoids.
+            const videoWant = {
                 streamUsage: STREAM_USAGE_LIVE_VIEW,
                 videoCodec: 0,
                 minRes: minResolution,
                 maxRes: maxResolution,
                 watermarkEnabled: avsmFeatures.wmark ? this.watermarkEnabled : undefined,
                 osdEnabled: avsmFeatures.osd ? this.osdEnabled : undefined,
-            });
+                budget: { maxEncodedPixelRate, snapshotReservation },
+            };
+            const reusedVideoId = this._findMatchingVideoStream(videoWant);
             let videoAlloc: unknown = null;
+            let usedFallbackReuse = false;
             if (reusedVideoId !== null) {
                 console.info("[webrtc-stream-view] reusing existing video stream", reusedVideoId);
                 this._videoStreamId = reusedVideoId;
@@ -348,31 +386,48 @@ export class WebRtcStreamView extends LitElement {
                         videoAllocPayload,
                     );
                 } catch (err) {
-                    // Cameras with shared encoder pools (Aqara G350) refuse VideoStreamAllocate
-                    // while a snapshot stream is held. Detect ResourceExhausted (Matter Status 137),
-                    // free the snapshot stream, retry once.
                     const message = err instanceof Error ? err.message : String(err);
                     const isResourceExhausted =
                         message.includes("Resource exhausted") || message.includes("(code 137)");
-                    if (!isResourceExhausted || this._snapshotStreamId === null) throw err;
-                    console.info(
-                        "[webrtc-stream-view] VideoStreamAllocate ResourceExhausted; freeing snapshot stream and retrying",
-                    );
-                    await this.deallocateSnapshot();
-                    videoAlloc = await this.client.deviceCommand(
-                        this.nodeId,
-                        this.endpointId,
-                        CAMERA_AV_STREAM_MANAGEMENT_CLUSTER_ID,
-                        "VideoStreamAllocate",
-                        videoAllocPayload,
-                    );
+                    if (!isResourceExhausted) throw err;
+                    // Cameras with shared encoder pools (Aqara G350) refuse VideoStreamAllocate
+                    // while a snapshot stream is held — free ours and retry once.
+                    if (this._snapshotStreamId !== null) {
+                        console.info(
+                            "[webrtc-stream-view] VideoStreamAllocate ResourceExhausted; freeing snapshot stream and retrying",
+                        );
+                        await this.deallocateSnapshot();
+                        videoAlloc = await this.client.deviceCommand(
+                            this.nodeId,
+                            this.endpointId,
+                            CAMERA_AV_STREAM_MANAGEMENT_CLUSTER_ID,
+                            "VideoStreamAllocate",
+                            videoAllocPayload,
+                        );
+                    } else {
+                        // The budget is held by a stream we didn't allocate (e.g. another
+                        // controller's 120 fps stream). Fall back to reusing it so live view
+                        // still works; a concurrent snapshot may then be refused.
+                        const fallbackId = this._findMatchingVideoStream({ ...videoWant, budget: undefined });
+                        if (fallbackId === null) throw err;
+                        console.warn(
+                            "[webrtc-stream-view] VideoStreamAllocate ResourceExhausted; reusing over-budget stream",
+                            fallbackId,
+                            "(concurrent snapshot may be unavailable)",
+                        );
+                        this._videoStreamId = fallbackId;
+                        this._videoStreamOwned = false;
+                        usedFallbackReuse = true;
+                    }
                 }
-                const videoStreamId = parseStreamAllocate(videoAlloc, "videoStreamId");
-                if (videoStreamId === null) {
-                    throw new Error("VideoStreamAllocate did not return a videoStreamId");
+                if (!usedFallbackReuse) {
+                    const videoStreamId = parseStreamAllocate(videoAlloc, "videoStreamId");
+                    if (videoStreamId === null) {
+                        throw new Error("VideoStreamAllocate did not return a videoStreamId");
+                    }
+                    this._videoStreamId = videoStreamId;
+                    this._videoStreamOwned = true;
                 }
-                this._videoStreamId = videoStreamId;
-                this._videoStreamOwned = true;
             }
 
             // Audio is best-effort: not all cameras expose it. Reuse if a matching
@@ -564,7 +619,7 @@ export class WebRtcStreamView extends LitElement {
         };
     }
 
-    private _readAvsmFeatures(): { wmark: boolean; osd: boolean } {
+    private _readAvsmFeatures(): { snp: boolean; wmark: boolean; osd: boolean } {
         const node = this.client?.nodes[String(this.nodeId)];
         const raw =
             node?.attributes[
@@ -572,9 +627,37 @@ export class WebRtcStreamView extends LitElement {
             ];
         const bits = typeof raw === "number" ? raw : 0;
         return {
+            snp: (bits & AVSM_FEAT_SNP) !== 0,
             wmark: (bits & AVSM_FEAT_WMARK) !== 0,
             osd: (bits & AVSM_FEAT_OSD) !== 0,
         };
+    }
+
+    private _readMaxEncodedPixelRate(): number | null {
+        const node = this.client?.nodes[String(this.nodeId)];
+        const raw =
+            node?.attributes[
+                `${this.endpointId}/${CAMERA_AV_STREAM_MANAGEMENT_CLUSTER_ID}/${AVSM_MAX_ENCODED_PIXEL_RATE_ATTR_ID}`
+            ];
+        return typeof raw === "number" && raw > 0 ? raw : null;
+    }
+
+    /**
+     * px/s a concurrent snapshot stream would reserve from MaxEncodedPixelRate, so the
+     * video stream can be sized to leave room. Zero when the camera has no snapshot feature
+     * or the chosen capability does not draw from the encoder budget.
+     */
+    private _snapshotBudgetReservation(): number {
+        if (!this._readAvsmFeatures().snp) return 0;
+        const node = this.client?.nodes[String(this.nodeId)];
+        const capsRaw = node?.attributes[`${this.endpointId}/${CAMERA_AV_STREAM_MANAGEMENT_CLUSTER_ID}/10`];
+        const cap =
+            Array.isArray(capsRaw) && capsRaw.length > 0
+                ? parseSnapshotCapabilitiesFromList(capsRaw, true)
+                : SNAPSHOT_DEFAULTS;
+        if (!cap.requiresEncodedPixels) return 0;
+        const resolution = this.snapshotResolution ?? cap.resolution;
+        return pixelRate(resolution, cap.maxFrameRate);
     }
 
     async deallocateSnapshot(): Promise<void> {
@@ -611,6 +694,7 @@ export class WebRtcStreamView extends LitElement {
         maxRes: { width: number; height: number };
         watermarkEnabled?: boolean;
         osdEnabled?: boolean;
+        budget?: { maxEncodedPixelRate: number | null; snapshotReservation: number };
     }): number | null {
         const node = this.client?.nodes[String(this.nodeId)];
         const list = node?.attributes[`${this.endpointId}/${CAMERA_AV_STREAM_MANAGEMENT_CLUSTER_ID}/15`];
@@ -630,6 +714,19 @@ export class WebRtcStreamView extends LitElement {
             const eMaxH = pickNumber(maxRes, "height", "1") ?? 0;
             if (eMinW > want.minRes.width || eMaxW < want.maxRes.width) continue;
             if (eMinH > want.minRes.height || eMaxH < want.maxRes.height) continue;
+            if (want.budget) {
+                // Unknown frame rate under a real budget can't be shown to fit → treat as infinite
+                // (skip). When the budget is unknown, videoStreamFitsSnapshotBudget short-circuits to
+                // true regardless, so an unparseable frame rate doesn't wrongly block reuse.
+                const eMaxFrameRate = pickNumber(obj, "maxFrameRate", "4") ?? Number.POSITIVE_INFINITY;
+                const fits = videoStreamFitsSnapshotBudget({
+                    maxEncodedPixelRate: want.budget.maxEncodedPixelRate,
+                    candidateResolution: { width: eMaxW, height: eMaxH },
+                    candidateFrameRate: eMaxFrameRate,
+                    snapshotReservation: want.budget.snapshotReservation,
+                });
+                if (!fits) continue;
+            }
             if (want.watermarkEnabled !== undefined) {
                 const v = obj["watermarkEnabled"] ?? obj["10"];
                 if (v !== want.watermarkEnabled) continue;
@@ -720,12 +817,21 @@ export class WebRtcStreamView extends LitElement {
         // SnapshotCapabilities (attr id 10) — preferred source. Aqara G350 advertises SNP via
         // FeatureMap bit 2 but ships an empty capabilities list, so fall back to sensible
         // defaults (matching the resolution range our VideoStream uses) when the list is empty.
+        // Once a video stream is allocated the sole encoder (MaxConcurrentEncoders=1) is held —
+        // through the whole connecting/streaming phase, not just once "streaming" — so a concurrent
+        // snapshot must use an encoder-free capability (typically a lower resolution).
+        const encoderBusy = this._videoStreamId !== null;
         const capsRaw = node?.attributes[`${this.endpointId}/${CAMERA_AV_STREAM_MANAGEMENT_CLUSTER_ID}/10`];
         const cap: SnapshotCapability =
             Array.isArray(capsRaw) && capsRaw.length > 0
-                ? parseSnapshotCapabilitiesFromList(capsRaw)
+                ? parseSnapshotCapabilitiesFromList(capsRaw, encoderBusy)
                 : SNAPSHOT_DEFAULTS;
-        const targetResolution = this.snapshotResolution ?? cap.resolution;
+        // Never request more than the chosen capability provides: a larger resolution would map
+        // to an encoder-requiring capability the busy encoder can't satisfy (ResourceExhausted).
+        let targetResolution = this.snapshotResolution ?? cap.resolution;
+        if (targetResolution.width > cap.resolution.width || targetResolution.height > cap.resolution.height) {
+            targetResolution = cap.resolution;
+        }
 
         const avsmFeatures = this._readAvsmFeatures();
 

--- a/packages/dashboard/src/components/webrtc-stream-view.ts
+++ b/packages/dashboard/src/components/webrtc-stream-view.ts
@@ -82,6 +82,14 @@ const SNAPSHOT_DEFAULTS: SnapshotCapability = {
     requiresEncodedPixels: true,
 };
 
+/** A snapshot capability provides a single max resolution; never request more than it offers. */
+function clampToCapability(
+    requested: { width: number; height: number },
+    cap: { width: number; height: number },
+): { width: number; height: number } {
+    return requested.width > cap.width || requested.height > cap.height ? cap : requested;
+}
+
 export function parseSnapshotCapabilitiesFromList(list: unknown[], preferEncoderFree: boolean): SnapshotCapability {
     // SnapshotCapabilitiesStruct field IDs per the Matter spec:
     // 0=resolution (VideoResolutionStruct {0=width, 1=height}), 1=maxFrameRate, 2=imageCodec,
@@ -656,7 +664,9 @@ export class WebRtcStreamView extends LitElement {
                 ? parseSnapshotCapabilitiesFromList(capsRaw, true)
                 : SNAPSHOT_DEFAULTS;
         if (!cap.requiresEncodedPixels) return 0;
-        const resolution = this.snapshotResolution ?? cap.resolution;
+        // Match the clamp _ensureSnapshotStream applies so the reservation reflects what will
+        // actually be requested, not an over-large snapshotResolution the capability can't provide.
+        const resolution = clampToCapability(this.snapshotResolution ?? cap.resolution, cap.resolution);
         return pixelRate(resolution, cap.maxFrameRate);
     }
 
@@ -828,10 +838,7 @@ export class WebRtcStreamView extends LitElement {
                 : SNAPSHOT_DEFAULTS;
         // Never request more than the chosen capability provides: a larger resolution would map
         // to an encoder-requiring capability the busy encoder can't satisfy (ResourceExhausted).
-        let targetResolution = this.snapshotResolution ?? cap.resolution;
-        if (targetResolution.width > cap.resolution.width || targetResolution.height > cap.resolution.height) {
-            targetResolution = cap.resolution;
-        }
+        const targetResolution = clampToCapability(this.snapshotResolution ?? cap.resolution, cap.resolution);
 
         const avsmFeatures = this._readAvsmFeatures();
 

--- a/packages/dashboard/src/components/webrtc-stream-view.ts
+++ b/packages/dashboard/src/components/webrtc-stream-view.ts
@@ -82,12 +82,15 @@ const SNAPSHOT_DEFAULTS: SnapshotCapability = {
     requiresEncodedPixels: true,
 };
 
-/** A snapshot capability provides a single max resolution; never request more than it offers. */
+/** Clamp a requested resolution down to a capability's max, per dimension (never increases either). */
 function clampToCapability(
     requested: { width: number; height: number },
     cap: { width: number; height: number },
 ): { width: number; height: number } {
-    return requested.width > cap.width || requested.height > cap.height ? cap : requested;
+    return {
+        width: Math.min(requested.width, cap.width),
+        height: Math.min(requested.height, cap.height),
+    };
 }
 
 export function parseSnapshotCapabilitiesFromList(list: unknown[], preferEncoderFree: boolean): SnapshotCapability {
@@ -95,7 +98,7 @@ export function parseSnapshotCapabilitiesFromList(list: unknown[], preferEncoder
     // 0=resolution (VideoResolutionStruct {0=width, 1=height}), 1=maxFrameRate, 2=imageCodec,
     // 3=requiresEncodedPixels. Cached attributes are tag-based (numeric keys); read_attribute
     // responses are name-based.
-    const candidates = list.map(asObject).filter((c): c is Record<string, unknown> => c !== undefined);
+    const candidates = list.map(asObject).filter((c): c is Record<string, unknown> => c !== null);
     if (candidates.length === 0) return SNAPSHOT_DEFAULTS;
     const parsed = candidates.map(cap => {
         const res = asObject(cap["resolution"] ?? cap["0"]);

--- a/packages/dashboard/src/pages/components/node-details.ts
+++ b/packages/dashboard/src/pages/components/node-details.ts
@@ -199,7 +199,6 @@ export class NodeDetails extends LitElement {
                 title: "Reinterview node",
                 text: "Success!",
             });
-            location.hash = "#";
         } catch (err: any) {
             showAlertDialog({
                 title: "Failed to reinterview node",

--- a/packages/dashboard/src/util/camera-stream-budget.ts
+++ b/packages/dashboard/src/util/camera-stream-budget.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Encoder-budget planning for concurrent camera video + snapshot streams.
+ *
+ * A Matter camera reserves encoder capacity per allocated stream as
+ * `maxFrameRate × width × height` (px/s) and enforces a ceiling advertised as
+ * the CameraAVStreamManagement `MaxEncodedPixelRate` attribute (0x0001). A live
+ * video stream that reserves the entire budget makes a concurrent
+ * SnapshotStreamAllocate fail with `ResourceExhausted` (status 0x89). These
+ * helpers choose a video frame rate that leaves room for a snapshot stream.
+ */
+
+export interface Resolution {
+    width: number;
+    height: number;
+}
+
+/** Live view is capped at 60 fps — higher rates buy nothing and starve the snapshot budget. */
+export const VIDEO_MAX_FRAME_RATE = 60;
+/** Never propose a video frame rate below this while a snapshot can still fit. */
+export const VIDEO_MIN_FRAME_RATE = 30;
+
+export function pixelRate(res: Resolution, frameRate: number): number {
+    return res.width * res.height * frameRate;
+}
+
+export interface VideoFrameRatePlan {
+    /** MaxEncodedPixelRate in px/s, or null when the camera doesn't advertise it. */
+    maxEncodedPixelRate: number | null;
+    /** MaxResolution the video stream will reserve. */
+    videoResolution: Resolution;
+    /** px/s a concurrent snapshot stream needs; 0 when no snapshot draws from the budget. */
+    snapshotReservation: number;
+}
+
+/**
+ * Pick a video `maxFrameRate` that keeps `snapshotReservation` px/s free within the
+ * camera's `MaxEncodedPixelRate`. Falls back to {@link VIDEO_MAX_FRAME_RATE} when the
+ * budget is unknown. When video + snapshot cannot both fit, video is given the whole
+ * budget (best effort — a concurrent snapshot may then still be refused).
+ */
+export function planVideoMaxFrameRate(plan: VideoFrameRatePlan): number {
+    const { maxEncodedPixelRate: budget, videoResolution, snapshotReservation } = plan;
+    const videoPixels = videoResolution.width * videoResolution.height;
+    if (!budget || budget <= 0 || videoPixels <= 0) return VIDEO_MAX_FRAME_RATE;
+
+    const withSnapshot = Math.floor((budget - snapshotReservation) / videoPixels);
+    if (withSnapshot >= VIDEO_MIN_FRAME_RATE) {
+        return Math.min(withSnapshot, VIDEO_MAX_FRAME_RATE);
+    }
+    const videoOnly = Math.floor(budget / videoPixels);
+    return Math.min(Math.max(videoOnly, 1), VIDEO_MAX_FRAME_RATE);
+}
+
+/**
+ * Whether reserving a candidate video stream still leaves room for a concurrent snapshot.
+ * Used to reject reuse of an over-budget (e.g. 120 fps) stream. Unknown budget, or no
+ * snapshot reservation, accepts any candidate.
+ */
+export function videoStreamFitsSnapshotBudget(args: {
+    maxEncodedPixelRate: number | null;
+    candidateResolution: Resolution;
+    candidateFrameRate: number;
+    snapshotReservation: number;
+}): boolean {
+    const { maxEncodedPixelRate: budget, candidateResolution, candidateFrameRate, snapshotReservation } = args;
+    if (!budget || budget <= 0 || snapshotReservation <= 0) return true;
+    return pixelRate(candidateResolution, candidateFrameRate) + snapshotReservation <= budget;
+}

--- a/packages/dashboard/test/CameraStreamBudgetTest.ts
+++ b/packages/dashboard/test/CameraStreamBudgetTest.ts
@@ -11,7 +11,7 @@ import {
 } from "../src/util/camera-stream-budget.js";
 
 const RES_1080P = { width: 1920, height: 1080 };
-// Aqara G350 advertises MaxEncodedPixelRate = 1080p @ 120 fps.
+// A camera advertising MaxEncodedPixelRate = 1080p @ 120 fps.
 const BUDGET_1080P_120 = 1920 * 1080 * 120;
 const SNAPSHOT_1080P_30 = 1920 * 1080 * 30;
 

--- a/packages/dashboard/test/CameraStreamBudgetTest.ts
+++ b/packages/dashboard/test/CameraStreamBudgetTest.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    planVideoMaxFrameRate,
+    VIDEO_MAX_FRAME_RATE,
+    videoStreamFitsSnapshotBudget,
+} from "../src/util/camera-stream-budget.js";
+
+const RES_1080P = { width: 1920, height: 1080 };
+// Aqara G350 advertises MaxEncodedPixelRate = 1080p @ 120 fps.
+const BUDGET_1080P_120 = 1920 * 1080 * 120;
+const SNAPSHOT_1080P_30 = 1920 * 1080 * 30;
+
+describe("camera-stream-budget", () => {
+    describe("planVideoMaxFrameRate", () => {
+        it("caps at 60 when the budget comfortably fits video + snapshot", () => {
+            expect(
+                planVideoMaxFrameRate({
+                    maxEncodedPixelRate: BUDGET_1080P_120,
+                    videoResolution: RES_1080P,
+                    snapshotReservation: SNAPSHOT_1080P_30,
+                }),
+            ).to.equal(VIDEO_MAX_FRAME_RATE);
+        });
+
+        it("reduces the rate when the snapshot reservation eats into the budget", () => {
+            // Budget one px/s short of video @ 45 fps once the snapshot is reserved → floors to 44.
+            const budget = 1920 * 1080 * 45 + SNAPSHOT_1080P_30 - 1;
+            expect(
+                planVideoMaxFrameRate({
+                    maxEncodedPixelRate: budget,
+                    videoResolution: RES_1080P,
+                    snapshotReservation: SNAPSHOT_1080P_30,
+                }),
+            ).to.equal(44);
+        });
+
+        it("gives video the whole budget when video + snapshot cannot both fit", () => {
+            // Budget for video @ 20 fps only; snapshot cannot be reserved concurrently.
+            const budget = 1920 * 1080 * 20;
+            expect(
+                planVideoMaxFrameRate({
+                    maxEncodedPixelRate: budget,
+                    videoResolution: RES_1080P,
+                    snapshotReservation: SNAPSHOT_1080P_30,
+                }),
+            ).to.equal(20);
+        });
+
+        it("falls back to the 60 fps cap when the budget is unknown", () => {
+            expect(
+                planVideoMaxFrameRate({
+                    maxEncodedPixelRate: null,
+                    videoResolution: RES_1080P,
+                    snapshotReservation: SNAPSHOT_1080P_30,
+                }),
+            ).to.equal(VIDEO_MAX_FRAME_RATE);
+        });
+
+        it("ignores the snapshot reservation when it is zero", () => {
+            expect(
+                planVideoMaxFrameRate({
+                    maxEncodedPixelRate: BUDGET_1080P_120,
+                    videoResolution: RES_1080P,
+                    snapshotReservation: 0,
+                }),
+            ).to.equal(VIDEO_MAX_FRAME_RATE);
+        });
+    });
+
+    describe("videoStreamFitsSnapshotBudget", () => {
+        it("rejects a 120 fps stream that would consume the whole budget", () => {
+            expect(
+                videoStreamFitsSnapshotBudget({
+                    maxEncodedPixelRate: BUDGET_1080P_120,
+                    candidateResolution: RES_1080P,
+                    candidateFrameRate: 120,
+                    snapshotReservation: SNAPSHOT_1080P_30,
+                }),
+            ).to.equal(false);
+        });
+
+        it("accepts a 60 fps stream that leaves room for the snapshot", () => {
+            expect(
+                videoStreamFitsSnapshotBudget({
+                    maxEncodedPixelRate: BUDGET_1080P_120,
+                    candidateResolution: RES_1080P,
+                    candidateFrameRate: 60,
+                    snapshotReservation: SNAPSHOT_1080P_30,
+                }),
+            ).to.equal(true);
+        });
+
+        it("accepts any candidate when the budget is unknown", () => {
+            expect(
+                videoStreamFitsSnapshotBudget({
+                    maxEncodedPixelRate: null,
+                    candidateResolution: RES_1080P,
+                    candidateFrameRate: 120,
+                    snapshotReservation: SNAPSHOT_1080P_30,
+                }),
+            ).to.equal(true);
+        });
+
+        it("accepts any candidate when no snapshot reservation is needed", () => {
+            expect(
+                videoStreamFitsSnapshotBudget({
+                    maxEncodedPixelRate: BUDGET_1080P_120,
+                    candidateResolution: RES_1080P,
+                    candidateFrameRate: 120,
+                    snapshotReservation: 0,
+                }),
+            ).to.equal(true);
+        });
+    });
+});

--- a/packages/dashboard/test/SnapshotCapabilitiesTest.ts
+++ b/packages/dashboard/test/SnapshotCapabilitiesTest.ts
@@ -46,6 +46,14 @@ describe("parseSnapshotCapabilitiesFromList", () => {
         expect(cap.resolution).to.deep.equal({ width: 1920, height: 1080 });
     });
 
+    it("skips non-object entries without crashing", () => {
+        const cap = parseSnapshotCapabilitiesFromList(
+            [null, 42, { "0": res(1920, 1080), "1": 30, "2": 0, "3": true }],
+            true,
+        );
+        expect(cap.resolution).to.deep.equal({ width: 1920, height: 1080 });
+    });
+
     it("parses name-based (read_attribute) shapes and treats a missing flag as encoder-requiring", () => {
         const cap = parseSnapshotCapabilitiesFromList(
             [{ resolution: { width: 1280, height: 720 }, maxFrameRate: 15, imageCodec: 0 }],

--- a/packages/dashboard/test/SnapshotCapabilitiesTest.ts
+++ b/packages/dashboard/test/SnapshotCapabilitiesTest.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { parseSnapshotCapabilitiesFromList } from "../src/components/webrtc-stream-view.js";
+
+// Tag-based (cached-attribute) SnapshotCapabilitiesStruct: 0=resolution {0:w,1:h},
+// 1=maxFrameRate, 2=imageCodec, 3=requiresEncodedPixels.
+const res = (w: number, h: number) => ({ "0": w, "1": h });
+
+// Aqara G350: encoder-free 640×480 + encoder-required 1080p.
+const G350 = [
+    { "0": res(640, 480), "1": 30, "2": 0, "3": false },
+    { "0": res(1920, 1080), "1": 30, "2": 0, "3": true },
+];
+
+describe("parseSnapshotCapabilitiesFromList", () => {
+    it("prefers the encoder-free capability when a stream is live (preferEncoderFree=true)", () => {
+        const cap = parseSnapshotCapabilitiesFromList(G350, true);
+        expect(cap.requiresEncodedPixels).to.equal(false);
+        expect(cap.resolution).to.deep.equal({ width: 640, height: 480 });
+    });
+
+    it("uses the highest-resolution capability when idle (preferEncoderFree=false)", () => {
+        const cap = parseSnapshotCapabilitiesFromList(G350, false);
+        expect(cap.requiresEncodedPixels).to.equal(true);
+        expect(cap.resolution).to.deep.equal({ width: 1920, height: 1080 });
+    });
+
+    it("takes the highest-resolution encoder-free entry when several exist", () => {
+        const cap = parseSnapshotCapabilitiesFromList(
+            [
+                { "0": res(640, 480), "1": 30, "2": 0, "3": false },
+                { "0": res(1280, 720), "1": 30, "2": 0, "3": false },
+            ],
+            true,
+        );
+        expect(cap.resolution).to.deep.equal({ width: 1280, height: 720 });
+    });
+
+    it("falls back to an encoder-requiring capability when none is encoder-free", () => {
+        const cap = parseSnapshotCapabilitiesFromList([{ "0": res(1920, 1080), "1": 30, "2": 0, "3": true }], true);
+        expect(cap.requiresEncodedPixels).to.equal(true);
+        expect(cap.resolution).to.deep.equal({ width: 1920, height: 1080 });
+    });
+
+    it("parses name-based (read_attribute) shapes and treats a missing flag as encoder-requiring", () => {
+        const cap = parseSnapshotCapabilitiesFromList(
+            [{ resolution: { width: 1280, height: 720 }, maxFrameRate: 15, imageCodec: 0 }],
+            true,
+        );
+        expect(cap.requiresEncodedPixels).to.equal(true);
+        expect(cap.resolution).to.deep.equal({ width: 1280, height: 720 });
+        expect(cap.maxFrameRate).to.equal(15);
+    });
+});

--- a/packages/dashboard/test/SnapshotCapabilitiesTest.ts
+++ b/packages/dashboard/test/SnapshotCapabilitiesTest.ts
@@ -10,21 +10,21 @@ import { parseSnapshotCapabilitiesFromList } from "../src/components/webrtc-stre
 // 1=maxFrameRate, 2=imageCodec, 3=requiresEncodedPixels.
 const res = (w: number, h: number) => ({ "0": w, "1": h });
 
-// Aqara G350: encoder-free 640×480 + encoder-required 1080p.
-const G350 = [
+// A camera exposing an encoder-free 640×480 capability plus an encoder-required 1080p one.
+const MIXED_CAPS = [
     { "0": res(640, 480), "1": 30, "2": 0, "3": false },
     { "0": res(1920, 1080), "1": 30, "2": 0, "3": true },
 ];
 
 describe("parseSnapshotCapabilitiesFromList", () => {
     it("prefers the encoder-free capability when a stream is live (preferEncoderFree=true)", () => {
-        const cap = parseSnapshotCapabilitiesFromList(G350, true);
+        const cap = parseSnapshotCapabilitiesFromList(MIXED_CAPS, true);
         expect(cap.requiresEncodedPixels).to.equal(false);
         expect(cap.resolution).to.deep.equal({ width: 640, height: 480 });
     });
 
     it("uses the highest-resolution capability when idle (preferEncoderFree=false)", () => {
-        const cap = parseSnapshotCapabilitiesFromList(G350, false);
+        const cap = parseSnapshotCapabilitiesFromList(MIXED_CAPS, false);
         expect(cap.requiresEncodedPixels).to.equal(true);
         expect(cap.resolution).to.deep.equal({ width: 1920, height: 1080 });
     });

--- a/packages/ws-controller/src/controller/MatterController.ts
+++ b/packages/ws-controller/src/controller/MatterController.ts
@@ -42,6 +42,9 @@ import { ThreadDiagnosticsService } from "./ThreadDiagnosticsService.js";
 
 const logger = Logger.get("MatterController");
 
+/** Max time stop() waits for in-flight background init before proceeding with teardown. */
+const BACKGROUND_INIT_STOP_TIMEOUT_MS = 2000;
+
 let bleSupportLoaded: Promise<void> | undefined;
 
 // Lazy-load the optional `@matter/nodejs-ble` so a missing install only fails when BLE is enabled.
@@ -187,6 +190,9 @@ export class MatterController {
     #enableTimeSync = false;
     #threadDiagnosticsDisabled = false;
     readonly #borderRouterRegistry: BorderRouterRegistry;
+    /** Background init tasks kept off the node-init critical path but given a bounded chance to settle on stop(). */
+    readonly #backgroundInit = new Array<Promise<unknown>>();
+    #stopped = false;
     readonly #credentials = new ThreadCredentialsRegistry();
     readonly #threadDiagnostics: ThreadDiagnosticsService;
     #webRtcRequestor?: Endpoint<typeof CameraControllerDevice>;
@@ -386,11 +392,15 @@ export class MatterController {
             );
 
             this.#commandHandler.events.started.once(async () => {
+                if (this.#stopped) return;
                 this.#controllerInstance!.node.behaviors.require(DclBehavior);
                 await this.#controllerInstance!.node.setStateOf(DclBehavior, {
                     fetchTestCertificates: true,
                     acceptTestCertificates: this.#enableTestNetDcl,
                 });
+                // Re-check after the await: if stop() ran during it, don't start background work
+                // (vendor fetch / BR discovery) that would outlive teardown.
+                if (this.#stopped) return;
 
                 const initPromises = new Array<Promise<unknown>>();
 
@@ -398,8 +408,10 @@ export class MatterController {
                     initPromises.push(this.injectCommissionedDates());
                 }
 
-                // Start loading and initialization of meta data
-                initPromises.push(this.vendorInfoService());
+                // Warm vendor info off the critical path. Node init doesn't need it, and the WS API
+                // paths that do (getAllVendors) await its construction lazily, so data is never
+                // missing — warming here only spares the first client request the DCL fetch latency.
+                this.#trackBackgroundInit(this.vendorInfoService(), "Vendor info preload failed");
                 // initPromises.push(this.certificateService()); // postponed to commissioning needs
 
                 if (!this.#disableOtaProvider && this.#enableTestNetDcl) {
@@ -409,7 +421,12 @@ export class MatterController {
                 initPromises.push(this.#enableWebRtcRequestor());
 
                 if (!this.#threadDiagnosticsDisabled) {
-                    initPromises.push(this.#borderRouterRegistry.start());
+                    // Border-router discovery is a diagnostics feature — never gate node init /
+                    // WS availability on it. Run it off the critical path.
+                    this.#trackBackgroundInit(
+                        this.#borderRouterRegistry.start(),
+                        "Border router registry start failed",
+                    );
                     this.#registerStoredThreadCredentials();
                 }
 
@@ -540,7 +557,36 @@ export class MatterController {
         }
     }
 
+    /**
+     * Track a background init task so it stays off the node-init critical path but is still
+     * awaited on stop(). The stored promise is catch-wrapped so a rejection is logged rather
+     * than left unhandled while it is in flight.
+     */
+    #trackBackgroundInit(promise: Promise<unknown>, failureMessage: string): void {
+        this.#backgroundInit.push(promise.catch(err => logger.warn(`${failureMessage}:`, err)));
+    }
+
+    /**
+     * Give in-flight background init a bounded chance to settle before teardown so it doesn't
+     * dangle, without letting slow/unreachable network work (DCL fetch, mDNS) block shutdown.
+     */
+    async #settleBackgroundInit(): Promise<void> {
+        if (this.#backgroundInit.length === 0) return;
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const timeout = new Promise<void>(resolve => {
+            timer = setTimeout(resolve, BACKGROUND_INIT_STOP_TIMEOUT_MS);
+            timer.unref?.();
+        });
+        try {
+            await Promise.race([Promise.allSettled(this.#backgroundInit), timeout]);
+        } finally {
+            if (timer !== undefined) clearTimeout(timer);
+        }
+    }
+
     async stop() {
+        this.#stopped = true;
+        await this.#settleBackgroundInit();
         if (!this.#threadDiagnosticsDisabled) {
             await this.#threadDiagnostics.stop();
             await this.#borderRouterRegistry.stop();

--- a/packages/ws-controller/src/controller/MatterController.ts
+++ b/packages/ws-controller/src/controller/MatterController.ts
@@ -15,9 +15,11 @@ import {
     GlobalFabricId,
     Logger,
     MatterAggregateError,
+    Millis,
     NodeId,
     SharedEnvironmentServices,
     SoftwareUpdateManager,
+    Time,
     Timestamp,
 } from "@matter/main";
 import { VendorInfo, DclCertificateService, DclVendorInfoService, OperationalDataset } from "@matter/main/protocol";
@@ -42,7 +44,6 @@ import { ThreadDiagnosticsService } from "./ThreadDiagnosticsService.js";
 
 const logger = Logger.get("MatterController");
 
-/** Max time stop() waits for in-flight background init before proceeding with teardown. */
 const BACKGROUND_INIT_STOP_TIMEOUT_MS = 2000;
 
 let bleSupportLoaded: Promise<void> | undefined;
@@ -398,8 +399,7 @@ export class MatterController {
                     fetchTestCertificates: true,
                     acceptTestCertificates: this.#enableTestNetDcl,
                 });
-                // Re-check after the await: if stop() ran during it, don't start background work
-                // (vendor fetch / BR discovery) that would outlive teardown.
+                // Re-check after the await — stop() may have run during it; don't start work that outlives teardown.
                 if (this.#stopped) return;
 
                 const initPromises = new Array<Promise<unknown>>();
@@ -408,9 +408,8 @@ export class MatterController {
                     initPromises.push(this.injectCommissionedDates());
                 }
 
-                // Warm vendor info off the critical path. Node init doesn't need it, and the WS API
-                // paths that do (getAllVendors) await its construction lazily, so data is never
-                // missing — warming here only spares the first client request the DCL fetch latency.
+                // Fire-and-forget: consumers (getAllVendors) await its construction lazily, so this
+                // only pre-warms to spare the first request the DCL fetch latency — node init needn't wait.
                 this.#trackBackgroundInit(this.vendorInfoService(), "Vendor info preload failed");
                 // initPromises.push(this.certificateService()); // postponed to commissioning needs
 
@@ -421,8 +420,7 @@ export class MatterController {
                 initPromises.push(this.#enableWebRtcRequestor());
 
                 if (!this.#threadDiagnosticsDisabled) {
-                    // Border-router discovery is a diagnostics feature — never gate node init /
-                    // WS availability on it. Run it off the critical path.
+                    // Diagnostics-only discovery — never gate node init / WS availability on it.
                     this.#trackBackgroundInit(
                         this.#borderRouterRegistry.start(),
                         "Border router registry start failed",
@@ -557,11 +555,7 @@ export class MatterController {
         }
     }
 
-    /**
-     * Track a background init task so it stays off the node-init critical path but is still
-     * awaited on stop(). The stored promise is catch-wrapped so a rejection is logged rather
-     * than left unhandled while it is in flight.
-     */
+    /** Store a background task catch-wrapped, so an in-flight rejection is logged, not unhandled, and it stays awaitable by stop(). */
     #trackBackgroundInit(promise: Promise<unknown>, failureMessage: string): void {
         this.#backgroundInit.push(promise.catch(err => logger.warn(`${failureMessage}:`, err)));
     }
@@ -572,15 +566,11 @@ export class MatterController {
      */
     async #settleBackgroundInit(): Promise<void> {
         if (this.#backgroundInit.length === 0) return;
-        let timer: ReturnType<typeof setTimeout> | undefined;
-        const timeout = new Promise<void>(resolve => {
-            timer = setTimeout(resolve, BACKGROUND_INIT_STOP_TIMEOUT_MS);
-            timer.unref?.();
-        });
+        const timeout = Time.sleep("MatterController background-init settle", Millis(BACKGROUND_INIT_STOP_TIMEOUT_MS));
         try {
             await Promise.race([Promise.allSettled(this.#backgroundInit), timeout]);
         } finally {
-            if (timer !== undefined) clearTimeout(timer);
+            timeout.cancel();
         }
     }
 


### PR DESCRIPTION
## Summary

Three fixes discovered while debugging camera snapshots on an encoder-constrained camera, verified live against the device.

### 1. Camera snapshot while a live stream is running (`feat`)
On cameras with `MaxConcurrentEncoders = 1`, the live WebRTC video stream holds the sole encoder, so `SnapshotStreamAllocate` returned **ResourceExhausted (0x89)** whenever it mapped to an encoder-requiring capability during streaming.

- Snapshot capability selection is now **encoder-aware**: while a video stream is allocated, prefer a `SnapshotCapabilities` entry with `RequiresEncodedPixels = false` and clamp the requested resolution to it; when idle, use the highest-resolution (encoder) capability.
- On such a camera this means a **concurrent** snapshot uses the encoder-free resolution and an **idle** snapshot uses the full resolution — the hardware limit of a single encoder.
- New `camera-stream-budget.ts` helper: derive video `maxFrameRate` from the camera's `MaxEncodedPixelRate` so a concurrent snapshot fits the shared encoder budget on pixel-rate-limited cameras, and reject reuse of an over-budget allocated video stream. Video `maxFrameRate` capped at 60 (was 120, which reserved the entire 1080p budget).

### 2. Stay on the node page after a reinterview (`fix`)
`_reinterview()` redirected to the overview (`location.hash = "#"`) on success, bouncing the user off the node detail page. The node still exists and `node_updated` refreshes it in place, so the redirect is removed. `_remove()` still navigates home (correct).

### 3. Keep vendor / border-router init off the node-init path (`refactor`)
Vendor-info warmup (DCL fetch) and border-router discovery were awaited before node initialization, delaying node connection / WS availability by ~1s. Both now run off the critical path, tracked in `#backgroundInit` and given a **bounded** chance to settle in `stop()` so they neither dangle into teardown nor block shutdown on slow/unreachable network work. A `#stopped` guard prevents a late `started` handler from spinning up background work after teardown.

## Testing
- `npm run format` / `npm run lint` / `npm run build` clean.
- Full `npm test` green (incl. matter-server integration).
- New unit tests: `CameraStreamBudgetTest` (budget math) and `SnapshotCapabilitiesTest` (encoder-aware selection, null-safe parsing).
- Verified live against an encoder-constrained camera: concurrent snapshot now succeeds; reinterview keeps the node page; startup reaches node init without the vendor/BR wait.

## Review
Passed an independent adversarial review over the cumulative diff; findings addressed (unbounded shutdown await → bounded; snapshot-during-connecting predicate → `_videoStreamId !== null`; unknown-budget reuse over-rejection; start-after-stop guard). PR review comments addressed: reservation clamp, per-dimension clamp, null-safe capability parsing, and generic (vendor-neutral) comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)