### PR TITLE
fix(ble-proxy): prevent crash when BTP handshake times out mid-write

### DIFF
--- a/packages/ble-proxy/src/ProxyBleChannel.ts
+++ b/packages/ble-proxy/src/ProxyBleChannel.ts
@@ -192,14 +192,17 @@ export class ProxyBleCentralInterface implements Transport {
 
             let handshakeResponse: Uint8Array;
             try {
-                await connection.sendCommand(BleProxyCommand.WriteAndSubscribe, {
+                // Await both together, not sequentially: the handshake timer can reject handshakePromise
+                // while the write is still pending, and Promise.all keeps a handler on it from the start so
+                // that rejection surfaces here instead of escaping as an unhandled rejection.
+                const writeAndSubscribe = connection.sendCommand(BleProxyCommand.WriteAndSubscribe, {
                     connection_handle,
                     write_uuid: c1Uuid,
                     write_value: Buffer.from(btpHandshakeRequest as ArrayBuffer).toString("base64"),
                     write_response: true,
                     subscribe_uuid: c2Uuid,
                 });
-                handshakeResponse = await handshakePromise;
+                [, handshakeResponse] = await Promise.all([writeAndSubscribe, handshakePromise]);
             } finally {
                 connection.binaryFrameReceived.off(handshakeObserver);
                 btpHandshakeTimeout.stop();

--- a/packages/ble-proxy/test/BleProxyIntegrationTest.ts
+++ b/packages/ble-proxy/test/BleProxyIntegrationTest.ts
@@ -278,10 +278,7 @@ describe("BLE Proxy Integration", function () {
             expect((disconnectCmd.args as { connection_handle: number }).connection_handle).to.equal(7);
         });
 
-        it("rejects openChannel (not crash) when the handshake times out while the write is still pending", async function () {
-            // Exercises the real 15s BTP_CONN_RSP_TIMEOUT, so allow more than the suite's 10s.
-            this.timeout(25_000);
-
+        it("rejects openChannel (not crash) when the handshake times out while the write is still pending", async () => {
             const proxyBle = new ProxyBle(handler);
             const mockDevice = new MockBleDevice({ discriminator: 8888, vendorId: 0xfff1, productId: 0x8000 });
 
@@ -300,14 +297,24 @@ describe("BLE Proxy Integration", function () {
             const central = proxyBle.centralInterface as ProxyBleCentralInterface;
             central.onData(() => {});
 
-            const outcome = await central.openChannel({ type: "ble", peripheralAddress: mockDevice.address }).then(
-                () => ({ ok: true as const }),
-                (err: Error) => ({ ok: false as const, err }),
-            );
+            // MockTime is disabled by default in this package; enable it only around the timed-out phase so
+            // the handshake timer fires without a real 15s wait — the proxy WS round-trips run on real IO.
+            MockTime.enable();
+            try {
+                const settled = central.openChannel({ type: "ble", peripheralAddress: mockDevice.address }).then(
+                    () => ({ ok: true as const }),
+                    (err: Error) => ({ ok: false as const, err }),
+                );
+                await testClient.waitForCommand("write_and_subscribe", 5000);
+                await MockTime.advance(Seconds(16));
 
-            expect(outcome.ok, "openChannel should reject, not resolve or crash").to.be.false;
-            if (!outcome.ok) {
-                expect(outcome.err.message).to.include("BTP handshake response not received");
+                const outcome = await settled;
+                expect(outcome.ok, "openChannel should reject, not resolve or crash").to.be.false;
+                if (!outcome.ok) {
+                    expect(outcome.err.message).to.include("BTP handshake response not received");
+                }
+            } finally {
+                MockTime.disable();
             }
         });
 

--- a/packages/ble-proxy/test/BleProxyIntegrationTest.ts
+++ b/packages/ble-proxy/test/BleProxyIntegrationTest.ts
@@ -278,6 +278,39 @@ describe("BLE Proxy Integration", function () {
             expect((disconnectCmd.args as { connection_handle: number }).connection_handle).to.equal(7);
         });
 
+        it("rejects openChannel (not crash) when the handshake times out while the write is still pending", async function () {
+            // Exercises the real 15s BTP_CONN_RSP_TIMEOUT, so allow more than the suite's 10s.
+            this.timeout(25_000);
+
+            const proxyBle = new ProxyBle(handler);
+            const mockDevice = new MockBleDevice({ discriminator: 8888, vendorId: 0xfff1, productId: 0x8000 });
+
+            await discoverDevice(proxyBle, mockDevice);
+
+            testClient.onCommand(BleProxyCommand.Connect, async () => ({ connection_handle: 9, mtu: 247 }));
+            testClient.onCommand(BleProxyCommand.DiscoverServices, async () => ({ services: mockDevice.services }));
+            testClient.onCommand(BleProxyCommand.DiscoverCharacteristics, async () => ({
+                characteristics: mockDevice.characteristics,
+            }));
+            // Write ack never returns and no handshake frame is sent, so the handshake timer fires while
+            // WriteAndSubscribe is still pending: openChannel must reject, not leave an unhandled rejection.
+            testClient.onCommand(BleProxyCommand.WriteAndSubscribe, () => new Promise<void>(() => {}));
+            testClient.onCommand(BleProxyCommand.Disconnect, async () => ({}));
+
+            const central = proxyBle.centralInterface as ProxyBleCentralInterface;
+            central.onData(() => {});
+
+            const outcome = await central.openChannel({ type: "ble", peripheralAddress: mockDevice.address }).then(
+                () => ({ ok: true as const }),
+                (err: Error) => ({ ok: false as const, err }),
+            );
+
+            expect(outcome.ok, "openChannel should reject, not resolve or crash").to.be.false;
+            if (!outcome.ok) {
+                expect(outcome.err.message).to.include("BTP handshake response not received");
+            }
+        });
+
         it("tears down the channel when the owning proxy client disconnects", async () => {
             const proxyBle = new ProxyBle(handler);
             const mockDevice = new MockBleDevice({ discriminator: 7000, vendorId: 0xfff1, productId: 0x8000 });


### PR DESCRIPTION
## Problem

Addresses #924.

The Matter server crashes (FATAL, exit code 1) during BLE commissioning with:

```
BleError: BTP handshake response not received from <mac>
    at StandardTimer.callback (ProxyBleChannel.ts:165)
```

This is **ProxyBLE-specific**, not a matter.js issue. It surfaces when two devices are commissioned concurrently (e.g. retrying an IKEA device several times), so the BLE proxy stalls one connection's `WriteAndSubscribe` command.

## Root cause

Unhandled promise rejection race in `ProxyBleChannel.openChannel`:

1. `handshakePromise` is created; the 15s BTP handshake timer holds its rejecter.
2. `openChannel` awaits `sendCommand(WriteAndSubscribe)`, whose proxy-command timeout is **60s** — longer than the 15s handshake timeout.
3. If the write stalls past 15s, the handshake timer rejects `handshakePromise` **before** execution reaches `await handshakePromise`, so no handler is attached.
4. Node raises `unhandledRejection` → matter.js's global handler rethrows → process exits.

matter.js's built-in noble channel has the same code shape but never triggers it: local `writeAsync`/`subscribeAsync` resolve in milliseconds and never outlive the 15s timer. The proxy's WebSocket round-trip to a busy remote host does.

## Fix

Await the write and the handshake together via `Promise.all`, which attaches a rejection handler to `handshakePromise` synchronously. A timeout that fires while the write is still pending now surfaces as a normal `openChannel` rejection instead of an unhandled rejection. Bonus: `openChannel` now fails fast at the 15s handshake timeout rather than hanging to the 60s command timeout.

## Test

Added a regression test that reproduces the exact race (write ack never returns, no handshake frame) — it hangs/crashes against the pre-fix code and passes now. Full `@matter-server/ble-proxy` suite: 35/35 green. format / lint / build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)