### PR TITLE
fix(ws-controller): harden WS observer and response paths against throws

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,38 @@ When the full `npm test` reports only these matter-server integration failures a
 
 Plan/design documents in `docs/plans/` are working files only. **Never commit them to git.** They may exist locally for reference but must not be included in any commit.
 
+### Code Comments
+
+WHY not WHAT. Only add a WHAT comment if the logic is genuinely non-obvious. Keep comments minimal. Audit every `//` and `/** */` before commit; **default to deleting, not shortening** — a wordy comment that survives review shorter is still a failure.
+
+**Decisive test (primary lens):** *"Would I need this comment to understand the code later if I had to fix something right here?"* If no → delete. This catches the true-but-useless comment the checklist below lets slip.
+
+Before adding any comment, ask in order:
+
+1. Does the commit message / `git blame` already carry this context? → no comment.
+2. Would a reader seeing only the final code (not the diff) benefit? → if no, no comment.
+3. Does the code already speak for itself via identifiers + jsdoc? → if yes, no comment.
+4. Am I narrating the change I just made rather than stating an invariant of the code? → put it in the commit message, not the code.
+5. Can I say the WHY in ≤1 line? → if no, it's almost certainly over-explanation.
+
+**Acceptable (rare) — keep to 1 line:**
+
+- An invariant a future refactor could innocently break (forward-looking).
+- A non-obvious spec / RFC / library constraint the code depends on.
+- A tradeoff record ("we accept X because Y is worse").
+- Cross-file / library coupling the type system can't express.
+
+Example from this codebase: `// Shared Observable: an uncaught throw here aborts the emit and starves other connections` on a `try/catch` around an observer body — matter.js's `Observable.emit` catches each observer error but its default `handleError` *rethrows*, so a per-connection throw aborts the shared emit and starves other connections; without the comment a future fixer assumes the guard is redundant and removes it.
+
+**Always-bad (delete on sight):**
+
+- WHAT-restatement of an identifier or `if` condition (`// Store event in the buffer` above `this.#addEventToHistory(...)`).
+- Changelog / historical narration ("Moved from A to B because…", "this used to do Y").
+- "Now do X" above code that does X; multi-line explanations of what the diff does.
+- Pointing at structure the reader can see ("Cleanup lives on an outer `.finally`", "Using a Map keyed by X").
+- Mechanism trivia about standard APIs (".finally runs in a microtask", "Promise.all rejects on first failure").
+- Rejected-alternative justification (`// .then().catch(), not .then(a,b)…`) — once the code IS that form, what it *isn't* is irrelevant; state the invariant, not the counterfactual.
+
 ## Dashboard Development
 
 ### Technology Stack

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -349,20 +349,28 @@ export class WebSocketControllerHandler implements WebServerHandler {
                 // `data` is emitter-owned; snapshot the value before deferring. Coalesce latest-wins
                 // per (node, path) and convert lazily so a superseded value is never converted.
                 const rawValue = data.value;
-                connection.sendCoalescable(`attr:${nodeId}/${pathStr}`, () => {
-                    const clusterData = ClusterMap[clusterId];
-                    const value = convertMatterToWebSocketTagBased(
-                        rawValue,
-                        clusterData?.attributes[attributeId],
-                        clusterData?.model,
+                // Shared Observable: an uncaught throw here aborts the emit and starves other connections.
+                try {
+                    connection.sendCoalescable(`attr:${nodeId}/${pathStr}`, () => {
+                        const clusterData = ClusterMap[clusterId];
+                        const value = convertMatterToWebSocketTagBased(
+                            rawValue,
+                            clusterData?.attributes[attributeId],
+                            clusterData?.model,
+                        );
+                        logger.debug(
+                            `[${connId}] Sending attribute_updated event for Node ${this.#commandHandler.formatNode(nodeId)}`,
+                            pathStr,
+                            value,
+                        );
+                        return toBigIntAwareJson({ event: "attribute_updated", data: [nodeId, pathStr, value] });
+                    });
+                } catch (err) {
+                    logger.error(
+                        `[${connId}] Failed to send attribute_updated for Node ${this.#commandHandler.formatNode(nodeId)} ${pathStr}`,
+                        err,
                     );
-                    logger.debug(
-                        `[${connId}] Sending attribute_updated event for Node ${this.#commandHandler.formatNode(nodeId)}`,
-                        pathStr,
-                        value,
-                    );
-                    return toBigIntAwareJson({ event: "attribute_updated", data: [nodeId, pathStr, value] });
-                });
+                }
             });
 
             observers.on(this.#commandHandler.events.eventChanged, (nodeId, data) => {
@@ -372,46 +380,54 @@ export class WebSocketControllerHandler implements WebServerHandler {
                 const clusterData = ClusterMap[clusterId];
 
                 for (const event of events) {
-                    let timestamp: number | bigint;
-                    let timestampType: number;
+                    // Shared Observable: an uncaught throw aborts the emit and starves other connections;
+                    // per event so one bad payload doesn't drop the rest of the batch.
+                    try {
+                        let timestamp: number | bigint;
+                        let timestampType: number;
 
-                    if (event.epochTimestamp !== undefined) {
-                        timestamp = event.epochTimestamp;
-                        timestampType = 1; // Epoch
-                    } else if (event.systemTimestamp !== undefined) {
-                        timestamp = event.systemTimestamp;
-                        timestampType = 0; // System
-                    } else {
-                        timestamp = Date.now();
-                        timestampType = 2; // POSIX (fallback)
+                        if (event.epochTimestamp !== undefined) {
+                            timestamp = event.epochTimestamp;
+                            timestampType = 1; // Epoch
+                        } else if (event.systemTimestamp !== undefined) {
+                            timestamp = event.systemTimestamp;
+                            timestampType = 0; // System
+                        } else {
+                            timestamp = Date.now();
+                            timestampType = 2; // POSIX (fallback)
+                        }
+
+                        const eventModel = clusterData?.events[eventId];
+                        const convertedData =
+                            event.data !== undefined
+                                ? convertMatterToWebSocketNameBased(event.data, eventModel, clusterData?.model)
+                                : null;
+
+                        const nodeEvent: MatterNodeEvent = {
+                            node_id: nodeId,
+                            endpoint_id: endpointId,
+                            cluster_id: clusterId,
+                            event_id: eventId,
+                            event_number: event.eventNumber,
+                            priority: event.priority,
+                            timestamp,
+                            timestamp_type: timestampType,
+                            data: convertedData,
+                        };
+
+                        this.#addEventToHistory(nodeEvent);
+
+                        logger.debug(
+                            `[${connId}] Sending node_event for Node ${this.#commandHandler.formatNode(nodeId)}`,
+                            nodeEvent,
+                        );
+                        connection.sendOrdered(toBigIntAwareJson({ event: "node_event", data: nodeEvent }));
+                    } catch (err) {
+                        logger.error(
+                            `[${connId}] Failed to send node_event for Node ${this.#commandHandler.formatNode(nodeId)}`,
+                            err,
+                        );
                     }
-
-                    const eventModel = clusterData?.events[eventId];
-                    const convertedData =
-                        event.data !== undefined
-                            ? convertMatterToWebSocketNameBased(event.data, eventModel, clusterData?.model)
-                            : null;
-
-                    const nodeEvent: MatterNodeEvent = {
-                        node_id: nodeId,
-                        endpoint_id: endpointId,
-                        cluster_id: clusterId,
-                        event_id: eventId,
-                        event_number: event.eventNumber,
-                        priority: event.priority,
-                        timestamp,
-                        timestamp_type: timestampType,
-                        data: convertedData,
-                    };
-
-                    // Store event in the history buffer
-                    this.#addEventToHistory(nodeEvent);
-
-                    logger.debug(
-                        `[${connId}] Sending node_event for Node ${this.#commandHandler.formatNode(nodeId)}`,
-                        nodeEvent,
-                    );
-                    connection.sendOrdered(toBigIntAwareJson({ event: "node_event", data: nodeEvent }));
                 }
             });
 
@@ -522,10 +538,9 @@ export class WebSocketControllerHandler implements WebServerHandler {
                 connection.dispose();
             };
 
-            ws.on(
-                "message",
-                data =>
-                    void this.#handleWebSocketRequest(connId, connection, data.toString()).then(
+            ws.on("message", data => {
+                this.#handleWebSocketRequest(connId, connection, data.toString())
+                    .then(
                         ({ response, enableListeners, wantsThreadDiagnostics: requested, wantsWebRtc: reqWebRtc }) => {
                             if (this.#closed) return;
                             if (enableListeners) {
@@ -539,9 +554,9 @@ export class WebSocketControllerHandler implements WebServerHandler {
                             }
                             connection.sendReliable(toBigIntAwareJson(response));
                         },
-                        err => logger.error(`[${connId}] WebSocket request error`, err),
-                    ),
-            );
+                    )
+                    .catch(err => logger.error(`[${connId}] WebSocket request error`, err));
+            });
 
             ws.on("close", onClose);
             ws.on("error", err => {
@@ -549,13 +564,12 @@ export class WebSocketControllerHandler implements WebServerHandler {
                 onClose();
             });
 
-            this.#getServerInfo().then(
-                response => {
+            this.#getServerInfo()
+                .then(response => {
                     logger.debug(`[${connId}] Sending server info`);
                     connection.sendReliable(toBigIntAwareJson(response));
-                },
-                err => logger.error(`[${connId}] WebSocket handshake error`, err),
-            );
+                })
+                .catch(err => logger.error(`[${connId}] WebSocket handshake error`, err));
         });
 
         // Initialize all nodes (populates attribute caches) and start connecting them.

