### PR TITLE
fix(python_client): classify a node from Thread diagnostics on any endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Fix: (LorbusChris) Python client: `node_diagnostics` classifies a node from the Thread diagnostics of whichever endpoint provides them, instead of only the root endpoint of a node attached over Thread, so a border router reached over Ethernet or Wi-Fi is reported by its routing role rather than as an unknown node type
+
 ## 1.3.3 (2026-07-28)
 
 - Enhancement: (pkese) Dashboard network graphs space nodes by signal quality (Thread LQI, Wi-Fi RSSI) instead of using one fixed edge length

--- a/python_client/matter_server/client/client.py
+++ b/python_client/matter_server/client/client.py
@@ -463,29 +463,42 @@ class MatterClient:
         # get thread/wifi specific info
         node_type = NodeType.UNKNOWN
         network_name = None
-        if network_type == NetworkType.THREAD:
-            thread_cluster: Clusters.ThreadNetworkDiagnostics = node.get_cluster(0, Clusters.ThreadNetworkDiagnostics)
-            if thread_cluster:
+        # A node does not have to be attached over Thread to be part of a
+        # Thread network, and it does not have to serve the diagnostics from
+        # the root endpoint: a border router is commonly reached over Ethernet
+        # or Wi-Fi and reports Thread from the endpoint that carries its
+        # border router device type. Take the cluster from wherever it is, so
+        # such a node is still described by the role it plays in the mesh.
+        thread_cluster: Clusters.ThreadNetworkDiagnostics | None = next(
+            (
+                cluster
+                for endpoint_id in sorted(node.endpoints)
+                if (cluster := node.endpoints[endpoint_id].get_cluster(Clusters.ThreadNetworkDiagnostics))
+            ),
+            None,
+        )
+        if thread_cluster:
+            if network_type == NetworkType.THREAD:
                 if isinstance(thread_cluster.networkName, bytes):
                     network_name = thread_cluster.networkName.decode("utf-8", errors="replace")
                 elif thread_cluster.networkName != NullValue:
                     network_name = thread_cluster.networkName
 
-                # parse routing role to (diagnostics) node type
-                RoutingRole = Clusters.ThreadNetworkDiagnostics.Enums.RoutingRoleEnum  # noqa: N806
-                if thread_cluster.routingRole == RoutingRole.kSleepyEndDevice:
-                    node_type = NodeType.SLEEPY_END_DEVICE
-                elif thread_cluster.routingRole in (
-                    RoutingRole.kLeader,
-                    RoutingRole.kRouter,
-                ):
-                    node_type = NodeType.ROUTING_END_DEVICE
-                elif thread_cluster.routingRole in (
-                    RoutingRole.kEndDevice,
-                    RoutingRole.kReed,
-                ):
-                    node_type = NodeType.END_DEVICE
-        elif network_type == NetworkType.WIFI:
+            # parse routing role to (diagnostics) node type
+            RoutingRole = Clusters.ThreadNetworkDiagnostics.Enums.RoutingRoleEnum  # noqa: N806
+            if thread_cluster.routingRole == RoutingRole.kSleepyEndDevice:
+                node_type = NodeType.SLEEPY_END_DEVICE
+            elif thread_cluster.routingRole in (
+                RoutingRole.kLeader,
+                RoutingRole.kRouter,
+            ):
+                node_type = NodeType.ROUTING_END_DEVICE
+            elif thread_cluster.routingRole in (
+                RoutingRole.kEndDevice,
+                RoutingRole.kReed,
+            ):
+                node_type = NodeType.END_DEVICE
+        if node_type == NodeType.UNKNOWN and network_type == NetworkType.WIFI:
             node_type = NodeType.END_DEVICE
         # use lastNetworkID from NetworkCommissioning cluster as fallback to get the network name
         # this allows getting the SSID as the wifi diagnostics cluster only has the BSSID

