### PR TITLE
fix(converters): also expose CHIP SDK/python-matter-server ID casing in name-based invoke responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
+- Fix: (lboue) Name-based command responses (e.g. `VideoStreamAllocate`, `ProvideOffer`) now also expose the CHIP SDK/python-matter-server "ID" casing (e.g. `videoStreamID`) alongside matter.js's own casing (`videoStreamId`), so clients following either convention can read the response
 - Fix: Fixes the DST determination
 
 ## 1.3.1 (2026-07-23)

--- a/packages/matter-server/test/converter/ConvertersTest.ts
+++ b/packages/matter-server/test/converter/ConvertersTest.ts
@@ -969,6 +969,91 @@ describe("Converters", () => {
             expect(result).to.be.null;
         });
 
+        it("should also expose the CHIP SDK/python-matter-server ID casing for VideoStreamAllocateResponse (issue #927)", () => {
+            // CameraAvStreamManagement (1361), VideoStreamAllocateResponse has a single field whose
+            // matter.js property name is "videoStreamId" (lowercase d) but whose CHIP SDK / python-
+            // matter-server wire name is "videoStreamID" (capital ID). Rather than guess/rename,
+            // both keys are exposed for backward compatibility until the WS protocol is
+            // redocumented and officially switches to matter.js's own camelCase.
+            const cameraCluster = ClusterMap[1361]!;
+            const videoStreamAllocateCmd = cameraCluster.commands["videostreamallocate"]!;
+
+            const matterValue = { videoStreamId: 7 };
+            const result = convertMatterToWebSocketNameBased(
+                matterValue,
+                videoStreamAllocateCmd.responseModel,
+                cameraCluster.model,
+            ) as Record<string, unknown>;
+
+            expect(result).to.deep.equal({ videoStreamId: 7, videoStreamID: 7 });
+        });
+
+        it("should also expose the CHIP SDK/python-matter-server ID casing for AudioStreamAllocateResponse (issue #927)", () => {
+            const cameraCluster = ClusterMap[1361]!;
+            const audioStreamAllocateCmd = cameraCluster.commands["audiostreamallocate"]!;
+
+            const matterValue = { audioStreamId: 3 };
+            const result = convertMatterToWebSocketNameBased(
+                matterValue,
+                audioStreamAllocateCmd.responseModel,
+                cameraCluster.model,
+            ) as Record<string, unknown>;
+
+            expect(result).to.deep.equal({ audioStreamId: 3, audioStreamID: 3 });
+        });
+
+        it("should also expose the CHIP SDK/python-matter-server ID casing for ProvideOfferResponse (issue #927)", () => {
+            // WebRtcTransportProvider (1363), ProvideOfferResponse.
+            const webRtcProviderCluster = ClusterMap[1363]!;
+            const provideOfferCmd = webRtcProviderCluster.commands["provideoffer"]!;
+
+            const matterValue = { webRtcSessionId: 5, videoStreamId: 7, audioStreamId: 3 };
+            const result = convertMatterToWebSocketNameBased(
+                matterValue,
+                provideOfferCmd.responseModel,
+                webRtcProviderCluster.model,
+            ) as Record<string, unknown>;
+
+            expect(result).to.deep.equal({
+                webRtcSessionId: 5,
+                webRtcSessionID: 5,
+                videoStreamId: 7,
+                videoStreamID: 7,
+                audioStreamId: 3,
+                audioStreamID: 3,
+            });
+        });
+
+        it("should not add a duplicate key for field names that don't end in a lowercase Id suffix (issue #927)", () => {
+            // OperationalCredentials (62), NOCResponse: statusCode/fabricIndex don't end in "Id",
+            // so they must be left exactly as matter.js names them, with no duplicate key added.
+            const opCredCluster = ClusterMap[62]!;
+            const updateFabricLabelCmd = opCredCluster.commands["updatefabriclabel"]!;
+
+            const matterValue = { statusCode: 0, fabricIndex: 5 };
+            const result = convertMatterToWebSocketNameBased(
+                matterValue,
+                updateFabricLabelCmd.responseModel,
+                opCredCluster.model,
+            ) as Record<string, unknown>;
+
+            expect(result).to.deep.equal({ statusCode: 0, fabricIndex: 5 });
+        });
+
+        it("should leave tag-based (numeric key) conversion unaffected by the ID-casing fix (issue #927)", () => {
+            const cameraCluster = ClusterMap[1361]!;
+            const videoStreamAllocateCmd = cameraCluster.commands["videostreamallocate"]!;
+
+            const matterValue = { videoStreamId: 7 };
+            const result = convertMatterToWebSocketTagBased(
+                matterValue,
+                videoStreamAllocateCmd.responseModel,
+                cameraCluster.model,
+            ) as Record<string, unknown>;
+
+            expect(result).to.deep.equal({ 0: 7 });
+        });
+
         it("should convert nested structs with names", () => {
             // Descriptor cluster, DeviceTypeStruct
             const descriptorCluster = ClusterMap[29]!;

--- a/packages/ws-controller/src/server/Converters.ts
+++ b/packages/ws-controller/src/server/Converters.ts
@@ -369,12 +369,21 @@ function convertMatterToWebSocket(
             const result: { [key: string]: any } = {};
             for (const { name, id, model: memberModel } of getStructMembers(model)) {
                 if (Object.hasOwn(value, name)) {
-                    result[tagBased ? id : name] = convertMatterToWebSocket(
-                        value[name],
-                        memberModel,
-                        clusterModel,
-                        tagBased,
-                    );
+                    const converted = convertMatterToWebSocket(value[name], memberModel, clusterModel, tagBased);
+                    if (tagBased) {
+                        result[id] = converted;
+                    } else {
+                        result[name] = converted;
+                        // Backward-compat: matter.js spells some fields with a lowercase "Id"
+                        // suffix (e.g. "videoStreamId") where the CHIP SDK / python-matter-server
+                        // convention capitalizes it ("videoStreamID"). Expose both keys for now
+                        // rather than guessing/renaming - simplest fix, and doesn't break clients
+                        // reading either casing. Clean up once the WS protocol is redocumented and
+                        // officially switches to matter.js's own camelCase (see #927).
+                        if (name.length > 2 && name.endsWith("Id")) {
+                            result[`${name.slice(0, -2)}ID`] = converted;
+                        }
+                    }
                 }
             }
             return result;


### PR DESCRIPTION
## Type of change

- [x] 🐛 **Fix** — corrects a defect or wrong behavior
- [ ] ✨ **Feature** — adds new functionality or capability

## Description

`convertMatterToWebSocketNameBased()` (`packages/ws-controller/src/server/Converters.ts`) builds each name-based command-response key from `member.propertyName` — matter.js's own field name — even though its doc comment says it exists "to match Python Matter Server behavior". matter.js hardcodes some fields with a lowercase `Id` suffix (e.g. `videoStreamId`) where the CHIP SDK / python-matter-server convention capitalizes it (`videoStreamID`), confirmed against this repo's own generated `python_client/chip/clusters/cluster_defs/*.py` typings. Clients following that convention (e.g. Home Assistant's Matter camera integration, allocating a stream via `CameraAvStreamManagement.VideoStreamAllocate` before a WebRTC offer) get a `KeyError` reading the response.

Per discussion on #927: rather than deriving/renaming the key from matter.js's own internal datatype references (the referenced type name isn't guaranteed to match the actual python-matter-server label for every field — the generated Python client typings are the real contract, not matter.js's internal model), this PR takes the simplest backward-compatible route and **exposes both keys**: the existing matter.js-cased entry is kept as-is, and a second entry with the trailing `Id` replaced by `ID` is added alongside it whenever a name-based struct field ends in `Id`. For `WebRtcSessionId` specifically this correctly yields `webRtcSessionID` (matter.js doesn't recognize "rtc" as an acronym at all, so only the trailing `Id`→`ID` flip applies — matching the Python client's `webRtcSessionID` label exactly). Tag-based (numeric-key) conversion is untouched.

**This is intentionally scoped to the reported ID-suffix case, not a general fix.** `python_client/scripts/generate-python-clusters.ts` already has a much more complete, battle-tested mechanism for this class of problem (`ACRONYMS`, `toChipName()`, `FIELD_NAME_OVERRIDES`, `K_VALUE_OVERRIDES` — covering MAC/URL/RFID/NOC/IPv4-IPv6/etc., plus dozens of one-off CHIP SDK spelling quirks) used to generate the very python_client typings this fix targets. A follow-up that extracts/shares that logic so `convertMatterToWebSocketNameBased` covers every cluster and acronym consistently (not just trailing `Id`) would be more correct long-term — this PR is the pragmatic stop-gap discussed in the issue, to be revisited "once the WS protocol is redocumented and officially switches to matter.js's own camelCase."

## Backing evidence

- Related issue: #927
- [x] This fix/change is backed by a **complete log file** — attached in #927 (`matterjs-server-casing-bug-debug.log` + repro script), reproducing the casing mismatch directly against the production `ClusterMap` → `convertMatterToWebSocketNameBased` code path for `VideoStreamAllocate`, `AudioStreamAllocate`, and `ProvideOffer`.

## Checklist

- [x] Tests added or updated to cover the change (`packages/matter-server/test/converter/ConvertersTest.ts`: dual-key assertions for `VideoStreamAllocateResponse`, `AudioStreamAllocateResponse`, `ProvideOfferResponse`; a non-`Id`-suffixed regression guard; a tag-based-conversion-unaffected guard)
- [x] `npm test` passes — `ws-controller` (241/241) and `matter-server`'s `Converters` suite (104/104) pass. The full `matter-server` suite has 2 pre-existing failures in `Integration Test › Device Discovery` (mDNS-dependent); reproduced identically against the unmodified base commit (`dc09ef9`) in a separate worktree, confirming they're environmental (no multicast in this sandbox), not caused by this change.
- [x] `npm run format-verify` and `npm run lint` pass (scoped to the changed files: `oxfmt --check` and `oxlint --type-aware` both clean)
- [x] CHANGELOG updated
