### PR TITLE
fix(ws-controller): use current-regime standard offset for TimeSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Fix: Fixes the DST determination
+
 ## 1.3.1 (2026-07-23)
 
 - Feature: (lboue) Dashboard cluster view shows an "Active Features" panel listing the cluster's supported features by name, decoded from the FeatureMap attribute

--- a/packages/ws-controller/src/util/hostTimeZone.ts
+++ b/packages/ws-controller/src/util/hostTimeZone.ts
@@ -59,10 +59,17 @@ export function offsetSecondsAt(zone: string, atMs: number): number {
 }
 
 export function standardOffsetSeconds(zone: string, atMs: number): number {
-    const year = new Date(atMs).getUTCFullYear();
-    // The non-DST period always carries the smaller UTC offset (holds for both hemispheres;
-    // no-DST zones return the same value for both samples).
-    return Math.min(offsetSecondsAt(zone, Date.UTC(year, 0, 1)), offsetSecondsAt(zone, Date.UTC(year, 6, 1)));
+    // Standard (non-DST) offset = the smallest UTC offset over the year starting at atMs.
+    // Sampling forward from atMs (not the fixed calendar year) keeps the window inside the
+    // current regime, so a past permanent standard-offset change — e.g. a zone abolishing DST
+    // mid-year — can't drag in a stale pre-change base. Reverse-DST zones (winter offset below
+    // the tzdata "standard") still resolve: the lowest offset is what SetTimeZone must carry,
+    // with dstWindows emitting the positive deltas on top.
+    let min = offsetSecondsAt(zone, atMs);
+    for (let day = 30; day <= 365; day += 30) {
+        min = Math.min(min, offsetSecondsAt(zone, atMs + day * DAY_MS));
+    }
+    return min;
 }
 
 function findTransitionInstant(zone: string, beforeMs: number, afterMs: number): number {

--- a/packages/ws-controller/test/HostTimeZoneTest.ts
+++ b/packages/ws-controller/test/HostTimeZoneTest.ts
@@ -31,6 +31,18 @@ describe("hostTimeZone", () => {
             expect(standardOffsetSeconds("Australia/Sydney", JAN_2026)).to.equal(36000); // AEST base
             expect(standardOffsetSeconds("America/Phoenix", JUL_2026)).to.equal(-25200);
         });
+
+        it("returns the base offset when atMs is mid-DST", () => {
+            expect(standardOffsetSeconds("Europe/Berlin", Date.UTC(2026, 3, 15))).to.equal(3600);
+            expect(standardOffsetSeconds("America/New_York", Date.UTC(2026, 4, 1))).to.equal(-18000);
+        });
+
+        it("uses the current regime after a permanent standard-offset change", () => {
+            // Europe/Istanbul abolished DST on 2016-09-07, moving permanently to +03:00.
+            // Sampling Jan+Jul of 2016 straddles the switch and would wrongly return the
+            // pre-switch +02:00 base; the offset after the switch is a permanent +03:00.
+            expect(standardOffsetSeconds("Europe/Istanbul", Date.UTC(2016, 10, 1))).to.equal(10800);
+        });
     });
 
     describe("dstWindows", () => {


### PR DESCRIPTION
## Problem

`standardOffsetSeconds` sampled Jan 1 and Jul 1 of the query instant's **calendar year** and took the min as the standard (non-DST) offset. For a zone that permanently changes its standard offset **mid-year**, the Jan 1 sample comes from the old regime, so `min` returns the stale pre-change offset.

Concrete case from #922: America/Vancouver adopted permanent UTC−7 (−25200) on 2026-03-08. Jan 1 2026 still samples the old PST −28800, so `min(−28800, −25200) = −28800`. The server pushed `SetTimeZone { offset: −28800 }` — 1h too far west — and the device's local clock ran an hour behind (matching the reporter's "moves back 1 hour every day").

Verified against the attached log: every `setTimeZone` pushed `offset: -28800`; the device accepted with `Success`. (`validAt: 946684800000000` is `MATTER_EPOCH_OFFSET_US`, encoding to wire-0 = valid-from-epoch — not a bug; the device was not rejecting the table.)

## Fix

Sample the **year forward from the query instant** (monthly steps to 365 days) and take the min. The window stays inside the current regime, so a past permanent transition can no longer pull in a stale offset. Reverse-DST zones (e.g. Europe/Dublin, winter offset below the tzdata "standard") still resolve correctly — the lowest offset is what `SetTimeZone` carries, with `dstWindows` emitting the positive deltas.

## Tests

Added cases to `HostTimeZoneTest`:
- mid-DST query instant (Berlin April, New York May) — regression guard: two-point sampling failed here because DST periods exceed 182 days
- permanent standard-offset change (Europe/Istanbul, DST abolished 2016-09-07 → permanent +03:00)

Manually verified: Vancouver, Berlin, New York, Sydney (southern hemisphere), Phoenix (no DST), Dublin (reverse DST). Full suite 251/251.

Addresses #922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)