--- a/python_client/tests/test_node_diagnostics.py
+++ b/python_client/tests/test_node_diagnostics.py
@@ -1,0 +1,109 @@
+"""Unit tests for the node type derived by node_diagnostics."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from matter_server.client import MatterClient
+from matter_server.client.models.node import MatterNode, NetworkType, NodeType
+from matter_server.common.models import MatterNodeData
+
+# GeneralDiagnostics/NetworkInterfaces and ThreadNetworkDiagnostics/RoutingRole
+NETWORK_INTERFACES = "0/51/0"
+ROUTING_ROLE = "{endpoint}/53/1"
+
+INTERFACE_TYPE_THREAD = 4
+INTERFACE_TYPE_ETHERNET = 2
+
+ROUTING_ROLE_END_DEVICE = 4
+ROUTING_ROLE_LEADER = 6
+
+
+def _interface(interface_type: int) -> dict[str, Any]:
+    """Return one operational network interface of the given type."""
+    return {
+        "name": "iface",
+        "isOperational": True,
+        "offPremiseServicesReachableIPv4": None,
+        "offPremiseServicesReachableIPv6": None,
+        "hardwareAddress": b"\x00\x11\x22\x33\x44\x55",
+        "IPv4Addresses": [],
+        "IPv6Addresses": [],
+        "type": interface_type,
+    }
+
+
+def _node(attributes: dict[str, Any]) -> MatterNode:
+    """Return a MatterNode carrying the given raw attributes."""
+    return MatterNode(
+        MatterNodeData(
+            node_id=1,
+            date_commissioned=datetime(2026, 1, 1, tzinfo=UTC),
+            last_interview=datetime(2026, 1, 1, tzinfo=UTC),
+            interview_version=6,
+            available=True,
+            attributes=attributes,
+        )
+    )
+
+
+def _client(node: MatterNode) -> MatterClient:
+    """Return a client that reports the given node and nothing else."""
+    client = MatterClient.__new__(MatterClient)
+    client.get_node = lambda _node_id: node  # type: ignore[method-assign]
+    client.get_node_ip_addresses = AsyncMock(return_value=[])  # type: ignore[method-assign]
+    client.get_matter_fabrics = AsyncMock(return_value=[])  # type: ignore[method-assign]
+    return client
+
+
+@pytest.mark.asyncio
+async def test_thread_node_type_from_root_endpoint() -> None:
+    """A Thread-attached node is classified from its root endpoint as before."""
+    node = _node(
+        {
+            NETWORK_INTERFACES: [_interface(INTERFACE_TYPE_THREAD)],
+            ROUTING_ROLE.format(endpoint=0): ROUTING_ROLE_END_DEVICE,
+        }
+    )
+
+    result = await _client(node).node_diagnostics(node_id=1)
+
+    assert result.network_type == NetworkType.THREAD
+    assert result.node_type == NodeType.END_DEVICE
+
+
+@pytest.mark.asyncio
+async def test_node_type_from_application_endpoint() -> None:
+    """A border router reports Thread from the endpoint that carries it.
+
+    Such a node is reached over Ethernet and serves its Thread diagnostics
+    beside the border router management cluster rather than on the root
+    endpoint, so neither the network type nor the endpoint used to say
+    anything about the role it plays in the mesh.
+    """
+    node = _node(
+        {
+            NETWORK_INTERFACES: [_interface(INTERFACE_TYPE_ETHERNET)],
+            ROUTING_ROLE.format(endpoint=1): ROUTING_ROLE_LEADER,
+        }
+    )
+
+    result = await _client(node).node_diagnostics(node_id=1)
+
+    assert result.network_type == NetworkType.ETHERNET
+    assert result.node_type == NodeType.ROUTING_END_DEVICE
+
+
+@pytest.mark.asyncio
+async def test_wifi_node_type_without_thread() -> None:
+    """A Wi-Fi node without Thread diagnostics stays an end device."""
+    node = _node({NETWORK_INTERFACES: [_interface(1)]})
+
+    result = await _client(node).node_diagnostics(node_id=1)
+
+    assert result.network_type == NetworkType.WIFI
+    assert result.node_type == NodeType.END_DEVICE


### PR DESCRIPTION
## Type of change

- [x] 🐛 **Fix** — corrects a defect or wrong behavior
- [ ] ✨ **Feature** — adds new functionality or capability

## Description

`MatterClient.node_diagnostics()` derives the node type only when the node is reached **over Thread**, and only from the `ThreadNetworkDiagnostics` cluster on **endpoint 0**:

```python
if network_type == NetworkType.THREAD:
    thread_cluster = node.get_cluster(0, Clusters.ThreadNetworkDiagnostics)
```

A Matter Network Infrastructure Manager (NIM) can satisfy neither condition, on the same device:

- it is commonly attached over **Ethernet or Wi-Fi**, so `network_type` is not `THREAD` and the whole block is skipped; and
- the Network Infrastructure Manager (`0x0090`) and Thread Border Router (`0x0091`) device types both **require** Thread Network Diagnostics on their own endpoint, and both are `Simple`, endpoint-scoped device types, so that endpoint is never the root one. On the Root Node device type (`0x0016`) the same cluster is optional and present only when the node is itself attached over Thread.

So `node_type` stays `UNKNOWN`, and Home Assistant shows no device type for a node that is in fact a Thread router or leader.

This takes the cluster from whichever endpoint provides it — lowest endpoint id first, so a device that reports on the root endpoint is unaffected — and derives the node type from its routing role regardless of how the node itself is attached. Two details preserved deliberately:

- the Wi-Fi `END_DEVICE` fallback now applies only when Thread said nothing, so a Wi-Fi-attached border router is described by its mesh role rather than flattened to an end device;
- `network_name` stays reserved for nodes actually attached over Thread — an Ethernet-attached border router should not report the Thread network as its own.

## Backing evidence

Tested and confirmed on an OpenWrt/Turris border router running the Matter `network-manager-app`: reached over Ethernet, with `ThreadNetworkDiagnostics` on the application endpoint beside `ThreadBorderRouterManagement`.

In the Home Assistant device page, under **Matter node diagnostics**:

| | Device type |
|---|---|
| Before | `Unknown` — the router is a Thread **leader**, but nothing in the UI says so |
| After | `Routing end device` |

Nothing else in that panel changes: the node still reports `Network type: Ethernet`, and the Thread network name stays empty for it, since the router is not itself attached over Thread.

The new test builds a node with an operational **Ethernet** interface on endpoint 0 and `RoutingRole = kLeader` on endpoint 1, and asserts `ROUTING_END_DEVICE`. It **fails on `main`** and passes with this change. The two tests covering the existing paths (Thread node classified from the root endpoint, Wi-Fi node without Thread) stay green, so the behaviour change is limited to the case above.

- Related issue: none yet, happy to open one if you prefer.
- [ ] This fix/change is backed by a **complete log file** — attached here or in the linked issue (not just a few quoted lines).

Left unchecked on purpose: I haven't attached a log. What backs this is my own deployment plus a test that fails without the fix. Happy to attach a diagnostics dump if you want the raw node data.

## Checklist

- [x] Tests added or updated to cover the change
- [x] `npm test` passes
- [x] `npm run format-verify` and `npm run lint` pass
- [x] CHANGELOG updated (if applicable)

Also run for the Python side: `npm run python:test` (55 passed, against 52 on `main` — the 3 new tests) and `npm run python:lint`, plus `ruff format --check`, `mypy`, `codespell` and `pylint` (10.00/10). The 4 `test_client_integration.py` errors in my environment occur identically on `main`: the Node mock server does not start here.

---

Written with AI assistance (Claude). I have reviewed every line, verified the behaviour on my own deployment, and will answer review feedback myself.
