### PR TITLE
Clarify Thread node descriptions in the network visualization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 - Enhancement: Update matter.js to 0.17.5
 - Enhancement: Adds a QR code when using the dashboard to share a device
+- Enhancement: Clarify Thread node role and unknown/external device descriptions in the network visualization (e.g. what a REED is, why a device shows as unknown/external) and link the OpenThread role primer
 
 ## 1.2.4 (2026-07-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This page shows a detailed overview of the changes between versions without the 
 ## **WORK IN PROGRESS**
 
 - Enhancement: Update matter.js to 0.17.5
-- Enhancement: Adds a QR code when using the dashboard to share a device
+- Enhancement: Add a QR code when using the dashboard to share a device
 - Enhancement: Clarify Thread node role and unknown/external device descriptions in the network visualization (e.g. what a REED is, why a device shows as unknown/external) and link the OpenThread role primer
 
 ## 1.2.4 (2026-07-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Enhancement: Update matter.js to 0.17.5
+- Enhancement: Adds a QR code when using the dashboard to share a device
+
 ## 1.2.4 (2026-07-12)
 
 - Enhancement: Update Docker base images to Debian trixie with the current Node 24 version
@@ -23,7 +28,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## 1.2.2 (2026-07-10)
 
-- Fix: Ensure that WebSocket backpressure keeps the send window full instead of draining one frame at a time, avoiding initial-sync stalls behind a high-latency proxy (e.g. Home Assistant ingress) that could drop the dashboard connection
+- Fix: Ensure that WebSocket backpressure keeps the send-window full instead of draining one frame at a time, avoiding initial-sync stalls behind a high-latency proxy (e.g. Home Assistant ingress) that could drop the dashboard connection
 - Fix: Optimize TBR address and data handling
 - Fix: Update WebRTC and Camera-related logic and respect separate Audio/Video streams in Dashboard
 - Fix: Update matter.js to the latest 0.17.5 nightly

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "packages/matter-server"
             ],
             "devDependencies": {
-                "@matter/testing": "0.17.5-alpha.0-20260711-a60245c75",
+                "@matter/testing": "0.17.5",
                 "@nacho-iot/js-tools": "^0.1.7",
                 "@types/mocha": "^10.0.10",
                 "glob": "^13.0.6",
@@ -2937,77 +2937,77 @@
             }
         },
         "node_modules/@matter/general": {
-            "version": "0.17.5-alpha.0-20260711-a60245c75",
-            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.5-alpha.0-20260711-a60245c75.tgz",
-            "integrity": "sha512-SSu3mGjw5/3KNIrTN7uhCgWGc6KWM2RlBZDLT2BQB2ouCh0GfquMlrXxBs9aBQtOqK3iJTwpb5HNctkkkt5fjA==",
+            "version": "0.17.5",
+            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.5.tgz",
+            "integrity": "sha512-5cao+PBV4mzP+/tH+Z86mgZJHg6SPyfLnF/Ly4v6jmcTqjsy+/eGzo4y9KB0N9FSsG0WjqcySh2F4ycUdw+oVw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/curves": "^2.2.0"
             }
         },
         "node_modules/@matter/main": {
-            "version": "0.17.5-alpha.0-20260711-a60245c75",
-            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.5-alpha.0-20260711-a60245c75.tgz",
-            "integrity": "sha512-zBhfgKEmB6HGzjOBvoYI0fh3WGYFG39nZ33dJpAO5CPjmzuZxU2VB9H6cE8id3Oij9P/BFsi+Zoi72pQILu+dA==",
+            "version": "0.17.5",
+            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.5.tgz",
+            "integrity": "sha512-JHIO/GIa3pdeKtAzvBrE0SpH+wwvZ+rDVme1usuRofKxPHWDiHcOrtgVURnyTHtY3bpFkFwSYyGlFWST3qwhAA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/model": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/node": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/protocol": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/types": "0.17.5-alpha.0-20260711-a60245c75"
+                "@matter/general": "0.17.5",
+                "@matter/model": "0.17.5",
+                "@matter/node": "0.17.5",
+                "@matter/protocol": "0.17.5",
+                "@matter/types": "0.17.5"
             },
             "optionalDependencies": {
-                "@matter/nodejs": "0.17.5-alpha.0-20260711-a60245c75"
+                "@matter/nodejs": "0.17.5"
             }
         },
         "node_modules/@matter/model": {
-            "version": "0.17.5-alpha.0-20260711-a60245c75",
-            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.5-alpha.0-20260711-a60245c75.tgz",
-            "integrity": "sha512-gOEQRf9WqrmTouiRvKlvbQtDXVPVv7qSGQAIFMhB+mY0+MEkAoxyWnxyskgH13wcxUNS/ypikFNVM8vEU/iukQ==",
+            "version": "0.17.5",
+            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.5.tgz",
+            "integrity": "sha512-GwaRBrGN8FWh6LKExPnFU99G5/aBUlaVIZtPplNGmvx6loN1pF5ziWCe7+ilLieQqG6XBUrtBL/PP+GjvOTJlw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260711-a60245c75"
+                "@matter/general": "0.17.5"
             }
         },
         "node_modules/@matter/node": {
-            "version": "0.17.5-alpha.0-20260711-a60245c75",
-            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.5-alpha.0-20260711-a60245c75.tgz",
-            "integrity": "sha512-FlJl11usJpjM0abyhPBwL7V48SxtW7yWef0ZUfStqmkC3aLHksS5wwxrQjFGMan/vAN+nO3lswvfPnNhRGRxjg==",
+            "version": "0.17.5",
+            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.5.tgz",
+            "integrity": "sha512-kbDiSu5MWz45UZQ7p5sky8A3Bcf93O8z3b0rH+iWvpCPAQ5k7o2GFEaoaMYmRYjuuqpEFTk0q0uc8z7+binOrQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/model": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/protocol": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/types": "0.17.5-alpha.0-20260711-a60245c75"
+                "@matter/general": "0.17.5",
+                "@matter/model": "0.17.5",
+                "@matter/protocol": "0.17.5",
+                "@matter/types": "0.17.5"
             }
         },
         "node_modules/@matter/nodejs": {
-            "version": "0.17.5-alpha.0-20260711-a60245c75",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.5-alpha.0-20260711-a60245c75.tgz",
-            "integrity": "sha512-tlNu96cA/QwC+TZ1UU4olyI2p9Ob46HVzKCMlLjqLSh2dVZGtT+ZQgWUSoFMYY3eRJ5l4IuQFX3DNnajh4KT0Q==",
+            "version": "0.17.5",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.5.tgz",
+            "integrity": "sha512-/NrvtBlha9V+VAIh2PhXNLcQjIqCvgOGAfm/PTjTuJO2UbeKmYB1qskIAu7cXc/ayoVXvWrsN1Tl9GsxRtKGXA==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/node": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/protocol": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/types": "0.17.5-alpha.0-20260711-a60245c75"
+                "@matter/general": "0.17.5",
+                "@matter/node": "0.17.5",
+                "@matter/protocol": "0.17.5",
+                "@matter/types": "0.17.5"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
             }
         },
         "node_modules/@matter/nodejs-ble": {
-            "version": "0.17.5-alpha.0-20260711-a60245c75",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.5-alpha.0-20260711-a60245c75.tgz",
-            "integrity": "sha512-vyx8qjRDdHMM/L2CglhObfpPcQKpeR1zKo8SnW/W/EnQwA0VloZ8MXXluW0k4s/4tl811IGzagV9Nul5HMMIaQ==",
+            "version": "0.17.5",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.5.tgz",
+            "integrity": "sha512-JxF+GI7Kjcu4QHvA+ho3s3gkqWnq6EU0ji0Ffem2ZIXGyIDKCef1bE1CEPTKIonDpCQxU32xscpx1u+z8IfdYg==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/protocol": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/types": "0.17.5-alpha.0-20260711-a60245c75"
+                "@matter/general": "0.17.5",
+                "@matter/protocol": "0.17.5",
+                "@matter/types": "0.17.5"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -3018,20 +3018,20 @@
             }
         },
         "node_modules/@matter/protocol": {
-            "version": "0.17.5-alpha.0-20260711-a60245c75",
-            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.5-alpha.0-20260711-a60245c75.tgz",
-            "integrity": "sha512-YcbCJhqo4dSPDTIaBQ1QVRQAQONMvzJ1LAmLCQbDLa1+9pxPyTkC6PFGZ+rFweX8bBw3BgKuUOGSHN/5mDNm8g==",
+            "version": "0.17.5",
+            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.5.tgz",
+            "integrity": "sha512-Nl8aLwA2FHPSD/v4Q8Eaghl4r35SN0I1SXmUPsJIA30zgYaUOAZGQFYGSlKyur7j5soDUQQKl7rLxmN616UnWA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/model": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/types": "0.17.5-alpha.0-20260711-a60245c75"
+                "@matter/general": "0.17.5",
+                "@matter/model": "0.17.5",
+                "@matter/types": "0.17.5"
             }
         },
         "node_modules/@matter/testing": {
-            "version": "0.17.5-alpha.0-20260711-a60245c75",
-            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.5-alpha.0-20260711-a60245c75.tgz",
-            "integrity": "sha512-Z9bnxeoJov3nGwWCqO+aDhT/BvkmLDA2Xx0MmHVMJRH6mv7IABG2x8rWqMpF9HSYmv8PsDaMOM7SLSa2/2+nLg==",
+            "version": "0.17.5",
+            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.5.tgz",
+            "integrity": "sha512-Bh9/dEiiXyZo5US+t4XbBQf2RMP5Hqsqy68Wk2ddmjAN7OaYfJXbNZKlyC9v5LBnm03FLxhnwm8lHNqcdYwcIQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3056,24 +3056,24 @@
             }
         },
         "node_modules/@matter/thread-br-client": {
-            "version": "0.17.5-alpha.0-20260711-a60245c75",
-            "resolved": "https://registry.npmjs.org/@matter/thread-br-client/-/thread-br-client-0.17.5-alpha.0-20260711-a60245c75.tgz",
-            "integrity": "sha512-NzznwpZAonKBPCqHO95Bmp/e3xxtlwy7nzCHu8W4RC571qhYypbK6ME+0Y6H1S/IEqhF5slaWLtXGrAXKithog==",
+            "version": "0.17.5",
+            "resolved": "https://registry.npmjs.org/@matter/thread-br-client/-/thread-br-client-0.17.5.tgz",
+            "integrity": "sha512-aMPmsYGMuJYIwJeWyr4NtfIfOCjlw1CrZLGJfHEvJ2bROrin+bHuPfizZieI8tKpm7eckCRNRxSqLlHZeVdIBg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/protocol": "0.17.5-alpha.0-20260711-a60245c75",
+                "@matter/general": "0.17.5",
+                "@matter/protocol": "0.17.5",
                 "@noble/curves": "^2.2.0"
             }
         },
         "node_modules/@matter/types": {
-            "version": "0.17.5-alpha.0-20260711-a60245c75",
-            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.5-alpha.0-20260711-a60245c75.tgz",
-            "integrity": "sha512-Xt2jGApmwAIUPs4G5CNiLR3vJmn0dqcp+kvhLQUpt6h9e1lTkQS6vvE44WVoYd6uWSJVcbEScmrhstHQZZiSgQ==",
+            "version": "0.17.5",
+            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.5.tgz",
+            "integrity": "sha512-aVFxSEwWLZrv8XkuPTGrPOw17XeuAcyZjoTxztuIAhkIk2/w+FdXUW5HEEwOFE81txKSz62NP/4iia3k7MimaA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/model": "0.17.5-alpha.0-20260711-a60245c75"
+                "@matter/general": "0.17.5",
+                "@matter/model": "0.17.5"
             }
         },
         "node_modules/@mdi/js": {
@@ -3984,16 +3984,16 @@
             }
         },
         "node_modules/@project-chip/matter.js": {
-            "version": "0.17.5-alpha.0-20260711-a60245c75",
-            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.5-alpha.0-20260711-a60245c75.tgz",
-            "integrity": "sha512-CdR1NJTzVgDhas4vbdHzfF3jcSFaC1uYDiC849pFBZX6QxcD1i5u4GjatoGfAf1SeQgOvuDu8ALTbvqkw/tgiw==",
+            "version": "0.17.5",
+            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.5.tgz",
+            "integrity": "sha512-gj1gmAPgB2/naolrncbzkLH8vIE6NR0JL7JhpWKcsrgCXXtrMpNzGVFb+DPhlTh8H39W6rRB8H11AkT4K6rSVA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/model": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/node": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/protocol": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/types": "0.17.5-alpha.0-20260711-a60245c75"
+                "@matter/general": "0.17.5",
+                "@matter/model": "0.17.5",
+                "@matter/node": "0.17.5",
+                "@matter/protocol": "0.17.5",
+                "@matter/types": "0.17.5"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -4990,9 +4990,9 @@
             }
         },
         "node_modules/@stoprocent/noble": {
-            "version": "2.5.5",
-            "resolved": "https://registry.npmjs.org/@stoprocent/noble/-/noble-2.5.5.tgz",
-            "integrity": "sha512-tHtc8nEvf+J11MedleT0YBhxBrWTqJaoXQJ9H983Gnrus1cHHxs2YtCHMk/3mFuoUAIvW0o1JcH8cHBieqkUYQ==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/@stoprocent/noble/-/noble-2.5.6.tgz",
+            "integrity": "sha512-P41tvKSQxBVmPSGB9JiVUxYiX85Z4hIconj8oGb2h8fSyumhsoePV1WN3VoZaxee5WsZpwKOsDoE2iI3poKyUA==",
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -10608,9 +10608,9 @@
             "license": "0BSD"
         },
         "node_modules/tsx": {
-            "version": "4.23.0",
-            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
-            "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+            "version": "4.23.1",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+            "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11301,7 +11301,7 @@
             "version": "0.0.0-git",
             "dependencies": {
                 "@matter-server/ws-controller": "*",
-                "@matter/main": "0.17.5-alpha.0-20260711-a60245c75",
+                "@matter/main": "0.17.5",
                 "ws": "^8.21.0"
             },
             "devDependencies": {
@@ -11312,7 +11312,7 @@
                 "node": ">=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.5-alpha.0-20260711-a60245c75",
+                "@matter/nodejs-ble": "0.17.5",
                 "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
             }
         },
