### PR TITLE
fix(dashboard): detect camera live view / snapshot by cluster, not device type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Fix: Detect camera Live View/Snapshot capabilities from the endpoint's clusters instead of hard-coding them by device type, so composed devices (e.g. Floodlight Camera) show the button only on the endpoint that actually supports streaming
+
 ## 1.2.8 (2026-07-20)
 
 - Fix: WebRTC camera live view — `ProvideOffer` again selects the stream fields by the provider's cluster revision

--- a/packages/dashboard/src/pages/camera-overlay.ts
+++ b/packages/dashboard/src/pages/camera-overlay.ts
@@ -28,8 +28,7 @@ import "../components/webrtc-stream-view.js";
 import type { WebRtcStreamView } from "../components/webrtc-stream-view.js";
 import { asObject, pickNumber } from "../util/attribute-shapes.js";
 import { hasAvsumOnEndpoint } from "../util/avsum.js";
-import { LIVE_VIEW_DEVICE_TYPE_IDS } from "../util/device-icons.js";
-import { getEndpointDeviceTypes } from "../util/endpoints.js";
+import { supportsLiveView, supportsSnapshot } from "../util/camera.js";
 
 type StreamState = "idle" | "connecting" | "streaming" | "error";
 
@@ -77,23 +76,12 @@ export class CameraOverlay extends LitElement {
 
     private get _liveViewSupported(): boolean {
         const node = this.client?.nodes[String(this.nodeId)];
-        if (!node) return false;
-        const deviceTypeIds = getEndpointDeviceTypes(node, this.endpointId).map(d => d.id);
-        return LIVE_VIEW_DEVICE_TYPE_IDS.some(id => deviceTypeIds.includes(id));
+        return node ? supportsLiveView(node, this.endpointId) : false;
     }
 
     private get _snapshotSupported(): boolean {
         const node = this.client?.nodes[String(this.nodeId)];
-        // CaptureSnapshot (cmd 12) must appear in AcceptedCommandList (attr 0xfff9 = 65529).
-        const accepted = node?.attributes[`${this.endpointId}/1361/65529`];
-        if (!Array.isArray(accepted) || !accepted.includes(12)) return false;
-        // FeatureMap (attr 0xfffc = 65532) bit 2 (SNP) advertises snapshot support — some cameras
-        // set the bit but leave SnapshotCapabilities empty, so the feature bit is the authoritative
-        // signal and SnapshotCapabilities a hint we fall back from.
-        const featureMap = node?.attributes[`${this.endpointId}/1361/65532`];
-        if (typeof featureMap === "number" && (featureMap & 0x04) !== 0) return true;
-        const caps = node?.attributes[`${this.endpointId}/1361/10`];
-        return Array.isArray(caps) && caps.length > 0;
+        return node ? supportsSnapshot(node, this.endpointId) : false;
     }
 
     private _streamViewRef = createRef<WebRtcStreamView>();

--- a/packages/dashboard/src/pages/components/node-details.ts
+++ b/packages/dashboard/src/pages/components/node-details.ts
@@ -23,13 +23,12 @@ import { showNodeLabelDialog } from "../../components/dialogs/node-label-dialog/
 import { handleAsync } from "../../util/async-handler.js";
 import "../../components/ha-svg-icon";
 import "../camera-overlay.js";
-import { DeviceTypes, LIVE_VIEW_DEVICE_TYPE_IDS, getDeviceIcon } from "../../util/device-icons.js";
+import { supportsCameraOverlay, supportsLiveView } from "../../util/camera.js";
+import { getDeviceIcon } from "../../util/device-icons.js";
 import { getEndpointDeviceTypes } from "../../util/endpoints.js";
 import { ICD_CLUSTER_ID, icdBadge } from "../../util/icd.js";
 import { formatManualPairingCode, renderPairingQrCodeDataUri } from "../../util/pairing-code.js";
 import { bindingContext } from "./context.js";
-
-const CAMERA_DEVICE_TYPE_IDS: number[] = [...LIVE_VIEW_DEVICE_TYPE_IDS, DeviceTypes.SNAPSHOT_CAMERA];
 
 /** Map updateState values to user-friendly labels */
 const UPDATE_STATE_LABELS: Record<number, string> = {
@@ -82,9 +81,8 @@ export class NodeDetails extends LitElement {
     protected override render() {
         if (!this.node) return html``;
 
-        const deviceTypeIds = getEndpointDeviceTypes(this.node, this.endpoint).map(d => d.id);
-        const isCamera = CAMERA_DEVICE_TYPE_IDS.some(id => deviceTypeIds.includes(id));
-        const isLiveViewCamera = LIVE_VIEW_DEVICE_TYPE_IDS.some(id => deviceTypeIds.includes(id));
+        const isCamera = supportsCameraOverlay(this.node, this.endpoint);
+        const isLiveViewCamera = supportsLiveView(this.node, this.endpoint);
         const badge = icdBadge(this.node.attributes, this.node.available);
 
         return html`

--- a/packages/dashboard/src/util/camera.ts
+++ b/packages/dashboard/src/util/camera.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MatterNode } from "@matter-server/ws-client";
+import {
+    AVSM_FEAT_SNP,
+    AVSM_FEATURE_MAP_ATTR_ID,
+    CAMERA_AV_STREAM_MANAGEMENT_CLUSTER_ID,
+} from "../components/webrtc-stream-view.js";
+
+export const WEBRTC_TRANSPORT_PROVIDER_CLUSTER_ID = 0x553;
+
+const DESCRIPTOR_CLUSTER_ID = 29;
+const SERVER_LIST_ATTR_ID = 1;
+const ACCEPTED_COMMAND_LIST_ATTR_ID = 0xfff9;
+const CAPTURE_SNAPSHOT_COMMAND_ID = 12;
+const SNAPSHOT_CAPABILITIES_ATTR_ID = 10;
+
+function serverClusters(node: MatterNode, endpoint: number): number[] {
+    const raw = node.attributes[`${endpoint}/${DESCRIPTOR_CLUSTER_ID}/${SERVER_LIST_ATTR_ID}`];
+    return Array.isArray(raw) ? raw.map(v => Number(v)) : new Array<number>();
+}
+
+/**
+ * Live view drives a WebRTC session (WebRtcTransportProvider) fed by a video stream allocated
+ * through CameraAvStreamManagement, so both clusters must be present on the endpoint.
+ */
+export function supportsLiveView(node: MatterNode, endpoint: number): boolean {
+    const clusters = serverClusters(node, endpoint);
+    return (
+        clusters.includes(WEBRTC_TRANSPORT_PROVIDER_CLUSTER_ID) &&
+        clusters.includes(CAMERA_AV_STREAM_MANAGEMENT_CLUSTER_ID)
+    );
+}
+
+export function supportsSnapshot(node: MatterNode, endpoint: number): boolean {
+    const accepted =
+        node.attributes[`${endpoint}/${CAMERA_AV_STREAM_MANAGEMENT_CLUSTER_ID}/${ACCEPTED_COMMAND_LIST_ATTR_ID}`];
+    if (!Array.isArray(accepted) || !accepted.includes(CAPTURE_SNAPSHOT_COMMAND_ID)) return false;
+    // Some cameras set the SNP feature bit but leave SnapshotCapabilities empty, so the feature bit
+    // is authoritative and the capabilities list a fallback hint.
+    const featureMap =
+        node.attributes[`${endpoint}/${CAMERA_AV_STREAM_MANAGEMENT_CLUSTER_ID}/${AVSM_FEATURE_MAP_ATTR_ID}`];
+    if (typeof featureMap === "number" && (featureMap & AVSM_FEAT_SNP) !== 0) return true;
+    const caps =
+        node.attributes[`${endpoint}/${CAMERA_AV_STREAM_MANAGEMENT_CLUSTER_ID}/${SNAPSHOT_CAPABILITIES_ATTR_ID}`];
+    return Array.isArray(caps) && caps.length > 0;
+}
+
+export function supportsCameraOverlay(node: MatterNode, endpoint: number): boolean {
+    return supportsLiveView(node, endpoint) || supportsSnapshot(node, endpoint);
+}

--- a/packages/dashboard/src/util/device-icons.ts
+++ b/packages/dashboard/src/util/device-icons.ts
@@ -189,13 +189,6 @@ export const DeviceTypes = {
     INTERCOM: 0x0140,
 };
 
-/** Device types whose mandatory clusters include WebRTCTransportProvider (0x553), i.e. support live streaming. */
-export const LIVE_VIEW_DEVICE_TYPE_IDS: readonly number[] = Object.freeze([
-    DeviceTypes.CAMERA,
-    DeviceTypes.VIDEO_DOORBELL,
-    DeviceTypes.FLOODLIGHT_CAMERA,
-]);
-
 /**
  * Maps device type IDs to MDI icon paths.
  */


### PR DESCRIPTION
## Summary

Supersedes #903 with a more general fix.

The dashboard gated the Live View / Snapshot button on a hardcoded device-type allowlist (`LIVE_VIEW_DEVICE_TYPE_IDS`). On composed devices like Floodlight Camera (0x0144), the root endpoint carries the device type but the streaming clusters live on a child endpoint, so the button appeared on the root and crashed on `CameraAvStreamManagement.videoStreamAllocate`.

Instead of excluding Floodlight by device type (#903), detect capability dynamically from each endpoint's Descriptor `ServerList`:

- **Live View** requires both `WebRtcTransportProvider` (0x553) **and** `CameraAvStreamManagement` (0x551) — a WebRTC session needs a video stream allocated through AVSM, which is exactly the command that crashed.
- **Snapshot** requires `CameraAvStreamManagement` with the `CaptureSnapshot` command.

The button now follows real cluster presence per endpoint. Composed-device root endpoints no longer show a broken button, and no per-device-type special-casing is needed — any current or future camera device type works automatically.

Capability logic centralized in new `packages/dashboard/src/util/camera.ts` (`supportsLiveView` / `supportsSnapshot` / `supportsCameraOverlay`), consumed by `camera-overlay.ts` and `node-details.ts`. `LIVE_VIEW_DEVICE_TYPE_IDS` removed.

## Test plan

- [ ] Floodlight Camera: Live View button appears only on the child Camera endpoint, not the composed root.
- [ ] Live View still works on the Camera child endpoint.
- [ ] Snapshot Camera device type still shows the Snapshot button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
