### PR TITLE
fix(dashboard): read connection data fabric-filtered so node store refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Fix: Ensures that updating Thread data from nodes in Thread visualization also updates the chart
+
 ## 1.2.7 (2026-07-16)
 
 - Fix: WebRTC camera live view — Use `ProvideOffer` format that all cluster versions support, skip rev2 for now

--- a/packages/dashboard/src/pages/network/update-connections-dialog.ts
+++ b/packages/dashboard/src/pages/network/update-connections-dialog.ts
@@ -146,11 +146,12 @@ export class UpdateConnectionsDialog extends LitElement {
                 const paths = this._getAttributePathsForNode(nodeIdStr);
                 if (paths.length === 0) return;
 
-                // Use the actual node_id from the node object (number | bigint)
-                await this.client.readAttribute(node.node_id, paths);
+                // fabric_filtered must match the node subscription's filter (true), else matter.js
+                // discards the read and no attribute_updated fires, leaving the store stale.
+                await this.client.readAttribute(node.node_id, paths, undefined, true);
             });
 
-            // Wait for all to complete (results come via events, we just need completion)
+            // Return values are discarded; refreshed data arrives via attribute_updated events.
             await Promise.all(updatePromises);
 
             // Close dialog on success

--- a/packages/ws-client/src/client.ts
+++ b/packages/ws-client/src/client.ts
@@ -337,7 +337,6 @@ export class MatterClient {
         timeout?: number,
         fabricFiltered = false,
     ): Promise<Record<string, unknown>> {
-        // Read one or more attribute(s) on a node by specifying an attributepath.
         return await this.sendCommand(
             "read_attribute",
             0,

--- a/packages/ws-client/src/client.ts
+++ b/packages/ws-client/src/client.ts
@@ -335,9 +335,15 @@ export class MatterClient {
         nodeId: number | bigint,
         attributePath: string | string[],
         timeout?: number,
+        fabricFiltered = false,
     ): Promise<Record<string, unknown>> {
         // Read one or more attribute(s) on a node by specifying an attributepath.
-        return await this.sendCommand("read_attribute", 0, { node_id: nodeId, attribute_path: attributePath }, timeout);
+        return await this.sendCommand(
+            "read_attribute",
+            0,
+            { node_id: nodeId, attribute_path: attributePath, fabric_filtered: fabricFiltered },
+            timeout,
+        );
     }
 
     async writeAttribute(


### PR DESCRIPTION
## Problem

The **"reload node data"** action in the Thread/WiFi network view (`update-connections-dialog`) read attributes with `fabric_filtered=false`.

matter.js only integrates a one-shot `interaction.read()` into the subscribed datasource — and thus fires `attributeChanged` → `attribute_updated` — when the read's fabric-filter **matches** the active subscription's. The gate is a pure filter-match check in `ClientStructure.#mutateAttribute`:

```js
if (this.subscribedFabricFiltered !== scope.isFabricFiltered) {
    return currentUpdates; // skip: no store write, no attributeChanged
}
```

`subscribedFabricFiltered` defaults to `true` (matter.js auto-subscription uses `fabricFilter: true`), while the reload read sent `false`. So the fresh values were fetched but **silently discarded** for state integration: the global node store kept its stale values and the topology never updated, even though `read_attribute` returned the new data.

## Fix

Read with `fabric_filtered=true` so the refreshed values match the subscription's representation, integrate into the datasource, and propagate to clients via `attribute_updated`.

- `MatterClient.readAttribute` gains an optional `fabricFiltered` arg (default `false`, appended after `timeout` — non-breaking for all existing callers).
- The reload path passes `true`.

No server change needed: `handleReadAttributes` already sets `includeKnownVersions: true`, which forces a full read (no `dataVersionFilters`), so a genuinely-changed value always flows through.

## Testing

- `npm run format` / `lint` / `build` — clean
- `npm test` — 251/251 (incl. integration)

Addresses #891