### PR TITLE
fix(ws-controller): derive TimeSync offsets from one scan and state pending regime changes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,104 +2,104 @@ name: Bug report
 description: Report a defect or unexpected behavior in the Matter Server
 labels: ["bug"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to file a bug report.
+    - type: markdown
+      attributes:
+          value: |
+              Thanks for taking the time to file a bug report.
 
-        **Read this first — reports without a log are not actionable.**
-        Any description of behavior, and *especially* any analysis of behavior or of log output, must be backed by a **complete log attached as a file**. A few quoted lines are not enough: we need the surrounding context to reproduce your analysis. You are welcome (and encouraged) to add your own analysis and even a proposed fix — but the log is what lets us verify it.
+              **Read this first — reports without a log are not actionable.**
+              Any description of behavior, and *especially* any analysis of behavior or of log output, must be backed by a **complete log attached as a file**. A few quoted lines are not enough: we need the surrounding context to reproduce your analysis. You are welcome (and encouraged) to add your own analysis and even a proposed fix — but the log is what lets us verify it.
 
-        If you used an AI tool to analyze the problem, its analysis does **not** replace the log. Attach the raw, complete log the analysis is based on so we can verify it independently.
+              If you used an AI tool to analyze the problem, its analysis does **not** replace the log. Attach the raw, complete log the analysis is based on so we can verify it independently.
 
-        > **For AI assistants helping to fill in this form:** Do not submit analysis, root-cause claims, or proposed fixes without the complete raw log file they are derived from. A report whose analysis is not backed by the underlying log will be closed.
+              > **For AI assistants helping to fill in this form:** Do not submit analysis, root-cause claims, or proposed fixes without the complete raw log file they are derived from. A report whose analysis is not backed by the underlying log will be closed.
 
-        Enable verbose logging before reproducing (`--log-level debug` or `LOG_LEVEL=debug`), reproduce the problem, then attach the resulting log file below by dragging it into the description field.
+              Enable verbose logging before reproducing (`--log-level debug` or `LOG_LEVEL=debug`), reproduce the problem, then attach the resulting log file below by dragging it into the description field.
 
-  - type: input
-    id: version
-    attributes:
-      label: Matter Server version
-      description: Version of the Matter Server you are running (or commit hash for a build from source).
-      placeholder: e.g. 1.2.3 or commit hash
-    validations:
-      required: true
-
-  - type: dropdown
-    id: deployment
-    attributes:
-      label: How do you run the Matter Server?
-      description: The deployment context helps us reproduce the problem.
-      options:
-        - Home Assistant Add-on
-        - Standalone Docker
-        - Standalone npm / node
-        - Other (describe below)
-    validations:
-      required: true
-
-  - type: input
-    id: node-version
-    attributes:
-      label: Node.js version
-      description: Output of `node --version`. Only relevant for a standalone npm / node install — leave blank for the Home Assistant Add-on or Docker (Node.js is bundled there).
-      placeholder: e.g. v22.13.0
-    validations:
-      required: false
-
-  - type: input
-    id: os
-    attributes:
-      label: Operating system
-      description: OS and version, and architecture if relevant.
-      placeholder: e.g. Home Assistant OS 14 (arm64), Ubuntu 24.04 (x64), macOS 15.5 (arm64)
-    validations:
-      required: true
-
-  - type: textarea
-    id: details
-    attributes:
-      label: Description
-      description: |
-        Describe what you did, what you expected, and what happened instead. Include steps to reproduce.
-        Optional but welcome: your own analysis of the behavior/log and a proposed fix.
-        **Attach the full log as a file** (drag & drop into this field). Do not paste only a few lines — the log must be long enough to carry the context around the problem.
-      placeholder: |
-        What I did:
-        What I expected:
-        What happened:
-
-        (Analysis / proposed fix, if any)
-
-        (Full log attached above as a file)
-    validations:
-      required: true
-
-  - type: textarea
-    id: device-info
-    attributes:
-      label: Device information
-      description: |
-        If this issue involves a specific Matter device, please provide:
-        - Device manufacturer and model
-        - Matter device type
-        - Vendor ID / Product ID (if known)
-      placeholder: |
-        Manufacturer: Philips Hue
-        Model: Smart Bulb
-        Device Type: On/Off Light
-        Vendor ID: 0x130A
-    validations:
-      required: false
-
-  - type: checkboxes
-    id: requirements
-    attributes:
-      label: Confirmation
-      options:
-        - label: I attached a **complete log file** (not just a few quoted lines) covering the context around the problem.
+    - type: input
+      id: version
+      attributes:
+          label: Matter Server version
+          description: Version of the Matter Server you are running (or commit hash for a build from source).
+          placeholder: e.g. 1.2.3 or commit hash
+      validations:
           required: true
-        - label: Any analysis of behavior or log output in my description — whether written by me or by an AI tool — is backed by that attached log.
+
+    - type: dropdown
+      id: deployment
+      attributes:
+          label: How do you run the Matter Server?
+          description: The deployment context helps us reproduce the problem.
+          options:
+              - Home Assistant Add-on
+              - Standalone Docker
+              - Standalone npm / node
+              - Other (describe below)
+      validations:
           required: true
-        - label: I searched existing issues and this is not a duplicate.
+
+    - type: input
+      id: node-version
+      attributes:
+          label: Node.js version
+          description: Output of `node --version`. Only relevant for a standalone npm / node install — leave blank for the Home Assistant Add-on or Docker (Node.js is bundled there).
+          placeholder: e.g. v22.13.0
+      validations:
+          required: false
+
+    - type: input
+      id: os
+      attributes:
+          label: Operating system
+          description: OS and version, and architecture if relevant.
+          placeholder: e.g. Home Assistant OS 14 (arm64), Ubuntu 24.04 (x64), macOS 15.5 (arm64)
+      validations:
           required: true
+
+    - type: textarea
+      id: details
+      attributes:
+          label: Description
+          description: |
+              Describe what you did, what you expected, and what happened instead. Include steps to reproduce.
+              Optional but welcome: your own analysis of the behavior/log and a proposed fix.
+              **Attach the full log as a file** (drag & drop into this field). Do not paste only a few lines — the log must be long enough to carry the context around the problem (minimum 2-3 minutes before and after). Do not limit the log to what you think is enough. All details are relevant!
+          placeholder: |
+              What I did:
+              What I expected:
+              What happened:
+
+              (Analysis / proposed fix, if any)
+
+              (Full log attached above as a file)
+      validations:
+          required: true
+
+    - type: textarea
+      id: device-info
+      attributes:
+          label: Device information
+          description: |
+              If this issue involves a specific Matter device, please provide:
+              - Device manufacturer and model
+              - Matter device type
+              - Vendor ID / Product ID (if known)
+          placeholder: |
+              Manufacturer: Philips Hue
+              Model: Smart Bulb
+              Device Type: On/Off Light
+              Vendor ID: 0x130A
+      validations:
+          required: false
+
+    - type: checkboxes
+      id: requirements
+      attributes:
+          label: Confirmation
+          options:
+              - label: I attached a **complete log file** (not just a few quoted lines) covering the context around the problem.
+                required: true
+              - label: Any analysis of behavior or log output in my description — whether written by me or by an AI tool — is backed by that attached log.
+                required: true
+              - label: I searched existing issues and this is not a duplicate.
+                required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This page shows a detailed overview of the changes between versions without the 
 ## **WORK IN PROGRESS**
 
 - Fix: Fixes and enhances the DST determination, and sends a second TimeZone entry when the host zone has an upcoming permanent offset change, plus a closing DST entry when the device has room for one
-- Fix: A node reporting that it has no usable time is now resynced within the hour instead of being held off for up to a day, while reconnect-driven syncs keep their longer spacing
+- Fix: A node reporting that it has no usable time is now resynced right away instead of being held off for up to a day (#938), while reconnect-driven syncs keep their longer spacing
 - Fix: Command responses and events now expose acronym field names in the Python Matter Server casing (e.g. `videoStreamID`, `groupID`, `PAKEPasscodeVerifier`), matching the generated Python client and Home Assistant; the previous lowercased-acronym keys are still emitted alongside for compatibility
 
 ## 1.3.1 (2026-07-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
-- Fix: Fixes and Enhances the DST determination and also send up to two DST entries to the device
+- Fix: Fixes and enhances the DST determination, and sends a second TimeZone entry when the host zone has an upcoming permanent offset change, plus a closing DST entry when the device has room for one
 - Fix: A node reporting that it has no usable time is now resynced within the hour instead of being held off for up to a day, while reconnect-driven syncs keep their longer spacing
 - Fix: Command responses and events now expose acronym field names in the Python Matter Server casing (e.g. `videoStreamID`, `groupID`, `PAKEPasscodeVerifier`), matching the generated Python client and Home Assistant; the previous lowercased-acronym keys are still emitted alongside for compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
-- Fix: Fixes the DST determination
+- Fix: Fixes and Enhances the DST determination and also send up to two DST entries to the device
 - Fix: Command responses and events now expose acronym field names in the Python Matter Server casing (e.g. `videoStreamID`, `groupID`, `PAKEPasscodeVerifier`), matching the generated Python client and Home Assistant; the previous lowercased-acronym keys are still emitted alongside for compatibility
 
 ## 1.3.1 (2026-07-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This page shows a detailed overview of the changes between versions without the 
 ## **WORK IN PROGRESS**
 
 - Fix: Fixes and Enhances the DST determination and also send up to two DST entries to the device
+- Fix: A node reporting that it has no usable time is now resynced within the hour instead of being held off for up to a day, while reconnect-driven syncs keep their longer spacing
 - Fix: Command responses and events now expose acronym field names in the Python Matter Server casing (e.g. `videoStreamID`, `groupID`, `PAKEPasscodeVerifier`), matching the generated Python client and Home Assistant; the previous lowercased-acronym keys are still emitted alongside for compatibility
 
 ## 1.3.1 (2026-07-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This page shows a detailed overview of the changes between versions without the 
 ## **WORK IN PROGRESS**
 
 - Fix: Fixes and enhances the DST determination, and sends a second TimeZone entry when the host zone has an upcoming permanent offset change, plus a closing DST entry when the device has room for one
-- Fix: A node reporting that it has no usable time is now resynced right away instead of being held off for up to a day (#938), while reconnect-driven syncs keep their longer spacing
+- Fix: A node reporting that it has no usable time is now resynced right away instead of being held off for up to a day, while reconnect-driven syncs keep their longer spacing
 - Fix: Command responses and events now expose acronym field names in the Python Matter Server casing (e.g. `videoStreamID`, `groupID`, `PAKEPasscodeVerifier`), matching the generated Python client and Home Assistant; the previous lowercased-acronym keys are still emitted alongside for compatibility
 
 ## 1.3.1 (2026-07-23)

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -583,7 +583,7 @@ export class ControllerCommandHandler {
                 data.path.clusterId === TIME_SYNC_CLUSTER_ID &&
                 data.path.eventId === TIME_FAILURE_EVENT_ID
             ) {
-                logger.debug(`Received timeFailure event from node ${this.formatNode(nodeId)}, triggering time sync`);
+                logger.debug(`Received timeFailure event from node ${this.formatNode(nodeId)}`);
                 this.#timeSyncManager.syncNode(this.#peerOf(nodeId), SyncTrigger.TimeFailure);
             }
         });

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -106,7 +106,7 @@ import { pingIp } from "../util/network.js";
 import { CustomClusterPoller } from "./CustomClusterPoller.js";
 import { Nodes } from "./Nodes.js";
 import { pushNodeTime, TimeSyncInvokers } from "./timeSyncCommands.js";
-import { TIME_FAILURE_EVENT_ID, TIME_SYNC_CLUSTER_ID, TimeSyncManager } from "./TimeSyncManager.js";
+import { SyncTrigger, TIME_FAILURE_EVENT_ID, TIME_SYNC_CLUSTER_ID, TimeSyncManager } from "./TimeSyncManager.js";
 import { attachWebRtcCallbackBridge } from "./WebRtcCallbackBridge.js";
 import {
     isTrackableWebRtcSession,
@@ -584,7 +584,7 @@ export class ControllerCommandHandler {
                 data.path.eventId === TIME_FAILURE_EVENT_ID
             ) {
                 logger.debug(`Received timeFailure event from node ${this.formatNode(nodeId)}, triggering time sync`);
-                this.#timeSyncManager.syncNode(this.#peerOf(nodeId));
+                this.#timeSyncManager.syncNode(this.#peerOf(nodeId), SyncTrigger.TimeFailure);
             }
         });
         nodeObservers.on(node.events.stateChanged, state => {

--- a/packages/ws-controller/src/controller/ControllerCommandHandler.ts
+++ b/packages/ws-controller/src/controller/ControllerCommandHandler.ts
@@ -224,6 +224,7 @@ export class ControllerCommandHandler {
             this.#timeSyncManager = new TimeSyncManager({
                 syncTime: peer => this.#syncNodeTime(peer.nodeId),
                 nodeConnected: peer => !!(this.#nodes.has(peer.nodeId) && this.#nodes.get(peer.nodeId).isConnected),
+                commissionedNodeCount: () => this.#controller.getCommissionedNodes().length,
             });
         }
     }