--- a/packages/ws-controller/test/WebSocketRequestSerializationTest.ts
+++ b/packages/ws-controller/test/WebSocketRequestSerializationTest.ts
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Guards that a throw while serializing an already-resolved response (toBigIntAwareJson on a circular
+ * value, in the fulfillment handler) does not leak as an unhandled rejection and the connection keeps
+ * serving. Cast-based ControllerCommandHandler stand-in over a real ws pair (the real class needs a
+ * live CommissioningController).
+ */
+
+import { Environment, FabricId, MockStorageService, NodeId, Observable } from "@matter/main";
+import { once } from "node:events";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { WebSocket } from "ws";
+import type { MatterController } from "../src/controller/MatterController.js";
+import { ConfigStorage } from "../src/server/ConfigStorage.js";
+import { WebSocketControllerHandler } from "../src/server/WebSocketControllerHandler.js";
+
+function createFakeCommandHandler(pingNode: () => unknown) {
+    return {
+        events: {
+            attributeChanged: new Observable(),
+            eventChanged: new Observable(),
+            nodeAdded: new Observable(),
+            nodeStateChanged: new Observable(),
+            nodeAvailabilityChanged: new Observable(),
+            nodeStructureChanged: new Observable(),
+            nodeDecommissioned: new Observable(),
+            nodeEndpointAdded: new Observable(),
+            nodeEndpointRemoved: new Observable(),
+            webRtcCallback: new Observable(),
+        },
+        getNodeIds: () => new Array<NodeId>(),
+        hasNode: () => false,
+        formatNode: (nodeId: NodeId) => `test-node-${nodeId}`,
+        bleEnabled: false,
+        bleProxyEnabled: false,
+        getCommissionerNodeId: () => NodeId(112233),
+        start: async () => {},
+        getCommissionerFabricData: async () => ({
+            fabricId: FabricId(1),
+            compressedFabricId: 1n,
+            fabricIndex: 1,
+        }),
+        initializeNodes: async () => {},
+        pingNode: async () => pingNode(),
+    };
+}
+
+async function createHarness(pingNode: () => unknown) {
+    const env = new Environment("test");
+    new MockStorageService(env);
+    const config = await ConfigStorage.create(env);
+
+    const fakeCommandHandler = createFakeCommandHandler(pingNode);
+    // register() subscribes to the controller-level thread-diagnostics observable; supply just that.
+    const fakeController = {
+        commandHandler: fakeCommandHandler,
+        threadDiagnostics: { events: { batchUpdated: new Observable() } },
+    } as unknown as MatterController;
+
+    const handler = new WebSocketControllerHandler(fakeController, config, "fix5-repro-test");
+
+    const httpServer = createServer();
+    await new Promise<void>((resolve, reject) => {
+        httpServer.once("error", reject);
+        httpServer.listen(0, "127.0.0.1", () => resolve());
+    });
+
+    await handler.register(httpServer);
+
+    return { env, config, handler, httpServer };
+}
+
+type WsMessage = Record<string, unknown>;
+
+function createMessageBuffer(ws: WebSocket) {
+    const backlog = new Array<WsMessage>();
+    const waiters = new Array<{ predicate: (msg: WsMessage) => boolean; resolve: (msg: WsMessage) => void }>();
+
+    ws.on("message", data => {
+        const msg = JSON.parse(data.toString()) as WsMessage;
+        const index = waiters.findIndex(w => w.predicate(msg));
+        if (index >= 0) {
+            waiters.splice(index, 1)[0].resolve(msg);
+        } else {
+            backlog.push(msg);
+        }
+    });
+
+    return {
+        wait(predicate: (msg: WsMessage) => boolean, timeoutMs = 5000): Promise<WsMessage> {
+            const index = backlog.findIndex(predicate);
+            if (index >= 0) {
+                return Promise.resolve(backlog.splice(index, 1)[0]);
+            }
+            return new Promise((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    const waiterIndex = waiters.findIndex(w => w.resolve === resolveAndClear);
+                    if (waiterIndex >= 0) waiters.splice(waiterIndex, 1);
+                    reject(new Error("Timed out waiting for message"));
+                }, timeoutMs);
+                const resolveAndClear = (msg: WsMessage) => {
+                    clearTimeout(timer);
+                    resolve(msg);
+                };
+                waiters.push({ predicate, resolve: resolveAndClear });
+            });
+        },
+    };
+}
+
+describe("WebSocketControllerHandler message response path", () => {
+    it("does not leak an unhandled rejection when the response fails to serialize, and keeps serving the connection", async () => {
+        // Circular result: toBigIntAwareJson throws serializing it, in the fulfillment handler after
+        // the command already resolved — so #handleWebSocketRequest's own try/catch never sees it.
+        const poisoned: Record<string, unknown> = { attempts: 1 };
+        poisoned.self = poisoned;
+
+        const harness = await createHarness(() => poisoned);
+        const unhandledRejections: unknown[] = [];
+        const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
+        process.on("unhandledRejection", onUnhandledRejection);
+
+        let client: WebSocket | undefined;
+        try {
+            const address = harness.httpServer.address() as AddressInfo;
+            client = new WebSocket(`ws://127.0.0.1:${address.port}/ws`);
+            const messages = createMessageBuffer(client);
+            await once(client, "open");
+            await messages.wait(msg => "sdk_version" in msg); // initial server_info
+
+            // The response never serializes, so no frame is sent — the test is about the promise, not the reply.
+            client.send(JSON.stringify({ message_id: "poison", command: "ping_node", args: { node_id: 1 } }));
+
+            // Let the promise chain settle (Node surfaces "unhandledRejection" a tick or two later).
+            await new Promise(resolve => setImmediate(resolve));
+            await new Promise(resolve => setImmediate(resolve));
+            await new Promise(resolve => setImmediate(resolve));
+
+            // Connection (and process) survived: a well-formed request on the same connection still serves.
+            client.send(JSON.stringify({ message_id: "after", command: "server_info", args: {} }));
+            const response = await messages.wait(msg => msg.message_id === "after");
+            expect(response.result).to.not.equal(undefined);
+        } finally {
+            process.off("unhandledRejection", onUnhandledRejection);
+            if (client && (client.readyState === WebSocket.OPEN || client.readyState === WebSocket.CONNECTING)) {
+                client.terminate();
+            }
+            await harness.handler.unregister().catch(() => undefined);
+            await new Promise<void>(resolve => harness.httpServer.close(() => resolve()));
+            await harness.config.close();
+        }
+
+        expect(
+            unhandledRejections,
+            "toBigIntAwareJson throwing during serialization leaked as an unhandled promise rejection instead of being caught",
+        ).to.deep.equal([]);
+    });
+});


