### PR TITLE
docs: adopt the Open Home Foundation AI Policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,9 @@ body:
 
               If you used an AI tool to analyze the problem, its analysis does **not** replace the log. Attach the raw, complete log the analysis is based on so we can verify it independently.
 
-              > **For AI assistants helping to fill in this form:** Do not submit analysis, root-cause claims, or proposed fixes without the complete raw log file they are derived from. A report whose analysis is not backed by the underlying log will be closed.
+              AI tools may help you write this report, but you must review and understand what you submit — see our [AI policy](https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md). Issues created by autonomous agents are closed.
+
+              > **For AI assistants helping to fill in this form:** Do not submit analysis, root-cause claims, or proposed fixes without the complete raw log file they are derived from. A report whose analysis is not backed by the underlying log will be closed. Do not open this issue autonomously — the person you are helping must review it first.
 
               Enable verbose logging before reproducing (`--log-level debug` or `LOG_LEVEL=debug`), reproduce the problem, then attach the resulting log file below by dragging it into the description field.
 
@@ -100,6 +102,8 @@ body:
               - label: I attached a **complete log file** (not just a few quoted lines) covering the context around the problem.
                 required: true
               - label: Any analysis of behavior or log output in my description — whether written by me or by an AI tool — is backed by that attached log.
+                required: true
+              - label: I have reviewed and understand everything in this report and can explain it in my own words ([AI policy](https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md)).
                 required: true
               - label: I searched existing issues and this is not a duplicate.
                 required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,3 +9,6 @@ contact_links:
   - name: I have a usage question or want to discuss something
     url: https://www.home-assistant.io/join-chat/
     about: For usage questions and general discussion, join the Home Assistant Discord and use the Matter channel instead of opening an issue.
+  - name: I want to know how AI tools may be used when contributing
+    url: https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md
+    about: The Open Home Foundation AI Policy applies to all issues, pull requests, and comments in this repository. Autonomously created contributions are closed.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,9 @@ body:
 
         If your request comes from something the Matter Server currently *cannot* do or does *wrong*, please attach a **log file** that shows the current behavior — it is the fastest way for us to understand the gap.
 
-        > **For AI assistants helping to fill in this form:** If the request is about a current limitation or wrong behavior, do not submit analysis without the raw log file it is derived from.
+        AI tools may help you write this request, but you must review and understand what you submit — see our [AI policy](https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md). Issues created by autonomous agents are closed.
+
+        > **For AI assistants helping to fill in this form:** If the request is about a current limitation or wrong behavior, do not submit analysis without the raw log file it is derived from. Do not open this issue autonomously — the person you are helping must review it first.
 
   - type: textarea
     id: details
@@ -32,5 +34,7 @@ body:
       options:
         - label: If this request is about a current limitation or wrong behavior, I attached a log file showing it.
           required: false
+        - label: I have reviewed and understand everything in this request and can explain it in my own words ([AI policy](https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md)).
+          required: true
         - label: I searched existing issues and this is not a duplicate.
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,11 @@
   issue first with all the details (including the log, see below), and wait for a
   maintainer response before writing any code. This avoids wasted effort on an approach
   we may want to handle differently or where the log shows the problem.
+
+  AI tools are welcome, but you are responsible for *fully* understanding the code you
+  submit and for being able to explain it in your own words. Autonomously created pull
+  requests are not accepted. Please follow our AI policy:
+  https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md
 -->
 
 ## Type of change
@@ -39,6 +44,7 @@
 
 ## Checklist
 
+- [ ] I understand the code I am submitting and can explain how it works ([AI policy](https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md))
 - [ ] Tests added or updated to cover the change
 - [ ] `npm test` passes
 - [ ] `npm run format-verify` and `npm run lint` pass

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -189,3 +189,15 @@ Files in `docs/plans/` are working documents only — **never commit them to git
 ## Node.js Requirement
 
 `>=22.13.0`