@@ -11320,7 +11320,7 @@
             "name": "@matter-server/custom-clusters",
             "version": "0.0.0-git",
             "dependencies": {
-                "@matter/main": "0.17.5-alpha.0-20260711-a60245c75"
+                "@matter/main": "0.17.5"
             },
             "engines": {
                 "node": ">=22.13.0"
@@ -11343,7 +11343,7 @@
             },
             "devDependencies": {
                 "@babel/preset-env": "^8.0.2",
-                "@matter/main": "0.17.5-alpha.0-20260711-a60245c75",
+                "@matter/main": "0.17.5",
                 "@rollup/plugin-babel": "^7.1.0",
                 "@rollup/plugin-commonjs": "^29.0.3",
                 "@rollup/plugin-json": "^6.1.0",
@@ -11616,14 +11616,14 @@
                 "@matter-server/custom-clusters": "*",
                 "@matter-server/dashboard": "*",
                 "@matter-server/ws-controller": "*",
-                "@matter/main": "0.17.5-alpha.0-20260711-a60245c75",
+                "@matter/main": "0.17.5",
                 "commander": "^15.0.0",
                 "express": "^5.2.1"
             },
             "devDependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/nodejs": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/testing": "0.17.5-alpha.0-20260711-a60245c75",
+                "@matter/nodejs": "0.17.5",
+                "@matter/testing": "0.17.5",
                 "@types/express": "^5.0.6",
                 "@types/node": "^26.1.1"
             },
