### PR TITLE
fix(dashboard): don't show live view on the Floodlight Camera composed root endpoint

### DIFF
--- a/packages/dashboard/src/util/device-icons.ts
+++ b/packages/dashboard/src/util/device-icons.ts
@@ -189,12 +189,15 @@ export const DeviceTypes = {
     INTERCOM: 0x0140,
 };
 
-/** Device types whose mandatory clusters include WebRTCTransportProvider (0x553), i.e. support live streaming. */
-export const LIVE_VIEW_DEVICE_TYPE_IDS: readonly number[] = Object.freeze([
-    DeviceTypes.CAMERA,
-    DeviceTypes.VIDEO_DOORBELL,
-    DeviceTypes.FLOODLIGHT_CAMERA,
-]);
+/**
+ * Device types whose mandatory clusters include WebRTCTransportProvider (0x553), i.e. support live streaming.
+ *
+ * Floodlight Camera (0x0144) is intentionally excluded: per Matter specs 1.6.0 chapter 16.2 it is a composed
+ * device type whose root endpoint only carries Basic Information and, optionally, Power Source — the
+ * WebRTCTransportProvider/CameraAvStreamManagement clusters live on its mandatory Camera (0x0142) child
+ * endpoint instead, which is already covered by DeviceTypes.CAMERA above.
+ */
+export const LIVE_VIEW_DEVICE_TYPE_IDS: readonly number[] = Object.freeze([DeviceTypes.CAMERA, DeviceTypes.VIDEO_DOORBELL]);
 
 /**
  * Maps device type IDs to MDI icon paths.

--- a/packages/dashboard/src/util/device-icons.ts
+++ b/packages/dashboard/src/util/device-icons.ts
@@ -197,7 +197,10 @@ export const DeviceTypes = {
  * WebRTCTransportProvider/CameraAvStreamManagement clusters live on its mandatory Camera (0x0142) child
  * endpoint instead, which is already covered by DeviceTypes.CAMERA above.
  */
-export const LIVE_VIEW_DEVICE_TYPE_IDS: readonly number[] = Object.freeze([DeviceTypes.CAMERA, DeviceTypes.VIDEO_DOORBELL]);
+export const LIVE_VIEW_DEVICE_TYPE_IDS: readonly number[] = Object.freeze([
+    DeviceTypes.CAMERA,
+    DeviceTypes.VIDEO_DOORBELL,
+]);
 
 /**
  * Maps device type IDs to MDI icon paths.


### PR DESCRIPTION
## Summary
- Floodlight Camera (0x0144) is a composed device type per Matter specs 1.6.0 chapter 16.2: its root endpoint only carries Basic Information/Power Source, while `WebRTCTransportProvider`/`CameraAvStreamManagement` live on its mandatory Camera (0x0142) child endpoint.
- `LIVE_VIEW_DEVICE_TYPE_IDS` incorrectly included `DeviceTypes.FLOODLIGHT_CAMERA`, which made the Live View button appear on the composed root endpoint too. Clicking it crashed with `Cannot read properties of undefined (reading 'videoStreamAllocate')` since that endpoint has no `CameraAvStreamManagement` cluster.
- Removed `FLOODLIGHT_CAMERA` from `LIVE_VIEW_DEVICE_TYPE_IDS`; the Camera child endpoint (already covered by `DeviceTypes.CAMERA`) is unaffected and continues to show the button correctly.

## Test plan
- [x] Pair a Floodlight Camera device (e.g. matterbridge-example-camera) and confirm the Live View button only appears on the child Camera endpoint, not the composed root endpoint.
- [x] Confirm Live View still works normally on the Camera child endpoint.