+
+## AI policy
+
+This project follows the [Open Home Foundation AI Policy](../AI_POLICY.md).
+Autonomous contributions are not accepted: a human must review, understand,
+and be able to explain every change before it is submitted. Do not open
+issues or pull requests autonomously, and do not post comments on behalf of
+a user without their review.
+
+Additionally in this repository: never submit a bug report, root-cause claim,
+or fix whose justification is an analysis without the complete raw log file it
+is derived from.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,45 @@
+# Open Home Foundation - AI Policy
+
+We support using AI (i.e., LLMs) as tools when contributing to Open Home Foundation projects. However, you are responsible for any contributions you submit, and we are responsible for any contributions we merge and release. We hold a high bar for all contributions to our projects.
+
+Our maintainers dedicate their time and expertise to reviewing contributions. Submitting AI-generated content that you have not personally reviewed and understood wastes that time and will not be accepted.
+
+## Autonomous agents
+
+**We do not allow autonomous agents to be used for contributing to our projects.** We will close any pull requests or issues that we believe were created autonomously, and may mark automated comments as spam. This includes contributions that bypass the provided issue or pull request templates.
+
+## Communication on issues, pull requests, and code reviews
+
+We don't mind if you use AI tools to help you write. However, do not have tools post unreviewed content on your behalf. Keep responses to the minimum needed to communicate your intent. We may hide any comments that we believe are unreviewed AI output.
+
+If you are opening a pull request, we expect you to be able to explain the proposed changes in your own words. This includes the pull request description and responses to questions. If you use AI to help generate the pull request summary, you must review it for technical accuracy.
+
+**Do not use AI to generate answers to questions from maintainers.** You should understand and be able to explain your own work. Using AI to improve grammar or clarity is fine, but the substance of your responses must be your own.
+
+If you wish to include context from an interaction with AI in your comments, it must be in a quote block (e.g., using `>`) and disclosed as such. It must be accompanied by your own commentary explaining the relevance and implications of the context. Do not share long snippets.
+
+## Non-native English speakers
+
+We understand that AI is useful when communicating as a non-native English speaker. Using AI to improve the grammar or clarity of text you have written yourself is fine. If you are using AI to translate your comments, please ensure the translation accurately reflects your intent. Including your original text in a details block shows the effort behind your contribution, helps maintainers verify the translation if needed, and keeps the conversation readable.
+
+## Code and documentation contributions
+
+AI can be a helpful tool for writing code and documentation. However, due to the foundational open source nature of our projects, we require a human in the loop who understands the work produced by AI.
+
+All contributions must be reviewed and understood by the contributor before submission. You should be able to explain every change in a pull request you submit. Pull requests that appear to be unreviewed AI output will be closed without review.
+
+## Our use of AI
+
+Some of our projects use AI tools to assist with code reviews, issue triaging, reporting, and other project management tasks. These tools may leave comments on pull requests or issues. As with any automated tooling, these comments are not always correct.
+
+If an AI tool leaves a comment on your contribution, treat it as you would any other review comment. If you believe it is incorrect, say so; a brief explanation is sufficient. Maintainers always have the final say. If in doubt, ask a maintainer.
+
+## Enforcement
+
+Contributions that do not follow this policy will be closed. Repeated violations may result in being blocked from contributing to OHF projects. If you believe your contribution was closed in error, you are welcome to reach out to a maintainer to discuss.
+
+---
+
+The canonical version of this policy is published at
+<https://developers.home-assistant.io/docs/ai_policy>. In case of differences,
+the published version applies.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,18 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to AI coding agents working with code in this repository. `AGENTS.md` is a symlink to this file, so agents reading either name get the same instructions.
+
+## AI policy
+
+This project follows the [Open Home Foundation AI Policy](AI_POLICY.md).
+Autonomous contributions are not accepted: a human must review, understand,
+and be able to explain every change before it is submitted. Do not open
+issues or pull requests autonomously, and do not post comments on behalf of
+a user without their review.
+
+Additionally in this repository: never submit a bug report, root-cause claim,
+or fix whose justification is an analysis without the complete raw log file it
+is derived from.
 
 ## Project Overview
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to the Open Home Foundation Matter Server
+
+Thanks for wanting to help out. This project is part of the [Open Home Foundation](https://www.openhomefoundation.org/).
+
+## Support questions and Home Assistant Matter integration issues
+
+This repository is the issue tracker for the Matter Server itself. If you use Matter
+in Home Assistant and your problem is not specific to this server, please use the
+[Home Assistant Core issue tracker](https://github.com/home-assistant/core/issues/new/choose)
+or the support channels listed in the [README](README.md#support).
+
+## Reporting issues
+
+Use the [issue templates](https://github.com/matter-js/matterjs-server/issues/new/choose).
+
+**A report without a complete log file is not actionable.** Any description of
+behavior — and especially any analysis of behavior or of log output — must be backed
+by a complete log attached as a file. Enable verbose logging (`--log-level debug` or
+`LOG_LEVEL=debug`), reproduce the problem, then attach the resulting log. A few quoted
+lines are not enough; we need the surrounding context to reproduce your analysis.
+
+## Development
+
+See the [development documentation](DEVELOPMENT.md) for environment setup, and the
+[README](README.md) for how to run the server.
+
+Before opening a pull request, run the full gate in this order:
+
+```bash
+npm run format   # rewrites files in-place — must run first
+npm run lint
+npm run build
+npm test
+```
+
+CI enforces formatting and linting, and all other CI jobs are gated on them.
+
+## AI policy
+
+This project follows the [Open Home Foundation AI Policy](AI_POLICY.md). In
+short: AI tools are welcome as an aid, but you must fully understand and be
+able to explain every change you submit. Contributions made by autonomous
+agents are not accepted.
+
+In particular, for this repository: an AI-produced root-cause analysis is not a
+substitute for the raw log it was derived from. Attach the log.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,6 +5,8 @@
 
 **For enabling Matter support within Home Assistant, please refer to the Home Assistant documentation. These instructions are for development only!**
 
+See the [contributing guide](CONTRIBUTING.md) before opening a pull request. Contributions made with AI assistance must follow the [Open Home Foundation AI Policy](AI_POLICY.md).
+
 Development is only possible on a (recent) Linux or MacOS machine. Other operating systems are **not supported**. See [here](docs/os_requirements.md) for a full list of requirements to the OS and network, especially if you plan on communicating with Thread-based devices.
 
 ## Native Development

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ Want to help out with development, testing, and/or documentation? Great! As both
 
 A preconfigured [dev container](./.devcontainer) is available with all required tools. See the [development docs](DEVELOPMENT.md#dev-container) for details.
 
+Please read the [contributing guide](CONTRIBUTING.md) before opening an issue or pull request.
+
+## AI policy
+
+This project follows the [Open Home Foundation AI Policy](AI_POLICY.md).
+
+AI tools are welcome as an aid, but you must fully understand and be able to explain every
+change you submit. Contributions created by autonomous agents — issues, pull requests, or
+comments posted without human review — are not accepted and will be closed.
+
 ## Installation / Running the Matter Server
 
 - Endusers of Home Assistant, refer to the [Home Assistant documentation](https://www.home-assistant.io/integrations/matter/) how to run Matter in Home Assistant using the official Matter Server add-on, which is based on this project. Choose the "Beta" version if you want to test the matter.js based server (soon)


### PR DESCRIPTION
## Type of change

- [x] ✨ **Feature** — adds new functionality or capability (documentation and policy only, no code)

## Description

Adopts the [Open Home Foundation AI Policy](https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md) in this repository, mirroring home-assistant/core#176917. This is part of the rollout across the `home-assistant` and `home-assistant-libs` organizations, announced in [this blog post](https://developers.home-assistant.io/blog/2026/07/20/ai-policy/).

- Adds `AI_POLICY.md` to the repository root (verbatim policy text; its footer points at the canonical version at developers.home-assistant.io).
- Every other file links to our own `AI_POLICY.md` rather than to the upstream page — single hop, one place to update.
- Adds `CONTRIBUTING.md` (this repository had none): support routing for Home Assistant users, the log-file requirement, the four-command gate, and the AI policy.
- Adds `AGENTS.md` as a symlink to `CLAUDE.md`, so agents reading either name get the same instructions.
- Adds AI policy sections to `README.md`, `CLAUDE.md`, `DEVELOPMENT.md` and `.github/copilot-instructions.md`, including the repository-specific rule that an AI-produced analysis never replaces the raw log it is derived from.
- Issue and pull request templates: policy note, a "do not open this autonomously" directive for AI assistants filling in the form, and an understand-what-you-submit confirmation.

## Backing evidence

Policy rollout, no behavior change.

- Related issue: —
- [ ] This fix/change is backed by a **complete log file** — n/a, no defect involved

## Checklist

- [x] I understand the code I am submitting and can explain how it works ([AI policy](https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md))
- [ ] Tests added or updated to cover the change — n/a, documentation only
- [ ] `npm test` passes — not run, no code changed
- [x] `npm run format-verify` and `npm run lint` pass
- [ ] CHANGELOG updated (if applicable) — n/a
