### PR TITLE
feat(dashboard): scale network graph edge length by signal quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
+- Enhancement: (pkese) Dashboard network graphs space nodes by signal quality (Thread LQI, Wi-Fi RSSI) instead of using one fixed edge length
 - Fix: Update BLE library
 
 ## 1.3.2 (2026-07-28)

--- a/packages/dashboard/src/pages/network/network-types.ts
+++ b/packages/dashboard/src/pages/network/network-types.ts
@@ -64,6 +64,8 @@ export interface NetworkGraphEdge {
     dashes?: boolean;
     /** Whether the edge should be hidden */
     hidden?: boolean;
+    /** vis.js per-edge spring length; overrides the global physics springLength */
+    length?: number;
     /** vis.js arrow configuration: shorthand string ("to", "from", "") or
      * object form for explicit head sizing on dashed edges. */
     arrows?: string | { to?: { enabled: boolean; scaleFactor: number } };

--- a/packages/dashboard/src/pages/network/network-utils.ts
+++ b/packages/dashboard/src/pages/network/network-utils.ts
@@ -81,6 +81,32 @@ export function signalLevelToColor(level: SignalLevel): string {
     }
 }
 
+/** Spring length per LQI stage, index = LQI 0..3 (OpenThread reports 0-3). */
+const LQI_EDGE_LENGTHS = [340, 270, 190, 100];
+
+/** Extra spring length for an edge on a node with a single link, pushing leaves outward. */
+export const LEAF_EDGE_LENGTH_PENALTY = 70;
+
+/** Map an averaged LQI to a physics spring length, interpolating between stages. */
+export function lqiToEdgeLength(avgLqi: number): number {
+    const clamped = Math.min(LQI_EDGE_LENGTHS.length - 1, Math.max(0, avgLqi));
+    const lower = Math.floor(clamped);
+    const upper = Math.ceil(clamped);
+    if (lower === upper) return LQI_EDGE_LENGTHS[lower];
+    return LQI_EDGE_LENGTHS[lower] + (LQI_EDGE_LENGTHS[upper] - LQI_EDGE_LENGTHS[lower]) * (clamped - lower);
+}
+
+/** RSSI (dBm) and spring-length bounds for the Wi-Fi star layout. */
+const RSSI_EDGE_LENGTH_BOUNDS = { strongRssi: -50, weakRssi: -90, strongLength: 90, weakLength: 260 };
+
+/** Map an RSSI to a physics spring length, so weakly-attached devices sit further from their AP. */
+export function rssiToEdgeLength(rssi: number): number {
+    const { strongRssi, weakRssi, strongLength, weakLength } = RSSI_EDGE_LENGTH_BOUNDS;
+    const clamped = Math.min(strongRssi, Math.max(weakRssi, rssi));
+    const weakness = (strongRssi - clamped) / (strongRssi - weakRssi);
+    return strongLength + weakness * (weakLength - strongLength);
+}
+
 /**
  * Get signal color from an LQI value (0-3 in practice on OpenThread).
  * 0 = grey (no link), 1 = red, 2 = orange, 3 = green.

--- a/packages/dashboard/src/pages/network/thread-graph.ts
+++ b/packages/dashboard/src/pages/network/thread-graph.ts
@@ -40,6 +40,8 @@ import {
     getThreadExtendedAddressHex,
     getThreadRole,
     getThreadRoleDescription,
+    LEAF_EDGE_LENGTH_PENALTY,
+    lqiToEdgeLength,
     mergeDiagnosticEdges,
     signalLevelToColor,
     stripMdnsHostname,
@@ -514,6 +516,16 @@ export class ThreadGraph extends BaseNetworkGraph {
 
         const graphEdges: NetworkGraphEdge[] = [];
 
+        // Spring lengths are applied after the loop: the leaf penalty needs every node's
+        // final link count.
+        const pairSprings = new Array<{
+            edges: NetworkGraphEdge[];
+            nodeA: string;
+            nodeB: string;
+            baseLength: number;
+        }>();
+        const linkCounts = new Map<string, number>();
+
         for (const pair of this._edgePairs.values()) {
             // Collect both directional edges for this pair
             const edgesInPair: { conn: ThreadConnection; visEdge: NetworkGraphEdge; filterHidden: boolean }[] = [];
@@ -632,6 +644,28 @@ export class ThreadGraph extends BaseNetworkGraph {
                 }
             }
 
+            if (edgesInPair.some(e => e.visEdge.hidden !== true)) {
+                // Count every visible link, LQI or not: excluding LQI-less links would
+                // make their peers look like leaves.
+                linkCounts.set(pair.nodeA, (linkCounts.get(pair.nodeA) ?? 0) + 1);
+                linkCounts.set(pair.nodeB, (linkCounts.get(pair.nodeB) ?? 0) + 1);
+
+                const liveLqis = new Array<number>();
+                for (const e of edgesInPair) {
+                    if (e.conn.signalLevel === "none" || e.conn.lqi === null) continue;
+                    liveLqis.push(e.conn.lqi);
+                }
+                if (liveLqis.length > 0) {
+                    const avgLqi = liveLqis.reduce((sum, lqi) => sum + lqi, 0) / liveLqis.length;
+                    pairSprings.push({
+                        edges: edgesInPair.map(e => e.visEdge),
+                        nodeA: pair.nodeA,
+                        nodeB: pair.nodeB,
+                        baseLength: lqiToEdgeLength(avgLqi),
+                    });
+                }
+            }
+
             // Save base state and collect edges for the dataset
             for (const e of edgesInPair) {
                 const isHidden = e.visEdge.hidden ?? false;
@@ -648,6 +682,14 @@ export class ThreadGraph extends BaseNetworkGraph {
                 });
 
                 graphEdges.push(e.visEdge);
+            }
+        }
+
+        for (const spring of pairSprings) {
+            const isLeafLink = linkCounts.get(spring.nodeA) === 1 || linkCounts.get(spring.nodeB) === 1;
+            const length = spring.baseLength + (isLeafLink ? LEAF_EDGE_LENGTH_PENALTY : 0);
+            for (const edge of spring.edges) {
+                edge.length = length;
             }
         }
 

--- a/packages/dashboard/src/pages/network/wifi-graph.ts
+++ b/packages/dashboard/src/pages/network/wifi-graph.ts
@@ -15,6 +15,7 @@ import {
     getNetworkType,
     getSignalColorFromRssi,
     getWiFiDiagnostics,
+    rssiToEdgeLength,
 } from "./network-utils.js";
 
 declare global {
@@ -146,7 +147,7 @@ export class WiFiGraph extends BaseNetworkGraph {
                 const apId = `ap_${wifiDiag.bssid.replace(/:/g, "")}`;
                 const signalColor = getSignalColorFromRssi(wifiDiag.rssi);
 
-                graphEdges.push({
+                const edge: NetworkGraphEdge = {
                     id: `edge_${edgeIndex++}`,
                     from: nodeId,
                     to: apId,
@@ -157,7 +158,11 @@ export class WiFiGraph extends BaseNetworkGraph {
                     width: 2,
                     title: wifiDiag.rssi !== null ? `RSSI: ${wifiDiag.rssi} dBm` : "RSSI: Unknown",
                     dashes: isOffline, // Dashed lines for offline devices
-                });
+                };
+                if (wifiDiag.rssi !== null) {
+                    edge.length = rssiToEdgeLength(wifiDiag.rssi);
+                }
+                graphEdges.push(edge);
             }
         }
 


### PR DESCRIPTION
Both network graphs drew every edge at the same spring length, so the force layout came out symmetric no matter how good each link actually was.

**Thread graph:** each edge pair gets a spring length from the LQI averaged over both reported directions — LQI 3/2/1/0 maps to 100/190/270/340, interpolated for fractional averages. Both directional edges of a pair share the length so the dedup-hidden twin doesn't fight the physics. A link whose endpoint has only one visible link gets one extra distance stage (+70), pushing leaves outward. Every visible link counts toward that degree, including links with no usable LQI, so a peer with unreported LQI doesn't turn its neighbor into a false leaf.

**Wi-Fi graph:** RSSI −50…−90 dBm maps linearly to 90…260, clamped outside. No leaf penalty — in a star topology every device is a leaf, so it would be a uniform no-op.

Edges without usable signal data keep each graph's global `springLength` (Thread 130, Wi-Fi 100).

Idea, stage values and the "extra stage for single-linked nodes" trick from @pkese in matter-js/matter.js#4107.

Gate: `npm run format` / `lint` / `build` clean, `npm test` 255/255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)