### PR TITLE
fix(webrtc): select ProvideOffer stream fields by provider ClusterRevision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,16 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
-- Fix: WebRTC camera live view — `ProvideOffer` now sends only the stream fields matching the provider's cluster revision, not both, fixing live view rejected by revision-2 providers (regression in 1.2.6, #880)
+- Fix: WebRTC camera live view — Use `ProvideOffer` format that all cluster versions support, skip rev2 for now
 - Fix: Debounce the full `node_updated` refresh into a single delayed event per node after basic-information changes
-- Fix: Suppress the repeated "ignoring set_default_fabric_label" log notice when the requested label is unchanged
+- Enhancement: Update matter.js to the latest 0.17.7 alpha
+    - Optimizes Cluster data initialization when the node structure changes
 
 ## 1.2.6 (2026-07-15)
 
 - Fix: Dashboard now shows the camera Live View/Snapshot button for the Floodlight Camera and Snapshot Camera device types, not just Camera and Video Doorbell
 - Fix: Dashboard `ProvideOffer` requests now include `videoStreams`/`audioStreams` alongside deprecated singular stream IDs for WebRTC provider compatibility across cluster revisions
-- Enhancement: Update matter.js to latest 0.17.6 alpha
+- Enhancement: Update matter.js to the latest 0.17.6 alpha
     - Optimizes OTA software updates
     - Prevents blocking on stop when a BLE discovery is still in progress
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Fix: WebRTC camera live view — `ProvideOffer` now sends only the stream fields matching the provider's cluster revision, not both, fixing live view rejected by revision-2 providers (regression in 1.2.6, #880)
+- Fix: Debounce the full `node_updated` refresh into a single delayed event per node after basic-information changes
+- Fix: Suppress the repeated "ignoring set_default_fabric_label" log notice when the requested label is unchanged
+
 ## 1.2.6 (2026-07-15)
 
 - Fix: Dashboard now shows the camera Live View/Snapshot button for the Floodlight Camera and Snapshot Camera device types, not just Camera and Video Doorbell

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "packages/matter-server"
             ],
             "devDependencies": {
-                "@matter/testing": "0.17.6-alpha.0-20260715-3585d95fe",
+                "@matter/testing": "0.17.7-alpha.0-20260716-1a7047cc7",
                 "@nacho-iot/js-tools": "^0.1.7",
                 "@types/mocha": "^10.0.10",
                 "glob": "^13.0.6",
@@ -2895,14 +2895,15 @@
             }
         },
         "node_modules/@material/web": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/@material/web/-/web-2.4.1.tgz",
-            "integrity": "sha512-0sk9t25acJ72Qv3r0n9r0lgDbPaAKnpm0p+QmEAAwYyZomHxuVbgrrAdtNXaRm7jFyGh+WsTr8bhtvCnpPRFjw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@material/web/-/web-2.5.0.tgz",
+            "integrity": "sha512-x2Uovyq8E/Zc1xHXd9s1eBMXF5pMHVAt70pISKd0fL3Ajj4L6zQaQUY/awcfR2RDAMKXC7i4+vr0arv1YaOR/g==",
             "license": "Apache-2.0",
             "workspaces": [
                 "catalog"
             ],
             "dependencies": {
+                "@lit/context": "^1.1.6",
                 "lit": "^2.8.0 || ^3.0.0",
                 "tslib": "^2.4.0"
             }