### PR DESCRIPTION
Adopts the two fixes from #844 that hold up under review, adapted to this codebase; skips the other four per the per-commit reasoning in https://github.com/matter-js/matterjs-server/pull/844#issuecomment-4951704261.

## Adopted

**1. Isolate the `attributeChanged` / `eventChanged` observers.** Both are shared Observables — every open connection subscribes its own callback, and matter.js's default Observable rethrows an observer error (`handleError → throw`), which aborts the emit loop and starves every later-subscribed connection (and can unwind further into matter.js's own node-level event dispatch). These two callbacks convert untrusted device-supplied values, so a converter throw on a non-compliant value would turn one bad value into a multi-connection outage. Each is now wrapped in the same `try/catch`-log-and-continue idiom already used by the `batchUpdated` and `webRtcCallback` observers in this file. Scope is limited to these two value-converting observers; the others do trivial work where a throw is our own bug and should surface.

**2. Unhandled-rejection hardening on the response paths.** Both WS response paths used the two-argument `.then(onFulfilled, onRejected)` form, which doesn't catch a throw from `onFulfilled`. `toBigIntAwareJson` on a pathological (e.g. circular) response throws at serialization time — inside the fulfillment handler — so it leaked as an unhandled rejection (process exit on modern Node). Both now chain `.catch()` after `.then()`. Regression test over a real `ws` client/server pair, proven RED without the fix.

## Skipped (per review)

- **Guard `AttributeDataCache.updateAttribute`** — silently skipping a rejected value drops a real state change (stale cache, wrong dashboard); worse than a loud throw.
- **Close stale ObserverGroup before replace** — `#registerNode` can't be reached twice for one node id; a silent guard would mask a "why twice?" bug. Better a throw if it ever happens.
- **Time-sync cooldown split / `TimeNotAccepted` backoff** — no reactive-resync failure backoff wanted; the current "24h for every outcome" already gives `TimeNotAccepted` the full cooldown.

Gate: `format`, `lint`, `build`, 230/230 tests green.

Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)