### PR TITLE
feat(dashboard): QR code + formatted setup code in share dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5154,6 +5154,13 @@
                 "undici-types": "~8.3.0"
             }
         },
+        "node_modules/@types/qrcode-generator": {
+            "version": "0.0.16",
+            "resolved": "https://registry.npmjs.org/@types/qrcode-generator/-/qrcode-generator-0.0.16.tgz",
+            "integrity": "sha512-i+wPpeHH64qJHUIz51+tPq5FRkgMxE9/uhDE5eSlj3qujIjHm3U1wHfy8nMD/m1VKaXHO/uDjHamPVz2Fr4IPA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/qs": {
             "version": "6.15.1",
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
@@ -9248,6 +9255,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/qrcode-generator": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-2.0.4.tgz",
+            "integrity": "sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==",
+            "license": "MIT"
+        },
         "node_modules/qs": {
             "version": "6.15.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
@@ -11324,6 +11337,7 @@
                 "@matter-server/ws-client": "*",
                 "@mdi/js": "^7.4.47",
                 "lit": "^3.3.3",
+                "qrcode-generator": "^2.0.4",
                 "tslib": "^2.8.1",
                 "vis-network": "^10.1.0"
             },
@@ -11336,6 +11350,7 @@
                 "@rollup/plugin-node-resolve": "^16.0.3",
                 "@rollup/plugin-terser": "^1.0.0",
                 "@rollup/plugin-typescript": "^12.3.0",
+                "@types/qrcode-generator": "^0.0.16",
                 "rollup": "^4.62.2",
                 "rollup-plugin-copy": "^3.5.0",
                 "serve": "^14.2.6"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -37,6 +37,7 @@
         "@matter-server/ws-client": "*",
         "@mdi/js": "^7.4.47",
         "lit": "^3.3.3",
+        "qrcode-generator": "^2.0.4",
         "tslib": "^2.8.1",
         "vis-network": "^10.1.0"
     },
@@ -49,6 +50,7 @@
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-typescript": "^12.3.0",
+        "@types/qrcode-generator": "^0.0.16",
         "rollup": "^4.62.2",
         "rollup-plugin-copy": "^3.5.0",
         "serve": "^14.2.6"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -28,7 +28,8 @@
         "generate": "tsx scripts/generate-descriptions.ts",
         "build": "npm run generate && nacho-build && npm run bundle",
         "build-clean": "npm run generate && nacho-build --clean && npm run bundle",
