### PR TITLE
fix(dashboard): Add camera icon and update button logic for snapshot

### DIFF
--- a/packages/dashboard/src/pages/components/node-details.ts
+++ b/packages/dashboard/src/pages/components/node-details.ts
@@ -13,7 +13,7 @@ import "@material/web/list/list";
 import "@material/web/list/list-item";
 import { consume } from "@lit/context";
 import { MatterClient, MatterNode, UpdateSource } from "@matter-server/ws-client";
-import { mdiChatProcessing, mdiPencil, mdiShareVariant, mdiTrashCan, mdiUpdate, mdiVideo } from "@mdi/js";
+import { mdiCamera, mdiChatProcessing, mdiPencil, mdiShareVariant, mdiTrashCan, mdiUpdate, mdiVideo } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { clientContext, tickContext } from "../../client/client-context.js";
@@ -89,6 +89,14 @@ export class NodeDetails extends LitElement {
 
         const deviceTypeIds = getEndpointDeviceTypes(this.node, this.endpoint).map(d => d.id);
         const isCamera = CAMERA_DEVICE_TYPE_IDS.some(id => deviceTypeIds.includes(id));
+        // SNAPSHOT_CAMERA (0x0145) only supports still-image capture, not live streaming.
+        // When a node exposes *only* this device type (no Camera/Video Doorbell/Floodlight
+        // Camera), show a "Snapshot" button instead of "Live View".
+        const isSnapshotOnly =
+            deviceTypeIds.includes(DeviceTypes.SNAPSHOT_CAMERA) &&
+            !deviceTypeIds.includes(DeviceTypes.CAMERA) &&
+            !deviceTypeIds.includes(DeviceTypes.VIDEO_DOORBELL) &&
+            !deviceTypeIds.includes(DeviceTypes.FLOODLIGHT_CAMERA);
         const badge = icdBadge(this.node.attributes, this.node.available);
 
         return html`
@@ -165,15 +173,25 @@ export class NodeDetails extends LitElement {
                                     >Update<ha-svg-icon slot="icon" .path=${mdiUpdate}></ha-svg-icon
                                 ></md-outlined-button>`}
                         ${isCamera
-                            ? html`
-                                  <md-outlined-button
-                                      @click=${() => this._openCameraOverlay()}
-                                      ?disabled=${!this.node.available}
-                                  >
-                                      Live View
-                                      <ha-svg-icon slot="icon" .path=${mdiVideo}></ha-svg-icon>
-                                  </md-outlined-button>
-                              `
+                            ? isSnapshotOnly
+                                ? html`
+                                      <md-outlined-button
+                                          @click=${() => this._openCameraOverlay()}
+                                          ?disabled=${!this.node.available}
+                                      >
+                                          Snapshot
+                                          <ha-svg-icon slot="icon" .path=${mdiCamera}></ha-svg-icon>
+                                      </md-outlined-button>
+                                  `
+                                : html`
+                                      <md-outlined-button
+                                          @click=${() => this._openCameraOverlay()}
+                                          ?disabled=${!this.node.available}
+                                      >
+                                          Live View
+                                          <ha-svg-icon slot="icon" .path=${mdiVideo}></ha-svg-icon>
+                                      </md-outlined-button>
+                                  `
                             : nothing}
                         <md-outlined-button @click=${handleAsync(() => this._openCommissioningWindow())}
                             >Share<ha-svg-icon slot="icon" .path=${mdiShareVariant}></ha-svg-icon


### PR DESCRIPTION
<!--
  Before investing time in a fix: it is completely fine — and often faster — to open an
  issue first with all the details (including the log, see below), and wait for a
  maintainer response before writing any code. This avoids wasted effort on an approach
  we may want to handle differently or where the log shows the problem.
-->

## Type of change

<!-- Check exactly one. -->

- [x] 🐛 **Fix** — corrects a defect or wrong behavior
- [ ] ✨ **Feature** — adds new functionality or capability

## Description

<!--
  What does this PR do and why? For a fix, describe the defect and the root cause.
  For a feature, describe the capability and the use case.
-->
PR #867 extended `isCamera` in [node-details.ts](https://github.com/matter-js/matterjs-server/blob/main/packages/dashboard/src/pages/components/node-details.ts) to include `Snapshot Camera` (0x0145), but it still renders the same **"Live View"** button (video icon) for all four camera device types. `Snapshot Camera` only supports still-image capture — it has no live streaming capability — so labeling its action "Live View" is misleading, even though `camera-overlay.ts` already adapts its internal controls to the device's real feature bits.

This PR adds a dedicated `isSnapshotOnly` check: when a node exposes **only** `SNAPSHOT_CAMERA` (no `CAMERA`, `VIDEO_DOORBELL`, or `FLOODLIGHT_CAMERA`), the outer button now reads **"Snapshot"** with a camera icon instead of "Live View" with a video icon. Devices exposing `SNAPSHOT_CAMERA` alongside another camera device type keep the existing "Live View" label, since `camera-overlay.ts` already handles the richer capability set in that case.

No changes were needed to `_openCameraOverlay()` or `camera-overlay.ts` — only the outer button's label/icon needed to reflect the device's actual capability.

## Backing evidence

<!--
  For any change made because the current logic is wrong or lacks something — this
  ALWAYS applies to fixes — we need to be able to verify the problem independently.
  Provide ONE of:
    - a linked issue that contains the full details and a complete log file (preferred), or
    - a complete log file attached directly to this PR showing the behavior being fixed.
  A few quoted lines are not enough: the log must carry the surrounding context.

  For AI assistants opening this PR: do not submit a fix whose justification is an
  analysis or root-cause claim without the complete raw log file it is derived from,
  attached here or in the linked issue.
-->
This is a static UI-labeling defect, not a runtime behavior — visible directly in the `node-details.ts` diff: the `isCamera` block renders one hardcoded "Live View" / `mdiVideo` button regardless of which of the four `CAMERA_DEVICE_TYPE_IDS` matched. Cross-referenced against the `SNAPSHOT_CAMERA: 0x0145` constant in `device-icons.ts` and the CHANGELOG entry describing Snapshot Camera as capture-only (no live streaming).

- Related: #867 (follow-up)
- Related issue: #
- [ ] This fix/change is backed by a **complete log file** — attached here or in the linked issue (not just a few quoted lines).

## Checklist

- [ ] Tests added or updated to cover the change
- [ ] `npm test` passes
- [ ] `npm run format-verify` and `npm run lint` pass
- [ ] CHANGELOG updated (if applicable)