--- a/packages/ws-controller/src/controller/CustomClusterPoller.ts
+++ b/packages/ws-controller/src/controller/CustomClusterPoller.ts
@@ -123,7 +123,8 @@ export class CustomClusterPoller extends NodeProcessor {
     readonly #attributeReader: NodeAttributeReader;
 
     constructor(attributeReader: NodeAttributeReader) {
-        super("eve-poller", INITIAL_DELAY_MS + Math.random() * INITIAL_DELAY_MS, POLLING_INTERVAL_MS);
+        // Whole milliseconds: a fractional timer deadline is meaningless and MockTime rejects it.
+        super("eve-poller", INITIAL_DELAY_MS + Math.floor(Math.random() * INITIAL_DELAY_MS), POLLING_INTERVAL_MS);
         this.#attributeReader = attributeReader;
     }
 

--- a/packages/ws-controller/src/controller/CustomClusterPoller.ts
+++ b/packages/ws-controller/src/controller/CustomClusterPoller.ts
@@ -121,7 +121,6 @@ export function checkPolledAttributes(attributes: AttributesData): Set<Attribute
 export class CustomClusterPoller extends NodeProcessor {
     #polledAttributes = new PeerAddressMap<Set<AttributePath>>();
     readonly #attributeReader: NodeAttributeReader;
-    #currentReadPromise?: Promise<void>;
 
     constructor(attributeReader: NodeAttributeReader) {
         super("eve-poller", INITIAL_DELAY_MS + Math.random() * INITIAL_DELAY_MS, POLLING_INTERVAL_MS);
@@ -161,10 +160,8 @@ export class CustomClusterPoller extends NodeProcessor {
     }
 
     override async stop(): Promise<void> {
+        // super.stop() awaits the processing cycle, so any in-flight read has already settled.
         await super.stop();
-        if (this.#currentReadPromise) {
-            await this.#currentReadPromise;
-        }
         this.#polledAttributes.clear();
         logger.info("Custom attribute poller stopped");
     }
@@ -183,19 +180,12 @@ export class CustomClusterPoller extends NodeProcessor {
         try {
             // Read with fabricFiltered=true as per Eve's requirements
             // This automatically updates the attribute cache and triggers change events
-            const readPromise = this.#attributeReader.handleReadAttributes(peer, paths, true);
-            this.#currentReadPromise = readPromise.then(
-                () => {},
-                () => {},
-            );
-            await readPromise;
+            await this.#attributeReader.handleReadAttributes(peer, paths, true);
         } catch (error) {
             logger.warn(
                 `Failed to poll custom attributes for node ${formatNodeId(peer)}: `,
                 Diagnostic.errorMessage(asError(error)),
             );
-        } finally {
-            this.#currentReadPromise = undefined;
         }
     }
 

--- a/packages/ws-controller/src/controller/NodeProcessor.ts
+++ b/packages/ws-controller/src/controller/NodeProcessor.ts
@@ -10,7 +10,7 @@ import { PeerAddress, PeerAddressSet } from "@matter/main/protocol";
 const logger = Logger.get("NodeProcessor");
 
 // Timer.interval rejects anything outside the 32-bit signed range.
-const MAX_TIMER_DELAY_MS = 2_147_483_647;
+export const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 /**
  * Abstract base class for timer-driven periodic processing of registered nodes.
@@ -78,6 +78,11 @@ export abstract class NodeProcessor {
      */
     protected setNextCycleDelay(delayMs: number): boolean {
         if (this.#timer.isRunning || this.#isProcessing || this.#closed) return false;
+        return this.#applyInterval(delayMs);
+    }
+
+    /** Both assignment paths go through here, since nextCycleDelay() is open to any subclass. */
+    #applyInterval(delayMs: number): boolean {
         if (!Number.isFinite(delayMs) || delayMs < 0) {
             // A NaN passes Timer.interval's range check and then fires immediately, every cycle.
             logger.warn(`Ignoring invalid cycle delay ${delayMs}`);
@@ -113,7 +118,7 @@ export abstract class NodeProcessor {
 
         const nextInterval = this.nextCycleDelay();
         if (this.#timer.interval !== nextInterval) {
-            this.#timer.interval = nextInterval;
+            this.#applyInterval(nextInterval);
         }
 
         this.#isProcessing = true;

--- a/packages/ws-controller/src/controller/NodeProcessor.ts
+++ b/packages/ws-controller/src/controller/NodeProcessor.ts
@@ -116,10 +116,16 @@ export abstract class NodeProcessor {
     async #processAll(): Promise<void> {
         if (this.#isProcessing) return;
 
-        const nextInterval = this.nextCycleDelay();
-        if (this.#timer.interval !== nextInterval) {
-            this.#applyInterval(nextInterval);
+        // A throw here would skip the finally below, leaving the timer stopped and this processor
+        // dead until a peer re-registers. The cadence is never worth that.
+        let nextInterval: Duration;
+        try {
+            nextInterval = this.nextCycleDelay();
+        } catch (error) {
+            logger.warn("Falling back to the target interval, computing the next cycle delay failed:", error);
+            nextInterval = this.#targetInterval;
         }
+        this.#applyInterval(nextInterval);
 
         this.#isProcessing = true;
         let processedCount = 0;

--- a/packages/ws-controller/src/controller/NodeProcessor.ts
+++ b/packages/ws-controller/src/controller/NodeProcessor.ts
@@ -117,7 +117,10 @@ export abstract class NodeProcessor {
      */
     protected onCycleStart(): void {}
 
-    /** Called after a full processing cycle completes. Override for cycle-complete logging. */
+    /**
+     * Called after a full processing cycle completes. `intervalFormatted` is empty when no next cycle
+     * was scheduled, i.e. every peer unregistered during this one.
+     */
     protected onCycleComplete(_processedCount: number, _intervalFormatted: string): void {}
 
     /** Delay before the cycle that follows this one. Override to vary the cadence. */
@@ -164,7 +167,9 @@ export abstract class NodeProcessor {
         }
 
         if (!this.#closed) {
-            this.onCycleComplete(processedCount, Duration.format(this.#timer.interval));
+            // scheduleIfNeeded() declines to arm the timer with no peers left, so naming an interval
+            // then would point at a timer that is not running.
+            this.onCycleComplete(processedCount, this.#timer.isRunning ? Duration.format(this.#timer.interval) : "");
         }
     }
 }

--- a/packages/ws-controller/src/controller/NodeProcessor.ts
+++ b/packages/ws-controller/src/controller/NodeProcessor.ts
@@ -9,6 +9,9 @@ import { PeerAddress, PeerAddressSet } from "@matter/main/protocol";
 
 const logger = Logger.get("NodeProcessor");
 
+// Timer.interval rejects anything outside the 32-bit signed range.
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
 /**
  * Abstract base class for timer-driven periodic processing of registered nodes.
  * Handles timer lifecycle, node registration, and the per-node processing loop
@@ -69,6 +72,21 @@ export abstract class NodeProcessor {
         this.#timer.start();
     }
 
+    /**
+     * Override the delay before the next cycle. Only takes effect while no cycle is scheduled or
+     * running, so callers must apply it before scheduleIfNeeded() starts the timer.
+     */
+    protected setNextCycleDelay(delayMs: number): boolean {
+        if (this.#timer.isRunning || this.#isProcessing || this.#closed) return false;
+        if (!Number.isFinite(delayMs) || delayMs < 0) {
+            // A NaN passes Timer.interval's range check and then fires immediately, every cycle.
+            logger.warn(`Ignoring invalid cycle delay ${delayMs}`);
+            return false;
+        }
+        this.#timer.interval = Millis(Math.min(delayMs, MAX_TIMER_DELAY_MS));
+        return true;
+    }
+
     async stop(): Promise<void> {
         this.#closed = true;
         this.#currentDelayPromise?.cancel(new Error("Close"));
@@ -85,11 +103,17 @@ export abstract class NodeProcessor {
     /** Called after a full processing cycle completes. Override for cycle-complete logging. */
     protected onCycleComplete(_processedCount: number, _intervalFormatted: string): void {}
 
+    /** Delay before the cycle that follows this one. Override to vary the cadence. */
+    protected nextCycleDelay(): Duration {
+        return this.#targetInterval;
+    }
+
     async #processAll(): Promise<void> {
         if (this.#isProcessing) return;
 
-        if (this.#timer.interval !== this.#targetInterval) {
-            this.#timer.interval = this.#targetInterval;
+        const nextInterval = this.nextCycleDelay();
+        if (this.#timer.interval !== nextInterval) {
+            this.#timer.interval = nextInterval;
         }
 
         this.#isProcessing = true;

--- a/packages/ws-controller/src/controller/NodeProcessor.ts
+++ b/packages/ws-controller/src/controller/NodeProcessor.ts
@@ -110,6 +110,13 @@ export abstract class NodeProcessor {
     /** Perform work for a single peer. Must handle its own errors. */
     protected abstract processNode(peer: PeerAddress): Promise<void>;
 
+    /**
+     * Called once a cycle is committed to running, before the peer list is snapshotted. A peer
+     * registering after this point is not in the snapshot, so anything a subclass gates on "the first
+     * cycle has run" must open here rather than in onCycleComplete, or that peer falls between the two.
+     */
+    protected onCycleStart(): void {}
+
     /** Called after a full processing cycle completes. Override for cycle-complete logging. */
     protected onCycleComplete(_processedCount: number, _intervalFormatted: string): void {}
 
@@ -136,6 +143,7 @@ export abstract class NodeProcessor {
         let processedCount = 0;
 
         try {
+            this.onCycleStart();
             const peers = Array.from(this.#peers);
             for (let i = 0; i < peers.length; i++) {
                 if (this.#closed) break;

--- a/packages/ws-controller/src/controller/NodeProcessor.ts
+++ b/packages/ws-controller/src/controller/NodeProcessor.ts
@@ -77,8 +77,13 @@ export abstract class NodeProcessor {
      * running, so callers must apply it before scheduleIfNeeded() starts the timer.
      */
     protected setNextCycleDelay(delayMs: number): boolean {
-        if (this.#timer.isRunning || this.#isProcessing || this.#closed) return false;
+        if (!this.cycleDelayAdjustable) return false;
         return this.#applyInterval(delayMs);
+    }
+
+    /** Whether setNextCycleDelay() can still take effect, so callers can skip computing a delay. */
+    protected get cycleDelayAdjustable(): boolean {
+        return !this.#timer.isRunning && !this.#isProcessing && !this.#closed;
     }
 
     /** Both assignment paths go through here, since nextCycleDelay() is open to any subclass. */

--- a/packages/ws-controller/src/controller/TimeSyncManager.ts
+++ b/packages/ws-controller/src/controller/TimeSyncManager.ts
@@ -181,9 +181,9 @@ export class TimeSyncManager extends NodeProcessor {
         // the first periodic resync handles all nodes once initialization is done.
         if (this.#startupComplete) {
             this.syncNode(peer);
-        } else {
-            // The commissioned count is known in full by the first registration, so this lands once
-            // and later registrations are no-ops against the already-running timer.
+        } else if (this.cycleDelayAdjustable) {
+            // The commissioned count is known in full by the first registration, so this lands once;
+            // later registrations meet an already-running timer and skip the count entirely.
             let nodeCount = 0;
             try {
                 nodeCount = this.#connector.commissionedNodeCount();

--- a/packages/ws-controller/src/controller/TimeSyncManager.ts
+++ b/packages/ws-controller/src/controller/TimeSyncManager.ts
@@ -61,6 +61,11 @@ const RECONNECT_SYNC_COOLDOWN = Hours(24);
 // giving up, so anything longer refuses the node and nothing asks again until the periodic pass.
 const TIME_FAILURE_SYNC_COOLDOWN = Minutes(1);
 
+// The periodic cycle and the trigger paths are otherwise blind to each other, so a peer registering
+// during the cycle's inter-node delay is pushed twice seconds apart. Long enough to cover that delay,
+// far short of any cooldown, so it can never defer a cycle.
+const RECENT_SYNC_GUARD = Minutes(1);
+
 /** Why a sync was triggered outside the periodic cycle. Decides how long the peer is then held off. */
 export enum SyncTrigger {
     /** The node reconnected; its time may well still be correct. */
@@ -155,6 +160,8 @@ export class TimeSyncManager extends NodeProcessor {
     // a timeFailure is entitled to, least of all when that attempt failed.
     #lastReconnectSyncMs = new PeerAddressMap<number>();
     #lastTimeFailureSyncMs = new PeerAddressMap<number>();
+    // Last push attempt by any path, so the periodic cycle and a trigger cannot double up on a peer.
+    #lastSyncMs = new PeerAddressMap<number>();
     // Successful syncs in the running cycle; the base class counts attempts.
     #cycleSyncedCount = 0;
     // True after the first periodic resync cycle, enabling immediate syncs on reconnect
@@ -211,6 +218,7 @@ export class TimeSyncManager extends NodeProcessor {
     unregisterNode(peer: PeerAddress): void {
         this.#lastReconnectSyncMs.delete(peer);
         this.#lastTimeFailureSyncMs.delete(peer);
+        this.#lastSyncMs.delete(peer);
         if (this.unregisterPeer(peer)) {
             logger.info(`Unregistered node ${formatNodeId(peer)} from time synchronization`);
         }
@@ -231,6 +239,12 @@ export class TimeSyncManager extends NodeProcessor {
             logger.debug(`Time sync already in progress for node ${formatNodeId(peer)}, skipping`);
             return;
         }
+        // Never on the timeFailure path: the node is reporting it has no usable time, so a push we
+        // just made is evidence it did not take, not a reason to refuse. Only its own cooldown applies.
+        if (trigger !== SyncTrigger.TimeFailure && this.#syncedRecently(peer)) {
+            logger.debug(`Time sync for node ${formatNodeId(peer)} skipped, pushed moments ago`);
+            return;
+        }
         const { cooldown, stamps } =
             trigger === SyncTrigger.TimeFailure
                 ? { cooldown: TIME_FAILURE_SYNC_COOLDOWN, stamps: this.#lastTimeFailureSyncMs }
@@ -243,6 +257,7 @@ export class TimeSyncManager extends NodeProcessor {
             return;
         }
         stamps.set(peer, Time.nowMs);
+        this.#lastSyncMs.set(peer, Time.nowMs);
         const promise = this.#connector
             .syncTime(peer)
             .then(() => logger.info(`Synced time on node ${formatNodeId(peer)}`))
@@ -264,11 +279,17 @@ export class TimeSyncManager extends NodeProcessor {
         this.#inFlightSyncs.clear();
         this.#lastReconnectSyncMs.clear();
         this.#lastTimeFailureSyncMs.clear();
+        this.#lastSyncMs.clear();
         logger.info("Time sync manager stopped");
     }
 
     protected override shouldProcess(peer: PeerAddress): boolean {
-        return this.#connector.nodeConnected(peer) && !this.#inFlightSyncs.has(peer);
+        return this.#connector.nodeConnected(peer) && !this.#inFlightSyncs.has(peer) && !this.#syncedRecently(peer);
+    }
+
+    #syncedRecently(peer: PeerAddress): boolean {
+        const last = this.#lastSyncMs.get(peer);
+        return last !== undefined && Time.nowMs - last < RECENT_SYNC_GUARD;
     }
 
     /**
@@ -290,6 +311,7 @@ export class TimeSyncManager extends NodeProcessor {
     }
 
     protected override async processNode(peer: PeerAddress): Promise<void> {
+        this.#lastSyncMs.set(peer, Time.nowMs);
         // Register in #inFlightSyncs so a concurrent trigger sync (syncNode) for the same
         // peer dedupes against the periodic push instead of double-sending.
         const promise = this.#connector
@@ -316,11 +338,13 @@ export class TimeSyncManager extends NodeProcessor {
         }
     }
 
-    protected override onCycleComplete(processedCount: number, _intervalFormatted: string): void {
+    protected override onCycleComplete(processedCount: number, intervalFormatted: string): void {
         if (processedCount > 0) {
+            // The interval comes from the timer, not RESYNC_INTERVAL: a cycle brought forward for an
+            // offset change is armed for hours, and naming a day here would contradict it.
             logger.info(
                 `Periodic resync complete: synced ${this.#cycleSyncedCount} of ${processedCount} nodes. ` +
-                    `Next resync in ${Duration.format(RESYNC_INTERVAL)}`,
+                    `Next resync in ${intervalFormatted}`,
             );
         }
     }

--- a/packages/ws-controller/src/controller/TimeSyncManager.ts
+++ b/packages/ws-controller/src/controller/TimeSyncManager.ts
@@ -55,10 +55,11 @@ const MIN_ACCELERATED_DELAY = Minutes(1);
 // whether the node's time is still good, so a flapping node must not storm setUtcTime.
 const RECONNECT_SYNC_COOLDOWN = Hours(24);
 
-// A timeFailure event is the node reporting it has no usable time, so it is answered on a much
-// shorter leash than a reconnect. The spec rate-limits the node to one such event per hour
-// (§11.17.10.4), which already bounds this path without a long cooldown of our own.
-const TIME_FAILURE_SYNC_COOLDOWN = Hours(1);
+// A timeFailure event is the node reporting it has no usable time, so it is answered almost
+// immediately: long enough only to absorb a burst from one loss. Do not widen this on the spec's
+// one-event-per-hour limit (§11.17.10.4) — devices are observed emitting four in 49 s and then
+// giving up, so anything longer refuses the node and nothing asks again until the periodic pass.
+const TIME_FAILURE_SYNC_COOLDOWN = Minutes(1);
 
 /** Why a sync was triggered outside the periodic cycle. Decides how long the peer is then held off. */
 export enum SyncTrigger {

--- a/packages/ws-controller/src/controller/TimeSyncManager.ts
+++ b/packages/ws-controller/src/controller/TimeSyncManager.ts
@@ -342,9 +342,9 @@ export class TimeSyncManager extends NodeProcessor {
         if (processedCount > 0) {
             // The interval comes from the timer, not RESYNC_INTERVAL: a cycle brought forward for an
             // offset change is armed for hours, and naming a day here would contradict it.
+            const next = intervalFormatted === "" ? "" : ` Next resync in ${intervalFormatted}.`;
             logger.info(
-                `Periodic resync complete: synced ${this.#cycleSyncedCount} of ${processedCount} nodes. ` +
-                    `Next resync in ${intervalFormatted}`,
+                `Periodic resync complete: synced ${this.#cycleSyncedCount} of ${processedCount} nodes.${next}`,
             );
         }
     }

--- a/packages/ws-controller/src/controller/TimeSyncManager.ts
+++ b/packages/ws-controller/src/controller/TimeSyncManager.ts
@@ -9,11 +9,14 @@
  * Syncs time on three triggers:
  * 1. Node connects/reconnects after startup (immediate, once startup window has elapsed)
  * 2. Periodic resync every 24 hours, brought forward when the host zone changes offset sooner
- * 3. Reactive resync when a node emits a timeFailure event (driven externally via syncNode())
+ * 3. Reactive resync when a node emits a timeFailure event (driven externally via syncNode()),
+ *    held off far more briefly than a reconnect because the node is asking to be given a time
  *
  * A startup window scaled to the number of commissioned nodes prevents syncing while nodes are
- * still being initialized. This manager must only be enabled when the host time source is known
- * to be reliable (see --enable-time-sync CLI flag).
+ * still being initialized, including on the reactive path: a restart can leave many nodes without
+ * a time at once, and answering each one individually is the traffic the window exists to avoid.
+ * This manager must only be enabled when the host time source is known to be reliable (see
+ * --enable-time-sync CLI flag).
  */
 
 import { Duration, Hours, Logger, Millis, Minutes, Seconds, Time } from "@matter/main";
@@ -48,10 +51,22 @@ const POST_CHANGE_MARGIN = Minutes(1);
 // catches a lookup returning an instant that has already passed, which would otherwise fire at once.
 const MIN_ACCELERATED_DELAY = Minutes(1);
 
-// Minimum spacing between trigger-driven (reconnect / timeFailure) syncs for one peer.
-// The periodic path already caps its own cadence; this stops a flapping node or a device
-// repeatedly emitting timeFailure from storming setUtcTime commands.
-const TRIGGER_SYNC_COOLDOWN = Hours(24);
+// Minimum spacing between reconnect-driven syncs for one peer. A reconnect says nothing about
+// whether the node's time is still good, so a flapping node must not storm setUtcTime.
+const RECONNECT_SYNC_COOLDOWN = Hours(24);
+
+// A timeFailure event is the node reporting it has no usable time, so it is answered on a much
+// shorter leash than a reconnect. The spec rate-limits the node to one such event per hour
+// (§11.17.10.4), which already bounds this path without a long cooldown of our own.
+const TIME_FAILURE_SYNC_COOLDOWN = Hours(1);
+
+/** Why a sync was triggered outside the periodic cycle. Decides how long the peer is then held off. */
+export enum SyncTrigger {
+    /** The node reconnected; its time may well still be correct. */
+    Reconnect = "reconnect",
+    /** The node reported it has no usable time and is asking to be given one. */
+    TimeFailure = "timeFailure",
+}
 
 export interface TimeSyncConnector {
     syncTime(peer: PeerAddress): Promise<void>;
@@ -196,16 +211,22 @@ export class TimeSyncManager extends NodeProcessor {
      * Trigger an immediate time sync for a node (fire-and-forget with deduplication).
      * Called externally when a timeFailure event is received from the node.
      */
-    syncNode(peer: PeerAddress): void {
+    syncNode(peer: PeerAddress, trigger = SyncTrigger.Reconnect): void {
         if (this.closed || !this.hasPeer(peer) || !this.#connector.nodeConnected(peer)) return;
+        if (!this.#startupComplete) {
+            // Nodes are still being initialized; the first periodic cycle covers every peer shortly.
+            logger.debug(`Time sync for node ${formatNodeId(peer)} deferred to the first periodic cycle`);
+            return;
+        }
         if (this.#inFlightSyncs.has(peer)) {
             logger.debug(`Time sync already in progress for node ${formatNodeId(peer)}, skipping`);
             return;
         }
+        const cooldown = trigger === SyncTrigger.TimeFailure ? TIME_FAILURE_SYNC_COOLDOWN : RECONNECT_SYNC_COOLDOWN;
         const lastSync = this.#lastTriggerSyncMs.get(peer);
-        if (lastSync !== undefined && Time.nowMs - lastSync < TRIGGER_SYNC_COOLDOWN) {
+        if (lastSync !== undefined && Time.nowMs - lastSync < cooldown) {
             logger.debug(
-                `Time sync for node ${formatNodeId(peer)} skipped, within ${Duration.format(TRIGGER_SYNC_COOLDOWN)} cooldown`,
+                `Time sync for node ${formatNodeId(peer)} skipped, within ${Duration.format(cooldown)} ${trigger} cooldown`,
             );
             return;
         }

--- a/packages/ws-controller/src/controller/TimeSyncManager.ts
+++ b/packages/ws-controller/src/controller/TimeSyncManager.ts
@@ -268,7 +268,15 @@ export class TimeSyncManager extends NodeProcessor {
      */
     protected override nextCycleDelay(): Duration {
         const nowMs = Time.nowMs;
-        return Millis(resyncDelayMs(nowMs, this.#offsetChangeLookup(nowMs)));
+        let nextChangeMs: number | null = null;
+        try {
+            nextChangeMs = this.#offsetChangeLookup(nowMs);
+        } catch (error) {
+            // Bringing the cycle forward is an optimization; the zone lookup rests on Intl and the
+            // host's zone name, neither of which is worth a missed resync.
+            logger.warn("Could not determine the next time zone offset change:", error);
+        }
+        return Millis(resyncDelayMs(nowMs, nextChangeMs));
     }
 
     protected override async processNode(peer: PeerAddress): Promise<void> {

--- a/packages/ws-controller/src/controller/TimeSyncManager.ts
+++ b/packages/ws-controller/src/controller/TimeSyncManager.ts
@@ -182,8 +182,8 @@ export class TimeSyncManager extends NodeProcessor {
         if (this.#startupComplete) {
             this.syncNode(peer);
         } else if (this.cycleDelayAdjustable) {
-            // The commissioned count is known in full by the first registration, so this lands once;
-            // later registrations meet an already-running timer and skip the count entirely.
+            // initializeNodes resolves the full commissioned list before registering any of it, so
+            // the first registration already sees the final count.
             let nodeCount = 0;
             try {
                 nodeCount = this.#connector.commissionedNodeCount();

--- a/packages/ws-controller/src/controller/TimeSyncManager.ts
+++ b/packages/ws-controller/src/controller/TimeSyncManager.ts
@@ -26,7 +26,7 @@ import { StatusResponseError } from "@matter/main/types";
 import { AttributesData } from "../types/CommandHandler.js";
 import { formatNodeId } from "../util/formatNodeId.js";
 import { nextOffsetChangeMs, resolveHostTimeZone, timeZonePlan } from "../util/hostTimeZone.js";
-import { NodeProcessor } from "./NodeProcessor.js";
+import { MAX_TIMER_DELAY_MS, NodeProcessor } from "./NodeProcessor.js";
 
 const logger = Logger.get("TimeSyncManager");
 
@@ -77,18 +77,21 @@ export interface TimeSyncConnector {
 /** Instant of the host zone's next offset change, or null when none is in view. */
 export type OffsetChangeLookup = (fromMs: number) => number | null;
 
-/** Delay before the first sync, long enough for node initialization to finish. */
+/**
+ * Delay before the first sync, long enough for node initialization to finish. Capped so the value
+ * reported to the log is the one the timer can actually be given.
+ */
 export function startupDelayMs(commissionedNodeCount: number): number {
-    return STARTUP_BASE_DELAY + commissionedNodeCount * STARTUP_DELAY_PER_NODE;
+    return Math.min(STARTUP_BASE_DELAY + commissionedNodeCount * STARTUP_DELAY_PER_NODE, MAX_TIMER_DELAY_MS);
 }
 
 /**
- * Delay before the next periodic cycle: normally the full interval, brought forward to just after an
- * upcoming offset change so a node's retired DST entry is replaced promptly. A change nearer than the
- * floor is left to the following cycle rather than scheduling a near-zero delay.
+ * Delay before the next periodic cycle: normally the full interval, brought forward to a minute past
+ * an upcoming offset change so a node's retired DST entry is replaced promptly. An instant that has
+ * already passed, or one beyond the interval, leaves the cadence alone.
  */
 export function resyncDelayMs(nowMs: number, nextChangeMs: number | null): number {
-    if (nextChangeMs === null) {
+    if (nextChangeMs === null || !Number.isFinite(nextChangeMs)) {
         return RESYNC_INTERVAL;
     }
     const delay = nextChangeMs + POST_CHANGE_MARGIN - nowMs;
@@ -147,7 +150,7 @@ export class TimeSyncManager extends NodeProcessor {
     readonly #offsetChangeLookup: OffsetChangeLookup;
     // Tracks in-flight immediate syncs per node to prevent parallel syncs
     #inFlightSyncs = new PeerAddressMap<Promise<void>>();
-    // Last trigger-driven sync attempt per node, used to enforce TRIGGER_SYNC_COOLDOWN
+    // Last trigger-driven sync attempt per node, measured against the cooldown for its trigger
     #lastTriggerSyncMs = new PeerAddressMap<number>();
     // True after the first periodic resync cycle, enabling immediate syncs on reconnect
     #startupComplete = false;

--- a/packages/ws-controller/src/controller/TimeSyncManager.ts
+++ b/packages/ws-controller/src/controller/TimeSyncManager.ts
@@ -150,8 +150,12 @@ export class TimeSyncManager extends NodeProcessor {
     readonly #offsetChangeLookup: OffsetChangeLookup;
     // Tracks in-flight immediate syncs per node to prevent parallel syncs
     #inFlightSyncs = new PeerAddressMap<Promise<void>>();
-    // Last trigger-driven sync attempt per node, measured against the cooldown for its trigger
-    #lastTriggerSyncMs = new PeerAddressMap<number>();
+    // Last attempt per node, kept per trigger: a reconnect attempt must not spend the shorter leash
+    // a timeFailure is entitled to, least of all when that attempt failed.
+    #lastReconnectSyncMs = new PeerAddressMap<number>();
+    #lastTimeFailureSyncMs = new PeerAddressMap<number>();
+    // Successful syncs in the running cycle; the base class counts attempts.
+    #cycleSyncedCount = 0;
     // True after the first periodic resync cycle, enabling immediate syncs on reconnect
     #startupComplete = false;
 
@@ -204,7 +208,8 @@ export class TimeSyncManager extends NodeProcessor {
      * Unregister a node from time sync tracking.
      */
     unregisterNode(peer: PeerAddress): void {
-        this.#lastTriggerSyncMs.delete(peer);
+        this.#lastReconnectSyncMs.delete(peer);
+        this.#lastTimeFailureSyncMs.delete(peer);
         if (this.unregisterPeer(peer)) {
             logger.info(`Unregistered node ${formatNodeId(peer)} from time synchronization`);
         }
@@ -225,15 +230,18 @@ export class TimeSyncManager extends NodeProcessor {
             logger.debug(`Time sync already in progress for node ${formatNodeId(peer)}, skipping`);
             return;
         }
-        const cooldown = trigger === SyncTrigger.TimeFailure ? TIME_FAILURE_SYNC_COOLDOWN : RECONNECT_SYNC_COOLDOWN;
-        const lastSync = this.#lastTriggerSyncMs.get(peer);
+        const { cooldown, stamps } =
+            trigger === SyncTrigger.TimeFailure
+                ? { cooldown: TIME_FAILURE_SYNC_COOLDOWN, stamps: this.#lastTimeFailureSyncMs }
+                : { cooldown: RECONNECT_SYNC_COOLDOWN, stamps: this.#lastReconnectSyncMs };
+        const lastSync = stamps.get(peer);
         if (lastSync !== undefined && Time.nowMs - lastSync < cooldown) {
             logger.debug(
                 `Time sync for node ${formatNodeId(peer)} skipped, within ${Duration.format(cooldown)} ${trigger} cooldown`,
             );
             return;
         }
-        this.#lastTriggerSyncMs.set(peer, Time.nowMs);
+        stamps.set(peer, Time.nowMs);
         const promise = this.#connector
             .syncTime(peer)
             .then(() => logger.info(`Synced time on node ${formatNodeId(peer)}`))
@@ -253,7 +261,8 @@ export class TimeSyncManager extends NodeProcessor {
         await super.stop();
         await Promise.allSettled(this.#inFlightSyncs.values());
         this.#inFlightSyncs.clear();
-        this.#lastTriggerSyncMs.clear();
+        this.#lastReconnectSyncMs.clear();
+        this.#lastTimeFailureSyncMs.clear();
         logger.info("Time sync manager stopped");
     }
 
@@ -284,7 +293,10 @@ export class TimeSyncManager extends NodeProcessor {
         // peer dedupes against the periodic push instead of double-sending.
         const promise = this.#connector
             .syncTime(peer)
-            .then(() => logger.info(`Periodic resync: synced time on node ${formatNodeId(peer)}`))
+            .then(() => {
+                this.#cycleSyncedCount++;
+                logger.info(`Periodic resync: synced time on node ${formatNodeId(peer)}`);
+            })
             .catch(error => logSyncFailure("Periodic resync: ", peer, error))
             .finally(() => {
                 this.#inFlightSyncs.delete(peer);
@@ -293,14 +305,21 @@ export class TimeSyncManager extends NodeProcessor {
         await promise;
     }
 
-    protected override onCycleComplete(processedCount: number, _intervalFormatted: string): void {
+    protected override onCycleStart(): void {
+        this.#cycleSyncedCount = 0;
         if (!this.#startupComplete) {
+            // Opening the window here, not on completion: a node registering mid-cycle is absent from
+            // the peer snapshot, so it needs the immediate-sync path to be available already.
             this.#startupComplete = true;
             logger.info("Time sync startup window complete, immediate syncs enabled on reconnect");
         }
+    }
+
+    protected override onCycleComplete(processedCount: number, _intervalFormatted: string): void {
         if (processedCount > 0) {
             logger.info(
-                `Periodic resync complete: synced ${processedCount} nodes. Next resync in ${Duration.format(RESYNC_INTERVAL)}`,
+                `Periodic resync complete: synced ${this.#cycleSyncedCount} of ${processedCount} nodes. ` +
+                    `Next resync in ${Duration.format(RESYNC_INTERVAL)}`,
             );
         }
     }

--- a/packages/ws-controller/src/controller/TimeSyncManager.ts
+++ b/packages/ws-controller/src/controller/TimeSyncManager.ts
@@ -8,20 +8,21 @@
  * Handles time synchronization for nodes with the TimeSynchronization cluster.
  * Syncs time on three triggers:
  * 1. Node connects/reconnects after startup (immediate, once startup window has elapsed)
- * 2. Periodic resync every 24 hours
+ * 2. Periodic resync every 24 hours, brought forward when the host zone changes offset sooner
  * 3. Reactive resync when a node emits a timeFailure event (driven externally via syncNode())
  *
- * A startup window of 30–60 minutes prevents syncing during initial node connection
- * while the host's NTP is still stabilizing. This manager must only be enabled when
- * the host time source is known to be reliable (see --enable-time-sync CLI flag).
+ * A startup window scaled to the number of commissioned nodes prevents syncing while nodes are
+ * still being initialized. This manager must only be enabled when the host time source is known
+ * to be reliable (see --enable-time-sync CLI flag).
  */
 
-import { Duration, Hours, Logger, Minutes, Time } from "@matter/main";
+import { Duration, Hours, Logger, Millis, Minutes, Seconds, Time } from "@matter/main";
 import { TimeSynchronization } from "@matter/main/clusters";
 import { PeerAddress, PeerAddressMap } from "@matter/main/protocol";
 import { StatusResponseError } from "@matter/main/types";
 import { AttributesData } from "../types/CommandHandler.js";
 import { formatNodeId } from "../util/formatNodeId.js";
+import { nextOffsetChangeMs, resolveHostTimeZone, timeZonePlan } from "../util/hostTimeZone.js";
 import { NodeProcessor } from "./NodeProcessor.js";
 
 const logger = Logger.get("TimeSyncManager");
@@ -35,6 +36,18 @@ export const TIME_FAILURE_EVENT_ID = 0x03;
 // Periodic resync interval: 24 hours
 const RESYNC_INTERVAL = Hours(24);
 
+// Startup window, scaled to the node count: nodes initialize at roughly 10 per minute, so this
+// clears initialization before the first sync without idling on small installations.
+const STARTUP_BASE_DELAY = Minutes(3);
+const STARTUP_DELAY_PER_NODE = Seconds(10);
+
+// Land past an upcoming offset change rather than on it, so the cycle sees the post-change zone
+// state and replaces any DST entry the node has just retired.
+const POST_CHANGE_MARGIN = Minutes(1);
+// Floor for a brought-forward cycle. A future change already clears it via POST_CHANGE_MARGIN; this
+// catches a lookup returning an instant that has already passed, which would otherwise fire at once.
+const MIN_ACCELERATED_DELAY = Minutes(1);
+
 // Minimum spacing between trigger-driven (reconnect / timeFailure) syncs for one peer.
 // The periodic path already caps its own cadence; this stops a flapping node or a device
 // repeatedly emitting timeFailure from storming setUtcTime commands.
@@ -43,7 +56,35 @@ const TRIGGER_SYNC_COOLDOWN = Hours(24);
 export interface TimeSyncConnector {
     syncTime(peer: PeerAddress): Promise<void>;
     nodeConnected(peer: PeerAddress): boolean;
+    commissionedNodeCount(): number;
 }
+
+/** Instant of the host zone's next offset change, or null when none is in view. */
+export type OffsetChangeLookup = (fromMs: number) => number | null;
+
+/** Delay before the first sync, long enough for node initialization to finish. */
+export function startupDelayMs(commissionedNodeCount: number): number {
+    return STARTUP_BASE_DELAY + commissionedNodeCount * STARTUP_DELAY_PER_NODE;
+}
+
+/**
+ * Delay before the next periodic cycle: normally the full interval, brought forward to just after an
+ * upcoming offset change so a node's retired DST entry is replaced promptly. A change nearer than the
+ * floor is left to the following cycle rather than scheduling a near-zero delay.
+ */
+export function resyncDelayMs(nowMs: number, nextChangeMs: number | null): number {
+    if (nextChangeMs === null) {
+        return RESYNC_INTERVAL;
+    }
+    const delay = nextChangeMs + POST_CHANGE_MARGIN - nowMs;
+    return delay < MIN_ACCELERATED_DELAY || delay >= RESYNC_INTERVAL ? RESYNC_INTERVAL : delay;
+}
+
+const defaultOffsetChangeLookup: OffsetChangeLookup = fromMs => {
+    const zone = resolveHostTimeZone();
+    // A node with less capacity cannot surface a nearer boundary than the cluster maxima do.
+    return nextOffsetChangeMs(timeZonePlan(zone, fromMs, { maxRegimes: 2, maxWindows: 2 }), fromMs);
+};
 
 /** TimeNotAccepted means the node keeps a time source it prefers — expected, not an error. */
 function logSyncFailure(prefix: string, peer: PeerAddress, error: unknown) {
@@ -77,11 +118,18 @@ export function dstOffsetListMaxSize(attributes: AttributesData): number | undef
     return typeof value === "number" ? value : undefined;
 }
 
+/** TimeZoneListMaxSize (attribute 10) if the node reports it as a number. */
+export function timeZoneListMaxSize(attributes: AttributesData): number | undefined {
+    const value = attributes[`0/${TIME_SYNC_CLUSTER_ID}/10`];
+    return typeof value === "number" ? value : undefined;
+}
+
 /**
  * Manages time synchronization for nodes with the TimeSynchronization cluster.
  */
 export class TimeSyncManager extends NodeProcessor {
     readonly #connector: TimeSyncConnector;
+    readonly #offsetChangeLookup: OffsetChangeLookup;
     // Tracks in-flight immediate syncs per node to prevent parallel syncs
     #inFlightSyncs = new PeerAddressMap<Promise<void>>();
     // Last trigger-driven sync attempt per node, used to enforce TRIGGER_SYNC_COOLDOWN
@@ -89,12 +137,10 @@ export class TimeSyncManager extends NodeProcessor {
     // True after the first periodic resync cycle, enabling immediate syncs on reconnect
     #startupComplete = false;
 
-    constructor(connector: TimeSyncConnector) {
-        // Startup window: random 30–60 minutes to stagger across server restarts and
-        // allow NTP to stabilize before pushing time to devices
-        const startupDelayMs = Minutes(30) + Math.floor(Math.random() * Minutes(30));
-        super("time-sync-resync", startupDelayMs, RESYNC_INTERVAL);
+    constructor(connector: TimeSyncConnector, offsetChangeLookup: OffsetChangeLookup = defaultOffsetChangeLookup) {
+        super("time-sync-resync", STARTUP_BASE_DELAY, RESYNC_INTERVAL);
         this.#connector = connector;
+        this.#offsetChangeLookup = offsetChangeLookup;
     }
 
     /**
@@ -114,9 +160,23 @@ export class TimeSyncManager extends NodeProcessor {
         }
 
         // Only sync immediately if the startup window has elapsed. During startup,
-        // the first periodic resync handles all nodes once NTP has stabilized.
+        // the first periodic resync handles all nodes once initialization is done.
         if (this.#startupComplete) {
             this.syncNode(peer);
+        } else {
+            // The commissioned count is known in full by the first registration, so this lands once
+            // and later registrations are no-ops against the already-running timer.
+            let nodeCount = 0;
+            try {
+                nodeCount = this.#connector.commissionedNodeCount();
+            } catch (error) {
+                // Scaling the delay is an optimization; it must not abort the node's registration.
+                logger.warn("Could not determine the commissioned node count:", error);
+            }
+            const delay = startupDelayMs(nodeCount);
+            if (this.setNextCycleDelay(delay)) {
+                logger.info(`First time synchronization in ${Duration.format(Millis(delay))}`);
+            }
         }
 
         this.scheduleIfNeeded();
@@ -175,6 +235,16 @@ export class TimeSyncManager extends NodeProcessor {
 
     protected override shouldProcess(peer: PeerAddress): boolean {
         return this.#connector.nodeConnected(peer) && !this.#inFlightSyncs.has(peer);
+    }
+
+    /**
+     * Bring the next cycle forward to just after the host zone's next offset change. Nodes apply the
+     * change themselves from the DST list they already hold; resyncing refreshes a list whose final
+     * entry has just expired, which a node is otherwise entitled to discard entirely.
+     */
+    protected override nextCycleDelay(): Duration {
+        const nowMs = Time.nowMs;
+        return Millis(resyncDelayMs(nowMs, this.#offsetChangeLookup(nowMs)));
     }
 
     protected override async processNode(peer: PeerAddress): Promise<void> {

--- a/packages/ws-controller/src/controller/timeSyncCommands.ts
+++ b/packages/ws-controller/src/controller/timeSyncCommands.ts
@@ -9,23 +9,25 @@ import { TimeSynchronization } from "@matter/main/clusters";
 import { MATTER_EPOCH_OFFSET_US } from "@matter/main/types";
 import { AttributesData } from "../types/CommandHandler.js";
 import {
-    DstWindow,
-    dstWindows as defaultDstWindows,
     resolveHostTimeZone as defaultResolveHostTimeZone,
-    standardOffsetSeconds as defaultStandardOffsetSeconds,
+    timeZonePlan as defaultTimeZonePlan,
+    TimeZonePlan,
+    TimeZonePlanLimits,
 } from "../util/hostTimeZone.js";
-import { dstOffsetListMaxSize, hasTimeZoneFeature } from "./TimeSyncManager.js";
+import { dstOffsetListMaxSize, hasTimeZoneFeature, timeZoneListMaxSize } from "./TimeSyncManager.js";
 
 const logger = Logger.get("TimeSyncCommands");
 
 // Default when the node does not advertise DSTOffsetListMaxSize: covers the current DST
-// window plus the next one (spec minimum is 1).
+// window plus the next one.
 const DEFAULT_DST_LIST_MAX = 2;
+// Default when the node does not advertise TimeZoneListMaxSize. The cluster caps the list at 2, and
+// the second entry is what lets an upcoming standard-offset change be stated as such.
+const DEFAULT_TIME_ZONE_LIST_MAX = 2;
 
 export interface TimeZoneProvider {
     resolveHostTimeZone(): string;
-    standardOffsetSeconds(zone: string, atMs: number): number;
-    dstWindows(zone: string, fromMs: number, max: number): DstWindow[];
+    timeZonePlan(zone: string, fromMs: number, limits: TimeZonePlanLimits): TimeZonePlan;
 }
 
 export interface TimeSyncInvokers {
@@ -38,8 +40,7 @@ export interface TimeSyncInvokers {
 
 const defaultTimeZoneProvider: TimeZoneProvider = {
     resolveHostTimeZone: defaultResolveHostTimeZone,
-    standardOffsetSeconds: defaultStandardOffsetSeconds,
-    dstWindows: defaultDstWindows,
+    timeZonePlan: defaultTimeZonePlan,
 };
 
 function unixMsToEpochUs(ms: number): bigint {
@@ -72,19 +73,26 @@ export async function pushNodeTime(opts: {
     try {
         const tz = opts.tz ?? defaultTimeZoneProvider;
         const zone = tz.resolveHostTimeZone();
-        const offset = tz.standardOffsetSeconds(zone, nowMs);
+        const plan = tz.timeZonePlan(zone, nowMs, {
+            maxRegimes: timeZoneListMaxSize(attributes) ?? DEFAULT_TIME_ZONE_LIST_MAX,
+            maxWindows: dstOffsetListMaxSize(attributes) ?? DEFAULT_DST_LIST_MAX,
+        });
 
         const response = await invokers.setTimeZone({
-            // Spec: the first TimeZone entry's ValidAt is Matter-epoch 0. TlvEpochUs takes
-            // Unix-epoch µs and subtracts the Matter epoch, so the Matter epoch itself encodes to 0.
-            timeZone: [{ offset, validAt: MATTER_EPOCH_OFFSET_US, name: zone }],
+            timeZone: plan.regimes.map(regime => ({
+                offset: regime.offsetSeconds,
+                // Spec: the first entry's ValidAt is Matter-epoch 0 and a later entry's must not be.
+                // TlvEpochUs subtracts the Matter epoch, so passing it encodes to 0.
+                validAt: regime.validFromMs === null ? MATTER_EPOCH_OFFSET_US : unixMsToEpochUs(regime.validFromMs),
+                name: zone,
+            })),
         });
 
         if (response?.dstOffsetRequired) {
-            const max = dstOffsetListMaxSize(attributes) ?? DEFAULT_DST_LIST_MAX;
-            const dstOffset: TimeSynchronization.DstOffset[] = tz.dstWindows(zone, nowMs, max).map(window => ({
+            const dstOffset: TimeSynchronization.DstOffset[] = plan.dstWindows.map(window => ({
                 offset: window.offsetSeconds,
-                validStarting: unixMsToEpochUs(window.validStartingMs),
+                validStarting:
+                    window.validStartingMs === null ? MATTER_EPOCH_OFFSET_US : unixMsToEpochUs(window.validStartingMs),
                 validUntil: window.validUntilMs === null ? null : unixMsToEpochUs(window.validUntilMs),
             }));
             if (dstOffset.length === 0) {

--- a/packages/ws-controller/src/util/hostTimeZone.ts
+++ b/packages/ws-controller/src/util/hostTimeZone.ts
@@ -45,7 +45,8 @@ function formatterFor(zone: string): Intl.DateTimeFormat {
 }
 
 export function resolveHostTimeZone(): string {
-    return new Intl.DateTimeFormat().resolvedOptions().timeZone;
+    // An unparseable TZ (e.g. "Bogus/Zone") makes Intl report no zone at all, against its own typing.
+    return new Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC";
 }
 
 export function offsetSecondsAt(zone: string, atMs: number): number {

--- a/packages/ws-controller/src/util/hostTimeZone.ts
+++ b/packages/ws-controller/src/util/hostTimeZone.ts
@@ -171,7 +171,7 @@ export interface TimeZonePlan {
 }
 
 export interface TimeZonePlanLimits {
-    /** The node's TimeZoneListMaxSize. The cluster permits 1 or 2. */
+    /** The node's TimeZoneListMaxSize. Values outside the cluster's range of 1 to 2 are brought into it. */
     maxRegimes: number;
     /** The node's DSTOffsetListMaxSize. Values below the spec minimum of 1 are raised. */
     maxWindows: number;
@@ -230,8 +230,10 @@ export function timeZonePlan(zone: string, fromMs: number, limits: TimeZonePlanL
     // the offset in effect now.
     const covered = segments.slice(currentIndex);
     const windowLimit = Math.max(1, limits.maxWindows);
+    // A TimeZone list always holds at least one entry and never more than two, whatever the node says.
+    const regimeLimit = Math.min(2, Math.max(1, limits.maxRegimes));
     // One TimeZone entry can only carry the change as a delta, which the whole-range minimum allows.
-    const splitIndex = limits.maxRegimes >= 2 ? permanentChangeIndex(covered) : undefined;
+    const splitIndex = regimeLimit >= 2 ? permanentChangeIndex(covered) : undefined;
 
     const runsFor = (index: number | undefined) =>
         index === undefined ? [covered] : [covered.slice(0, index), covered.slice(index)];

--- a/packages/ws-controller/src/util/hostTimeZone.ts
+++ b/packages/ws-controller/src/util/hostTimeZone.ts
@@ -139,7 +139,12 @@ export function offsetSegments(zone: string, fromMs: number): OffsetSegment[] {
 export interface DstWindow {
     /** Offset in seconds added on top of the plan's standard offset. */
     offsetSeconds: number;
-    /** UTC instant (ms) the offset starts applying; null when it already applied at `fromMs`. */
+    /**
+     * UTC instant (ms) the offset starts applying, or null when it was already in effect before the
+     * scanned range began and so has no known start. A window covering `fromMs` normally carries a
+     * real instant, since the scan reaches back past the opening transition. Callers push null as
+     * the Matter epoch.
+     */
     validStartingMs: number | null;
     /** UTC instant (ms) the offset stops applying; null when it never does. */
     validUntilMs: number | null;
@@ -264,9 +269,9 @@ export function timeZonePlan(zone: string, fromMs: number, limits: TimeZonePlanL
 }
 
 /**
- * The next instant at or after `fromMs` where the plan changes the offset it reports, or null when
- * it reports the same offset throughout. Regime and window bounds are real transition instants, so
- * this covers seasonal DST changes and permanent offset changes alike.
+ * The next instant after `fromMs` where the plan changes the offset it reports, or null when it
+ * reports the same offset throughout. Bounds that carry an instant are real transitions, so this
+ * covers seasonal DST changes and permanent offset changes alike.
  */
 export function nextOffsetChangeMs(plan: TimeZonePlan, fromMs: number): number | null {
     let next: number | null = null;

--- a/packages/ws-controller/src/util/hostTimeZone.ts
+++ b/packages/ws-controller/src/util/hostTimeZone.ts
@@ -7,18 +7,23 @@
 /**
  * Host time-zone math derived from Node's Intl (full-icu). Pure and dependency-free:
  * inputs are an IANA zone string and timestamps in Unix-epoch milliseconds.
+ *
+ * The TimeSynchronization cluster splits the local offset into a standard offset (SetTimeZone)
+ * plus a DST delta (SetDstOffset). Both halves are derived here from a single scan of the zone's
+ * transitions, so they cannot disagree: for every instant a plan covers, the standard offset plus
+ * the DST delta the device would pick equals the zone's true offset.
  */
 
-export interface DstWindow {
-    /** DST offset in seconds, added on top of the standard offset (typically 3600). */
-    offsetSeconds: number;
-    /** UTC instant (ms) the DST offset starts applying. */
-    validStartingMs: number;
-    /** UTC instant (ms) the DST offset stops applying; null for a permanent change. */
-    validUntilMs: number | null;
-}
-
 const DAY_MS = 86_400_000;
+
+// Reaches back past the opening transition of a DST period still running at fromMs, so its window
+// carries a real starting instant rather than "already in effect" (US periods run 238 days).
+const SCAN_BACK_DAYS = 400;
+const SCAN_FORWARD_DAYS = 550;
+// Probe past the last transition found. Longer than any seasonal cycle, so finding nothing means
+// the offset is permanent rather than merely outstaying the scan.
+const PROBE_DAYS = 400;
+
 const formatterCache = new Map<string, Intl.DateTimeFormat>();
 
 function formatterFor(zone: string): Intl.DateTimeFormat {
@@ -58,20 +63,6 @@ export function offsetSecondsAt(zone: string, atMs: number): number {
     return Math.round((asUtc - atSecondMs) / 1000);
 }
 
-export function standardOffsetSeconds(zone: string, atMs: number): number {
-    // Standard (non-DST) offset = the smallest UTC offset over the year starting at atMs.
-    // Sampling forward from atMs (not the fixed calendar year) keeps the window inside the
-    // current regime, so a past permanent standard-offset change — e.g. a zone abolishing DST
-    // mid-year — can't drag in a stale pre-change base. Reverse-DST zones (winter offset below
-    // the tzdata "standard") still resolve: the lowest offset is what SetTimeZone must carry,
-    // with dstWindows emitting the positive deltas on top.
-    let min = offsetSecondsAt(zone, atMs);
-    for (let day = 30; day <= 365; day += 30) {
-        min = Math.min(min, offsetSecondsAt(zone, atMs + day * DAY_MS));
-    }
-    return min;
-}
-
 function findTransitionInstant(zone: string, beforeMs: number, afterMs: number): number {
     let lo = beforeMs;
     let hi = afterMs;
@@ -89,14 +80,31 @@ function findTransitionInstant(zone: string, beforeMs: number, afterMs: number):
     return hi;
 }
 
-export function dstWindows(zone: string, fromMs: number, max: number): DstWindow[] {
-    const windows = new Array<DstWindow>();
-    if (max <= 0) {
-        return windows;
+function nextTransitionAfter(zone: string, afterMs: number, horizonMs: number): number | null {
+    const baseOffset = offsetSecondsAt(zone, afterMs);
+    let prev = afterMs;
+    for (let t = afterMs + DAY_MS; t <= horizonMs; t += DAY_MS) {
+        if (offsetSecondsAt(zone, t) !== baseOffset) {
+            return findTransitionInstant(zone, prev, t);
+        }
+        prev = t;
     }
-    const standard = standardOffsetSeconds(zone, fromMs);
-    const scanStart = fromMs - 200 * DAY_MS;
-    const scanEnd = fromMs + 550 * DAY_MS;
+    return null;
+}
+
+export interface OffsetSegment {
+    /** Total UTC offset in seconds in effect throughout the segment. */
+    offsetSeconds: number;
+    /** UTC instant (ms) the segment begins; null when it began before the scanned range. */
+    startMs: number | null;
+    /** UTC instant (ms) the segment ends; null when it holds past the scanned range. */
+    endMs: number | null;
+}
+
+/** Constant-offset segments spanning the scanned range around `fromMs`, chronological and gap-free. */
+export function offsetSegments(zone: string, fromMs: number): OffsetSegment[] {
+    const scanStart = fromMs - SCAN_BACK_DAYS * DAY_MS;
+    const scanEnd = fromMs + SCAN_FORWARD_DAYS * DAY_MS;
 
     const transitions = new Array<number>();
     let prev = scanStart;
@@ -110,18 +118,166 @@ export function dstWindows(zone: string, fromMs: number, max: number): DstWindow
         prev = t;
     }
 
-    // Emit only segments bounded by two real transitions, so no window has an artificial
-    // scan-boundary start or end. Keep windows still in effect at or after fromMs.
-    for (let i = 0; i < transitions.length - 1 && windows.length < max; i++) {
-        const start = transitions[i];
-        const until = transitions[i + 1];
-        if (until <= fromMs) {
-            continue;
-        }
-        const offset = offsetSecondsAt(zone, start);
-        if (offset > standard) {
-            windows.push({ offsetSeconds: offset - standard, validStartingMs: start, validUntilMs: until });
+    const segments = new Array<OffsetSegment>();
+    let start: number | null = null;
+    for (const transition of transitions) {
+        segments.push({
+            offsetSeconds: offsetSecondsAt(zone, start ?? scanStart),
+            startMs: start,
+            endMs: transition,
+        });
+        start = transition;
+    }
+    segments.push({
+        offsetSeconds: offsetSecondsAt(zone, start ?? scanStart),
+        startMs: start,
+        endMs: start === null ? null : nextTransitionAfter(zone, start, start + PROBE_DAYS * DAY_MS),
+    });
+    return segments;
+}
+
+export interface DstWindow {
+    /** Offset in seconds added on top of the plan's standard offset. */
+    offsetSeconds: number;
+    /** UTC instant (ms) the offset starts applying; null when it already applied at `fromMs`. */
+    validStartingMs: number | null;
+    /** UTC instant (ms) the offset stops applying; null when it never does. */
+    validUntilMs: number | null;
+}
+
+export interface StandardOffsetRegime {
+    /** Standard (non-DST) UTC offset in seconds. */
+    offsetSeconds: number;
+    /** UTC instant (ms) the regime takes over; null for the one already in effect at `fromMs`. */
+    validFromMs: number | null;
+}
+
+export interface TimeZonePlan {
+    /**
+     * Offsets for the cluster's TimeZone list, chronological. Entry 0 is in effect at `fromMs` and
+     * always has a null `validFromMs`, as the cluster requires of its first entry.
+     */
+    regimes: StandardOffsetRegime[];
+    /**
+     * Deltas on top of the regime in effect at the same instant, chronological and non-overlapping.
+     * At most one entry has a null `validUntilMs` and it is last, as SetDstOffset requires.
+     */
+    dstWindows: DstWindow[];
+}
+
+export interface TimeZonePlanLimits {
+    /** The node's TimeZoneListMaxSize. The cluster permits 1 or 2. */
+    maxRegimes: number;
+    /** The node's DSTOffsetListMaxSize. Values below the spec minimum of 1 are raised. */
+    maxWindows: number;
+}
+
+/**
+ * A permanent offset change leaves its previous base behind for good, whereas a seasonal excursion
+ * returns to it. Three conditions must hold, and each rejects a distinct false positive:
+ *
+ * - the trailing segment is open-ended, i.e. the probe found the offset holding indefinitely.
+ *   Otherwise "the old base never recurs" may only mean the scan ended mid-cycle, which would make
+ *   every zone's last summer in view look like a permanent adoption.
+ * - the minimum offset differs across the split, so a seasonal excursion inside one base is skipped.
+ * - the earlier minimum never recurs after the split, which rejects a zone that merely happens to be
+ *   mid-DST at `fromMs` and so has a higher minimum in its leading segment than in the rest.
+ */
+function permanentChangeIndex(covered: OffsetSegment[]): number | undefined {
+    if (covered[covered.length - 1].endMs !== null) {
+        return undefined;
+    }
+    for (let i = 1; i < covered.length; i++) {
+        const before = covered.slice(0, i).map(segment => segment.offsetSeconds);
+        const after = covered.slice(i).map(segment => segment.offsetSeconds);
+        const beforeMin = Math.min(...before);
+        if (beforeMin !== Math.min(...after) && !after.includes(beforeMin)) {
+            return i;
         }
     }
-    return windows;
+    return undefined;
+}
+
+/** Deltas a decomposition has to send: one per segment sitting above its own run's base. */
+function windowsNeeded(runs: OffsetSegment[][]): number {
+    return runs.reduce((total, run) => {
+        const base = Math.min(...run.map(segment => segment.offsetSeconds));
+        return total + run.filter(segment => segment.offsetSeconds !== base).length;
+    }, 0);
+}
+
+/** Decompose a zone's upcoming offsets into the standard offsets and DST windows to push. */
+export function timeZonePlan(zone: string, fromMs: number, limits: TimeZonePlanLimits): TimeZonePlan {
+    const segments = offsetSegments(zone, fromMs);
+    const currentIndex = segments.findIndex(
+        segment =>
+            (segment.startMs === null || segment.startMs <= fromMs) &&
+            (segment.endMs === null || segment.endMs > fromMs),
+    );
+    if (currentIndex < 0) {
+        return {
+            regimes: [{ offsetSeconds: offsetSecondsAt(zone, fromMs), validFromMs: null }],
+            dstWindows: [],
+        };
+    }
+
+    // Segments before fromMs are excluded so a past permanent change cannot pull the base away from
+    // the offset in effect now.
+    const covered = segments.slice(currentIndex);
+    const windowLimit = Math.max(1, limits.maxWindows);
+    // One TimeZone entry can only carry the change as a delta, which the whole-range minimum allows.
+    const splitIndex = limits.maxRegimes >= 2 ? permanentChangeIndex(covered) : undefined;
+
+    const runsFor = (index: number | undefined) =>
+        index === undefined ? [covered] : [covered.slice(0, index), covered.slice(index)];
+    // Splitting gives each run its own base and so can need more deltas than the budget holds, and a
+    // dropped delta would leave the node on a base that does not apply yet.
+    const runs = windowsNeeded(runsFor(splitIndex)) > windowLimit ? runsFor(undefined) : runsFor(splitIndex);
+    const regimes = runs.map((run, index) => ({
+        offsetSeconds: Math.min(...run.map(segment => segment.offsetSeconds)),
+        validFromMs: index === 0 ? null : run[0].startMs,
+    }));
+
+    const dstWindows = new Array<DstWindow>();
+    for (const [index, run] of runs.entries()) {
+        const standard = regimes[index].offsetSeconds;
+        for (const segment of run) {
+            if (dstWindows.length >= windowLimit || segment.offsetSeconds === standard) {
+                continue;
+            }
+            dstWindows.push({
+                offsetSeconds: segment.offsetSeconds - standard,
+                validStartingMs: segment.startMs,
+                validUntilMs: segment.endMs,
+            });
+        }
+    }
+
+    // A node whose last window expires drops the whole list and reports no valid local time until
+    // the next resync, so spend a spare slot stating that the standard offset then applies alone.
+    const last = dstWindows[dstWindows.length - 1];
+    if (last !== undefined && last.validUntilMs !== null && dstWindows.length < windowLimit) {
+        dstWindows.push({ offsetSeconds: 0, validStartingMs: last.validUntilMs, validUntilMs: null });
+    }
+
+    return { regimes, dstWindows };
+}
+
+/**
+ * The next instant at or after `fromMs` where the plan changes the offset it reports, or null when
+ * it reports the same offset throughout. Regime and window bounds are real transition instants, so
+ * this covers seasonal DST changes and permanent offset changes alike.
+ */
+export function nextOffsetChangeMs(plan: TimeZonePlan, fromMs: number): number | null {
+    let next: number | null = null;
+    const boundaries = [
+        ...plan.regimes.map(regime => regime.validFromMs),
+        ...plan.dstWindows.flatMap(window => [window.validStartingMs, window.validUntilMs]),
+    ];
+    for (const boundary of boundaries) {
+        if (boundary !== null && boundary > fromMs && (next === null || boundary < next)) {
+            next = boundary;
+        }
+    }
+    return next;
 }

--- a/packages/ws-controller/test/CustomClusterPollerTest.ts
+++ b/packages/ws-controller/test/CustomClusterPollerTest.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { FabricIndex, NodeId } from "@matter/main";
+import { PeerAddress } from "@matter/main/protocol";
+import { CustomClusterPoller, NodeAttributeReader } from "../src/controller/CustomClusterPoller.js";
+import { AttributesData } from "../src/types/CommandHandler.js";
+
+const ONE_MINUTE_MS = 60_000;
+// The initial delay is 30 s plus up to 30 s of jitter; 61 s clears either.
+const PAST_INITIAL_DELAY_MS = 61_000;
+
+const PEER_1 = PeerAddress({ fabricIndex: FabricIndex(1), nodeId: NodeId(1) });
+
+const EVE_VENDOR_ID = 4874;
+const EVE_CLUSTER_ID = 0x130afc01;
+
+/** An Eve device with the custom cluster and no standard ElectricalPowerMeasurement. */
+function eveAttributes(): AttributesData {
+    return {
+        "0/40/2": EVE_VENDOR_ID,
+        [`1/${EVE_CLUSTER_ID}/${0x130a000a}`]: 0,
+    };
+}
+
+class StubReader implements NodeAttributeReader {
+    readonly reads: PeerAddress[] = [];
+    slowRead = false;
+    failRead = false;
+    #resolvers = new Array<(value: AttributesData) => void>();
+
+    nodeConnected(): boolean {
+        return true;
+    }
+
+    async handleReadAttributes(peer: PeerAddress): Promise<AttributesData> {
+        this.reads.push(peer);
+        if (this.failRead) {
+            throw new Error("read exploded");
+        }
+        if (this.slowRead) {
+            return new Promise<AttributesData>(resolve => this.#resolvers.push(resolve));
+        }
+        return {};
+    }
+
+    get pending(): number {
+        return this.#resolvers.length;
+    }
+
+    resolveAll(): void {
+        this.#resolvers.splice(0).forEach(resolve => resolve({}));
+    }
+}
+
+describe("CustomClusterPoller", () => {
+    let reader: StubReader;
+    let poller: CustomClusterPoller;
+
+    beforeEach(() => {
+        MockTime.reset();
+        reader = new StubReader();
+        poller = new CustomClusterPoller(reader);
+    });
+
+    afterEach(async () => {
+        reader.resolveAll();
+        await poller.stop();
+    });
+
+    it("polls a registered Eve node once the initial delay elapses", async () => {
+        poller.registerNode(PEER_1, eveAttributes());
+        await MockTime.yield3();
+        expect(reader.reads.length).to.equal(0);
+
+        await MockTime.advance(PAST_INITIAL_DELAY_MS);
+        await MockTime.yield3();
+        expect(reader.reads.length).to.equal(1);
+    });
+
+    it("ignores a node that is not an Eve device", async () => {
+        poller.registerNode(PEER_1, { "0/40/2": 1, "1/6/0": true });
+        await MockTime.advance(PAST_INITIAL_DELAY_MS);
+        await MockTime.yield3();
+        expect(reader.reads.length).to.equal(0);
+    });
+
+    it("does not return from stop() while a read is still in flight", async () => {
+        reader.slowRead = true;
+        poller.registerNode(PEER_1, eveAttributes());
+
+        await MockTime.advance(PAST_INITIAL_DELAY_MS);
+        await MockTime.yield3();
+        expect(reader.pending, "a read must be in flight for this to prove anything").to.equal(1);
+
+        let stopped = false;
+        const stopping = poller.stop().then(() => {
+            stopped = true;
+        });
+        await MockTime.yield3();
+        expect(stopped, "stop() must await the in-flight read").to.equal(false);
+
+        reader.resolveAll();
+        await stopping;
+        expect(stopped).to.equal(true);
+    });
+
+    it("keeps polling after a read fails", async () => {
+        reader.failRead = true;
+        poller.registerNode(PEER_1, eveAttributes());
+
+        await MockTime.advance(PAST_INITIAL_DELAY_MS);
+        await MockTime.yield3();
+        expect(reader.reads.length).to.equal(1);
+
+        reader.failRead = false;
+        for (let i = 0; i < 3; i++) {
+            await MockTime.advance(ONE_MINUTE_MS);
+            await MockTime.yield3();
+        }
+        expect(reader.reads.length, "a failed read must not stop the cycle").to.be.greaterThan(1);
+    });
+
+    it("stops polling a node that unregisters", async () => {
+        poller.registerNode(PEER_1, eveAttributes());
+        await MockTime.advance(PAST_INITIAL_DELAY_MS);
+        await MockTime.yield3();
+        const afterFirst = reader.reads.length;
+
+        poller.unregisterNode(PEER_1);
+        for (let i = 0; i < 3; i++) {
+            await MockTime.advance(ONE_MINUTE_MS);
+            await MockTime.yield3();
+        }
+        expect(reader.reads.length).to.equal(afterFirst);
+    });
+});

--- a/packages/ws-controller/test/HostTimeZoneTest.ts
+++ b/packages/ws-controller/test/HostTimeZoneTest.ts
@@ -4,10 +4,61 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { dstWindows, offsetSecondsAt, resolveHostTimeZone, standardOffsetSeconds } from "../src/util/hostTimeZone.js";
+import {
+    nextOffsetChangeMs,
+    offsetSecondsAt,
+    offsetSegments,
+    resolveHostTimeZone,
+    TimeZonePlan,
+    timeZonePlan,
+} from "../src/util/hostTimeZone.js";
 
 const JAN_2026 = Date.UTC(2026, 0, 15);
 const JUL_2026 = Date.UTC(2026, 6, 1);
+const DAY_MS = 86_400_000;
+
+const BOTH_MAX = { maxRegimes: 2, maxWindows: 2 };
+const SINGLE_TIME_ZONE_ENTRY = { maxRegimes: 1, maxWindows: 2 };
+
+/**
+ * The standard offset a compliant node would have active, mirroring
+ * TimeSynchronizationCluster.cpp's UpdateTimeZoneState: the active entry is the last one whose
+ * ValidAt has passed.
+ */
+function nodeRegimeOffsetSeconds(plan: TimeZonePlan, atMs: number): number {
+    let active = plan.regimes[0];
+    for (const regime of plan.regimes) {
+        if (regime.validFromMs !== null && regime.validFromMs <= atMs) {
+            active = regime;
+        }
+    }
+    return active.offsetSeconds;
+}
+
+/**
+ * The offset a compliant node would compute from a pushed plan, mirroring
+ * TimeSynchronizationCluster.cpp's UpdateDSTOffsetState: the active entry is the last one whose
+ * ValidStarting has passed, and an active entry whose ValidUntil has passed contributes nothing.
+ */
+function nodeOffsetSeconds(plan: TimeZonePlan, atMs: number): number {
+    const standard = nodeRegimeOffsetSeconds(plan, atMs);
+    let active;
+    for (const window of plan.dstWindows) {
+        if ((window.validStartingMs ?? Number.NEGATIVE_INFINITY) <= atMs) {
+            active = window;
+        }
+    }
+    if (active === undefined || (active.validUntilMs !== null && active.validUntilMs <= atMs)) {
+        return standard;
+    }
+    return standard + active.offsetSeconds;
+}
+
+function expectPlanMatchesZone(zone: string, atMs: number, limits = BOTH_MAX) {
+    const plan = timeZonePlan(zone, atMs, limits);
+    const label = `${zone} @ ${new Date(atMs).toISOString()}`;
+    expect(nodeOffsetSeconds(plan, atMs), label).to.equal(offsetSecondsAt(zone, atMs));
+}
 
 describe("hostTimeZone", () => {
     describe("offsetSecondsAt", () => {
@@ -25,58 +76,329 @@ describe("hostTimeZone", () => {
         });
     });
 
-    describe("standardOffsetSeconds", () => {
-        it("returns the non-DST base offset in both hemispheres", () => {
-            expect(standardOffsetSeconds("Europe/Berlin", JUL_2026)).to.equal(3600);
-            expect(standardOffsetSeconds("Australia/Sydney", JAN_2026)).to.equal(36000); // AEST base
-            expect(standardOffsetSeconds("America/Phoenix", JUL_2026)).to.equal(-25200);
+    describe("offsetSegments", () => {
+        it("returns gap-free chronological segments that agree with the zone's offsets", () => {
+            const segments = offsetSegments("Europe/Berlin", JAN_2026);
+            expect(segments.length).to.be.greaterThan(1);
+            expect(segments[0].startMs).to.equal(null);
+            expect(segments[segments.length - 1].endMs).to.not.equal(null);
+            for (let i = 0; i < segments.length; i++) {
+                if (i > 0) {
+                    expect(segments[i].startMs).to.equal(segments[i - 1].endMs);
+                }
+                const probe = (segments[i].startMs ?? JAN_2026 - 399 * DAY_MS) + DAY_MS;
+                expect(offsetSecondsAt("Europe/Berlin", probe)).to.equal(segments[i].offsetSeconds);
+            }
         });
 
-        it("returns the base offset when atMs is mid-DST", () => {
-            expect(standardOffsetSeconds("Europe/Berlin", Date.UTC(2026, 3, 15))).to.equal(3600);
-            expect(standardOffsetSeconds("America/New_York", Date.UTC(2026, 4, 1))).to.equal(-18000);
+        it("reports a single open-ended segment for a zone without transitions", () => {
+            const segments = offsetSegments("America/Phoenix", JAN_2026);
+            expect(segments.length).to.equal(1);
+            expect(segments[0].startMs).to.equal(null);
+            expect(segments[0].endMs).to.equal(null);
+            expect(segments[0].offsetSeconds).to.equal(-25200);
         });
 
-        it("uses the current regime after a permanent standard-offset change", () => {
-            // Europe/Istanbul abolished DST on 2016-09-07, moving permanently to +03:00.
-            // Sampling Jan+Jul of 2016 straddles the switch and would wrongly return the
-            // pre-switch +02:00 base; the offset after the switch is a permanent +03:00.
-            expect(standardOffsetSeconds("Europe/Istanbul", Date.UTC(2016, 10, 1))).to.equal(10800);
+        it("leaves a permanently adopted offset open-ended rather than closing it at the scan edge", () => {
+            // Turkey stayed on EEST (+03) after 2016-03-27 instead of falling back that autumn.
+            const segments = offsetSegments("Europe/Istanbul", Date.UTC(2016, 0, 15));
+            const last = segments[segments.length - 1];
+            expect(last.offsetSeconds).to.equal(10800);
+            expect(last.startMs).to.equal(Date.UTC(2016, 2, 27, 1, 0, 0));
+            expect(last.endMs).to.equal(null);
         });
     });
 
-    describe("dstWindows", () => {
-        it("returns the upcoming DST window for a northern-hemisphere zone", () => {
-            const windows = dstWindows("Europe/Berlin", JAN_2026, 2);
-            expect(windows.length).to.equal(1);
-            expect(windows[0].offsetSeconds).to.equal(3600);
+    describe("timeZonePlan", () => {
+        it("emits the upcoming DST window for a northern-hemisphere zone", () => {
+            const plan = timeZonePlan("Europe/Berlin", JAN_2026, BOTH_MAX);
+            expect(plan.regimes[0].offsetSeconds).to.equal(3600);
+            expect(plan.dstWindows.length).to.equal(2);
+            expect(plan.dstWindows[0].offsetSeconds).to.equal(3600);
             // DST 2026 begins 2026-03-29 01:00 UTC, ends 2026-10-25 01:00 UTC
-            expect(windows[0].validStartingMs).to.equal(Date.UTC(2026, 2, 29, 1, 0, 0));
-            expect(windows[0].validUntilMs).to.equal(Date.UTC(2026, 9, 25, 1, 0, 0));
+            expect(plan.dstWindows[0].validStartingMs).to.equal(Date.UTC(2026, 2, 29, 1, 0, 0));
+            expect(plan.dstWindows[0].validUntilMs).to.equal(Date.UTC(2026, 9, 25, 1, 0, 0));
+            expect(plan.dstWindows[1].validStartingMs).to.equal(Date.UTC(2027, 2, 28, 1, 0, 0));
+            expect(plan.dstWindows[1].validUntilMs).to.equal(Date.UTC(2027, 9, 31, 1, 0, 0));
         });
 
-        it("returns the currently-active window when already in DST", () => {
-            const windows = dstWindows("Europe/Berlin", JUL_2026, 2);
-            expect(windows.length).to.be.greaterThan(0);
-            expect(windows[0].validStartingMs).to.equal(Date.UTC(2026, 2, 29, 1, 0, 0));
-            expect(windows[0].validUntilMs).to.equal(Date.UTC(2026, 9, 25, 1, 0, 0));
+        it("emits the currently-active window when already in DST", () => {
+            const plan = timeZonePlan("Europe/Berlin", JUL_2026, BOTH_MAX);
+            expect(plan.regimes[0].offsetSeconds).to.equal(3600);
+            expect(plan.dstWindows[0].validStartingMs).to.equal(Date.UTC(2026, 2, 29, 1, 0, 0));
+            expect(plan.dstWindows[0].validUntilMs).to.equal(Date.UTC(2026, 9, 25, 1, 0, 0));
         });
 
-        it("returns an empty list for a zone without DST", () => {
-            expect(dstWindows("America/Phoenix", JAN_2026, 2)).to.deep.equal([]);
+        it("emits no windows for a zone without DST", () => {
+            const plan = timeZonePlan("America/Phoenix", JAN_2026, BOTH_MAX);
+            expect(plan.regimes[0].offsetSeconds).to.equal(-25200);
+            expect(plan.dstWindows).to.deep.equal([]);
         });
 
-        it("respects the max cap", () => {
-            expect(dstWindows("Europe/Berlin", JUL_2026, 1).length).to.equal(1);
-            expect(dstWindows("Europe/Berlin", JAN_2026, 0)).to.deep.equal([]);
+        it("terminates a truncated list so the node does not drop it when the last window expires", () => {
+            const plan = timeZonePlan("Europe/Berlin", JAN_2026, { maxRegimes: 2, maxWindows: 3 });
+            const last = plan.dstWindows[plan.dstWindows.length - 1];
+            expect(last.offsetSeconds).to.equal(0);
+            expect(last.validUntilMs).to.equal(null);
+            expect(last.validStartingMs).to.equal(plan.dstWindows[plan.dstWindows.length - 2].validUntilMs);
         });
 
-        it("returns the currently-active window for a southern-hemisphere zone spanning New Year", () => {
-            const windows = dstWindows("Australia/Sydney", JAN_2026, 2);
-            expect(windows.length).to.be.greaterThan(0);
-            expect(windows[0].offsetSeconds).to.equal(3600);
-            expect(windows[0].validStartingMs).to.be.lessThan(JAN_2026);
-            expect(windows[0].validUntilMs).to.be.greaterThan(JAN_2026);
+        it("respects maxWindows and raises values below the spec minimum of 1", () => {
+            expect(
+                timeZonePlan("Europe/Berlin", JUL_2026, { maxRegimes: 2, maxWindows: 1 }).dstWindows.length,
+            ).to.equal(1);
+            // DSTOffsetListMaxSize 0 is a device bug; returning nothing would assert "never uses DST".
+            const clamped = timeZonePlan("Europe/Berlin", JUL_2026, { maxRegimes: 2, maxWindows: 0 });
+            expect(clamped.dstWindows.length).to.equal(1);
+            expect(nodeOffsetSeconds(clamped, JUL_2026)).to.equal(7200);
+        });
+
+        it("emits the currently-active window for a southern-hemisphere zone spanning New Year", () => {
+            const plan = timeZonePlan("Australia/Sydney", JAN_2026, BOTH_MAX);
+            expect(plan.regimes[0].offsetSeconds).to.equal(36000); // AEST base
+            expect(plan.dstWindows[0].offsetSeconds).to.equal(3600);
+            expect(plan.dstWindows[0].validStartingMs).to.be.lessThan(JAN_2026);
+            expect(plan.dstWindows[0].validUntilMs).to.be.greaterThan(JAN_2026);
+        });
+    });
+
+    describe("timeZonePlan standard-offset regimes", () => {
+        it("states a pending permanent reduction as a second regime rather than a DST delta", () => {
+            // Kazakhstan moved Asia/Almaty +06 -> +05 permanently at 2024-03-01 00:00 local.
+            const plan = timeZonePlan("Asia/Almaty", Date.UTC(2024, 0, 15), BOTH_MAX);
+            expect(plan.regimes.length).to.equal(2);
+            expect(plan.regimes[0].offsetSeconds).to.equal(21600); // +06, in effect now
+            expect(plan.regimes[0].validFromMs).to.equal(null);
+            expect(plan.regimes[1].offsetSeconds).to.equal(18000); // +05, from the change
+            expect(plan.regimes[1].validFromMs).to.equal(Date.UTC(2024, 1, 29, 18));
+            // The zone has no DST at all, so nothing may claim otherwise.
+            expect(plan.dstWindows).to.deep.equal([]);
+        });
+
+        it("states a pending permanent adoption of a higher offset as a second regime", () => {
+            const plan = timeZonePlan("Europe/Istanbul", Date.UTC(2016, 0, 15), BOTH_MAX);
+            expect(plan.regimes.length).to.equal(2);
+            expect(plan.regimes[0].offsetSeconds).to.equal(7200); // +02 EET
+            expect(plan.regimes[1].offsetSeconds).to.equal(10800); // +03, permanent from 2016-03-27
+            expect(plan.regimes[1].validFromMs).to.equal(Date.UTC(2016, 2, 27, 1));
+            expect(plan.dstWindows).to.deep.equal([]);
+        });
+
+        it("falls back to a DST delta when the node holds only one TimeZone entry", () => {
+            const plan = timeZonePlan("Asia/Almaty", Date.UTC(2024, 0, 15), SINGLE_TIME_ZONE_ENTRY);
+            expect(plan.regimes.length).to.equal(1);
+            expect(plan.regimes[0].offsetSeconds).to.equal(18000); // the post-change base
+            expect(plan.dstWindows.length).to.be.greaterThan(0);
+            expect(plan.dstWindows[0].offsetSeconds).to.equal(3600);
+            // Local time must still come out right, which is the point of the fallback.
+            expectPlanMatchesZone("Asia/Almaty", Date.UTC(2024, 0, 15), SINGLE_TIME_ZONE_ENTRY);
+        });
+
+        it("does not split a zone that is merely mid-DST at the sync instant", () => {
+            // Sydney in January sits in DST, so its leading segment has a higher minimum than the
+            // rest. Splitting there would call +11 a standard offset and +10 a future regime.
+            const plan = timeZonePlan("Australia/Sydney", JAN_2026, BOTH_MAX);
+            expect(plan.regimes.length).to.equal(1);
+            expect(plan.regimes[0].offsetSeconds).to.equal(36000); // AEST
+            expect(plan.dstWindows[0].offsetSeconds).to.equal(3600);
+        });
+
+        it("does not split an ordinary DST zone or a recurring seasonal dip", () => {
+            for (const zone of ["Europe/Berlin", "America/New_York", "Africa/Casablanca"]) {
+                for (const month of [0, 3, 6, 9]) {
+                    const plan = timeZonePlan(zone, Date.UTC(2026, month, 10), BOTH_MAX);
+                    expect(plan.regimes.length, `${zone} month ${month}`).to.equal(1);
+                }
+            }
+        });
+
+        it("keeps real DST windows alongside a pending permanent change", () => {
+            // Paraguay ran DST and then abolished it, staying on -03 from 2024-10-06. Both facts have
+            // to reach the node: the summer window before the change, and the change itself.
+            const plan = timeZonePlan("America/Asuncion", Date.UTC(2024, 0, 1, 12), BOTH_MAX);
+            expect(plan.regimes.length).to.equal(2);
+            expect(plan.regimes[0].offsetSeconds).to.equal(-14400);
+            expect(plan.regimes[1].offsetSeconds).to.equal(-10800);
+            expect(plan.regimes[1].validFromMs).to.equal(Date.UTC(2024, 9, 6, 4));
+            expect(plan.dstWindows[0].offsetSeconds).to.equal(3600);
+            expect(plan.dstWindows[0].validUntilMs).to.equal(Date.UTC(2024, 2, 24, 3));
+            for (const atMs of [Date.UTC(2024, 0, 1, 12), Date.UTC(2024, 5, 1), Date.UTC(2024, 10, 1)]) {
+                expectPlanMatchesZone("America/Asuncion", atMs);
+            }
+        });
+
+        it("declines to split when the node cannot hold the deltas the split would need", () => {
+            // Yukon kept DST until moving permanently to -07 on 2020-03-08, so a split here needs a
+            // delta for each remaining summer. Splitting with only one slot would drop the delta the
+            // later run depends on and leave the node on a base that does not apply yet.
+            const atMs = Date.UTC(2018, 8, 10, 12);
+            const roomy = timeZonePlan("America/Dawson", atMs, { maxRegimes: 2, maxWindows: 4 });
+            expect(roomy.regimes.length).to.equal(2);
+            expect(roomy.dstWindows.filter(window => window.offsetSeconds !== 0).length).to.equal(2);
+
+            const tight = timeZonePlan("America/Dawson", atMs, { maxRegimes: 2, maxWindows: 1 });
+            expect(tight.regimes.length).to.equal(1);
+            expect(tight.regimes[0].offsetSeconds).to.equal(-28800);
+            for (const at of [atMs, Date.UTC(2018, 11, 1), Date.UTC(2019, 5, 1)]) {
+                expectPlanMatchesZone("America/Dawson", at, { maxRegimes: 2, maxWindows: 1 });
+                expectPlanMatchesZone("America/Dawson", at, { maxRegimes: 2, maxWindows: 4 });
+            }
+        });
+
+        it("reports a single regime once a permanent change is in the past", () => {
+            const plan = timeZonePlan("Asia/Almaty", Date.UTC(2024, 5, 1), BOTH_MAX);
+            expect(plan.regimes.length).to.equal(1);
+            expect(plan.regimes[0].offsetSeconds).to.equal(18000);
+            expect(plan.dstWindows).to.deep.equal([]);
+        });
+    });
+
+    describe("timeZonePlan regressions", () => {
+        it("keeps a past permanent offset change out of the standard offset (#922 / #923)", () => {
+            // Europe/Istanbul abolished DST on 2016-09-07, moving permanently to +03:00. A base
+            // drawn from before the switch would be +02:00.
+            const plan = timeZonePlan("Europe/Istanbul", Date.UTC(2016, 10, 1), BOTH_MAX);
+            expect(plan.regimes[0].offsetSeconds).to.equal(10800);
+            expectPlanMatchesZone("Europe/Istanbul", Date.UTC(2016, 10, 1));
+        });
+
+        it("covers a DST period that began more than 200 days before the sync", () => {
+            // US DST runs 238 days, so late in the period the opening transition is far behind the
+            // sync instant. Missing it left nothing covering "now" and the node an hour behind.
+            const lateInDst = Date.UTC(2026, 9, 1, 12);
+            for (const zone of ["America/New_York", "America/Los_Angeles", "Europe/Berlin", "Africa/Casablanca"]) {
+                expectPlanMatchesZone(zone, lateInDst);
+            }
+        });
+
+        it("carries a permanently adopted higher offset instead of claiming the zone has no DST", () => {
+            // Turkey's +03 from 2016-03-27 has no closing transition; dropping it made the caller
+            // assert DST never applies, leaving the node an hour off from the switch onward.
+            expectPlanMatchesZone("Europe/Istanbul", Date.UTC(2016, 0, 15));
+            expectPlanMatchesZone("Europe/Istanbul", Date.UTC(2016, 5, 1));
+        });
+
+        it("handles a permanent offset reduction scheduled inside the horizon", () => {
+            // Kazakhstan moved Asia/Almaty +06 -> +05 permanently on 2024-03-01. A base taken as the
+            // minimum over the next 12 months alone would push +05 while the zone is still on +06.
+            expectPlanMatchesZone("Asia/Almaty", Date.UTC(2024, 0, 15));
+            expectPlanMatchesZone("Asia/Almaty", Date.UTC(2024, 1, 20));
+            expectPlanMatchesZone("Asia/Almaty", Date.UTC(2024, 3, 1));
+        });
+
+        it("agrees with the zone's true offset across zones, dates and list sizes", () => {
+            const zones = [
+                "Europe/Berlin",
+                "Europe/London",
+                "Europe/Istanbul",
+                "America/New_York",
+                "America/Los_Angeles",
+                "America/Phoenix",
+                "America/Santiago",
+                "Australia/Sydney",
+                "Pacific/Chatham", // 45-minute DST delta
+                "Asia/Kolkata", // half-hour offset, no DST
+                "Asia/Almaty",
+                "Africa/Casablanca",
+            ];
+            for (const zone of zones) {
+                for (let month = 0; month < 12; month++) {
+                    for (const maxWindows of [1, 2]) {
+                        expectPlanMatchesZone(zone, Date.UTC(2026, month, 5, 6), { maxRegimes: 2, maxWindows });
+                        expectPlanMatchesZone(zone, Date.UTC(2026, month, 20, 18), { maxRegimes: 2, maxWindows });
+                    }
+                }
+            }
+        });
+
+        it("produces lists SetTimeZone and SetDstOffset accept", () => {
+            const zones = [
+                "Europe/Berlin",
+                "America/New_York",
+                "Europe/Istanbul",
+                "Asia/Almaty",
+                "America/Asuncion",
+                "Africa/Casablanca",
+                "Australia/Sydney",
+            ];
+            const years = [2016, 2024, 2026];
+            let checked = 0;
+            for (const zone of zones) {
+                for (const year of years) {
+                    for (const maxRegimes of [1, 2]) {
+                        for (const maxWindows of [1, 2, 3]) {
+                            for (const month of [0, 3, 6, 9]) {
+                                const atMs = Date.UTC(year, month, 10);
+                                const { regimes, dstWindows } = timeZonePlan(zone, atMs, { maxRegimes, maxWindows });
+                                const label = `${zone} @ ${new Date(atMs).toISOString()} tz=${maxRegimes} dst=${maxWindows}`;
+                                checked++;
+
+                                expect(regimes.length, label).to.be.at.least(1);
+                                expect(regimes.length, label).to.be.at.most(maxRegimes);
+                                // The cluster requires entry 0 at the Matter epoch and any later entry
+                                // strictly after it, in ascending order.
+                                expect(regimes[0].validFromMs, label).to.equal(null);
+                                regimes.slice(1).forEach((regime, index) => {
+                                    expect(regime.validFromMs, label).to.not.equal(null);
+                                    const previous = regimes[index].validFromMs;
+                                    if (previous !== null) {
+                                        expect(regime.validFromMs, label).to.be.greaterThan(previous);
+                                    }
+                                });
+
+                                expect(dstWindows.length, label).to.be.at.most(maxWindows);
+                                dstWindows.forEach((window, index) => {
+                                    // Only the final entry may be open-ended, and ValidUntil must follow
+                                    // ValidStarting.
+                                    if (window.validUntilMs === null) {
+                                        expect(index, label).to.equal(dstWindows.length - 1);
+                                    } else {
+                                        // A null validStartingMs is pushed as the Matter epoch, so the only
+                                        // meaningful bound left for an already-active window is the sync instant.
+                                        expect(window.validUntilMs, label).to.be.greaterThan(
+                                            window.validStartingMs ?? atMs,
+                                        );
+                                    }
+                                    // Entries must be sorted and must not overlap the previous one.
+                                    const previous = dstWindows[index - 1];
+                                    if (previous !== undefined) {
+                                        expect(window.validStartingMs, label).to.be.at.least(
+                                            previous.validUntilMs ?? 0,
+                                        );
+                                    }
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            expect(checked).to.equal(zones.length * years.length * 2 * 3 * 4);
+        });
+    });
+
+    describe("nextOffsetChangeMs", () => {
+        it("finds an imminent seasonal change", () => {
+            const beforeSpringForward = Date.UTC(2026, 2, 28, 12);
+            const plan = timeZonePlan("Europe/Berlin", beforeSpringForward, BOTH_MAX);
+            expect(nextOffsetChangeMs(plan, beforeSpringForward)).to.equal(Date.UTC(2026, 2, 29, 1));
+        });
+
+        it("finds an imminent permanent change", () => {
+            // Asia/Almaty dropped +06 -> +05 at 2024-03-01 00:00 local (2024-02-29 18:00 UTC).
+            const beforeChange = Date.UTC(2024, 1, 29, 12);
+            const plan = timeZonePlan("Asia/Almaty", beforeChange, BOTH_MAX);
+            expect(nextOffsetChangeMs(plan, beforeChange)).to.equal(Date.UTC(2024, 1, 29, 18));
+        });
+
+        it("returns the window end when mid-DST rather than a boundary already passed", () => {
+            const midDst = Date.UTC(2026, 5, 1, 12);
+            const plan = timeZonePlan("Europe/Berlin", midDst, BOTH_MAX);
+            expect(nextOffsetChangeMs(plan, midDst)).to.equal(Date.UTC(2026, 9, 25, 1));
+        });
+
+        it("returns null for a zone whose offset never changes", () => {
+            const plan = timeZonePlan("America/Phoenix", JAN_2026, BOTH_MAX);
+            expect(nextOffsetChangeMs(plan, JAN_2026)).to.equal(null);
         });
     });
 

--- a/packages/ws-controller/test/HostTimeZoneTest.ts
+++ b/packages/ws-controller/test/HostTimeZoneTest.ts
@@ -194,6 +194,18 @@ describe("hostTimeZone", () => {
             expectPlanMatchesZone("Asia/Almaty", Date.UTC(2024, 0, 15), SINGLE_TIME_ZONE_ENTRY);
         });
 
+        it("keeps the regime count inside the cluster's range whatever the node reports", () => {
+            // TimeZoneListMaxSize is 1..2; a node outside that range must not produce an empty list
+            // nor more entries than the cluster allows.
+            for (const maxRegimes of [-1, 0, 1, 2, 5]) {
+                const plan = timeZonePlan("Asia/Almaty", Date.UTC(2024, 0, 15), { maxRegimes, maxWindows: 2 });
+                const label = `maxRegimes=${maxRegimes}`;
+                expect(plan.regimes.length, label).to.be.at.least(1);
+                expect(plan.regimes.length, label).to.be.at.most(2);
+                expect(nodeOffsetSeconds(plan, Date.UTC(2024, 0, 15)), label).to.equal(21600);
+            }
+        });
+
         it("does not split a zone that is merely mid-DST at the sync instant", () => {
             // Sydney in January sits in DST, so its leading segment has a higher minimum than the
             // rest. Splitting there would call +11 a standard offset and +10 a future regime.

--- a/packages/ws-controller/test/HostTimeZoneTest.ts
+++ b/packages/ws-controller/test/HostTimeZoneTest.ts
@@ -60,6 +60,19 @@ function expectPlanMatchesZone(zone: string, atMs: number, limits = BOTH_MAX) {
     expect(nodeOffsetSeconds(plan, atMs), label).to.equal(offsetSecondsAt(zone, atMs));
 }
 
+/**
+ * A node holds one plan between syncs, so check hourly across a span it must cover rather than only
+ * at the instant it was built. The span is fixed by the caller on purpose: deriving it from the plan
+ * would let a plan that under-reports a change shrink its own window and pass.
+ */
+function expectPlanHoldsFor(zone: string, atMs: number, spanMs: number, limits = BOTH_MAX) {
+    const plan = timeZonePlan(zone, atMs, limits);
+    for (let t = atMs; t <= atMs + spanMs; t += 3_600_000) {
+        const label = `${zone}, plan built ${new Date(atMs).toISOString()}, checked ${new Date(t).toISOString()}`;
+        expect(nodeOffsetSeconds(plan, t), label).to.equal(offsetSecondsAt(zone, t));
+    }
+}
+
 describe("hostTimeZone", () => {
     describe("offsetSecondsAt", () => {
         it("returns the total offset including DST", () => {
@@ -118,8 +131,18 @@ describe("hostTimeZone", () => {
             // DST 2026 begins 2026-03-29 01:00 UTC, ends 2026-10-25 01:00 UTC
             expect(plan.dstWindows[0].validStartingMs).to.equal(Date.UTC(2026, 2, 29, 1, 0, 0));
             expect(plan.dstWindows[0].validUntilMs).to.equal(Date.UTC(2026, 9, 25, 1, 0, 0));
+            // These pin the current EU rule (last Sunday of March and October, 01:00 UTC). If the EU
+            // abolishes DST and tzdata follows, this failing is the correct signal, not test rot.
             expect(plan.dstWindows[1].validStartingMs).to.equal(Date.UTC(2027, 2, 28, 1, 0, 0));
             expect(plan.dstWindows[1].validUntilMs).to.equal(Date.UTC(2027, 9, 31, 1, 0, 0));
+        });
+
+        it("stays correct across a transition for the whole span a node holds it", () => {
+            // Built mid-winter and checked hourly for 300 days, so it crosses both the spring and the
+            // autumn transition without being rebuilt.
+            expectPlanHoldsFor("Europe/Berlin", JAN_2026, 300 * DAY_MS);
+            expectPlanHoldsFor("Australia/Sydney", JAN_2026, 300 * DAY_MS);
+            expectPlanHoldsFor("America/Asuncion", Date.UTC(2024, 0, 1, 12), 300 * DAY_MS);
         });
 
         it("emits the currently-active window when already in DST", () => {
@@ -248,13 +271,15 @@ describe("hostTimeZone", () => {
             expect(roomy.regimes.length).to.equal(2);
             expect(roomy.dstWindows.filter(window => window.offsetSeconds !== 0).length).to.equal(2);
 
-            const tight = timeZonePlan("America/Dawson", atMs, { maxRegimes: 2, maxWindows: 1 });
-            expect(tight.regimes.length).to.equal(1);
-            expect(tight.regimes[0].offsetSeconds).to.equal(-28800);
-            for (const at of [atMs, Date.UTC(2018, 11, 1), Date.UTC(2019, 5, 1)]) {
-                expectPlanMatchesZone("America/Dawson", at, { maxRegimes: 2, maxWindows: 1 });
-                expectPlanMatchesZone("America/Dawson", at, { maxRegimes: 2, maxWindows: 4 });
-            }
+            const tight = { maxRegimes: 2, maxWindows: 1 };
+            const plan = timeZonePlan("America/Dawson", atMs, tight);
+            expect(plan.regimes.length).to.equal(1);
+            expect(plan.regimes[0].offsetSeconds).to.equal(-28800);
+
+            // The single window runs to 2018-11-04, and the plan is only answerable that far: it holds
+            // through 54 days, and the resync it asks for lands on the boundary where it stops.
+            expectPlanHoldsFor("America/Dawson", atMs, 54 * DAY_MS, tight);
+            expect(nextOffsetChangeMs(plan, atMs)).to.equal(Date.UTC(2018, 10, 4, 9));
         });
 
         it("reports a single regime once a permanent change is in the past", () => {

--- a/packages/ws-controller/test/HostTimeZoneTest.ts
+++ b/packages/ws-controller/test/HostTimeZoneTest.ts
@@ -286,93 +286,85 @@ describe("hostTimeZone", () => {
             expectPlanMatchesZone("Asia/Almaty", Date.UTC(2024, 3, 1));
         });
 
-        it("agrees with the zone's true offset across zones, dates and list sizes", () => {
+        it("agrees with the zone's true offset across behaviours, dates and list sizes", function () {
+            this.timeout(20_000);
+            // One zone per behaviour the decomposition has to get right. Breadth across every IANA
+            // zone and year is covered by the offline sweep, not here, so this stays inside the
+            // per-test timeout on a slow runner: each plan day-steps its whole scan range.
             const zones = [
-                "Europe/Berlin",
-                "Europe/London",
-                "Europe/Istanbul",
-                "America/New_York",
-                "America/Los_Angeles",
-                "America/Phoenix",
-                "America/Santiago",
-                "Australia/Sydney",
-                "Pacific/Chatham", // 45-minute DST delta
+                "Europe/Berlin", // northern seasonal DST
+                "Australia/Sydney", // southern, window spans New Year
+                "America/Phoenix", // no DST
                 "Asia/Kolkata", // half-hour offset, no DST
-                "Asia/Almaty",
-                "Africa/Casablanca",
+                "Pacific/Chatham", // 45-minute DST delta
+                "Africa/Casablanca", // recurring dip below the base
             ];
-            for (const zone of zones) {
-                for (let month = 0; month < 12; month++) {
-                    for (const maxWindows of [1, 2]) {
-                        expectPlanMatchesZone(zone, Date.UTC(2026, month, 5, 6), { maxRegimes: 2, maxWindows });
-                        expectPlanMatchesZone(zone, Date.UTC(2026, month, 20, 18), { maxRegimes: 2, maxWindows });
-                    }
-                }
-            }
-        });
-
-        it("produces lists SetTimeZone and SetDstOffset accept", () => {
-            const zones = [
-                "Europe/Berlin",
-                "America/New_York",
-                "Europe/Istanbul",
-                "Asia/Almaty",
-                "America/Asuncion",
-                "Africa/Casablanca",
-                "Australia/Sydney",
-            ];
-            const years = [2016, 2024, 2026];
             let checked = 0;
             for (const zone of zones) {
-                for (const year of years) {
-                    for (const maxRegimes of [1, 2]) {
-                        for (const maxWindows of [1, 2, 3]) {
-                            for (const month of [0, 3, 6, 9]) {
-                                const atMs = Date.UTC(year, month, 10);
-                                const { regimes, dstWindows } = timeZonePlan(zone, atMs, { maxRegimes, maxWindows });
-                                const label = `${zone} @ ${new Date(atMs).toISOString()} tz=${maxRegimes} dst=${maxWindows}`;
-                                checked++;
-
-                                expect(regimes.length, label).to.be.at.least(1);
-                                expect(regimes.length, label).to.be.at.most(maxRegimes);
-                                // The cluster requires entry 0 at the Matter epoch and any later entry
-                                // strictly after it, in ascending order.
-                                expect(regimes[0].validFromMs, label).to.equal(null);
-                                regimes.slice(1).forEach((regime, index) => {
-                                    expect(regime.validFromMs, label).to.not.equal(null);
-                                    const previous = regimes[index].validFromMs;
-                                    if (previous !== null) {
-                                        expect(regime.validFromMs, label).to.be.greaterThan(previous);
-                                    }
-                                });
-
-                                expect(dstWindows.length, label).to.be.at.most(maxWindows);
-                                dstWindows.forEach((window, index) => {
-                                    // Only the final entry may be open-ended, and ValidUntil must follow
-                                    // ValidStarting.
-                                    if (window.validUntilMs === null) {
-                                        expect(index, label).to.equal(dstWindows.length - 1);
-                                    } else {
-                                        // A null validStartingMs is pushed as the Matter epoch, so the only
-                                        // meaningful bound left for an already-active window is the sync instant.
-                                        expect(window.validUntilMs, label).to.be.greaterThan(
-                                            window.validStartingMs ?? atMs,
-                                        );
-                                    }
-                                    // Entries must be sorted and must not overlap the previous one.
-                                    const previous = dstWindows[index - 1];
-                                    if (previous !== undefined) {
-                                        expect(window.validStartingMs, label).to.be.at.least(
-                                            previous.validUntilMs ?? 0,
-                                        );
-                                    }
-                                });
-                            }
-                        }
+                for (const month of [0, 3, 6, 9]) {
+                    for (const maxWindows of [1, 2]) {
+                        expectPlanMatchesZone(zone, Date.UTC(2026, month, 5, 6), { maxRegimes: 2, maxWindows });
+                        checked++;
                     }
                 }
             }
-            expect(checked).to.equal(zones.length * years.length * 2 * 3 * 4);
+            expect(checked).to.equal(zones.length * 4 * 2);
+        });
+
+        it("produces lists SetTimeZone and SetDstOffset accept", function () {
+            this.timeout(20_000);
+            // One case per shape the lists can take, rather than a cross-product: each plan day-steps
+            // its whole scan range, so breadth here would cost more than the per-test timeout allows.
+            const cases: Array<[string, number]> = [
+                ["Europe/Berlin", Date.UTC(2026, 0, 10)], // seasonal, next window ahead
+                ["Europe/Berlin", Date.UTC(2026, 6, 10)], // seasonal, window active now
+                ["Australia/Sydney", Date.UTC(2026, 0, 10)], // southern, window spans New Year
+                ["Asia/Almaty", Date.UTC(2024, 0, 10)], // pending permanent reduction
+                ["Europe/Istanbul", Date.UTC(2016, 0, 10)], // pending permanent adoption
+                ["America/Asuncion", Date.UTC(2024, 0, 10)], // real DST plus a pending change
+                ["Africa/Casablanca", Date.UTC(2026, 3, 10)], // recurring dip below the base
+            ];
+            let checked = 0;
+            for (const [zone, atMs] of cases) {
+                for (const maxRegimes of [1, 2]) {
+                    for (const maxWindows of [1, 2, 3]) {
+                        const { regimes, dstWindows } = timeZonePlan(zone, atMs, { maxRegimes, maxWindows });
+                        const label = `${zone} @ ${new Date(atMs).toISOString()} tz=${maxRegimes} dst=${maxWindows}`;
+                        checked++;
+
+                        expect(regimes.length, label).to.be.at.least(1);
+                        expect(regimes.length, label).to.be.at.most(maxRegimes);
+                        // The cluster requires entry 0 at the Matter epoch and any later entry strictly
+                        // after it, in ascending order.
+                        expect(regimes[0].validFromMs, label).to.equal(null);
+                        regimes.slice(1).forEach((regime, index) => {
+                            expect(regime.validFromMs, label).to.not.equal(null);
+                            const previous = regimes[index].validFromMs;
+                            if (previous !== null) {
+                                expect(regime.validFromMs, label).to.be.greaterThan(previous);
+                            }
+                        });
+
+                        expect(dstWindows.length, label).to.be.at.most(maxWindows);
+                        dstWindows.forEach((window, index) => {
+                            // Only the final entry may be open-ended, and ValidUntil must follow ValidStarting.
+                            if (window.validUntilMs === null) {
+                                expect(index, label).to.equal(dstWindows.length - 1);
+                            } else {
+                                // A window with no known start is pushed as the Matter epoch, so the only
+                                // bound left to check it against is the sync instant.
+                                expect(window.validUntilMs, label).to.be.greaterThan(window.validStartingMs ?? atMs);
+                            }
+                            // Entries must be sorted and must not overlap the previous one.
+                            const previous = dstWindows[index - 1];
+                            if (previous !== undefined) {
+                                expect(window.validStartingMs, label).to.be.at.least(previous.validUntilMs ?? 0);
+                            }
+                        });
+                    }
+                }
+            }
+            expect(checked).to.equal(cases.length * 2 * 3);
         });
     });
 

--- a/packages/ws-controller/test/HostTimeZoneTest.ts
+++ b/packages/ws-controller/test/HostTimeZoneTest.ts
@@ -288,9 +288,8 @@ describe("hostTimeZone", () => {
 
         it("agrees with the zone's true offset across behaviours, dates and list sizes", function () {
             this.timeout(20_000);
-            // One zone per behaviour the decomposition has to get right. Breadth across every IANA
-            // zone and year is covered by the offline sweep, not here, so this stays inside the
-            // per-test timeout on a slow runner: each plan day-steps its whole scan range.
+            // One zone per behaviour: each plan day-steps its whole scan range, so breadth across
+            // every IANA zone and year belongs to the offline sweep.
             const zones = [
                 "Europe/Berlin", // northern seasonal DST
                 "Australia/Sydney", // southern, window spans New Year
@@ -347,7 +346,6 @@ describe("hostTimeZone", () => {
 
                         expect(dstWindows.length, label).to.be.at.most(maxWindows);
                         dstWindows.forEach((window, index) => {
-                            // Only the final entry may be open-ended, and ValidUntil must follow ValidStarting.
                             if (window.validUntilMs === null) {
                                 expect(index, label).to.equal(dstWindows.length - 1);
                             } else {
@@ -355,7 +353,6 @@ describe("hostTimeZone", () => {
                                 // bound left to check it against is the sync instant.
                                 expect(window.validUntilMs, label).to.be.greaterThan(window.validStartingMs ?? atMs);
                             }
-                            // Entries must be sorted and must not overlap the previous one.
                             const previous = dstWindows[index - 1];
                             if (previous !== undefined) {
                                 expect(window.validStartingMs, label).to.be.at.least(previous.validUntilMs ?? 0);

--- a/packages/ws-controller/test/TimeSyncCommandsTest.ts
+++ b/packages/ws-controller/test/TimeSyncCommandsTest.ts
@@ -8,6 +8,7 @@ import { TimeSynchronization } from "@matter/main/clusters";
 import { MATTER_EPOCH_OFFSET_US, TlvEpochUs } from "@matter/main/types";
 import { pushNodeTime, TimeSyncInvokers, TimeZoneProvider } from "../src/controller/timeSyncCommands.js";
 import { AttributesData } from "../src/types/CommandHandler.js";
+import { TimeZonePlan } from "../src/util/hostTimeZone.js";
 
 const NOW_MS = 1_700_000_000_000;
 const TZ_ATTRS: AttributesData = { "0/56/1": 1, "0/56/5": [] };
@@ -31,9 +32,25 @@ function recorder(dstOffsetRequired: boolean) {
 
 const tz: TimeZoneProvider = {
     resolveHostTimeZone: () => "Europe/Berlin",
-    standardOffsetSeconds: () => 3600,
-    dstWindows: () => [{ offsetSeconds: 3600, validStartingMs: 1000, validUntilMs: 2000 }],
+    timeZonePlan: () => ({
+        regimes: [{ offsetSeconds: 3600, validFromMs: null }],
+        dstWindows: [{ offsetSeconds: 3600, validStartingMs: 1000, validUntilMs: 2000 }],
+    }),
 };
+
+function planWith(dstWindows: TimeZonePlan["dstWindows"]): TimeZoneProvider {
+    return { ...tz, timeZonePlan: () => ({ regimes: [{ offsetSeconds: 3600, validFromMs: null }], dstWindows }) };
+}
+
+function capturing(maxSeen: number[]): TimeZoneProvider {
+    return {
+        ...tz,
+        timeZonePlan: (_zone, _fromMs, limits) => {
+            maxSeen.push(limits.maxWindows);
+            return { regimes: [{ offsetSeconds: 3600, validFromMs: null }], dstWindows: [] };
+        },
+    };
+}
 
 describe("pushNodeTime", () => {
     it("sends UtcTime, TimeZone, then DstOffset when the node requires DST", async () => {
@@ -107,55 +124,100 @@ describe("pushNodeTime", () => {
 
     it("falls back to a max DST list size of 2 when DSTOffsetListMaxSize is not advertised", async () => {
         const maxSeen = new Array<number>();
-        const capturingTz: TimeZoneProvider = {
-            ...tz,
-            dstWindows: (_zone, _fromMs, max) => {
-                maxSeen.push(max);
-                return [];
-            },
-        };
         const { invokers } = recorder(true);
-        await pushNodeTime({ invokers, attributes: TZ_ATTRS, nowMs: NOW_MS, tz: capturingTz });
+        await pushNodeTime({ invokers, attributes: TZ_ATTRS, nowMs: NOW_MS, tz: capturing(maxSeen) });
         expect(maxSeen).to.deep.equal([2]);
     });
 
-    it("forwards DSTOffsetListMaxSize from attributes when advertised", async () => {
+    it("forwards DSTOffsetListMaxSize from attributes verbatim", async () => {
         const maxSeen = new Array<number>();
-        const capturingTz: TimeZoneProvider = {
-            ...tz,
-            dstWindows: (_zone, _fromMs, max) => {
-                maxSeen.push(max);
-                return [];
-            },
-        };
         const { invokers } = recorder(true);
         await pushNodeTime({
             invokers,
             attributes: { ...TZ_ATTRS, "0/56/11": 5 },
             nowMs: NOW_MS,
-            tz: capturingTz,
+            tz: capturing(maxSeen),
         });
         expect(maxSeen).to.deep.equal([5]);
     });
 
+    it("leaves a DSTOffsetListMaxSize below the spec minimum to the plan builder", async () => {
+        const maxSeen = new Array<number>();
+        const { invokers } = recorder(true);
+        await pushNodeTime({
+            invokers,
+            attributes: { ...TZ_ATTRS, "0/56/11": 0 },
+            nowMs: NOW_MS,
+            tz: capturing(maxSeen),
+        });
+        expect(maxSeen).to.deep.equal([0]);
+    });
+
+    it("sends a second TimeZone entry for a pending standard-offset change", async () => {
+        const changeMs = Date.UTC(2024, 1, 29, 18);
+        const twoRegimes: TimeZoneProvider = {
+            ...tz,
+            timeZonePlan: () => ({
+                regimes: [
+                    { offsetSeconds: 21600, validFromMs: null },
+                    { offsetSeconds: 18000, validFromMs: changeMs },
+                ],
+                dstWindows: [],
+            }),
+        };
+        const { calls, invokers } = recorder(true);
+        await pushNodeTime({ invokers, attributes: TZ_ATTRS, nowMs: NOW_MS, tz: twoRegimes });
+
+        const tzReq = calls[1].fields as TimeSynchronization.SetTimeZoneRequest;
+        expect(tzReq.timeZone).to.deep.equal([
+            { offset: 21600, validAt: MATTER_EPOCH_OFFSET_US, name: "Europe/Berlin" },
+            { offset: 18000, validAt: BigInt(changeMs) * 1000n, name: "Europe/Berlin" },
+        ]);
+        // The cluster requires entry 0 at the Matter epoch and any later entry strictly after it.
+        expect(tzReq.timeZone[1].validAt > tzReq.timeZone[0].validAt).to.equal(true);
+        tzReq.timeZone.forEach(entry => expect(() => TlvEpochUs.encode(entry.validAt)).not.to.throw());
+    });
+
+    it("forwards TimeZoneListMaxSize from attributes and defaults it to 2", async () => {
+        const seen = new Array<number>();
+        const capturingRegimes: TimeZoneProvider = {
+            ...tz,
+            timeZonePlan: (_zone, _fromMs, limits) => {
+                seen.push(limits.maxRegimes);
+                return { regimes: [{ offsetSeconds: 3600, validFromMs: null }], dstWindows: [] };
+            },
+        };
+        const { invokers } = recorder(true);
+        await pushNodeTime({ invokers, attributes: TZ_ATTRS, nowMs: NOW_MS, tz: capturingRegimes });
+        await pushNodeTime({
+            invokers,
+            attributes: { ...TZ_ATTRS, "0/56/10": 1 },
+            nowMs: NOW_MS,
+            tz: capturingRegimes,
+        });
+        expect(seen).to.deep.equal([2, 1]);
+    });
+
     it("maps a null validUntil through unchanged", async () => {
         const { calls, invokers } = recorder(true);
-        const openTz: TimeZoneProvider = {
-            ...tz,
-            dstWindows: () => [{ offsetSeconds: 3600, validStartingMs: 1000, validUntilMs: null }],
-        };
+        const openTz = planWith([{ offsetSeconds: 3600, validStartingMs: 1000, validUntilMs: null }]);
         await pushNodeTime({ invokers, attributes: TZ_ATTRS, nowMs: NOW_MS, tz: openTz });
         const dstReq = calls[2].fields as TimeSynchronization.SetDstOffsetRequest;
         expect(dstReq.dstOffset[0].validUntil).to.equal(null);
     });
 
+    it("maps a null validStarting to the Matter epoch so an already-active window applies at once", async () => {
+        const { calls, invokers } = recorder(true);
+        const activeTz = planWith([{ offsetSeconds: 3600, validStartingMs: null, validUntilMs: 2000 }]);
+        await pushNodeTime({ invokers, attributes: TZ_ATTRS, nowMs: NOW_MS, tz: activeTz });
+        const dstReq = calls[2].fields as TimeSynchronization.SetDstOffsetRequest;
+        expect(dstReq.dstOffset[0].validStarting).to.equal(MATTER_EPOCH_OFFSET_US);
+        expect(() => TlvEpochUs.encode(dstReq.dstOffset[0].validStarting)).not.to.throw();
+    });
+
     it("sends the canonical no-DST entry instead of an empty list for a no-DST zone", async () => {
         const { calls, invokers } = recorder(true);
-        const noDstTz: TimeZoneProvider = {
-            ...tz,
-            dstWindows: () => [],
-        };
-        await pushNodeTime({ invokers, attributes: TZ_ATTRS, nowMs: NOW_MS, tz: noDstTz });
+        await pushNodeTime({ invokers, attributes: TZ_ATTRS, nowMs: NOW_MS, tz: planWith([]) });
 
         expect(calls.map(c => c.command)).to.deep.equal(["setUtcTime", "setTimeZone", "setDstOffset"]);
         const dstReq = calls[2].fields as TimeSynchronization.SetDstOffsetRequest;
@@ -168,10 +230,7 @@ describe("pushNodeTime", () => {
         const validStartingMs = Date.UTC(2026, 2, 29, 1);
         const validUntilMs = Date.UTC(2026, 9, 25, 1);
         const { calls, invokers } = recorder(true);
-        const realisticTz: TimeZoneProvider = {
-            ...tz,
-            dstWindows: () => [{ offsetSeconds: 3600, validStartingMs, validUntilMs }],
-        };
+        const realisticTz = planWith([{ offsetSeconds: 3600, validStartingMs, validUntilMs }]);
         await pushNodeTime({ invokers, attributes: TZ_ATTRS, nowMs: NOW_MS, tz: realisticTz });
 
         const dstReq = calls[2].fields as TimeSynchronization.SetDstOffsetRequest;

--- a/packages/ws-controller/test/TimeSyncManagerTest.ts
+++ b/packages/ws-controller/test/TimeSyncManagerTest.ts
@@ -29,6 +29,8 @@ const PAST_STARTUP_MS = 61 * ONE_MINUTE_MS;
 
 const PEER_1 = PeerAddress({ fabricIndex: FabricIndex(1), nodeId: NodeId(1) });
 const PEER_2 = PeerAddress({ fabricIndex: FabricIndex(1), nodeId: NodeId(2) });
+const PEER_3 = PeerAddress({ fabricIndex: FabricIndex(1), nodeId: NodeId(3) });
+const PEER_4 = PeerAddress({ fabricIndex: FabricIndex(1), nodeId: NodeId(4) });
 
 function makeTimeSyncAttrs(): AttributesData {
     return { [`0/${TIME_SYNC_CLUSTER_ID}/1`]: 1 };
@@ -38,6 +40,7 @@ class StubConnector implements TimeSyncConnector {
     readonly syncCalls: PeerAddress[] = [];
     private readonly _connected = new PeerAddressSet();
     slowSync = false;
+    failSync = false;
     nodeCount = 0;
     readonly syncResolvers: Array<() => void> = [];
 
@@ -58,6 +61,9 @@ class StubConnector implements TimeSyncConnector {
             await new Promise<void>(resolve => this.syncResolvers.push(resolve));
         }
         this.syncCalls.push(peer);
+        if (this.failSync) {
+            throw new Error("sync exploded");
+        }
     }
 
     resolveAll(): void {
@@ -275,6 +281,27 @@ describe("TimeSyncManager", () => {
         });
     });
 
+    describe("first cycle", () => {
+        it("syncs a node that registers while the cycle is already running", async () => {
+            // Three peers so the cycle is still between nodes when the late one arrives; the peer list
+            // is snapshotted at cycle start, so the late node can only be covered by the direct path.
+            for (const peer of [PEER_1, PEER_2, PEER_3]) {
+                connector.setConnected(peer);
+                manager.registerNode(peer, makeTimeSyncAttrs());
+            }
+
+            await MockTime.advance(PAST_STARTUP_MS);
+            await MockTime.yield3();
+
+            connector.setConnected(PEER_4);
+            manager.registerNode(PEER_4, makeTimeSyncAttrs());
+            await MockTime.yield3();
+
+            const synced = connector.syncCalls.map(peer => peer.nodeId);
+            expect(synced.includes(PEER_4.nodeId), `late registrant missing from ${synced}`).to.equal(true);
+        });
+    });
+
     describe("cadence wiring", () => {
         // MockTimer ignores interval assignment, so the timer cannot show which delay was chosen;
         // assert the hook's own return value instead.
@@ -402,6 +429,18 @@ describe("TimeSyncManager", () => {
             manager.syncNode(PEER_1, SyncTrigger.TimeFailure);
             await MockTime.yield3();
             expect(connector.syncCalls.length, "a node asking for a time is answered").to.equal(afterHour + 1);
+        });
+
+        it("does not let a failed reconnect attempt spend the timeFailure leash", async () => {
+            connector.failSync = true;
+            manager.syncNode(PEER_1, SyncTrigger.Reconnect);
+            await MockTime.yield3();
+            expect(connector.syncCalls.length, "the reconnect attempt happened and failed").to.equal(1);
+
+            connector.failSync = false;
+            manager.syncNode(PEER_1, SyncTrigger.TimeFailure);
+            await MockTime.yield3();
+            expect(connector.syncCalls.length, "a node asking for a time must still be answered").to.equal(2);
         });
 
         it("holds off a timeFailure repeated inside the hour", async () => {

--- a/packages/ws-controller/test/TimeSyncManagerTest.ts
+++ b/packages/ws-controller/test/TimeSyncManagerTest.ts
@@ -275,6 +275,29 @@ describe("TimeSyncManager", () => {
         });
     });
 
+    describe("cadence wiring", () => {
+        // MockTimer ignores interval assignment, so the timer cannot show which delay was chosen;
+        // assert the hook's own return value instead.
+        class Probe extends TimeSyncManager {
+            delay(): number {
+                return this.nextCycleDelay();
+            }
+        }
+
+        it("hands the timer a delay just past an imminent change, and the interval otherwise", async () => {
+            const near = new Probe(connector, fromMs => fromMs + 5 * ONE_HOUR_MS);
+            const none = new Probe(connector, () => null);
+            const past = new Probe(connector, fromMs => fromMs - ONE_HOUR_MS);
+            try {
+                expect(near.delay()).to.equal(5 * ONE_HOUR_MS + ONE_MINUTE_MS);
+                expect(none.delay()).to.equal(ONE_DAY_MS);
+                expect(past.delay()).to.equal(ONE_DAY_MS);
+            } finally {
+                await Promise.all([near.stop(), none.stop(), past.stop()]);
+            }
+        });
+    });
+
     describe("commissioned node count", () => {
         it("is read only while the startup delay can still change", async () => {
             let lookups = 0;

--- a/packages/ws-controller/test/TimeSyncManagerTest.ts
+++ b/packages/ws-controller/test/TimeSyncManagerTest.ts
@@ -281,6 +281,44 @@ describe("TimeSyncManager", () => {
         });
     });
 
+    describe("duplicate pushes", () => {
+        /** Advance a second at a time until the cycle has pushed its first peer, and stop there. */
+        async function advanceIntoCycle(): Promise<number> {
+            for (let i = 0; i < 400 && connector.syncCalls.length === 0; i++) {
+                await MockTime.advance(1000);
+                await MockTime.yield3();
+            }
+            expect(connector.syncCalls.length, "the cycle must have started").to.be.greaterThan(0);
+            return connector.syncCalls.length;
+        }
+
+        it("does not re-push a peer the periodic cycle just handled", async () => {
+            for (const peer of [PEER_1, PEER_2]) {
+                connector.setConnected(peer);
+                manager.registerNode(peer, makeTimeSyncAttrs());
+            }
+            const duringCycle = await advanceIntoCycle();
+
+            // Any reconnect signal re-registers a peer; here it lands inside the inter-node delay.
+            manager.registerNode(PEER_1, makeTimeSyncAttrs());
+            await MockTime.yield3();
+            expect(connector.syncCalls.length, "a routine re-register must not push again").to.equal(duringCycle);
+        });
+
+        it("still answers a timeFailure from a peer the cycle just handled", async () => {
+            for (const peer of [PEER_1, PEER_2]) {
+                connector.setConnected(peer);
+                manager.registerNode(peer, makeTimeSyncAttrs());
+            }
+            const duringCycle = await advanceIntoCycle();
+
+            // The node reporting no usable time means the push did not take, so it must be answered.
+            manager.syncNode(PEER_1, SyncTrigger.TimeFailure);
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.equal(duringCycle + 1);
+        });
+    });
+
     describe("first cycle", () => {
         it("syncs a node that registers while the cycle is already running", async () => {
             // Three peers so the cycle is still between nodes when the late one arrives; the peer list

--- a/packages/ws-controller/test/TimeSyncManagerTest.ts
+++ b/packages/ws-controller/test/TimeSyncManagerTest.ts
@@ -275,6 +275,34 @@ describe("TimeSyncManager", () => {
         });
     });
 
+    describe("offset lookup failure", () => {
+        it("keeps syncing and rescheduling when the lookup throws", async () => {
+            const failing = new TimeSyncManager(connector, () => {
+                throw new Error("zone lookup exploded");
+            });
+            try {
+                connector.setConnected(PEER_1);
+                failing.registerNode(PEER_1, makeTimeSyncAttrs());
+
+                // The delay is computed before the cycle body, so a throw used to abort the cycle
+                // before the finally that restarts the timer, stopping resyncs for good.
+                await MockTime.advance(PAST_STARTUP_MS);
+                await MockTime.yield3();
+                expect(connector.syncCalls.length, "first cycle must still run").to.be.greaterThan(0);
+
+                const afterFirst = connector.syncCalls.length;
+                for (let i = 0; i < 3; i++) {
+                    await MockTime.advance(PAST_STARTUP_MS);
+                    await MockTime.yield3();
+                }
+                expect(connector.syncCalls.length, "timer must still be scheduled").to.be.greaterThan(afterFirst);
+            } finally {
+                connector.resolveAll();
+                await failing.stop();
+            }
+        });
+    });
+
     describe("startup window", () => {
         it("defers a trigger sync until the first periodic cycle", async () => {
             connector.setConnected(PEER_1);

--- a/packages/ws-controller/test/TimeSyncManagerTest.ts
+++ b/packages/ws-controller/test/TimeSyncManagerTest.ts
@@ -12,6 +12,7 @@ import {
     hasTimeZoneFeature,
     resyncDelayMs,
     startupDelayMs,
+    SyncTrigger,
     TimeSyncConnector,
     TimeSyncManager,
 } from "../src/controller/TimeSyncManager.js";
@@ -19,7 +20,8 @@ import { AttributesData } from "../src/types/CommandHandler.js";
 
 const TIME_SYNC_CLUSTER_ID = 0x0038; // 56 decimal
 const ONE_MINUTE_MS = 60_000;
-const ONE_DAY_MS = 24 * 60 * ONE_MINUTE_MS;
+const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+const ONE_DAY_MS = 24 * ONE_HOUR_MS;
 
 // Startup delay is 3 min plus 10 s per commissioned node; advancing 61 min always fires it
 const PAST_STARTUP_MS = 61 * ONE_MINUTE_MS;
@@ -266,6 +268,23 @@ describe("TimeSyncManager", () => {
         });
     });
 
+    describe("startup window", () => {
+        it("defers a trigger sync until the first periodic cycle", async () => {
+            connector.setConnected(PEER_1);
+            manager.registerNode(PEER_1, makeTimeSyncAttrs());
+
+            // A restart can leave many nodes reporting timeFailure at once, which is the traffic the
+            // window exists to avoid; the first cycle covers all of them together.
+            manager.syncNode(PEER_1, SyncTrigger.TimeFailure);
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.equal(0);
+
+            await MockTime.advance(PAST_STARTUP_MS);
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.be.greaterThan(0);
+        });
+    });
+
     describe("trigger sync cooldown", () => {
         beforeEach(() => {
             manager.registerNode(PEER_1, makeTimeSyncAttrs());
@@ -279,6 +298,34 @@ describe("TimeSyncManager", () => {
             expect(connector.syncCalls.length).to.equal(1);
 
             manager.syncNode(PEER_1); // within cooldown — dropped
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.equal(1);
+        });
+
+        it("answers a timeFailure long before a reconnect would be allowed again", async () => {
+            manager.syncNode(PEER_1, SyncTrigger.Reconnect);
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.equal(1);
+
+            await MockTime.advance(ONE_HOUR_MS);
+            await MockTime.yield3();
+            const afterHour = connector.syncCalls.length;
+
+            manager.syncNode(PEER_1, SyncTrigger.Reconnect);
+            await MockTime.yield3();
+            expect(connector.syncCalls.length, "reconnect stays held off for 24 h").to.equal(afterHour);
+
+            manager.syncNode(PEER_1, SyncTrigger.TimeFailure);
+            await MockTime.yield3();
+            expect(connector.syncCalls.length, "a node asking for a time is answered").to.equal(afterHour + 1);
+        });
+
+        it("holds off a timeFailure repeated inside the hour", async () => {
+            manager.syncNode(PEER_1, SyncTrigger.TimeFailure);
+            await MockTime.yield3();
+            expect(connector.syncCalls.length).to.equal(1);
+
+            manager.syncNode(PEER_1, SyncTrigger.TimeFailure);
             await MockTime.yield3();
             expect(connector.syncCalls.length).to.equal(1);
         });

--- a/packages/ws-controller/test/TimeSyncManagerTest.ts
+++ b/packages/ws-controller/test/TimeSyncManagerTest.ts
@@ -443,14 +443,38 @@ describe("TimeSyncManager", () => {
             expect(connector.syncCalls.length, "a node asking for a time must still be answered").to.equal(2);
         });
 
-        it("holds off a timeFailure repeated inside the hour", async () => {
+        it("absorbs a burst of timeFailure events from one loss", async () => {
+            // Devices are observed emitting four within 49 s; only the first should be answered.
             manager.syncNode(PEER_1, SyncTrigger.TimeFailure);
             await MockTime.yield3();
             expect(connector.syncCalls.length).to.equal(1);
 
+            for (const offset of [9_000, 29_000, 49_000]) {
+                await MockTime.advance(offset === 9_000 ? 9_000 : 20_000);
+                await MockTime.yield3();
+                manager.syncNode(PEER_1, SyncTrigger.TimeFailure);
+                await MockTime.yield3();
+                expect(connector.syncCalls.length, `event at +${offset}ms must be absorbed`).to.equal(1);
+            }
+        });
+
+        it("answers a node that lost its clock minutes after its last timeFailure sync (#938)", async () => {
+            // Reported timeline: synced from a timeFailure, then power-cycled ~15 min later. The node
+            // asks again with no usable time and must not be refused; it stops asking after a few
+            // tries, so a refusal here is not retried until the periodic pass.
             manager.syncNode(PEER_1, SyncTrigger.TimeFailure);
             await MockTime.yield3();
             expect(connector.syncCalls.length).to.equal(1);
+
+            await MockTime.advance(15 * ONE_MINUTE_MS + 31_000);
+            await MockTime.yield3();
+            const afterIdle = connector.syncCalls.length;
+
+            manager.syncNode(PEER_1, SyncTrigger.TimeFailure);
+            await MockTime.yield3();
+            expect(connector.syncCalls.length, "the node reporting no usable time must be answered").to.equal(
+                afterIdle + 1,
+            );
         });
 
         it("allows a trigger sync after the 24h cooldown elapses", async () => {

--- a/packages/ws-controller/test/TimeSyncManagerTest.ts
+++ b/packages/ws-controller/test/TimeSyncManagerTest.ts
@@ -4,12 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { FabricIndex, NodeId } from "@matter/main";
+import { FabricIndex, Hours, Minutes, NodeId, Seconds } from "@matter/main";
 import { PeerAddress, PeerAddressSet } from "@matter/main/protocol";
 import {
     dstOffsetListMaxSize,
     hasTimeSyncCluster,
     hasTimeZoneFeature,
+    resyncDelayMs,
+    startupDelayMs,
     TimeSyncConnector,
     TimeSyncManager,
 } from "../src/controller/TimeSyncManager.js";
@@ -19,7 +21,7 @@ const TIME_SYNC_CLUSTER_ID = 0x0038; // 56 decimal
 const ONE_MINUTE_MS = 60_000;
 const ONE_DAY_MS = 24 * 60 * ONE_MINUTE_MS;
 
-// Startup delay is random 30–60 min; advancing 61 min always fires it
+// Startup delay is 3 min plus 10 s per commissioned node; advancing 61 min always fires it
 const PAST_STARTUP_MS = 61 * ONE_MINUTE_MS;
 
 const PEER_1 = PeerAddress({ fabricIndex: FabricIndex(1), nodeId: NodeId(1) });
@@ -33,6 +35,7 @@ class StubConnector implements TimeSyncConnector {
     readonly syncCalls: PeerAddress[] = [];
     private readonly _connected = new PeerAddressSet();
     slowSync = false;
+    nodeCount = 0;
     readonly syncResolvers: Array<() => void> = [];
 
     setConnected(peer: PeerAddress): void {
@@ -41,6 +44,10 @@ class StubConnector implements TimeSyncConnector {
 
     nodeConnected(peer: PeerAddress): boolean {
         return this._connected.has(peer);
+    }
+
+    commissionedNodeCount(): number {
+        return this.nodeCount;
     }
 
     async syncTime(peer: PeerAddress): Promise<void> {
@@ -103,6 +110,46 @@ describe("dstOffsetListMaxSize", () => {
     });
 });
 
+describe("startupDelayMs", () => {
+    it("is 3 minutes plus 10 seconds per commissioned node", () => {
+        expect(startupDelayMs(0)).to.equal(Minutes(3));
+        expect(startupDelayMs(12)).to.equal(Minutes(5));
+        expect(startupDelayMs(100)).to.equal(Minutes(3) + Seconds(1000));
+    });
+
+    it("is deterministic, so restarts do not vary the first sync", () => {
+        expect(startupDelayMs(7)).to.equal(startupDelayMs(7));
+    });
+});
+
+describe("resyncDelayMs", () => {
+    const NOW = 1_700_000_000_000;
+
+    it("uses the full interval when no offset change is in view", () => {
+        expect(resyncDelayMs(NOW, null)).to.equal(Hours(24));
+    });
+
+    it("lands a minute past an offset change inside the interval", () => {
+        expect(resyncDelayMs(NOW, NOW + Hours(5))).to.equal(Hours(5) + Minutes(1));
+    });
+
+    it("uses the full interval when the change falls beyond it", () => {
+        expect(resyncDelayMs(NOW, NOW + Hours(30))).to.equal(Hours(24));
+        // A change exactly at the interval must not schedule past it.
+        expect(resyncDelayMs(NOW, NOW + Hours(24))).to.equal(Hours(24));
+    });
+
+    it("still clears the floor for a change moments away, via the margin", () => {
+        expect(resyncDelayMs(NOW, NOW + 1000)).to.equal(Minutes(1) + 1000);
+        expect(resyncDelayMs(NOW, NOW)).to.equal(Minutes(1));
+    });
+
+    it("defers a change whose instant has already passed", () => {
+        expect(resyncDelayMs(NOW, NOW - Hours(1))).to.equal(Hours(24));
+        expect(resyncDelayMs(NOW, NOW - Minutes(2))).to.equal(Hours(24));
+    });
+});
+
 describe("TimeSyncManager", () => {
     let connector: StubConnector;
     let manager: TimeSyncManager;
@@ -110,7 +157,8 @@ describe("TimeSyncManager", () => {
     beforeEach(() => {
         MockTime.reset();
         connector = new StubConnector();
-        manager = new TimeSyncManager(connector);
+        // No offset change in view, so these cases see the plain 24 h cadence.
+        manager = new TimeSyncManager(connector, () => null);
     });
 
     afterEach(async () => {
@@ -285,6 +333,31 @@ describe("TimeSyncManager", () => {
             manager.syncNode(PEER_1);
             await MockTime.yield3();
             expect(connector.syncCalls.length).to.equal(0);
+        });
+    });
+
+    describe("offset-change lookup", () => {
+        it("consults the lookup when scheduling the cycle that follows a sync", async () => {
+            const lookupCalls = new Array<number>();
+            const probed = new TimeSyncManager(connector, fromMs => {
+                lookupCalls.push(fromMs);
+                return null;
+            });
+            try {
+                connector.setConnected(PEER_1);
+                probed.registerNode(PEER_1, makeTimeSyncAttrs());
+                expect(lookupCalls.length, "not consulted before the first cycle").to.equal(0);
+
+                await MockTime.advance(PAST_STARTUP_MS);
+                await MockTime.yield3();
+
+                expect(connector.syncCalls.length).to.equal(1);
+                expect(lookupCalls.length).to.be.greaterThan(0);
+                expect(lookupCalls[0]).to.be.greaterThan(0);
+            } finally {
+                connector.resolveAll();
+                await probed.stop();
+            }
         });
     });
 

--- a/packages/ws-controller/test/TimeSyncManagerTest.ts
+++ b/packages/ws-controller/test/TimeSyncManagerTest.ts
@@ -23,7 +23,8 @@ const ONE_MINUTE_MS = 60_000;
 const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
 const ONE_DAY_MS = 24 * ONE_HOUR_MS;
 
-// Startup delay is 3 min plus 10 s per commissioned node; advancing 61 min always fires it
+// MockTimer ignores interval assignment, so the startup delay these cases see is the constructor
+// seed of 3 min rather than the node-count-scaled value; 61 min is well past either.
 const PAST_STARTUP_MS = 61 * ONE_MINUTE_MS;
 
 const PEER_1 = PeerAddress({ fabricIndex: FabricIndex(1), nodeId: NodeId(1) });
@@ -144,6 +145,12 @@ describe("resyncDelayMs", () => {
     it("still clears the floor for a change moments away, via the margin", () => {
         expect(resyncDelayMs(NOW, NOW + 1000)).to.equal(Minutes(1) + 1000);
         expect(resyncDelayMs(NOW, NOW)).to.equal(Minutes(1));
+    });
+
+    it("treats a non-finite instant as no change in view", () => {
+        // The lookup is injectable, and a NaN delay would otherwise reach the timer and fire at once.
+        expect(resyncDelayMs(NOW, NaN)).to.equal(Hours(24));
+        expect(resyncDelayMs(NOW, Number.POSITIVE_INFINITY)).to.equal(Hours(24));
     });
 
     it("defers a change whose instant has already passed", () => {

--- a/packages/ws-controller/test/TimeSyncManagerTest.ts
+++ b/packages/ws-controller/test/TimeSyncManagerTest.ts
@@ -275,6 +275,32 @@ describe("TimeSyncManager", () => {
         });
     });
 
+    describe("commissioned node count", () => {
+        it("is read only while the startup delay can still change", async () => {
+            let lookups = 0;
+            const counting = new (class extends StubConnector {
+                override commissionedNodeCount(): number {
+                    lookups++;
+                    return 6;
+                }
+            })();
+            const probed = new TimeSyncManager(counting, () => null);
+            try {
+                counting.setConnected(PEER_1);
+                probed.registerNode(PEER_1, makeTimeSyncAttrs());
+                expect(lookups).to.equal(1);
+
+                // The timer is running now, so a recomputed delay could not be applied anyway.
+                probed.registerNode(PEER_2, makeTimeSyncAttrs());
+                probed.registerNode(PEER_1, makeTimeSyncAttrs());
+                expect(lookups).to.equal(1);
+            } finally {
+                counting.resolveAll();
+                await probed.stop();
+            }
+        });
+    });
+
     describe("offset lookup failure", () => {
         it("keeps syncing and rescheduling when the lookup throws", async () => {
             const failing = new TimeSyncManager(connector, () => {

--- a/packages/ws-controller/test/TimeSyncManagerTest.ts
+++ b/packages/ws-controller/test/TimeSyncManagerTest.ts
@@ -284,8 +284,8 @@ describe("TimeSyncManager", () => {
                 connector.setConnected(PEER_1);
                 failing.registerNode(PEER_1, makeTimeSyncAttrs());
 
-                // The delay is computed before the cycle body, so a throw used to abort the cycle
-                // before the finally that restarts the timer, stopping resyncs for good.
+                // The delay is computed before the cycle body and outside its finally, so a throw
+                // there must not cost the cycle or the reschedule that keeps the timer alive.
                 await MockTime.advance(PAST_STARTUP_MS);
                 await MockTime.yield3();
                 expect(connector.syncCalls.length, "first cycle must still run").to.be.greaterThan(0);


### PR DESCRIPTION
## Problem

`standardOffsetSeconds` and `dstWindows` were independent heuristics over different ranges, free to disagree. Four failure modes followed from that, all of which put a wrong offset on the device:

| # | Symptom | Reach |
|---|---|---|
| A | The currently-active DST window was dropped once it had opened more than 200 days earlier, so nothing in the pushed list covered "now" | **117 of 418 zones** in 2026 — 38 days/year for US zones, 10 for EU, 130 for `Africa/Casablanca` |
| B | A trailing segment with no closing transition inside the scan was dropped, and the caller turned the empty list into a positive "this zone never uses DST" | e.g. `Europe/Istanbul` from 2016-03-27 |
| C | A node advertising `DSTOffsetListMaxSize: 0` produced the same false no-DST claim | any such (non-conformant) node |
| D | A permanent offset **reduction** inside the horizon put the future base into `SetTimeZone` while the old one was still in effect | `Asia/Almaty` / `Asia/Qostanay`, 60 days in 2024 |

D is the mirror image of #923: that change made `standardOffsetSeconds` sample 12 months *forward*, which fixed past permanent changes and introduced sensitivity to future ones. No value of the scan constant fixes it — it is a model problem, not a tuning problem.

## Approach

Both halves of the push now come from one scan, so they cannot diverge.

- **`offsetSegments(zone, fromMs)`** — constant-offset segments around the sync instant, gap-free, with nullable bounds meaning "began before" / "holds past" the scanned range.
- **`timeZonePlan(zone, fromMs, limits)`** → `{ regimes, dstWindows }`. The base comes from the segments at and after the sync instant; everything above it becomes a delta.

Each failure mode now dies structurally rather than by constant-tuning: A (the base comes from the segment containing `fromMs`, so no scan length is needed to *cover* now), B (`endMs: null` is explicit and probed for), C (clamped inside the producer, the only place that can emit the false claim), D (minimum over the covered range keeps a future change expressible), and #922/#923 (segments before `fromMs` are excluded from the base by construction).

## Second `TimeZone` entry

`TimeZoneListMaxSize` is `min=1 max=2`, and the second entry exists to announce an upcoming standard-offset change. We previously sent one entry and disguised a pending permanent change as a DST delta. Local time came out right, but the device then reported a `TimeZoneStatus` offset that was not in effect yet and fired `DSTStatus { DSTOffsetActive: true }` for a zone with no DST at all.

`Asia/Almaty`, January 2024 — before and after:

```
before: TimeZone [{+05, epoch}]                    DSTOffset [{+3600, …}]   ← claims DST
after:  TimeZone [{+06, epoch}, {+05, 2024-03-01}] DSTOffset []
```

A split is only taken when all four hold, and each rejects a distinct false positive:

1. **the trailing segment is open-ended** — otherwise "the old base never recurs" can just mean the scan ended mid-cycle. Without this, `Europe/Berlin` in January splits at the *2027* summer.
2. **the base differs across the split** — skips seasonal excursions within one base.
3. **the earlier base never recurs after it** — rejects a zone merely mid-DST at the sync instant, e.g. `Australia/Sydney` in January, whose leading segment has a higher minimum than the rest.
4. **the node can hold the deltas the split needs** — each run carries its own base, so splitting can need more deltas than the budget holds, and a dropped delta leaves the node on a base that does not apply yet. Reachable with real tzdata: `Africa/Windhoek` 2016, `America/Dawson` 2018, `America/Vancouver` 2024.

Nodes reporting `TimeZoneListMaxSize == 1` keep the previous fold-into-a-delta behaviour, which falls out of the same code path rather than needing a branch.

## DST list terminator

Per `TimeSynchronizationCluster.cpp:984-990`, a node whose active DST entry expires **and is last** discards the entire list and reports no valid local time. Lists now end with an explicit `offset: 0, validUntil: null` entry when a slot remains.

## Resync cadence

- The periodic cycle is brought forward to a minute past the host zone's next offset change when that falls inside the interval. This bounds how long a node with a single DST slot can sit without a usable list — from ≤24h to ~1 minute. `NodeProcessor` gained a `nextCycleDelay()` hook, defaulted so `CustomClusterPoller` is unaffected.
- The startup delay becomes `3min + 10s` per commissioned node, deterministic, sized to let node initialization finish (~10 nodes/minute) rather than to wait out a random 30–60 minute window.

## Verification

Beyond the unit tests, every IANA zone (418) was swept across 2016–2027 and both list capacities, comparing the offset a **compliant node would compute** — modelling `UpdateTimeZoneState` and `UpdateDSTOffsetState` from the SDK — against the zone's true offset at the sync instant, one second either side of every emitted boundary, and with the plan left stale for up to 30 days within its coverage. Result: **no wrong offsets and no lists the cluster would reject**, in every combination.

The same sweep against the previous code reports 117 failing zones for 2026 alone.

Tests assert against that node model rather than against implementation internals, so they stay meaningful across further rewrites. One regression case per failure mode above, plus a spec-validity case covering 7 zones × 3 years × both capacities × 3 window sizes × 4 months, which asserts its own iteration count so it cannot silently degrade to a no-op.

`npm run format`, `npm run lint`, `npm run build` and the full `npm test` (including the matter-server integration tests) all pass.

## Notes for review

- **Not yet verified against real hardware.** Everything above is checked against a model of the reference firmware read from the CHIP SDK. The two-entry `TimeZone` list is a path no device has been sent before, so a node with `TimeZoneListMaxSize == 2` late in a DST period is the interesting target. Being tested in parallel with this review.
- **Condition 1 of the split rule came from a failing test, not from analysis.** It is a heuristic over tzdata, and heuristics here are what produced #923 and bugs A and D. It is measured rather than argued, which is why I am comfortable with it, but it is the part most worth a reviewer's scepticism.
- **Accepted tradeoff:** a permanent change into a base that *also* has DST will not split and falls back to delta-folding. Correct local time, weaker semantics. The failure direction is deliberate.
- `packages/ws-controller/src/util/hostTimeZone.ts` and `timeSyncCommands.ts` are not part of the package's public exports, so the `TimeZonePlan` shape change is internal.
- Related: `@matter/testing`'s `MockTimer` ignores `timer.interval` assignment, so timer-cadence changes cannot be observed under MockTime. The cadence logic is therefore extracted into pure functions (`startupDelayMs`, `resyncDelayMs`) and tested directly; that the timer obeys the returned value rests on `StandardTime`'s implementation. Filed separately against matter.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