@@ -2937,77 +2938,77 @@
             }
         },
         "node_modules/@matter/general": {
-            "version": "0.17.6-alpha.0-20260715-3585d95fe",
-            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.6-alpha.0-20260715-3585d95fe.tgz",
-            "integrity": "sha512-fwetjrppKRGg8jkl7h+/agAHjUgCFwurP/K7yceHTuRApmnuxO7q/yuGl4jnqOoUTcq89R94FDasnyMjC23U+A==",
+            "version": "0.17.7-alpha.0-20260716-1a7047cc7",
+            "resolved": "https://registry.npmjs.org/@matter/general/-/general-0.17.7-alpha.0-20260716-1a7047cc7.tgz",
+            "integrity": "sha512-B9Dx5qcuUofbcmEADenUDKqdV/Pi08WF7SLwTZJj+tq3XqLemyIu/jLv0VVojvGHXX/42T4pLx7wk/RUYIaHAg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/curves": "^2.2.0"
             }
         },
         "node_modules/@matter/main": {
-            "version": "0.17.6-alpha.0-20260715-3585d95fe",
-            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.6-alpha.0-20260715-3585d95fe.tgz",
-            "integrity": "sha512-GiIykSUkBreSJ7t7IwyHyDFXe+m00WBtfx1qEnieDh+Lqg6jlCbFUZQnlPLSdDYnqGwTPjwq85Vx5rHTMCB6OA==",
+            "version": "0.17.7-alpha.0-20260716-1a7047cc7",
+            "resolved": "https://registry.npmjs.org/@matter/main/-/main-0.17.7-alpha.0-20260716-1a7047cc7.tgz",
+            "integrity": "sha512-D0Kf6qKYfmwrpyQ0/T7diqdInEOJQopUO2sBX6QWWT4GC/J4bQ+pdCr6n3PcoVp7TflttzBBurlKRBgln0a7CQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/model": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/node": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/protocol": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/types": "0.17.6-alpha.0-20260715-3585d95fe"
+                "@matter/general": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/model": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/node": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/protocol": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/types": "0.17.7-alpha.0-20260716-1a7047cc7"
             },
             "optionalDependencies": {
-                "@matter/nodejs": "0.17.6-alpha.0-20260715-3585d95fe"
+                "@matter/nodejs": "0.17.7-alpha.0-20260716-1a7047cc7"
             }
         },
         "node_modules/@matter/model": {
-            "version": "0.17.6-alpha.0-20260715-3585d95fe",
-            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.6-alpha.0-20260715-3585d95fe.tgz",
-            "integrity": "sha512-ZyETqKQT519n2kYfWqZ4OWr3nP7m2CFKfO9ETqqOJqsiaYx1g4Ah1h0GFGgQ6YXZXLRlQi+1RHNKwDOdbJSTBA==",
+            "version": "0.17.7-alpha.0-20260716-1a7047cc7",
+            "resolved": "https://registry.npmjs.org/@matter/model/-/model-0.17.7-alpha.0-20260716-1a7047cc7.tgz",
+            "integrity": "sha512-aHUETKHEsIJFIa/f/Q+VAQP9QLbIzwQZgU0qnjgk5qGeEomUXgLflZ4B7jmzHAw8dqZlFq4ttH3PyQGC1NGipg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.6-alpha.0-20260715-3585d95fe"
+                "@matter/general": "0.17.7-alpha.0-20260716-1a7047cc7"
             }
         },
         "node_modules/@matter/node": {
-            "version": "0.17.6-alpha.0-20260715-3585d95fe",
-            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.6-alpha.0-20260715-3585d95fe.tgz",
-            "integrity": "sha512-ud8m/E18Q5mwvh1bQ2ygM6vkPJ3pZT9nyDwFWy+irJEIiAgTwFusyHJRXFHyDbU7HTvaTCfA3x+LS7rlFp3AIw==",
+            "version": "0.17.7-alpha.0-20260716-1a7047cc7",
+            "resolved": "https://registry.npmjs.org/@matter/node/-/node-0.17.7-alpha.0-20260716-1a7047cc7.tgz",
+            "integrity": "sha512-0220KNLY/g66ojPQmpluIpTPLQvSeup1Tz/9Ylee6keNGKInsBf1RJX4UWNdmFB1e9qY378wHEgrU7OcKZa+Sw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/model": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/protocol": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/types": "0.17.6-alpha.0-20260715-3585d95fe"
+                "@matter/general": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/model": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/protocol": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/types": "0.17.7-alpha.0-20260716-1a7047cc7"
             }
         },
         "node_modules/@matter/nodejs": {
-            "version": "0.17.6-alpha.0-20260715-3585d95fe",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.6-alpha.0-20260715-3585d95fe.tgz",
-            "integrity": "sha512-eSw3t06eGnaugmO+UxxHrcgFMtkptzo1M9y9AZOGAK5pTkaGMHSXZRDWHK8t07uEd/M+cq0JTnZ6J31ohdO44Q==",
+            "version": "0.17.7-alpha.0-20260716-1a7047cc7",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs/-/nodejs-0.17.7-alpha.0-20260716-1a7047cc7.tgz",
+            "integrity": "sha512-Ttda1igHeMr6HLYVnuxAMwE0sU/eiptM1aNHF4YOKAc23WqknpAa03qs7bfU/izbcT8xj/pQQoakggFA+ItrzQ==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/node": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/protocol": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/types": "0.17.6-alpha.0-20260715-3585d95fe"
+                "@matter/general": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/node": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/protocol": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/types": "0.17.7-alpha.0-20260716-1a7047cc7"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
             }
         },
         "node_modules/@matter/nodejs-ble": {
-            "version": "0.17.6-alpha.0-20260715-3585d95fe",
-            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.6-alpha.0-20260715-3585d95fe.tgz",
-            "integrity": "sha512-i7VTut5b5u2QRGanzx+fxuxC+Y1ZE2/FeFhk2HKvsw3DKpd5j5pIlEa1WHxu7YgFhR4kMbP5vVWHvY986OLs/w==",
+            "version": "0.17.7-alpha.0-20260716-1a7047cc7",
+            "resolved": "https://registry.npmjs.org/@matter/nodejs-ble/-/nodejs-ble-0.17.7-alpha.0-20260716-1a7047cc7.tgz",
+            "integrity": "sha512-sfdNp6m5Fx/L1RVnlYtEiJrTX8T4U2PnK2Rq+N8zJVRF9pywSKBlz91YZIk0vfHudRjQTqIHJaHKkkxuVPkLPA==",
             "license": "Apache-2.0",
             "optional": true,
             "dependencies": {
-                "@matter/general": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/protocol": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/types": "0.17.6-alpha.0-20260715-3585d95fe"
+                "@matter/general": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/protocol": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/types": "0.17.7-alpha.0-20260716-1a7047cc7"
             },
             "engines": {
                 "node": ">=20.19.0 <22.0.0 || >=22.13.0"
@@ -3018,20 +3019,20 @@
             }
         },
         "node_modules/@matter/protocol": {
-            "version": "0.17.6-alpha.0-20260715-3585d95fe",
-            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.6-alpha.0-20260715-3585d95fe.tgz",
-            "integrity": "sha512-zCm1buHj0ts6FRKD5KN7q1x156u5NlgSqOicKRPF6PNxFfN4tAd1OWKk4ZOZ7a5XEVYwFayoCNpNzw75WKB0JA==",
+            "version": "0.17.7-alpha.0-20260716-1a7047cc7",
+            "resolved": "https://registry.npmjs.org/@matter/protocol/-/protocol-0.17.7-alpha.0-20260716-1a7047cc7.tgz",
+            "integrity": "sha512-OJBSRybFbVemOwqQiEti3WghurGr4WyFGKCSWhBzQrWGwu/W2XveWVmc2/Ilw0PdG4PN8LJ8z7qAkuy8QkatqQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/model": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/types": "0.17.6-alpha.0-20260715-3585d95fe"
+                "@matter/general": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/model": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/types": "0.17.7-alpha.0-20260716-1a7047cc7"
             }
         },
         "node_modules/@matter/testing": {
-            "version": "0.17.6-alpha.0-20260715-3585d95fe",
-            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.6-alpha.0-20260715-3585d95fe.tgz",
-            "integrity": "sha512-Tg/X3ZAJVXyU6ddSW+riqSrCCPLqEiwj+xwvtIiTCEFuXe1BvWfEV9lvmhxKMBUydEbf5P3BRPZLlaDlsspuDA==",
+            "version": "0.17.7-alpha.0-20260716-1a7047cc7",
+            "resolved": "https://registry.npmjs.org/@matter/testing/-/testing-0.17.7-alpha.0-20260716-1a7047cc7.tgz",
+            "integrity": "sha512-oM+frxAYRhFKXar58YkrzgKXmuFA8L3OzpwRRW/TiCwKzOJdvzIViFjmMIjzP8hOLFJyNw3I3YdgXwXkUVLWKg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -3056,24 +3057,24 @@
             }
         },
         "node_modules/@matter/thread-br-client": {
-            "version": "0.17.6-alpha.0-20260715-3585d95fe",
-            "resolved": "https://registry.npmjs.org/@matter/thread-br-client/-/thread-br-client-0.17.6-alpha.0-20260715-3585d95fe.tgz",
-            "integrity": "sha512-l2yo9gPOwdNFZkxgSNY/z+DbkdAtX7OxsXMGEkfg5SiSVSqBJaeLvAJr7Kr9+Y2uo1jANoKh/slAGnnxhrTxMQ==",
+            "version": "0.17.7-alpha.0-20260716-1a7047cc7",
+            "resolved": "https://registry.npmjs.org/@matter/thread-br-client/-/thread-br-client-0.17.7-alpha.0-20260716-1a7047cc7.tgz",
+            "integrity": "sha512-M/7A9wpLLrx52mUz4w5lkXiucFSparVmNueBNj9iXkamAAJ99qaxVU1ZbYD0bJZX4mD5W3uCU1pRHPcCO/F3nw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/protocol": "0.17.6-alpha.0-20260715-3585d95fe",
+                "@matter/general": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/protocol": "0.17.7-alpha.0-20260716-1a7047cc7",
                 "@noble/curves": "^2.2.0"
             }
         },
         "node_modules/@matter/types": {
-            "version": "0.17.6-alpha.0-20260715-3585d95fe",
-            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.6-alpha.0-20260715-3585d95fe.tgz",
-            "integrity": "sha512-n02xI7/g4wjdgC9Z28GVkqef51E4XJAQAgAcAHdAKJ3xGijW5ZUyzVEvRwi9fBBiRwRaPtGuOTfXN08Qse5WRw==",
+            "version": "0.17.7-alpha.0-20260716-1a7047cc7",
+            "resolved": "https://registry.npmjs.org/@matter/types/-/types-0.17.7-alpha.0-20260716-1a7047cc7.tgz",
+            "integrity": "sha512-iT36e11XY0J2xWHK9xYpDCLRWOqNChZHkZuV/YgmiUDe34wQY/0hV6qNRbG9YqKeM0tkkKuHuzcExJk33xNPEg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/model": "0.17.6-alpha.0-20260715-3585d95fe"
+                "@matter/general": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/model": "0.17.7-alpha.0-20260716-1a7047cc7"
             }
         },
         "node_modules/@mdi/js": {
@@ -3984,16 +3985,16 @@
             }
         },
         "node_modules/@project-chip/matter.js": {
-            "version": "0.17.6-alpha.0-20260715-3585d95fe",
-            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.6-alpha.0-20260715-3585d95fe.tgz",
-            "integrity": "sha512-gBq02DSgmYeV6Vz0Ja90ayzYWZB+rg5pAlDMJS1Xf1mysl3/UbTw0AWFJz1529plN50DNsPKWXhxymX87kQoSQ==",
+            "version": "0.17.7-alpha.0-20260716-1a7047cc7",
+            "resolved": "https://registry.npmjs.org/@project-chip/matter.js/-/matter.js-0.17.7-alpha.0-20260716-1a7047cc7.tgz",
+            "integrity": "sha512-OOcCr9l9AP/nXpDU4wdmbMMF4ENijzkKvv6J9mK/VAvF4Wlb3QpnS42AE9SBFglhOYr9o2+lWW+eCr+5ecE8JA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/general": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/model": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/node": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/protocol": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/types": "0.17.6-alpha.0-20260715-3585d95fe"
+                "@matter/general": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/model": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/node": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/protocol": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/types": "0.17.7-alpha.0-20260716-1a7047cc7"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -6117,9 +6118,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001805",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
-            "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+            "version": "1.0.30001806",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+            "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
             "dev": true,
             "funding": [
                 {
@@ -11294,7 +11295,7 @@
             "version": "0.0.0-git",
             "dependencies": {
                 "@matter-server/ws-controller": "*",
-                "@matter/main": "0.17.6-alpha.0-20260715-3585d95fe",
+                "@matter/main": "0.17.7-alpha.0-20260716-1a7047cc7",
                 "ws": "^8.21.1"
             },
             "devDependencies": {
@@ -11305,7 +11306,7 @@
                 "node": ">=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.6-alpha.0-20260715-3585d95fe",
+                "@matter/nodejs-ble": "0.17.7-alpha.0-20260716-1a7047cc7",
                 "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
             }
         },
@@ -11313,7 +11314,7 @@
             "name": "@matter-server/custom-clusters",
             "version": "0.0.0-git",
             "dependencies": {
-                "@matter/main": "0.17.6-alpha.0-20260715-3585d95fe"
+                "@matter/main": "0.17.7-alpha.0-20260716-1a7047cc7"
             },
             "engines": {
                 "node": ">=22.13.0"
@@ -11336,7 +11337,7 @@
             },
             "devDependencies": {
                 "@babel/preset-env": "^8.0.2",
-                "@matter/main": "0.17.6-alpha.0-20260715-3585d95fe",
+                "@matter/main": "0.17.7-alpha.0-20260716-1a7047cc7",
                 "@rollup/plugin-babel": "^7.1.0",
                 "@rollup/plugin-commonjs": "^29.0.3",
                 "@rollup/plugin-json": "^6.1.0",
@@ -11608,14 +11609,14 @@
                 "@matter-server/custom-clusters": "*",
                 "@matter-server/dashboard": "*",
                 "@matter-server/ws-controller": "*",
-                "@matter/main": "0.17.6-alpha.0-20260715-3585d95fe",
+                "@matter/main": "0.17.7-alpha.0-20260716-1a7047cc7",
                 "commander": "^15.0.0",
                 "express": "^5.2.1"
             },
             "devDependencies": {
                 "@matter-server/ws-client": "*",
-                "@matter/nodejs": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/testing": "0.17.6-alpha.0-20260715-3585d95fe",
+                "@matter/nodejs": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/testing": "0.17.7-alpha.0-20260716-1a7047cc7",
                 "@types/express": "^5.0.6",
                 "@types/node": "^26.1.1"
             },
@@ -11637,10 +11638,10 @@
             "version": "0.0.0-git",
             "license": "Apache-2.0",
             "dependencies": {
-                "@matter/thread-br-client": "0.17.6-alpha.0-20260715-3585d95fe"
+                "@matter/thread-br-client": "0.17.7-alpha.0-20260716-1a7047cc7"
             },
             "devDependencies": {
-                "@matter/testing": "0.17.6-alpha.0-20260715-3585d95fe",
+                "@matter/testing": "0.17.7-alpha.0-20260716-1a7047cc7",
                 "@types/node": "^26.1.1",
                 "@types/ws": "^8.18.1",
                 "ws": "^8.21.1"
@@ -11655,9 +11656,9 @@
             "dependencies": {
                 "@matter-server/ws-client": "*",
                 "@matter/dcl-data": ">=2026.7.15",
-                "@matter/main": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@matter/thread-br-client": "0.17.6-alpha.0-20260715-3585d95fe",
-                "@project-chip/matter.js": "0.17.6-alpha.0-20260715-3585d95fe",
+                "@matter/main": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@matter/thread-br-client": "0.17.7-alpha.0-20260716-1a7047cc7",
+                "@project-chip/matter.js": "0.17.7-alpha.0-20260716-1a7047cc7",
                 "ws": "^8.21.1"
             },
             "devDependencies": {
@@ -11668,7 +11669,7 @@
                 "node": ">=22.13.0"
             },
             "optionalDependencies": {
-                "@matter/nodejs-ble": "0.17.6-alpha.0-20260715-3585d95fe",
+                "@matter/nodejs-ble": "0.17.7-alpha.0-20260716-1a7047cc7",
                 "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
             }
         }

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "python-ble-proxy:run": "cd python_ble_proxy && { [ -x .venv/bin/matter-ble-proxy ] || (python3 -m venv .venv && .venv/bin/pip install -e .); } && .venv/bin/matter-ble-proxy"
     },
     "devDependencies": {
-        "@matter/testing": "0.17.6-alpha.0-20260715-3585d95fe",
+        "@matter/testing": "0.17.7-alpha.0-20260716-1a7047cc7",
         "@nacho-iot/js-tools": "^0.1.7",
         "@types/mocha": "^10.0.10",
         "glob": "^13.0.6",

--- a/packages/ble-proxy/package.json
+++ b/packages/ble-proxy/package.json
@@ -30,7 +30,7 @@
     },
     "dependencies": {
         "@matter-server/ws-controller": "*",
-        "@matter/main": "0.17.6-alpha.0-20260715-3585d95fe",
+        "@matter/main": "0.17.7-alpha.0-20260716-1a7047cc7",
         "ws": "^8.21.1"
     },
     "devDependencies": {
@@ -38,7 +38,7 @@
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.6-alpha.0-20260715-3585d95fe",
+        "@matter/nodejs-ble": "0.17.7-alpha.0-20260716-1a7047cc7",
         "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
     },
     "engines": {

--- a/packages/custom-clusters/package.json
+++ b/packages/custom-clusters/package.json
@@ -39,7 +39,7 @@
         "build-clean": "nacho-build --clean"
     },
     "dependencies": {
-        "@matter/main": "0.17.6-alpha.0-20260715-3585d95fe"
+        "@matter/main": "0.17.7-alpha.0-20260716-1a7047cc7"
     },
     "engines": {
         "node": ">=22.13.0"

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -44,7 +44,7 @@
     },
     "devDependencies": {
         "@babel/preset-env": "^8.0.2",
-        "@matter/main": "0.17.6-alpha.0-20260715-3585d95fe",
+        "@matter/main": "0.17.7-alpha.0-20260716-1a7047cc7",
         "@rollup/plugin-babel": "^7.1.0",
         "@rollup/plugin-commonjs": "^29.0.3",
         "@rollup/plugin-json": "^6.1.0",

--- a/packages/dashboard/src/util/webrtc-provider-payload.ts
+++ b/packages/dashboard/src/util/webrtc-provider-payload.ts
@@ -9,12 +9,12 @@ export interface ProvideOfferRequest {
     webRtcSessionId: number | null;
     sdp: string;
     streamUsage: number;
-    videoStreamId: number | null;
-    audioStreamId: number | null;
     videoStreams?: number[];
     audioStreams?: number[];
 }
 
+// Send the canonical revision-2 VideoStreams/AudioStreams lists; the server down-converts them to the
+// deprecated singular ids for a revision-1 provider per its advertised ClusterRevision.
 export function buildProvideOfferRequest(
     sdp: string,
     streamUsage: number,
@@ -25,8 +25,6 @@ export function buildProvideOfferRequest(
         webRtcSessionId: null,
         sdp,
         streamUsage,
-        videoStreamId,
-        audioStreamId,
         ...(videoStreamId !== null ? { videoStreams: [videoStreamId] } : {}),
         ...(audioStreamId !== null ? { audioStreams: [audioStreamId] } : {}),
     };

--- a/packages/dashboard/test/WebRtcProviderPayloadTest.ts
+++ b/packages/dashboard/test/WebRtcProviderPayloadTest.ts
@@ -7,36 +7,36 @@
 import { buildProvideOfferRequest } from "../src/util/webrtc-provider-payload.js";
 
 describe("buildProvideOfferRequest", () => {
-    it("includes list fields when stream IDs are present", () => {
+    it("sends the stream lists when both ids are present", () => {
         expect(buildProvideOfferRequest("v=0", 3, 7, 9)).to.deep.equal({
             webRtcSessionId: null,
             sdp: "v=0",
             streamUsage: 3,
-            videoStreamId: 7,
-            audioStreamId: 9,
             videoStreams: [7],
             audioStreams: [9],
         });
     });
 
-    it("omits list fields when stream IDs are null", () => {
+    it("omits the lists when ids are null", () => {
         expect(buildProvideOfferRequest("v=0", 3, null, null)).to.deep.equal({
             webRtcSessionId: null,
             sdp: "v=0",
             streamUsage: 3,
-            videoStreamId: null,
-            audioStreamId: null,
         });
     });
 
-    it("keeps only videoStreams when only video is allocated", () => {
+    it("sends only videoStreams when only video is allocated", () => {
         expect(buildProvideOfferRequest("v=0", 3, 5, null)).to.deep.equal({
             webRtcSessionId: null,
             sdp: "v=0",
             streamUsage: 3,
-            videoStreamId: 5,
-            audioStreamId: null,
             videoStreams: [5],
         });
+    });
+
+    it("never emits the deprecated singular ids", () => {
+        const request = buildProvideOfferRequest("v=0", 3, 5, 6);
+        expect(request).to.not.have.property("videoStreamId");
+        expect(request).to.not.have.property("audioStreamId");
     });
 });

--- a/packages/matter-server/package.json
+++ b/packages/matter-server/package.json
@@ -44,14 +44,14 @@
         "@matter-server/custom-clusters": "*",
         "@matter-server/dashboard": "*",
         "@matter-server/ws-controller": "*",
-        "@matter/main": "0.17.6-alpha.0-20260715-3585d95fe",
+        "@matter/main": "0.17.7-alpha.0-20260716-1a7047cc7",
         "commander": "^15.0.0",
         "express": "^5.2.1"
     },
     "devDependencies": {
         "@matter-server/ws-client": "*",
-        "@matter/nodejs": "0.17.6-alpha.0-20260715-3585d95fe",
-        "@matter/testing": "0.17.6-alpha.0-20260715-3585d95fe",
+        "@matter/nodejs": "0.17.7-alpha.0-20260716-1a7047cc7",
+        "@matter/testing": "0.17.7-alpha.0-20260716-1a7047cc7",
         "@types/express": "^5.0.6",
         "@types/node": "^26.1.1"
     },

--- a/packages/ws-client/package.json
+++ b/packages/ws-client/package.json
@@ -40,10 +40,10 @@
         "build-clean": "nacho-build --clean"
     },
     "dependencies": {
-        "@matter/thread-br-client": "0.17.6-alpha.0-20260715-3585d95fe"
+        "@matter/thread-br-client": "0.17.7-alpha.0-20260716-1a7047cc7"
     },
     "devDependencies": {
-        "@matter/testing": "0.17.6-alpha.0-20260715-3585d95fe",
+        "@matter/testing": "0.17.7-alpha.0-20260716-1a7047cc7",
         "@types/node": "^26.1.1",
         "@types/ws": "^8.18.1",
         "ws": "^8.21.1"

--- a/packages/ws-controller/package.json
+++ b/packages/ws-controller/package.json
@@ -42,9 +42,9 @@
     "dependencies": {
         "@matter-server/ws-client": "*",
         "@matter/dcl-data": ">=2026.7.15",
-        "@matter/main": "0.17.6-alpha.0-20260715-3585d95fe",
-        "@matter/thread-br-client": "0.17.6-alpha.0-20260715-3585d95fe",
-        "@project-chip/matter.js": "0.17.6-alpha.0-20260715-3585d95fe",
+        "@matter/main": "0.17.7-alpha.0-20260716-1a7047cc7",
+        "@matter/thread-br-client": "0.17.7-alpha.0-20260716-1a7047cc7",
+        "@project-chip/matter.js": "0.17.7-alpha.0-20260716-1a7047cc7",
         "ws": "^8.21.1"
     },
     "devDependencies": {
@@ -52,7 +52,7 @@
         "@types/ws": "^8.18.1"
     },
     "optionalDependencies": {
-        "@matter/nodejs-ble": "0.17.6-alpha.0-20260715-3585d95fe",
+        "@matter/nodejs-ble": "0.17.7-alpha.0-20260716-1a7047cc7",
         "dbus-next": "npm:@jellybrick/dbus-next@^0.10.3"
     },
     "engines": {

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -45,7 +45,6 @@ import {
 } from "@matter/main/clusters";
 import { WebRtcTransportDefinitions } from "@matter/main/clusters/web-rtc-transport-definitions";
 import { WebRtcTransportProvider } from "@matter/main/clusters/web-rtc-transport-provider";
-import { ClusterRevision } from "@matter/main/model";
 import { DeviceAttestationCheck, Invoke, PeerAddress, Read, Specifier, PeerSet } from "@matter/main/protocol";
 import {
     AttributeId,
@@ -385,11 +384,11 @@ export class ControllerCommandHandler {
             originatingEndpointId,
         };
 
-        const clusterRevision =
-            this.#nodes.attributeCache.get(nodeId)?.[
-                `${endpointId}/${WebRtcTransportProvider.id}/${ClusterRevision.id}`
-            ];
-        selectWebRtcStreamFields(fields, clusterRevision);
+        // TODO: force the deprecated singular stream id fields for now — some providers advertising
+        // cluster revision 2 reject the revision-2 VideoStreams/AudioStreams list fields. Restore
+        // revision-based selection (read the provider's ClusterRevision from the attribute cache at
+        // `${endpointId}/${WebRtcTransportProvider.id}/${ClusterRevision.id}` and pass it) once resolved.
+        selectWebRtcStreamFields(fields, 1);
 
         const response = (await this.#invokeCommand(node.node, {
             endpoint: endpointId,

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -45,6 +45,7 @@ import {
 } from "@matter/main/clusters";
 import { WebRtcTransportDefinitions } from "@matter/main/clusters/web-rtc-transport-definitions";
 import { WebRtcTransportProvider } from "@matter/main/clusters/web-rtc-transport-provider";
+import { ClusterRevision } from "@matter/main/model";
 import { DeviceAttestationCheck, Invoke, PeerAddress, Read, Specifier, PeerSet } from "@matter/main/protocol";
 import {
     AttributeId,
@@ -107,7 +108,11 @@ import { Nodes } from "./Nodes.js";
 import { pushNodeTime, TimeSyncInvokers } from "./timeSyncCommands.js";
 import { TIME_FAILURE_EVENT_ID, TIME_SYNC_CLUSTER_ID, TimeSyncManager } from "./TimeSyncManager.js";
 import { attachWebRtcCallbackBridge } from "./WebRtcCallbackBridge.js";
-import { isTrackableWebRtcSession, resolveWebRtcSessionStreams } from "./webRtcSessionStreams.js";
+import {
+    isTrackableWebRtcSession,
+    resolveWebRtcSessionStreams,
+    selectWebRtcStreamFields,
+} from "./webRtcSessionStreams.js";
 
 const logger = Logger.get("ControllerCommandHandler");
 
@@ -378,6 +383,12 @@ export class ControllerCommandHandler {
             originatingEndpointId,
         };
 
+        const clusterRevision =
+            this.#nodes.attributeCache.get(nodeId)?.[
+                `${endpointId}/${WebRtcTransportProvider.id}/${ClusterRevision.id}`
+            ];
+        selectWebRtcStreamFields(fields, clusterRevision);
+
         const response = (await this.#invokeCommand(node.node, {
             endpoint: endpointId,
             cluster: WebRtcTransportProvider,
@@ -395,13 +406,13 @@ export class ControllerCommandHandler {
         const metadataEnabled = convertedPayload.metadataEnabled === true;
 
         const videoStreams = resolveWebRtcSessionStreams(
-            convertedPayload.videoStreams,
-            convertedPayload.videoStreamId,
+            fields.videoStreams,
+            fields.videoStreamId,
             response.videoStreamId,
         );
         const audioStreams = resolveWebRtcSessionStreams(
-            convertedPayload.audioStreams,
-            convertedPayload.audioStreamId,
+            fields.audioStreams,
+            fields.audioStreamId,
             response.audioStreamId,
         );
 

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -170,7 +170,7 @@ export class ControllerCommandHandler {
     #nodeObservers = new Map<NodeId, ObserverGroup>();
     /** Per-node timers that fire when Reconnecting state exceeds the timeout */
     #reconnectTimers = new Map<NodeId, Timer>();
-    /** Per-node timers that fire a node_updated event when no  structure update happened */
+    /** Per-node timers that coalesce basic-info changes into a single delayed node_updated refresh. */
     #nodeUpdateTimers = new Map<NodeId, Timer>();
     /**
      * Nodes whose basic information changed within the current subscription batch. A full node_updated

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -170,6 +170,8 @@ export class ControllerCommandHandler {
     #nodeObservers = new Map<NodeId, ObserverGroup>();
     /** Per-node timers that fire when Reconnecting state exceeds the timeout */
     #reconnectTimers = new Map<NodeId, Timer>();
+    /** Per-node timers that fire a node_updated event when no  structure update happened */
+    #nodeUpdateTimers = new Map<NodeId, Timer>();
     /**
      * Nodes whose basic information changed within the current subscription batch. A full node_updated
      * is deferred until the batch ends (connectionAlive) so consumers see one update per batch.
@@ -523,6 +525,10 @@ export class ControllerCommandHandler {
             timer.stop();
         }
         this.#reconnectTimers.clear();
+        for (const timer of this.#nodeUpdateTimers.values()) {
+            timer.stop();
+        }
+        this.#nodeUpdateTimers.clear();
         await this.#customClusterPoller.stop();
         await this.#timeSyncManager?.stop();
         for (const observers of this.#nodeObservers.values()) {
@@ -555,9 +561,17 @@ export class ControllerCommandHandler {
             }
         });
         nodeObservers.on(node.events.connectionAlive, () => {
-            if (this.#basicInfoChangedInBatch.delete(nodeId)) {
-                logger.info(`Node ${this.formatNode(nodeId)} basic information changed, sending full node_updated`);
-                this.events.nodeStructureChanged.emit(nodeId);
+            if (this.#basicInfoChangedInBatch.delete(nodeId) && !this.#nodeUpdateTimers.has(nodeId)) {
+                logger.info(
+                    `Node ${this.formatNode(nodeId)} basic information changed, sending full node_updated in 6s`,
+                );
+                // TODO remove timer based refresh when migrating to the ClientNode API for events
+                const timer = Time.getTimer(`node-update-${nodeId}`, Seconds(6), () =>
+                    this.#handleNodeStructureChange(node).catch(error =>
+                        logger.warn(`Failed to handle structure change for node ${this.formatNode(nodeId)}:`, error),
+                    ),
+                ).start();
+                this.#nodeUpdateTimers.set(nodeId, timer);
             }
         });
         nodeObservers.on(node.events.eventTriggered, data => {
@@ -676,10 +690,14 @@ export class ControllerCommandHandler {
         const nodeId = node.nodeId;
         this.#basicInfoChangedInBatch.delete(nodeId);
 
+        this.#nodeUpdateTimers.get(nodeId)?.stop();
+        this.#nodeUpdateTimers.delete(nodeId);
+
         if (node.isConnected) {
             await this.#nodes.attributeCache.update(node);
         }
         this.events.nodeStructureChanged.emit(nodeId);
+
         for (const endpointId of this.#nodes.drainPendingEndpointAdds(nodeId)) {
             this.events.nodeEndpointAdded.emit(nodeId, endpointId);
         }
@@ -1408,6 +1426,8 @@ export class ControllerCommandHandler {
     #cleanupNodeAfterRemoval(nodeId: NodeId) {
         this.#reconnectTimers.get(nodeId)?.stop();
         this.#reconnectTimers.delete(nodeId);
+        this.#nodeUpdateTimers.get(nodeId)?.stop();
+        this.#nodeUpdateTimers.delete(nodeId);
         this.#nodeObservers.get(nodeId)?.close();
         this.#nodeObservers.delete(nodeId);
         this.#basicInfoChangedInBatch.delete(nodeId);

--- a/packages/ws-controller/src/controller/webRtcSessionStreams.ts
+++ b/packages/ws-controller/src/controller/webRtcSessionStreams.ts
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Logger } from "@matter/main";
+
+const logger = Logger.get("webRtcSessionStreams");
+
 /** A stream id is a non-negative integer (matter.js VideoStreamID/AudioStreamID are uint16). */
 function isStreamId(value: unknown): value is number {
     return typeof value === "number" && Number.isInteger(value) && value >= 0;
@@ -38,6 +42,59 @@ export function resolveWebRtcSessionStreams(
         return [responseId];
     }
     return undefined;
+}
+
+/** WebRtcTransportProvider ClusterRevision from which VideoStreams/AudioStreams replace the singular ids. */
+const STREAM_LIST_MIN_REVISION = 2;
+
+/**
+ * Enforce the ProvideOffer/SolicitOffer video/audio stream field choice on a request, in place.
+ *
+ * VideoStreams/AudioStreams (cluster revision 2) deprecate the singular VideoStreamID/AudioStreamID
+ * (revision 1); a provider fails the command with InvalidCommand when both are present. Callers pass the
+ * canonical revision-2 lists; this narrows the request to exactly the set the provider expects: the lists
+ * for revision >= 2, or the singular ids for revision 1 / unknown. A revision-1 provider carries a single
+ * id per media kind, so a multi-entry list is truncated to its first entry.
+ */
+export function selectWebRtcStreamFields(fields: Record<string, unknown>, clusterRevision: unknown): void {
+    const videoStreams = resolveWebRtcSessionStreams(fields.videoStreams, fields.videoStreamId, undefined);
+    const audioStreams = resolveWebRtcSessionStreams(fields.audioStreams, fields.audioStreamId, undefined);
+    if (typeof clusterRevision === "number" && clusterRevision >= STREAM_LIST_MIN_REVISION) {
+        // A provider fails the command when any list coexists with any singular id (the check spans both
+        // media kinds, not each in isolation), so a list on one kind forces both singular ids out. With no
+        // list to send, the deprecated singular ids stay — they remain valid on rev 2 and preserve a null
+        // (auto-select) request.
+        if (videoStreams !== undefined || audioStreams !== undefined) {
+            delete fields.videoStreamId;
+            delete fields.audioStreamId;
+        }
+        if (videoStreams !== undefined) fields.videoStreams = videoStreams;
+        else delete fields.videoStreams;
+        if (audioStreams !== undefined) fields.audioStreams = audioStreams;
+        else delete fields.audioStreams;
+    } else {
+        delete fields.videoStreams;
+        delete fields.audioStreams;
+        downconvertToSingularStreamId(fields, "videoStreamId", videoStreams, "video");
+        downconvertToSingularStreamId(fields, "audioStreamId", audioStreams, "audio");
+    }
+}
+
+function downconvertToSingularStreamId(
+    fields: Record<string, unknown>,
+    key: "videoStreamId" | "audioStreamId",
+    resolved: number[] | undefined,
+    kind: string,
+): void {
+    if (resolved === undefined) {
+        return;
+    }
+    if (resolved.length > 1) {
+        logger.warn(
+            `WebRTC provider does not advertise ClusterRevision >= 2 (revision 1 or not yet cached): ${resolved.length} ${kind} streams requested but only a single stream id can be sent; using ${resolved[0]}`,
+        );
+    }
+    fields[key] = resolved[0];
 }
 
 /**

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -870,15 +870,19 @@ export class WebSocketControllerHandler implements WebServerHandler {
         const { label } = args;
         const effectiveLabel = normalizeFabricLabel(label);
         if (this.#config.fabricLabelLocked) {
-            logger.notice(
-                `[${connection.connId}] Ignoring set_default_fabric_label "${effectiveLabel}" and keeping "${this.#config.fabricLabel}" (pinned via --default-fabric-label)`,
-            );
+            if (this.#config.fabricLabel !== effectiveLabel) {
+                logger.notice(
+                    `[${connection.connId}] Ignoring set_default_fabric_label "${effectiveLabel}" and keeping "${this.#config.fabricLabel}" (pinned via --default-fabric-label)`,
+                );
+            }
             return null;
         }
         if (this.#fabricLabelOwner !== undefined && this.#fabricLabelOwner !== connection) {
-            logger.notice(
-                `[${connection.connId}] Ignoring set_default_fabric_label "${effectiveLabel}"; fabric label is owned by connection ${this.#fabricLabelOwner.connId} this session, keeping "${this.#config.fabricLabel}"`,
-            );
+            if (this.#config.fabricLabel !== effectiveLabel) {
+                logger.notice(
+                    `[${connection.connId}] Ignoring set_default_fabric_label "${effectiveLabel}"; fabric label is owned by connection ${this.#fabricLabelOwner.connId} this session, keeping "${this.#config.fabricLabel}"`,
+                );
+            }
             return null;
         }
         // Claim before awaiting so a second connection racing its first set can't slip past the guard while

--- a/packages/ws-controller/test/WebRtcSessionStreamsTest.ts
+++ b/packages/ws-controller/test/WebRtcSessionStreamsTest.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isTrackableWebRtcSession, resolveWebRtcSessionStreams } from "../src/controller/webRtcSessionStreams.js";
+import {
+    isTrackableWebRtcSession,
+    resolveWebRtcSessionStreams,
+    selectWebRtcStreamFields,
+} from "../src/controller/webRtcSessionStreams.js";
 
 describe("resolveWebRtcSessionStreams", () => {
     it("uses the requested rev-2 list verbatim", () => {
@@ -77,6 +81,62 @@ describe("resolveWebRtcSessionStreams", () => {
 
     it("accepts stream id 0", () => {
         expect(resolveWebRtcSessionStreams(undefined, 0, undefined)).to.deep.equal([0]);
+    });
+});
+
+describe("selectWebRtcStreamFields", () => {
+    it("sends the lists verbatim for a rev-2 provider", () => {
+        const fields: Record<string, unknown> = { sdp: "v=0", videoStreams: [7], audioStreams: [9] };
+        selectWebRtcStreamFields(fields, 2);
+        expect(fields).to.deep.equal({ sdp: "v=0", videoStreams: [7], audioStreams: [9] });
+    });
+
+    it("keeps multiple streams for a rev-2 provider", () => {
+        const fields: Record<string, unknown> = { videoStreams: [3, 5] };
+        selectWebRtcStreamFields(fields, 2);
+        expect(fields).to.deep.equal({ videoStreams: [3, 5] });
+    });
+
+    it("synthesises the lists from a legacy caller's singular ids for a rev-2 provider", () => {
+        const fields: Record<string, unknown> = { videoStreamId: 5, audioStreamId: null };
+        selectWebRtcStreamFields(fields, 3);
+        expect(fields).to.deep.equal({ videoStreams: [5] });
+    });
+
+    it("down-converts the lists to singular ids for a rev-1 provider", () => {
+        const fields: Record<string, unknown> = { videoStreams: [7], audioStreams: [9] };
+        selectWebRtcStreamFields(fields, 1);
+        expect(fields).to.deep.equal({ videoStreamId: 7, audioStreamId: 9 });
+    });
+
+    it("truncates a multi-stream list to its first entry for a rev-1 provider", () => {
+        const fields: Record<string, unknown> = { videoStreams: [3, 5] };
+        selectWebRtcStreamFields(fields, 1);
+        expect(fields).to.deep.equal({ videoStreamId: 3 });
+    });
+
+    it("down-converts the lists when the provider revision is unknown", () => {
+        const fields: Record<string, unknown> = { videoStreams: [7] };
+        selectWebRtcStreamFields(fields, undefined);
+        expect(fields).to.deep.equal({ videoStreamId: 7 });
+    });
+
+    it("leaves a rev-1 auto-select request untouched", () => {
+        const fields: Record<string, unknown> = { videoStreamId: null };
+        selectWebRtcStreamFields(fields, 1);
+        expect(fields).to.deep.equal({ videoStreamId: null });
+    });
+
+    it("preserves a legacy null auto-select request on a rev-2 provider when no list is sent", () => {
+        const fields: Record<string, unknown> = { videoStreamId: null, audioStreamId: null };
+        selectWebRtcStreamFields(fields, 2);
+        expect(fields).to.deep.equal({ videoStreamId: null, audioStreamId: null });
+    });
+
+    it("drops a null auto-select on the other media kind once any list is sent to a rev-2 provider", () => {
+        const fields: Record<string, unknown> = { videoStreams: [5], audioStreamId: null };
+        selectWebRtcStreamFields(fields, 2);
+        expect(fields).to.deep.equal({ videoStreams: [5] });
     });
 });
 


### PR DESCRIPTION
## Summary

Fixes #880 — a regression where WebRTC live view broke for revision-2 camera providers on 1.2.6.

Two related fixes, one commit each.

### 1. `fix(webrtc)` — ProvideOffer stream field selection

A `WebRtcTransportProvider` fails `ProvideOffer`/`SolicitOffer` with `InvalidCommand` when a request carries **both** the deprecated singular `videoStreamId`/`audioStreamId` **and** the revision-2 `videoStreams`/`audioStreams` lists (the reference SDK rejects the pair; the matter.js model marks the lists as deprecating the singular ids). Since #865 the dashboard sent both, so every offer to a revision-2 provider was rejected — a regression from 1.1.7, which sent only the singular ids.

- **Dashboard** now sends only the canonical revision-2 lists.
- **Server** narrows the request to exactly the set the provider expects, keyed on its advertised `ClusterRevision` (read from the attribute cache):
  - revision ≥ 2 → lists (multi-stream preserved; synthesised from singular ids for legacy callers),
  - revision 1 / uncached → singular ids (a multi-entry list is truncated to its first id, with a warning).
- The two sets are **never** both present on the wire — the invariant is structural, not conditional.
- Session tracking now reads the post-selection fields, so the tracked stream set always matches what was sent.

### 2. `fix(ws-controller)` — node_updated refresh + fabric-label log

- Coalesce the post-batch `node_updated` into a single **one-shot 6s** refresh per node (re-reads attributes via `#handleNodeStructureChange`) instead of an immediate per-batch emit. The timer is cancelled/cleared on structure change, node removal, and handler close — no leak, no fire against a removed node.
- Only log the "ignoring set_default_fabric_label" notice when the requested label actually differs, so re-sending the same label no longer spams the log.

## Testing

`npm run format-verify`, `npm run lint`, `npm run build`, and the full `npm test` suite (exit 0, all suites) pass.

New/updated unit coverage:
- `selectWebRtcStreamFields` — rev-2 verbatim/multi-stream, legacy singular up-convert, rev-1 down-convert + truncation, unknown-revision fallback, rev-1 and rev-2 auto-select handling.
- `buildProvideOfferRequest` — lists only, never the deprecated singular ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)