@@ -11645,10 +11645,10 @@
             "version": "0.0.0-git",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/thread-br-client": "0.17.5-alpha.0-20260711-a60245c75"
+                "@matter/thread-br-client": "0.17.5"
             },
             "devDependencies": {
-                "@matter/testing": "0.17.5-alpha.0-20260711-a60245c75",
+                "@matter/testing": "0.17.5",
                 "@types/node": "^26.1.1",
                 "@types/ws": "^8.18.1",
                 "ws": "^8.21.0"
@@ -11663,9 +11663,9 @@
             "dependencies": {
                 "@matter-server/ws-client": "*",
                 "@matter/dcl-data": ">=2026.7.10",
-                "@matter/main": "0.17.5-alpha.0-20260711-a60245c75",
-                "@matter/thread-br-client": "0.17.5-alpha.0-20260711-a60245c75",
-                "@project-chip/matter.js": "0.17.5-alpha.0-20260711-a60245c75",
+                "@matter/main": "0.17.5",
+                "@matter/thread-br-client": "0.17.5",
+                "@project-chip/matter.js": "0.17.5",
                 "ws": "^8.21.0"
             },
             "devDependencies": {
@@ -11676,7 +11676,7 @@
                 "node": ">=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.5-alpha.0-20260711-a60245c75",
+                "@matter/nodejs-ble": "0.17.5",
                 "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
             }
         }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "python-ble-proxy:run": "cd python_ble_proxy && { [ -x .venv/bin/matter-ble-proxy ] || (python3 -m venv .venv && .venv/bin/pip install -e .); } && .venv/bin/matter-ble-proxy"
     },
     "devDependencies": {
-        "@matter/testing": "0.17.5-alpha.0-20260711-a60245c75",
+        "@matter/testing": "0.17.5",
         "@nacho-iot/js-tools": "^0.1.7",
         "@types/mocha": "^10.0.10",
         "glob": "^13.0.6",
@@ -79,7 +79,7 @@
         "@serialport/bindings-cpp@12.0.1": true,
         "@stoprocent/bleno@0.12.5": true,
         "@stoprocent/bluetooth-hci-socket@2.2.6": true,
-        "@stoprocent/noble@2.5.5": true,
+        "@stoprocent/noble@2.5.6": true,
         "fsevents@2.3.2": true,
         "fsevents@2.3.3": true
     }