-        "bundle": "rollup -c"
+        "bundle": "rollup -c",
+        "test": "matter-test --force-exit"
     },
     "dependencies": {
         "@lit/context": "^1.1.6",

--- a/packages/dashboard/src/pages/components/node-details.ts
+++ b/packages/dashboard/src/pages/components/node-details.ts
@@ -16,7 +16,6 @@ import { MatterClient, MatterNode, UpdateSource } from "@matter-server/ws-client
 import { mdiChatProcessing, mdiPencil, mdiShareVariant, mdiTrashCan, mdiUpdate, mdiVideo } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { unsafeSVG } from "lit/directives/unsafe-svg.js";
 import { clientContext, tickContext } from "../../client/client-context.js";
 import { DeviceType } from "../../client/models/descriptions.js";
 import { showAlertDialog, showPromptDialog } from "../../components/dialog-box/show-dialog-box.js";
@@ -27,7 +26,7 @@ import "../camera-overlay.js";
 import { getDeviceIcon } from "../../util/device-icons.js";
 import { getEndpointDeviceTypes } from "../../util/endpoints.js";
 import { ICD_CLUSTER_ID, icdBadge } from "../../util/icd.js";
-import { formatManualPairingCode, renderPairingQrCodeSvg } from "../../util/pairing-code.js";
+import { formatManualPairingCode, renderPairingQrCodeDataUri } from "../../util/pairing-code.js";
 import { bindingContext } from "./context.js";
 
 /** Map updateState values to user-friendly labels */
@@ -323,12 +322,12 @@ export class NodeDetails extends LitElement {
         try {
             const shareCode = await this.client.openCommissioningWindow(this.node!.node_id);
             const manualCode = formatManualPairingCode(shareCode.setup_manual_code);
-            const qrSvg = unsafeSVG(renderPairingQrCodeSvg(shareCode.setup_qr_code));
+            const qrDataUri = renderPairingQrCodeDataUri(shareCode.setup_qr_code);
             showAlertDialog({
                 title: "Share device",
                 text: html`
                     <div style="display:flex;flex-direction:column;align-items:center;gap:16px;">
-                        <div style="background:#fff;padding:12px;border-radius:8px;line-height:0;">${qrSvg}</div>
+                        <img src=${qrDataUri} alt="Commissioning QR code" style="width:200px;height:200px;" />
                         <div style="text-align:center;">
                             <div style="font-size:0.8rem;color:var(--md-sys-color-on-surface-variant);">Setup code</div>
                             <div style="font-size:1.4rem;font-family:monospace;letter-spacing:0.05em;">

--- a/packages/dashboard/src/pages/components/node-details.ts
+++ b/packages/dashboard/src/pages/components/node-details.ts
@@ -16,6 +16,7 @@ import { MatterClient, MatterNode, UpdateSource } from "@matter-server/ws-client
 import { mdiChatProcessing, mdiPencil, mdiShareVariant, mdiTrashCan, mdiUpdate, mdiVideo } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { unsafeSVG } from "lit/directives/unsafe-svg.js";
 import { clientContext, tickContext } from "../../client/client-context.js";
 import { DeviceType } from "../../client/models/descriptions.js";
 import { showAlertDialog, showPromptDialog } from "../../components/dialog-box/show-dialog-box.js";
@@ -26,6 +27,7 @@ import "../camera-overlay.js";
 import { getDeviceIcon } from "../../util/device-icons.js";
 import { getEndpointDeviceTypes } from "../../util/endpoints.js";
 import { ICD_CLUSTER_ID, icdBadge } from "../../util/icd.js";
+import { formatManualPairingCode, renderPairingQrCodeSvg } from "../../util/pairing-code.js";
 import { bindingContext } from "./context.js";
 
 /** Map updateState values to user-friendly labels */
@@ -320,9 +322,21 @@ export class NodeDetails extends LitElement {
         }
         try {
             const shareCode = await this.client.openCommissioningWindow(this.node!.node_id);
+            const manualCode = formatManualPairingCode(shareCode.setup_manual_code);
+            const qrSvg = unsafeSVG(renderPairingQrCodeSvg(shareCode.setup_qr_code));
             showAlertDialog({
                 title: "Share device",
-                text: `Setup code: ${shareCode.setup_manual_code}`,
+                text: html`
+                    <div style="display:flex;flex-direction:column;align-items:center;gap:16px;">
+                        <div style="background:#fff;padding:12px;border-radius:8px;line-height:0;">${qrSvg}</div>
+                        <div style="text-align:center;">
+                            <div style="font-size:0.8rem;color:var(--md-sys-color-on-surface-variant);">Setup code</div>
+                            <div style="font-size:1.4rem;font-family:monospace;letter-spacing:0.05em;">
+                                ${manualCode}
+                            </div>
+                        </div>
+                    </div>
+                `,
             });
         } catch (err: any) {
             showAlertDialog({

--- a/packages/dashboard/src/util/pairing-code.ts
+++ b/packages/dashboard/src/util/pairing-code.ts
@@ -8,8 +8,8 @@ import qrcode from "qrcode-generator";
 
 /**
  * Format a Matter manual pairing code for display. The 11-digit short code is
- * grouped as `XXXX-XXX-XXXX` per the Matter spec; other lengths are returned
- * with digits only.
+ * grouped as `XXXX-XXX-XXXX` per the Matter spec; codes of any other length are
+ * returned stripped to their digits, or unchanged when they contain no digits.
  */
 export function formatManualPairingCode(code: string): string {
     const digits = code.replace(/\D/g, "");
@@ -20,13 +20,13 @@ export function formatManualPairingCode(code: string): string {
 }
 
 /**
- * Render a Matter QR pairing payload (the `MT:...` string) as an SVG QR code.
- * Modules are drawn black on a transparent background, so callers must place it
- * on a light surface to stay scannable in dark mode.
+ * Render a Matter QR pairing payload (the `MT:...` string) as an SVG data URI.
+ * The generated SVG carries an opaque white background, so the code stays
+ * scannable regardless of the surrounding theme.
  */
-export function renderPairingQrCodeSvg(qrPayload: string, cellSize = 5, margin = 4): string {
+export function renderPairingQrCodeDataUri(qrPayload: string, cellSize = 5, margin = 4): string {
     const qr = qrcode(0, "M");
     qr.addData(qrPayload);
     qr.make();
-    return qr.createSvgTag(cellSize, margin);
+    return `data:image/svg+xml,${encodeURIComponent(qr.createSvgTag(cellSize, margin))}`;
 }

--- a/packages/dashboard/src/util/pairing-code.ts
+++ b/packages/dashboard/src/util/pairing-code.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import qrcode from "qrcode-generator";
+
+/**
+ * Format a Matter manual pairing code for display. The 11-digit short code is
+ * grouped as `XXXX-XXX-XXXX` per the Matter spec; other lengths are returned
+ * with digits only.
+ */
+export function formatManualPairingCode(code: string): string {
+    const digits = code.replace(/\D/g, "");
+    if (digits.length === 11) {
+        return `${digits.slice(0, 4)}-${digits.slice(4, 7)}-${digits.slice(7, 11)}`;
+    }
+    return digits || code;
+}
+
+/**
+ * Render a Matter QR pairing payload (the `MT:...` string) as an SVG QR code.
+ * Modules are drawn black on a transparent background, so callers must place it
+ * on a light surface to stay scannable in dark mode.
+ */
+export function renderPairingQrCodeSvg(qrPayload: string, cellSize = 5, margin = 4): string {
+    const qr = qrcode(0, "M");
+    qr.addData(qrPayload);
+    qr.make();
+    return qr.createSvgTag(cellSize, margin);
+}

--- a/packages/dashboard/test/PairingCodeTest.ts
+++ b/packages/dashboard/test/PairingCodeTest.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { formatManualPairingCode, renderPairingQrCodeDataUri } from "../src/util/pairing-code.js";
+
+describe("formatManualPairingCode", () => {
+    it("groups an 11-digit code as XXXX-XXX-XXXX", () => {
+        expect(formatManualPairingCode("34315849284")).to.equal("3431-584-9284");
+    });
+    it("strips non-digit characters before grouping", () => {
+        expect(formatManualPairingCode("3431-584-9284")).to.equal("3431-584-9284");
+    });
+    it("returns digits only for non-11-digit codes", () => {
+        expect(formatManualPairingCode("749701123365521327694")).to.equal("749701123365521327694");
+    });
+    it("returns the original string when it holds no digits", () => {
+        expect(formatManualPairingCode("no-digits")).to.equal("no-digits");
+    });
+});
+
+describe("renderPairingQrCodeDataUri", () => {
+    it("returns an SVG data URI containing an <svg> tag", () => {
+        const uri = renderPairingQrCodeDataUri("MT:Y.K9042C00KA0648G00");
+        expect(uri).to.match(/^data:image\/svg\+xml,/);
+        expect(decodeURIComponent(uri)).to.contain("<svg");
+    });
+});


### PR DESCRIPTION
## What

The **Share device** dialog previously showed the raw 11-digit manual pairing code (e.g. `Setup code: 34315849284`). This PR:

- Formats the manual code per Matter spec as `XXXX-XXX-XXXX` (e.g. `3431-584-9284`)
- Renders the `setup_qr_code` payload — already returned by the server (`setup_qr_code` in `CommissioningParameters`) but previously unused — as a scannable QR code

## How

- New util `packages/dashboard/src/util/pairing-code.ts`:
  - `formatManualPairingCode()` — groups the 11-digit short code
  - `renderPairingQrCodeSvg()` — generates an SVG QR via `qrcode-generator` (zero-dep, ~10KB, pure JS)
- `node-details.ts` share dialog now uses a Lit `TemplateResult` (already supported by `showAlertDialog`)
- QR drawn black-on-white in a padded box so it stays scannable in dark mode

No server/protocol changes — dashboard-only.

## Verification

- `npm run format` / `npm run lint` / `npm run build` all green
- Util logic verified: `34315849284` → `3431-584-9284`; QR produces valid SVG
- Independent adversarial review: no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)