### PR TITLE
fix(dashboard): snapshot download extension + client-side PTZ clamp

### DIFF
--- a/packages/dashboard/src/components/avsum-ptz-strip.ts
+++ b/packages/dashboard/src/components/avsum-ptz-strip.ts
@@ -13,6 +13,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { clientContext } from "../client/client-context.js";
 import { handleAsync, handleAsyncEvent } from "../util/async-handler.js";
 import {
+    clampMptzDelta,
     dptzRelativeMove,
     hasAvsumOnEndpoint,
     moveToPreset,
@@ -20,6 +21,7 @@ import {
     readMovementState,
     readPosition,
     readPresets,
+    readRanges,
     relativeMove,
 } from "../util/avsum.js";
 import "./ha-svg-icon.js";
@@ -223,7 +225,11 @@ export class AvsumPtzStrip extends LitElement {
                 if (axis === "pan") delta.panDelta = step;
                 else if (axis === "tilt") delta.tiltDelta = step;
                 else delta.zoomDelta = step;
-                await relativeMove(this.client, this.nodeId, this.endpointId, delta);
+                const node = this._node;
+                const clamped = node
+                    ? clampMptzDelta(delta, readPosition(node, this.endpointId), readRanges(node, this.endpointId))
+                    : delta;
+                await relativeMove(this.client, this.nodeId, this.endpointId, clamped);
             } else {
                 if (this.activeVideoStreamId === null) return;
                 // step magnitude (10 or 1) scales the sensor-relative pixel delta so Shift gives 1% nudges.

--- a/packages/dashboard/src/pages/camera-overlay.ts
+++ b/packages/dashboard/src/pages/camera-overlay.ts
@@ -42,6 +42,11 @@ const HA_DEFAULT_RESOLUTIONS: Resolution[] = [
     { width: 640, height: 480 },
 ];
 
+function snapshotExtension(dataUri: string): string {
+    const mime = /^data:image\/([a-z0-9.+-]+)/i.exec(dataUri)?.[1]?.toLowerCase();
+    return mime === "png" ? "png" : "jpg";
+}
+
 @customElement("camera-overlay")
 export class CameraOverlay extends LitElement {
     @consume({ context: clientContext, subscribe: true })
@@ -257,7 +262,9 @@ export class CameraOverlay extends LitElement {
         if (!this._snapshotDataUri) return;
         const a = document.createElement("a");
         a.href = this._snapshotDataUri;
-        a.download = `snapshot-node${this.nodeId}-ep${this.endpointId}-${Date.now()}.jpg`;
+        a.download = `snapshot-node${this.nodeId}-ep${this.endpointId}-${Date.now()}.${snapshotExtension(
+            this._snapshotDataUri,
+        )}`;
         a.click();
     }
 

--- a/packages/dashboard/src/pages/cluster-commands/clusters/avsum-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/avsum-commands.ts
@@ -25,6 +25,7 @@ import { showAlertDialog, showPromptDialog } from "../../../components/dialog-bo
 import { handleAsync, handleAsyncEvent } from "../../../util/async-handler.js";
 import {
     AVSUM_CLUSTER_ID,
+    clampMptzDelta,
     moveToPreset,
     readDptzStreams,
     readFeatures,
@@ -293,8 +294,9 @@ class AvsumClusterCommands extends BaseClusterCommands {
     private async _move(delta: { panDelta?: number; tiltDelta?: number; zoomDelta?: number }) {
         const node = this.node;
         const endpoint = this.endpoint;
+        const clamped = clampMptzDelta(delta, readPosition(node, endpoint), readRanges(node, endpoint));
         try {
-            await relativeMove(this.client, node.node_id, endpoint, delta);
+            await relativeMove(this.client, node.node_id, endpoint, clamped);
         } catch (err) {
             if (!this.isSameContext(node, endpoint)) return;
             if (this._isBusy(err)) {

--- a/packages/dashboard/src/util/avsum.ts
+++ b/packages/dashboard/src/util/avsum.ts
@@ -166,7 +166,10 @@ export function clampMptzDelta(
 ): { panDelta?: number; tiltDelta?: number; zoomDelta?: number } {
     const clampAxis = (d: number, current: number | null, min: number | null, max: number | null): number => {
         if (current === null || min === null || max === null || min > max) return d;
-        return Math.min(max, Math.max(min, current + d)) - current;
+        const adjusted = Math.min(max, Math.max(min, current + d)) - current;
+        // A current position already outside [min,max] would otherwise make `adjusted` reverse the
+        // requested direction or exceed its magnitude; keep the move within [0, d].
+        return d >= 0 ? Math.max(0, Math.min(d, adjusted)) : Math.min(0, Math.max(d, adjusted));
     };
     const out: { panDelta?: number; tiltDelta?: number; zoomDelta?: number } = {};
     if (delta.panDelta !== undefined)

--- a/packages/dashboard/src/util/avsum.ts
+++ b/packages/dashboard/src/util/avsum.ts
@@ -154,6 +154,30 @@ export function readDptzStreams(node: MatterNode, endpoint: number): DptzStreamE
     return out;
 }
 
+/**
+ * Clamp a mechanical PTZ relative move so the resulting absolute position stays within the
+ * device-advertised ranges (zoom minimum is fixed at 1×). Axes whose current position or bound is
+ * unknown pass through unclamped, since we can't compute a safe target.
+ */
+export function clampMptzDelta(
+    delta: { panDelta?: number; tiltDelta?: number; zoomDelta?: number },
+    position: MptzPosition,
+    ranges: MptzRanges,
+): { panDelta?: number; tiltDelta?: number; zoomDelta?: number } {
+    const clampAxis = (d: number, current: number | null, min: number | null, max: number | null): number => {
+        if (current === null || min === null || max === null || min > max) return d;
+        return Math.min(max, Math.max(min, current + d)) - current;
+    };
+    const out: { panDelta?: number; tiltDelta?: number; zoomDelta?: number } = {};
+    if (delta.panDelta !== undefined)
+        out.panDelta = clampAxis(delta.panDelta, position.pan, ranges.panMin, ranges.panMax);
+    if (delta.tiltDelta !== undefined) {
+        out.tiltDelta = clampAxis(delta.tiltDelta, position.tilt, ranges.tiltMin, ranges.tiltMax);
+    }
+    if (delta.zoomDelta !== undefined) out.zoomDelta = clampAxis(delta.zoomDelta, position.zoom, 1, ranges.zoomMax);
+    return out;
+}
+
 export async function relativeMove(
     client: MatterClient,
     nodeId: number | bigint,

--- a/packages/dashboard/src/util/avsum.ts
+++ b/packages/dashboard/src/util/avsum.ts
@@ -168,7 +168,7 @@ export function clampMptzDelta(
         if (current === null || min === null || max === null || min > max) return d;
         const adjusted = Math.min(max, Math.max(min, current + d)) - current;
         // A current position already outside [min,max] would otherwise make `adjusted` reverse the
-        // requested direction or exceed its magnitude; keep the move within [0, d].
+        // requested direction or exceed its magnitude; keep it between 0 and d (same sign, no larger).
         return d >= 0 ? Math.max(0, Math.min(d, adjusted)) : Math.min(0, Math.max(d, adjusted));
     };
     const out: { panDelta?: number; tiltDelta?: number; zoomDelta?: number } = {};


### PR DESCRIPTION
## Summary

Two dashboard camera fixes surfaced while documenting camera/stream logic.

1. **Snapshot download filename always `.jpg`.** The download name hardcoded `.jpg` even when the camera returns a PNG (`imageCodec != 0`). `snapshotExtension()` now derives the extension from the data URI MIME (`png` → `png`, everything else → `jpg`; snapshots only ever emit JPEG or PNG).

2. **Mechanical PTZ deltas sent unclamped.** MPTZRelativeMove pan/tilt/zoom deltas went to the device raw, relying on the device to reject out-of-range targets. A non-clamping device got out-of-range moves. New `clampMptzDelta()` clamps each axis so `current + delta` stays within the advertised ranges (`[panMin,panMax]`, `[tiltMin,tiltMax]`, `[1, zoomMax]`), wired into both mech-move callers (`avsum-ptz-strip.ts`, `avsum-commands.ts`).

   - Axes with unknown position/bounds, or a malformed `min > max` range, pass through unclamped.
   - Digital PTZ (DPTZRelativeMove) is unaffected — those deltas are sensor pixels, not degrees; a server-side `camera_ptz_move` remains the preferred long-term clamp point.

## Verification

`npm run format` / `npm run lint` / `npm run build` all clean. Clamp math sanity-checked against range boundaries. Adversarial review run; both edge findings (odd MIME extension, inverted range) addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)