### PR TITLE
fix(dashboard): restrict live view controls to camera device types that support WebRTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Fix: Dashboard no longer offers live-view streaming controls for the Snapshot Camera device type, which doesn't support WebRTC — only Snapshot capture is offered
+
 ## 1.2.7 (2026-07-16)
 
 - Fix: WebRTC camera live view — Use `ProvideOffer` format that all cluster versions support, skip rev2 for now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
-- Fix: Dashboard no longer offers live-view streaming controls for the Snapshot Camera device type, which doesn't support WebRTC — only Snapshot capture is offered
 - Fix: Ensures that updating Thread data from nodes in Thread visualization also updates the chart
+- Fix: Dashboard no longer offers live-view streaming controls for the Snapshot Camera device type, which doesn't support WebRTC — only Snapshot capture is offered
 
 ## 1.2.7 (2026-07-16)
 

--- a/packages/dashboard/src/components/webrtc-stream-view.ts
+++ b/packages/dashboard/src/components/webrtc-stream-view.ts
@@ -188,6 +188,7 @@ export class WebRtcStreamView extends LitElement {
 
     @property({ attribute: false }) nodeId!: number | bigint;
     @property({ type: Number }) endpointId!: number;
+    @property({ type: Boolean }) liveViewSupported = true;
     @property({ type: Object }) resolution: { width: number; height: number } | null = null;
 
     @property({ type: Boolean }) watermarkEnabled = false;
@@ -253,7 +254,11 @@ export class WebRtcStreamView extends LitElement {
             ${this._state === "idle"
                 ? html`<div class="placeholder">
                       <ha-svg-icon class="placeholder-icon" .path=${mdiVideoOutline}></ha-svg-icon>
-                      <div class="placeholder-text">Click <b>Start</b> to begin streaming</div>
+                      <div class="placeholder-text">
+                          ${this.liveViewSupported
+                              ? html`Click <b>Start</b> to begin streaming`
+                              : "Live view not supported — use Snapshot"}
+                      </div>
                   </div>`
                 : null}
             ${this._state === "connecting"
@@ -272,6 +277,7 @@ export class WebRtcStreamView extends LitElement {
     }
 
     async start(): Promise<void> {
+        if (!this.liveViewSupported) throw new Error("Live view is not supported on this device");
         if (!this.client) throw new Error("Matter client not available");
         if (this._state === "connecting" || this._state === "streaming") return;
 

--- a/packages/dashboard/src/components/webrtc-stream-view.ts
+++ b/packages/dashboard/src/components/webrtc-stream-view.ts
@@ -277,7 +277,10 @@ export class WebRtcStreamView extends LitElement {
     }
 
     async start(): Promise<void> {
-        if (!this.liveViewSupported) throw new Error("Live view is not supported on this device");
+        if (!this.liveViewSupported) {
+            this._fireStateChange("error", "Live view is not supported on this device");
+            return;
+        }
         if (!this.client) throw new Error("Matter client not available");
         if (this._state === "connecting" || this._state === "streaming") return;
 

--- a/packages/dashboard/src/pages/camera-overlay.ts
+++ b/packages/dashboard/src/pages/camera-overlay.ts
@@ -28,6 +28,8 @@ import "../components/webrtc-stream-view.js";
 import type { WebRtcStreamView } from "../components/webrtc-stream-view.js";
 import { asObject, pickNumber } from "../util/attribute-shapes.js";
 import { hasAvsumOnEndpoint } from "../util/avsum.js";
+import { LIVE_VIEW_DEVICE_TYPE_IDS } from "../util/device-icons.js";
+import { getEndpointDeviceTypes } from "../util/endpoints.js";
 
 type StreamState = "idle" | "connecting" | "streaming" | "error";
 
@@ -72,6 +74,13 @@ export class CameraOverlay extends LitElement {
     @state() private _osdEnabled = false;
     @state() private _snapshotResolutions: Resolution[] = [];
     @state() private _selectedSnapshotResolution: Resolution | null = null;
+
+    private get _liveViewSupported(): boolean {
+        const node = this.client?.nodes[String(this.nodeId)];
+        if (!node) return false;
+        const deviceTypeIds = getEndpointDeviceTypes(node, this.endpointId).map(d => d.id);
+        return LIVE_VIEW_DEVICE_TYPE_IDS.some(id => deviceTypeIds.includes(id));
+    }
 
     private get _snapshotSupported(): boolean {
         const node = this.client?.nodes[String(this.nodeId)];
@@ -276,7 +285,9 @@ export class CameraOverlay extends LitElement {
     }
 
     override render() {
-        const canStart = this._state === "idle" || this._state === "error";
+        const liveViewSupported = this._liveViewSupported;
+        const idleOrError = this._state === "idle" || this._state === "error";
+        const canStart = liveViewSupported && idleOrError;
 
         return html`
             <div class="backdrop" @click=${this._closing ? undefined : this._close}></div>
@@ -301,6 +312,7 @@ export class CameraOverlay extends LitElement {
                               ${ref(this._streamViewRef)}
                               .nodeId=${this.nodeId}
                               .endpointId=${this.endpointId}
+                              .liveViewSupported=${liveViewSupported}
                               .resolution=${this._selectedResolution}
                               .watermarkEnabled=${this._watermarkEnabled}
                               .osdEnabled=${this._osdEnabled}
@@ -359,7 +371,7 @@ export class CameraOverlay extends LitElement {
                               </md-outlined-select>
                           `
                         : nothing}
-                    ${canStart && this._snapshotSupported && this._snapshotResolutions.length > 0
+                    ${idleOrError && this._snapshotSupported && this._snapshotResolutions.length > 0
                         ? html`
                               <md-outlined-select
                                   label="Snapshot"

--- a/packages/dashboard/src/pages/components/node-details.ts
+++ b/packages/dashboard/src/pages/components/node-details.ts
@@ -13,7 +13,7 @@ import "@material/web/list/list";
 import "@material/web/list/list-item";
 import { consume } from "@lit/context";
 import { MatterClient, MatterNode, UpdateSource } from "@matter-server/ws-client";
-import { mdiChatProcessing, mdiPencil, mdiShareVariant, mdiTrashCan, mdiUpdate, mdiVideo } from "@mdi/js";
+import { mdiCamera, mdiChatProcessing, mdiPencil, mdiShareVariant, mdiTrashCan, mdiUpdate, mdiVideo } from "@mdi/js";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { clientContext, tickContext } from "../../client/client-context.js";
@@ -23,18 +23,13 @@ import { showNodeLabelDialog } from "../../components/dialogs/node-label-dialog/
 import { handleAsync } from "../../util/async-handler.js";
 import "../../components/ha-svg-icon";
 import "../camera-overlay.js";
-import { DeviceTypes, getDeviceIcon } from "../../util/device-icons.js";
+import { DeviceTypes, LIVE_VIEW_DEVICE_TYPE_IDS, getDeviceIcon } from "../../util/device-icons.js";
 import { getEndpointDeviceTypes } from "../../util/endpoints.js";
 import { ICD_CLUSTER_ID, icdBadge } from "../../util/icd.js";
 import { formatManualPairingCode, renderPairingQrCodeDataUri } from "../../util/pairing-code.js";
 import { bindingContext } from "./context.js";
 
-const CAMERA_DEVICE_TYPE_IDS: number[] = [
-    DeviceTypes.CAMERA,
-    DeviceTypes.VIDEO_DOORBELL,
-    DeviceTypes.FLOODLIGHT_CAMERA,
-    DeviceTypes.SNAPSHOT_CAMERA,
-];
+const CAMERA_DEVICE_TYPE_IDS: number[] = [...LIVE_VIEW_DEVICE_TYPE_IDS, DeviceTypes.SNAPSHOT_CAMERA];
 
 /** Map updateState values to user-friendly labels */
 const UPDATE_STATE_LABELS: Record<number, string> = {
@@ -89,6 +84,7 @@ export class NodeDetails extends LitElement {
 
         const deviceTypeIds = getEndpointDeviceTypes(this.node, this.endpoint).map(d => d.id);
         const isCamera = CAMERA_DEVICE_TYPE_IDS.some(id => deviceTypeIds.includes(id));
+        const isLiveViewCamera = LIVE_VIEW_DEVICE_TYPE_IDS.some(id => deviceTypeIds.includes(id));
         const badge = icdBadge(this.node.attributes, this.node.available);
 
         return html`
@@ -170,8 +166,11 @@ export class NodeDetails extends LitElement {
                                       @click=${() => this._openCameraOverlay()}
                                       ?disabled=${!this.node.available}
                                   >
-                                      Live View
-                                      <ha-svg-icon slot="icon" .path=${mdiVideo}></ha-svg-icon>
+                                      ${isLiveViewCamera ? "Live View" : "Snapshot"}
+                                      <ha-svg-icon
+                                          slot="icon"
+                                          .path=${isLiveViewCamera ? mdiVideo : mdiCamera}
+                                      ></ha-svg-icon>
                                   </md-outlined-button>
                               `
                             : nothing}

--- a/packages/dashboard/src/util/device-icons.ts
+++ b/packages/dashboard/src/util/device-icons.ts
@@ -190,11 +190,11 @@ export const DeviceTypes = {
 };
 
 /** Device types whose mandatory clusters include WebRTCTransportProvider (0x553), i.e. support live streaming. */
-export const LIVE_VIEW_DEVICE_TYPE_IDS: number[] = [
+export const LIVE_VIEW_DEVICE_TYPE_IDS: readonly number[] = Object.freeze([
     DeviceTypes.CAMERA,
     DeviceTypes.VIDEO_DOORBELL,
     DeviceTypes.FLOODLIGHT_CAMERA,
-];
+]);
 
 /**
  * Maps device type IDs to MDI icon paths.

--- a/packages/dashboard/src/util/device-icons.ts
+++ b/packages/dashboard/src/util/device-icons.ts
@@ -189,6 +189,13 @@ export const DeviceTypes = {
     INTERCOM: 0x0140,
 };
 
+/** Device types whose mandatory clusters include WebRTCTransportProvider (0x553), i.e. support live streaming. */
+export const LIVE_VIEW_DEVICE_TYPE_IDS: number[] = [
+    DeviceTypes.CAMERA,
+    DeviceTypes.VIDEO_DOORBELL,
+    DeviceTypes.FLOODLIGHT_CAMERA,
+];
+
 /**
  * Maps device type IDs to MDI icon paths.
  */

--- a/packages/dashboard/test/SnapshotCapabilitiesTest.ts
+++ b/packages/dashboard/test/SnapshotCapabilitiesTest.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { parseSnapshotCapabilitiesFromList } from "../src/components/webrtc-stream-view.js";
+import { WebRtcStreamView, parseSnapshotCapabilitiesFromList } from "../src/components/webrtc-stream-view.js";
 
 // Tag-based (cached-attribute) SnapshotCapabilitiesStruct: 0=resolution {0:w,1:h},
 // 1=maxFrameRate, 2=imageCodec, 3=requiresEncodedPixels.
@@ -62,5 +62,19 @@ describe("parseSnapshotCapabilitiesFromList", () => {
         expect(cap.requiresEncodedPixels).to.equal(true);
         expect(cap.resolution).to.deep.equal({ width: 1280, height: 720 });
         expect(cap.maxFrameRate).to.equal(15);
+    });
+});
+
+describe("WebRtcStreamView#start", () => {
+    it("reports an error state instead of throwing when live view is unsupported", async () => {
+        const view = new WebRtcStreamView();
+        view.liveViewSupported = false;
+        const states: { state: string; errorMessage: string | null }[] = [];
+        view.addEventListener("streamstate", ev => states.push((ev as CustomEvent).detail));
+
+        await view.start();
+
+        expect(view.state).to.equal("error");
+        expect(states).to.deep.equal([{ state: "error", errorMessage: "Live view is not supported on this device" }]);
     });
 });


### PR DESCRIPTION
## Type of change

- [x] 🐛 **Fix** — corrects a defect or wrong behavior
- [ ] ✨ **Feature** — adds new functionality or capability

## Description

The camera overlay always rendered the live-view controls (resolution selector, Start/Retry button, watermark/OSD toggles) regardless of the endpoint's Matter device type. For a **Snapshot Camera** (`0x0145`) endpoint — which does not implement the mandatory `WebRTCTransportProvider` cluster (`0x0553`) — this let a user click Start and attempt to negotiate a WebRTC session the camera cannot serve.

Root cause: `camera-overlay.ts` gated the Snapshot button independently on the AVSM `SNP` feature bit, but gated nothing on device type — the assumption was that any endpoint opening the overlay (Camera / Video Doorbell / Floodlight Camera / Snapshot Camera) supports live view.

Fix:

- New `LIVE_VIEW_DEVICE_TYPE_IDS` constant (`device-icons.ts`, `readonly` + `Object.freeze`d): Camera, Video Doorbell, Floodlight Camera — the device types that mandate `WebRTCTransportProvider`.
- `camera-overlay.ts`: new `_liveViewSupported` getter (endpoint device type lookup); `canStart` now requires it, hiding the resolution selector / watermark / OSD toggles / Start button for Snapshot Camera. The Snapshot resolution dropdown and Snapshot button stay independently gated on `_snapshotSupported`, unaffected.
- `webrtc-stream-view.ts`: new `liveViewSupported` prop; the idle placeholder text changes to "Live view not supported — use Snapshot"; `start()` reports the unsupported case via the existing `_fireStateChange("error", …)` path (not a throw), consistent with the method's other error handling and safe for fire-and-forget callers (`void view.start()`).
- `node-details.ts`: the node action button relabels from "Live View" to "Snapshot" (camera icon instead of video icon) when the endpoint's device type doesn't support live view; reuses the shared `LIVE_VIEW_DEVICE_TYPE_IDS` constant instead of duplicating the device type list.
- `CHANGELOG.md`: added an entry under the work-in-progress placeholder (rebased onto the 1.2.7 release cut after main advanced).

**Review feedback addressed** (Copilot):
- Reporting unsupported live view via `_fireStateChange("error", …)` instead of throwing from `start()`, since callers invoke it fire-and-forget.
- Made `LIVE_VIEW_DEVICE_TYPE_IDS` immutable (`readonly` + `Object.freeze`) since it's shared/copied by other modules.

## Backing evidence

- Related issue: #887
- [x] This fix/change is backed by a **complete log file** — attached here or in the linked issue (not just a few quoted lines).

## Checklist

- [x] Tests added or updated to cover the change
- [x] `npm test` passes (`PRIMARY_INTERFACE=ens33 MATTER_MDNS_NETWORKINTERFACE=ens33 npm test`, full monorepo run, all packages green including `matter-server` integration tests: 251/251)
- [x] `npm run format-verify` and `npm run lint` pass
- [x] CHANGELOG updated (if applicable)
