### PR TITLE
fix(dashboard): show camera button for Floodlight/Snapshot Camera device types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Fix: Dashboard now shows the camera Live View/Snapshot button for the Floodlight Camera and Snapshot Camera device types, not just Camera and Video Doorbell
+
 ## 1.2.5 (2026-07-13)
 
 - Enhancement: Update matter.js to 0.17.5

--- a/packages/dashboard/src/pages/components/node-details.ts
+++ b/packages/dashboard/src/pages/components/node-details.ts
@@ -23,11 +23,18 @@ import { showNodeLabelDialog } from "../../components/dialogs/node-label-dialog/
 import { handleAsync } from "../../util/async-handler.js";
 import "../../components/ha-svg-icon";
 import "../camera-overlay.js";
-import { getDeviceIcon } from "../../util/device-icons.js";
+import { DeviceTypes, getDeviceIcon } from "../../util/device-icons.js";
 import { getEndpointDeviceTypes } from "../../util/endpoints.js";
 import { ICD_CLUSTER_ID, icdBadge } from "../../util/icd.js";
 import { formatManualPairingCode, renderPairingQrCodeDataUri } from "../../util/pairing-code.js";
 import { bindingContext } from "./context.js";
+
+const CAMERA_DEVICE_TYPE_IDS: number[] = [
+    DeviceTypes.CAMERA,
+    DeviceTypes.VIDEO_DOORBELL,
+    DeviceTypes.FLOODLIGHT_CAMERA,
+    DeviceTypes.SNAPSHOT_CAMERA,
+];
 
 /** Map updateState values to user-friendly labels */
 const UPDATE_STATE_LABELS: Record<number, string> = {
@@ -81,7 +88,7 @@ export class NodeDetails extends LitElement {
         if (!this.node) return html``;
 
         const deviceTypeIds = getEndpointDeviceTypes(this.node, this.endpoint).map(d => d.id);
-        const isCamera = deviceTypeIds.includes(0x0142) || deviceTypeIds.includes(0x0143);
+        const isCamera = CAMERA_DEVICE_TYPE_IDS.some(id => deviceTypeIds.includes(id));
         const badge = icdBadge(this.node.attributes, this.node.available);
 
         return html`

--- a/packages/dashboard/src/util/device-icons.ts
+++ b/packages/dashboard/src/util/device-icons.ts
@@ -75,7 +75,7 @@ function getDefaultIconColor(): string {
  * Device type IDs from the Matter Device Library Specification.
  * Organized by spec categories. See https://csa-iot.org/ for the full specification.
  */
-const DeviceTypes = {
+export const DeviceTypes = {
     // Utility (per Matter spec - deprioritized for icon selection)
     ROOT_NODE: 0x0016,
     POWER_SOURCE: 0x0011,


### PR DESCRIPTION
## Type of change

- [x] 🐛 **Fix** — corrects a defect or wrong behavior
- [ ] ✨ **Feature** — adds new functionality or capability

## Description

`isCamera` in [node-details.ts](https://github.com/matter-js/matterjs-server/blob/main/packages/dashboard/src/pages/components/node-details.ts) gated the button that opens the camera overlay (Live View + Snapshot) to only two device types:

```ts
const isCamera = deviceTypeIds.includes(0x0142) || deviceTypeIds.includes(0x0143);
```

`Snapshot Camera` (0x0145) and `Floodlight Camera` (0x0144) — both already known device types in `device-icons.ts` with their own icons — were missing from this list, so nodes exposing them had no way to open the camera overlay at all (not just Live View, but Snapshot capture too, since the overlay never renders). `camera-overlay.ts` already adapts its controls to the device's real capabilities (feature bits / accepted command list), so no changes were needed there — only the outer gate needed extending.

Fix: `DeviceTypes` is exported from `device-icons.ts` (was module-private) and `isCamera` now checks against all four camera device type IDs by name instead of two hardcoded hex literals.

## Backing evidence

This is a static logic defect, not a runtime behavior — the device type IDs excluded from the `isCamera` check are visible directly in the source diff (`node-details.ts`, previously `deviceTypeIds.includes(0x0142) || deviceTypeIds.includes(0x0143)`), cross-referenced against the `SNAPSHOT_CAMERA: 0x0145` / `FLOODLIGHT_CAMERA: 0x0144` constants already defined in `packages/dashboard/src/util/device-icons.ts`. There is no server/client log that would demonstrate a purely client-side conditional-rendering gap; the code itself is the evidence.

- Related issue: #866

## Checklist

- [ ] Tests added or updated to cover the change
- [x] `npm test` passes (only the two pre-existing mDNS integration-test failures documented in CLAUDE.md, unrelated to this change)
- [x] `npm run format-verify` and `npm run lint` pass
- [ ] CHANGELOG updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)