--- a/packages/ble-proxy/package.json
+++ b/packages/ble-proxy/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@matter-server/ws-controller": "*",
-        "@matter/main": "0.17.5-alpha.0-20260711-a60245c75",
+        "@matter/main": "0.17.5",
         "ws": "^8.21.0"
     },
     "devDependencies": {
@@ -38,7 +38,7 @@
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.5-alpha.0-20260711-a60245c75",
+        "@matter/nodejs-ble": "0.17.5",
         "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
     },
     "engines": {

--- a/packages/custom-clusters/package.json
+++ b/packages/custom-clusters/package.json
@@ -39,7 +39,7 @@
         "build-clean": "nacho-build --clean"
     },
     "dependencies": {
-        "@matter/main": "0.17.5-alpha.0-20260711-a60245c75"
+        "@matter/main": "0.17.5"
     },
     "engines": {
         "node": ">=22.13.0"

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -41,13 +41,26 @@ Node colors indicate device status:
 - **Red**: Offline device (not responding)
 - **Orange**: Unknown/external device (not commissioned to this fabric, detected in neighbor tables)
 
+### Why a device shows as unknown/external
+
+Orange nodes are inferred from a commissioned node's Thread neighbor table but are not part of this fabric. The server cannot tell these cases apart, so an orange node may be any of:
+
+- A device commissioned to **another Matter fabric** on the same Thread network (Apple Home, Google, SmartThings, …).
+- A **native (non-Matter) Thread accessory** (HomeKit-over-Thread, Eve, Nanoleaf, …).
+- A **Border Router** whose Thread radio MAC differs from its MeshCoP border-agent ID, so it can't be matched to a known BR (common with Apple and Aqara).
+- A **stale neighbor entry** for a device that has left. Obvious stale ghosts (all observers offline, or a single-source entry from an otherwise-reachable node) are filtered out automatically.
+
+An **external router** is such a device advertising rx-on-when-idle (mains-powered, so router-capable); an **external device** is one that is not. "Router-capable" is not a confirmed routing role.
+
+A separate **Diagnostic Mesh Node** is inferred from a Border Router's own Route64 / child-table diagnostics rather than a neighbor table; it is likewise not commissioned to this fabric.
+
 ### Understanding Node Role Badges
 
-Thread nodes commissioned to this fabric carry a small corner badge over the device icon showing their Thread routing role:
+Thread nodes commissioned to this fabric carry a small corner badge over the device icon showing their Thread routing role. For the underlying Thread role definitions, see the [OpenThread node roles and types primer](https://openthread.io/guides/thread-primer/node-roles-and-types).
 
 - **Crown (amber)**: Leader — the elected coordinator of the Thread network
 - **Swap arrows (blue)**: Router — forwards traffic for other nodes
-- **Small dot (grey-blue)**: End Device or REED (Router-Eligible End Device)
+- **Small dot (grey-blue)**: End Device, or REED (Router-Eligible End Device) — a node that currently acts as an end device but can be promoted to a full Router when the mesh needs more routing capacity
 - **Zzz / sleep (grey-blue)**: Sleepy End Device — radio off when idle to save battery
 - **No badge**: Role unassigned/unspecified, or an external device whose role can't be queried
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -44,7 +44,7 @@
     },
     "devDependencies": {
         "@babel/preset-env": "^8.0.2",
-        "@matter/main": "0.17.5-alpha.0-20260711-a60245c75",
+        "@matter/main": "0.17.5",
         "@rollup/plugin-babel": "^7.1.0",
         "@rollup/plugin-commonjs": "^29.0.3",
         "@rollup/plugin-json": "^6.1.0",

--- a/packages/dashboard/src/pages/network/network-details.ts
+++ b/packages/dashboard/src/pages/network/network-details.ts
@@ -1839,7 +1839,7 @@ export class NetworkDetails extends LitElement {
                 margin-top: 6px;
                 margin-bottom: 4px;
                 padding-left: 10px;
-                border-left: 2px solid var(--md-sys-color-outline-variant, #444);
+                border-left: 2px solid var(--md-sys-color-outline-variant, #ccc);
                 font-size: 0.72rem;
             }
 

--- a/packages/dashboard/src/pages/network/network-details.ts
+++ b/packages/dashboard/src/pages/network/network-details.ts
@@ -37,12 +37,16 @@ import {
     formatThreadVersion,
     getDeviceName,
     getNetworkType,
+    DIAGNOSTIC_MESH_NODE_EXPLANATION,
+    EXTERNAL_ROUTER_CAPABLE_NOTE,
+    EXTERNAL_THREAD_DEVICE_CASES,
     getNodeConnectionsFromPairs,
     getRoutableDestinationsCount,
     getSignalColorFromRssi,
     getThreadChannel,
     getThreadExtendedAddressHex,
     getThreadRole,
+    getThreadRoleDescription,
     getThreadRoleName,
     getThreadVersion,
     getWiFiDiagnostics,
@@ -237,6 +241,7 @@ export class NetworkDetails extends LitElement {
                     <span class="label">Role:</span>
                     <span class="value">${getThreadRoleName(threadRole)}</span>
                 </div>
+                <p class="hint-text inline-note">${getThreadRoleDescription(threadRole)}</p>
                 ${threadVersion !== undefined
                     ? html`
                           <div class="info-row">
@@ -482,10 +487,7 @@ export class NetworkDetails extends LitElement {
 
             <md-divider></md-divider>
             <div class="section">
-                <p class="hint-text">
-                    This node was inferred from Border Router diagnostics (Route64 / child table) and is not
-                    commissioned to this fabric, so no device details are available.
-                </p>
+                <p class="hint-text">${DIAGNOSTIC_MESH_NODE_EXPLANATION}</p>
             </div>
         `;
     }
@@ -504,6 +506,9 @@ export class NetworkDetails extends LitElement {
                     <span class="label">Type:</span>
                     <span class="value">${unknown.isRouter ? "Router (external)" : "End Device (external)"}</span>
                 </div>
+                ${unknown.isRouter
+                    ? html`<p class="hint-text inline-note">${EXTERNAL_ROUTER_CAPABLE_NOTE}</p>`
+                    : nothing}
                 <div class="info-row">
                     <span class="label">Extended Address:</span>
                     <span class="value mono">${unknown.extAddressHex}</span>
@@ -539,10 +544,12 @@ export class NetworkDetails extends LitElement {
             <md-divider></md-divider>
             <div class="section">
                 <p class="hint-text">
-                    This device appears in Thread neighbor tables but is not commissioned to this fabric. It may be a
-                    Thread Border Router whose Thread radio MAC differs from its MeshCoP border-agent ID (common with
-                    Apple and Aqara), or a device from another Matter ecosystem.
+                    This device appears in a commissioned node's Thread neighbor table but is not part of this fabric.
+                    It may be:
                 </p>
+                <ul class="hint-text">
+                    ${EXTERNAL_THREAD_DEVICE_CASES.map(c => html`<li>${c}</li>`)}
+                </ul>
             </div>
         `;
     }
@@ -1826,6 +1833,14 @@ export class NetworkDetails extends LitElement {
                 color: var(--md-sys-color-on-surface-variant, #666);
                 line-height: 1.4;
                 margin: 0;
+            }
+
+            .hint-text.inline-note {
+                margin-top: 6px;
+                margin-bottom: 4px;
+                padding-left: 10px;
+                border-left: 2px solid var(--md-sys-color-outline-variant, #444);
+                font-size: 0.72rem;
             }
 
             .connected-nodes-list {

--- a/packages/dashboard/src/pages/network/network-types.ts
+++ b/packages/dashboard/src/pages/network/network-types.ts
@@ -35,6 +35,8 @@ export interface NetworkGraphNode {
     shape: "image";
     networkType: NetworkType;
     threadRole?: ThreadRoutingRole;
+    /** Hover tooltip (vis.js): role or unknown/external explanation. */
+    title?: string;
     /** Whether the node is offline */
     offline?: boolean;
     /** Whether this is an unknown/external device */

--- a/packages/dashboard/src/pages/network/network-utils.ts
+++ b/packages/dashboard/src/pages/network/network-utils.ts
@@ -190,8 +190,7 @@ export const EXTERNAL_THREAD_DEVICE_EXPLANATION = `Seen in a commissioned node's
  * `isRouter` for an external neighbor is derived from rx-on-when-idle, so it means
  * router-capable (mains-powered), not a confirmed routing role.
  */
-export const EXTERNAL_ROUTER_CAPABLE_NOTE =
-    "“Router” here means the neighbor advertised rx-on-when-idle (mains-powered / router-capable), not a confirmed routing role.";
+export const EXTERNAL_ROUTER_CAPABLE_NOTE = `"Router" here means the neighbor advertised rx-on-when-idle (mains-powered / router-capable), not a confirmed routing role.`;
 
 export const DIAGNOSTIC_MESH_NODE_EXPLANATION =
     "Inferred from Border Router diagnostics (Route64 / child table) and not commissioned to this fabric, so no device details are available.";

--- a/packages/dashboard/src/pages/network/network-utils.ts
+++ b/packages/dashboard/src/pages/network/network-utils.ts
@@ -150,6 +150,52 @@ export function getThreadRoleName(role: number | undefined): string {
     }
 }
 
+/** Tooltip-friendly long form of {@link getThreadRoleName}. */
+export function getThreadRoleDescription(role: number | undefined): string {
+    switch (role) {
+        case 2:
+            return "Sleepy End Device: keeps its radio off while idle to save battery and reaches the mesh only through a parent router. The links shown for it can include stale router-table entries for Thread addresses it no longer uses.";
+        case 3:
+            return "End Device: a leaf node that reaches the mesh through a parent router and does not route for other nodes. The links shown for it can include stale router-table entries for old or unused Thread addresses.";
+        case 4:
+            return "REED (Router-Eligible End Device): currently acts as an end device but can be promoted to a full Router when the mesh needs more routing capacity.";
+        case 5:
+            return "Router: forwards traffic for other nodes in the Thread mesh.";
+        case 6:
+            return "Leader: the elected node that manages router assignments for the Thread network.";
+        case 0:
+        case 1:
+            return "Thread routing role is unassigned or unspecified.";
+        default:
+            return "Thread routing role could not be determined.";
+    }
+}
+
+/**
+ * Cases a Thread node shown as unknown/external may actually be. These devices are
+ * inferred from a commissioned node's neighbor table; the code cannot tell the cases
+ * apart, so the copy enumerates the possibilities rather than asserting one.
+ */
+export const EXTERNAL_THREAD_DEVICE_CASES = [
+    "a device commissioned to another Matter fabric on the same Thread network",
+    "a native (non-Matter) Thread accessory",
+    "a Border Router whose Thread radio MAC differs from its MeshCoP border-agent ID (common with Apple and Aqara)",
+    "a stale neighbor entry for a device that has left",
+] as const;
+
+/** Single-sentence form of {@link EXTERNAL_THREAD_DEVICE_CASES} for plain-text tooltips. */
+export const EXTERNAL_THREAD_DEVICE_EXPLANATION = `Seen in a commissioned node's Thread neighbor table but not part of this fabric. It may be ${EXTERNAL_THREAD_DEVICE_CASES.slice(0, -1).join(", ")}, or ${EXTERNAL_THREAD_DEVICE_CASES[EXTERNAL_THREAD_DEVICE_CASES.length - 1]}.`;
+
+/**
+ * `isRouter` for an external neighbor is derived from rx-on-when-idle, so it means
+ * router-capable (mains-powered), not a confirmed routing role.
+ */
+export const EXTERNAL_ROUTER_CAPABLE_NOTE =
+    "“Router” here means the neighbor advertised rx-on-when-idle (mains-powered / router-capable), not a confirmed routing role.";
+
+export const DIAGNOSTIC_MESH_NODE_EXPLANATION =
+    "Inferred from Border Router diagnostics (Route64 / child table) and not commissioned to this fabric, so no device details are available.";
+
 /**
  * Gets WiFi security type name.
  */

--- a/packages/dashboard/src/pages/network/thread-graph.ts
+++ b/packages/dashboard/src/pages/network/thread-graph.ts
@@ -406,9 +406,16 @@ export class ThreadGraph extends BaseNetworkGraph {
                 const decodedState = decodeMeshcopStateBitmap(device.stateBitmapHex);
                 const isLeader = decodedState?.threadRoleValue === 3;
                 const isPrimaryBbr = decodedState?.bbr === true && decodedState.bbrFunction === "primary";
+                const brRole = new Array<string>();
+                if (isLeader) brRole.push("currently the Thread Leader");
+                if (isPrimaryBbr) brRole.push("Primary Backbone Border Router (BBR)");
+                const brTitle =
+                    "Thread Border Router bridging the Thread mesh to the IP network" +
+                    (brRole.length > 0 ? ` — ${brRole.join("; ")}.` : ".");
                 graphNodes.push({
                     id: device.id,
                     label,
+                    title: brTitle,
                     image: createBorderRouterIconDataUrl(isSelected, isLeader, isPrimaryBbr),
                     shape: "image" as const,
                     networkType: "thread" as const,

--- a/packages/dashboard/src/pages/network/thread-graph.ts
+++ b/packages/dashboard/src/pages/network/thread-graph.ts
@@ -27,6 +27,9 @@ import {
     buildRloc16Map,
     buildThreadEdgePairs,
     decodeMeshcopStateBitmap,
+    DIAGNOSTIC_MESH_NODE_EXPLANATION,
+    EXTERNAL_ROUTER_CAPABLE_NOTE,
+    EXTERNAL_THREAD_DEVICE_EXPLANATION,
     findDiagnosticMeshNodes,
     findUnknownDevices,
     makeDiagnosticRloc16Resolver,
@@ -36,6 +39,7 @@ import {
     getNetworkType,
     getThreadExtendedAddressHex,
     getThreadRole,
+    getThreadRoleDescription,
     mergeDiagnosticEdges,
     signalLevelToColor,
     stripMdnsHostname,
@@ -340,6 +344,7 @@ export class ThreadGraph extends BaseNetworkGraph {
             return {
                 id: nodeId,
                 label: getDeviceName(node),
+                title: getThreadRoleDescription(threadRole),
                 image: createNodeIconDataUrl(node, threadRole, false, isOffline),
                 shape: "image" as const,
                 networkType: "thread" as const,
@@ -415,9 +420,13 @@ export class ThreadGraph extends BaseNetworkGraph {
                 const typeLabel =
                     diagNode?.vendorName !== undefined ? `${baseType} (${diagNode.vendorName})` : baseType;
                 const suffix = device.networkName !== undefined ? `\n${device.networkName}` : "";
+                const title = device.isRouter
+                    ? `${EXTERNAL_THREAD_DEVICE_EXPLANATION} ${EXTERNAL_ROUTER_CAPABLE_NOTE}`
+                    : EXTERNAL_THREAD_DEVICE_EXPLANATION;
                 graphNodes.push({
                     id: device.id,
                     label: `${typeLabel} [${device.extAddressHex.slice(-8)}]${suffix}`,
+                    title,
                     image: createUnknownDeviceIconDataUrl(device.isRouter, isSelected),
                     shape: "image" as const,
                     networkType: "thread" as const,
@@ -485,6 +494,7 @@ export class ThreadGraph extends BaseNetworkGraph {
             graphNodes.push({
                 id: meshNode.id,
                 label,
+                title: DIAGNOSTIC_MESH_NODE_EXPLANATION,
                 image: createUnknownDeviceIconDataUrl(meshNode.isRouter, meshNode.id === this._selectedNodeId),
                 shape: "image" as const,
                 networkType: "thread" as const,

--- a/packages/matter-server/package.json
+++ b/packages/matter-server/package.json
@@ -44,14 +44,14 @@
         "@matter-server/custom-clusters": "*",
         "@matter-server/dashboard": "*",
         "@matter-server/ws-controller": "*",
-        "@matter/main": "0.17.5-alpha.0-20260711-a60245c75",
+        "@matter/main": "0.17.5",
         "commander": "^15.0.0",
         "express": "^5.2.1"
     },
     "devDependencies": {
         "@matter-server/ws-client": "*",
-        "@matter/nodejs": "0.17.5-alpha.0-20260711-a60245c75",
-        "@matter/testing": "0.17.5-alpha.0-20260711-a60245c75",
+        "@matter/nodejs": "0.17.5",
+        "@matter/testing": "0.17.5",
         "@types/express": "^5.0.6",
         "@types/node": "^26.1.1"
     },

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -40,10 +40,10 @@
         "build-clean": "nacho-build --clean"
     },
     "dependencies": {
-        "@matter/thread-br-client": "0.17.5-alpha.0-20260711-a60245c75"
+        "@matter/thread-br-client": "0.17.5"
     },
     "devDependencies": {
-        "@matter/testing": "0.17.5-alpha.0-20260711-a60245c75",
+        "@matter/testing": "0.17.5",
         "@types/node": "^26.1.1",
         "@types/ws": "^8.18.1",
         "ws": "^8.21.0"

--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -42,9 +42,9 @@
     "dependencies": {
         "@matter-server/ws-client": "*",
         "@matter/dcl-data": ">=2026.7.10",
-        "@matter/main": "0.17.5-alpha.0-20260711-a60245c75",
-        "@matter/thread-br-client": "0.17.5-alpha.0-20260711-a60245c75",
-        "@project-chip/matter.js": "0.17.5-alpha.0-20260711-a60245c75",
+        "@matter/main": "0.17.5",
+        "@matter/thread-br-client": "0.17.5",
+        "@project-chip/matter.js": "0.17.5",
         "ws": "^8.21.0"
     },
     "devDependencies": {
@@ -52,7 +52,7 @@
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.5-alpha.0-20260711-a60245c75",
+        "@matter/nodejs-ble": "0.17.5",
         "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
     },
     "engines": {


### PR DESCRIPTION
## What

Users reported the Thread network visualization was unclear on **what a REED is** and **which cases produce an unknown/external router**. This surfaces plain-language explanations everywhere those concepts appear, plus a matter.js dependency bump.

### Thread visualization clarity
- **Details panel (visible, not hover-only):**
  - Role now has a description line beneath it — click a REED node → "REED (Router-Eligible End Device): currently acts as an end device but can be promoted to a full Router…". Sleepy/End Device carry a note that their link list may include stale router-table entries.
  - Unknown Device panel enumerates the actual cases (another Matter fabric / native non-Matter Thread accessory / split-MAC Border Router / stale neighbor entry). The code cannot distinguish these, so the copy lists possibilities rather than asserting one.
  - Notes that an external **"Router"** means rx-on-when-idle (mains-powered / router-capable), **not** a confirmed routing role.
- **Graph:** role / external / diagnostic-mesh nodes now have hover tooltips (`title` on `NetworkGraphNode`).
- **README:** REED definition, a "why a device shows as unknown/external" section (incl. the auto-filtering of obvious stale ghosts), and a link to the [OpenThread node roles and types primer](https://openthread.io/guides/thread-primer/node-roles-and-types).

Copy is single-sourced (`EXTERNAL_THREAD_DEVICE_CASES` drives both the panel list and the tooltip sentence).

### Dependencies
- Bump `@matter/*` + `@project-chip/matter.js` from the `0.17.5` alpha nightly to stable **0.17.5**; `@stoprocent/noble` → 2.5.6.

## Verification
`npm run format`, `npm run lint`, `npm run build`, and the full `npm test` suite (251/251) all pass against matter.js 0.17.5 stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)