### PR TITLE
fix(dashboard): include stream lists in ProvideOffer for WebRTC provider conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Fix: Dashboard `ProvideOffer` requests now include `videoStreams`/`audioStreams` alongside deprecated singular stream IDs for WebRTC provider compatibility across cluster revisions
+
 ## 1.2.5 (2026-07-13)
 
 - Enhancement: Update matter.js to 0.17.5

--- a/packages/dashboard/src/components/webrtc-stream-view.ts
+++ b/packages/dashboard/src/components/webrtc-stream-view.ts
@@ -23,6 +23,7 @@ import {
     VIDEO_MIN_FRAME_RATE,
     videoStreamFitsSnapshotBudget,
 } from "../util/camera-stream-budget.js";
+import { buildProvideOfferRequest } from "../util/webrtc-provider-payload.js";
 import "./ha-svg-icon.js";
 
 // Spec values from @matter/types globals/StreamUsage.ts and
@@ -496,15 +497,7 @@ export class WebRtcStreamView extends LitElement {
                 this.nodeId,
                 this.endpointId,
                 "ProvideOffer",
-                {
-                    webRtcSessionId: null,
-                    sdp,
-                    streamUsage: STREAM_USAGE_LIVE_VIEW,
-                    videoStreamId: this._videoStreamId,
-                    audioStreamId: this._audioStreamId,
-                    videoStreams: this._videoStreamId !== null ? [this._videoStreamId] : undefined,
-                    audioStreams: this._audioStreamId !== null ? [this._audioStreamId] : undefined,
-                },
+                buildProvideOfferRequest(sdp, STREAM_USAGE_LIVE_VIEW, this._videoStreamId, this._audioStreamId),
             );
             console.log("[webrtc-stream-view] ProvideOffer response", offerResponse);
             const parsed = parseProvideOfferResponse(offerResponse);

--- a/packages/dashboard/src/components/webrtc-stream-view.ts
+++ b/packages/dashboard/src/components/webrtc-stream-view.ts
@@ -502,6 +502,8 @@ export class WebRtcStreamView extends LitElement {
                     streamUsage: STREAM_USAGE_LIVE_VIEW,
                     videoStreamId: this._videoStreamId,
                     audioStreamId: this._audioStreamId,
+                    videoStreams: this._videoStreamId !== null ? [this._videoStreamId] : undefined,
+                    audioStreams: this._audioStreamId !== null ? [this._audioStreamId] : undefined,
                 },
             );
             console.log("[webrtc-stream-view] ProvideOffer response", offerResponse);

--- a/packages/dashboard/src/util/webrtc-provider-payload.ts
+++ b/packages/dashboard/src/util/webrtc-provider-payload.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface ProvideOfferRequest {
+    [key: string]: unknown;
+    webRtcSessionId: number | null;
+    sdp: string;
+    streamUsage: number;
+    videoStreamId: number | null;
+    audioStreamId: number | null;
+    videoStreams?: number[];
+    audioStreams?: number[];
+}
+
+export function buildProvideOfferRequest(
+    sdp: string,
+    streamUsage: number,
+    videoStreamId: number | null,
+    audioStreamId: number | null,
+): ProvideOfferRequest {
+    return {
+        webRtcSessionId: null,
+        sdp,
+        streamUsage,
+        videoStreamId,
+        audioStreamId,
+        ...(videoStreamId !== null ? { videoStreams: [videoStreamId] } : {}),
+        ...(audioStreamId !== null ? { audioStreams: [audioStreamId] } : {}),
+    };
+}

--- a/packages/dashboard/test/WebRtcProviderPayloadTest.ts
+++ b/packages/dashboard/test/WebRtcProviderPayloadTest.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { buildProvideOfferRequest } from "../src/util/webrtc-provider-payload.js";
+
+describe("buildProvideOfferRequest", () => {
+    it("includes list fields when stream IDs are present", () => {
+        expect(buildProvideOfferRequest("v=0", 3, 7, 9)).to.deep.equal({
+            webRtcSessionId: null,
+            sdp: "v=0",
+            streamUsage: 3,
+            videoStreamId: 7,
+            audioStreamId: 9,
+            videoStreams: [7],
+            audioStreams: [9],
+        });
+    });
+
+    it("omits list fields when stream IDs are null", () => {
+        expect(buildProvideOfferRequest("v=0", 3, null, null)).to.deep.equal({
+            webRtcSessionId: null,
+            sdp: "v=0",
+            streamUsage: 3,
+            videoStreamId: null,
+            audioStreamId: null,
+        });
+    });
+
+    it("keeps only videoStreams when only video is allocated", () => {
+        expect(buildProvideOfferRequest("v=0", 3, 5, null)).to.deep.equal({
+            webRtcSessionId: null,
+            sdp: "v=0",
+            streamUsage: 3,
+            videoStreamId: 5,
+            audioStreamId: null,
+            videoStreams: [5],
+        });
+    });
+});


### PR DESCRIPTION
## Type of change

- [x] 🐛 **Fix** — corrects a defect or wrong behavior
- [ ] ✨ **Feature** — adds new functionality or capability

## Description

This PR fixes the `ProvideOffer` payload built in the dashboard WebRTC view so it works with both legacy and revision >= 2 WebRTC providers.

Root cause:
- The dashboard only sent deprecated singular fields (`videoStreamId`/`audioStreamId`).
- For providers implementing the newer choice conformance, at least one of the list fields (`videoStreams`/`audioStreams`) is required.

Change made:
- Keep sending `videoStreamId` and `audioStreamId` for backward compatibility.
- Also send:
  - `videoStreams: [videoStreamId]` when `videoStreamId !== null`
  - `audioStreams: [audioStreamId]` when `audioStreamId !== null`

## Backing evidence

- Related issue: #864
- [ ] This fix/change is backed by a **complete log file** — attached here or in the linked issue (not just a few quoted lines).

## Checklist

- [ ] Tests added or updated to cover the change
- [ ] `npm test` passes
- [ ] `npm run format-verify` and `npm run lint` pass
- [ ] CHANGELOG updated (if applicable)

Additional verification performed locally:
- `npm run format` passes.
- Targeted lint on modified file passes (`packages/dashboard/src/components/webrtc-stream-view.ts`).
- Repository-wide lint/build are currently failing due to pre-existing unrelated errors in this workspace state.
