### PR TITLE
fix(dashboard): index cluster feature bits by constraint, not sibling position

### DIFF
--- a/packages/dashboard/scripts/generate-descriptions.ts
+++ b/packages/dashboard/scripts/generate-descriptions.ts
@@ -160,9 +160,12 @@ function generateDescriptions(): string {
 
         const features: { [id: string]: ClusterFeatureDescription } = {};
         for (const feature of cluster.features) {
-            if (feature.effectiveId === undefined) continue;
-            features[feature.effectiveId] = {
-                bit: feature.effectiveId,
+            // Feature fields are keyed by their bitmap constraint (the actual bit position), not
+            // effectiveId, which falls back to sibling index and collapses gaps left by unused bits.
+            const bit = Number(feature.key);
+            if (Number.isNaN(bit)) continue;
+            features[bit] = {
+                bit,
                 code: feature.name,
                 label: toLabel(feature.title ?? feature.name, true),
             };

--- a/packages/dashboard/scripts/generate-descriptions.ts
+++ b/packages/dashboard/scripts/generate-descriptions.ts
@@ -160,10 +160,12 @@ function generateDescriptions(): string {
 
         const features: { [id: string]: ClusterFeatureDescription } = {};
         for (const feature of cluster.features) {
-            // Feature fields are keyed by their bitmap constraint (the actual bit position), not
-            // effectiveId, which falls back to sibling index and collapses gaps left by unused bits.
-            const bit = Number(feature.key);
-            if (Number.isNaN(bit)) continue;
+            // Bitmap children key by constraint (the real bit); effectiveId collapses reserved-bit gaps.
+            const key = feature.key;
+            if (key === undefined || !/^\d+$/.test(key)) {
+                throw new Error(`Cluster ${cluster.name} feature ${feature.name} has non-numeric bit key "${key}"`);
+            }
+            const bit = Number(key);
             features[bit] = {
                 bit,
                 code: feature.name,

--- a/packages/dashboard/src/client/models/descriptions.ts
+++ b/packages/dashboard/src/client/models/descriptions.ts
@@ -4210,8 +4210,8 @@ export const clusters: Record<number, ClusterDescription> = {
             }
         },
         "features": {
-            "0": {
-                "bit": 0,
+            "20": {
+                "bit": 20,
                 "code": "BIS",
                 "label": "Bridged Icd Support"
             }
@@ -5763,8 +5763,8 @@ export const clusters: Record<number, ClusterDescription> = {
                 "code": "DEPONOFF",
                 "label": "On Off"
             },
-            "1": {
-                "bit": 1,
+            "20": {
+                "bit": 20,
                 "code": "DIRECTMODECH",
                 "label": "Direct Mode Change"
             }
@@ -5859,8 +5859,8 @@ export const clusters: Record<number, ClusterDescription> = {
                 "code": "DEPONOFF",
                 "label": "On Off"
             },
-            "1": {
-                "bit": 1,
+            "20": {
+                "bit": 20,
                 "code": "DIRECTMODECH",
                 "label": "Direct Mode Change"
             }
@@ -7252,48 +7252,53 @@ export const clusters: Record<number, ClusterDescription> = {
                 "code": "RESET",
                 "label": "Reset"
             },
-            "1": {
-                "bit": 1,
+            "20": {
+                "bit": 20,
+                "code": "OVER",
+                "label": "Over Temperature"
+            },
+            "21": {
+                "bit": 21,
                 "code": "UNDER",
                 "label": "Under Temperature"
             },
-            "2": {
-                "bit": 2,
+            "22": {
+                "bit": 22,
                 "code": "MAJOR",
                 "label": "Major Threshold"
             },
-            "3": {
-                "bit": 3,
+            "23": {
+                "bit": 23,
                 "code": "MINOR",
                 "label": "Minor Threshold"
             },
-            "4": {
-                "bit": 4,
+            "24": {
+                "bit": 24,
                 "code": "OCRIADJ",
                 "label": "Over Critical Adjustable"
             },
-            "5": {
-                "bit": 5,
+            "25": {
+                "bit": 25,
                 "code": "OMAJADJ",
                 "label": "Over Major Adjustable"
             },
-            "6": {
-                "bit": 6,
+            "26": {
+                "bit": 26,
                 "code": "OMINADJ",
                 "label": "Over Minor Adjustable"
             },
-            "7": {
-                "bit": 7,
+            "27": {
+                "bit": 27,
                 "code": "UMINADJ",
                 "label": "Under Minor Adjustable"
             },
-            "8": {
-                "bit": 8,
+            "28": {
+                "bit": 28,
                 "code": "UMAJADJ",
                 "label": "Under Major Adjustable"
             },
-            "9": {
-                "bit": 9,
+            "29": {
+                "bit": 29,
                 "code": "UCRIADJ",
                 "label": "Under Critical Adjustable"
             }
@@ -10236,53 +10241,53 @@ export const clusters: Record<number, ClusterDescription> = {
                 "code": "FGP",
                 "label": "Finger Credentials"
             },
-            "3": {
-                "bit": 3,
+            "4": {
+                "bit": 4,
                 "code": "WDSCH",
                 "label": "Week Day Access Schedules"
             },
-            "4": {
-                "bit": 4,
+            "5": {
+                "bit": 5,
                 "code": "DPS",
                 "label": "Door Position Sensor"
             },
-            "5": {
-                "bit": 5,
+            "6": {
+                "bit": 6,
                 "code": "FACE",
                 "label": "Face Credentials"
             },
-            "6": {
-                "bit": 6,
+            "7": {
+                "bit": 7,
                 "code": "COTA",
                 "label": "Credential Over The Air Access"
             },
-            "7": {
-                "bit": 7,
+            "8": {
+                "bit": 8,
                 "code": "USR",
                 "label": "User"
             },
-            "8": {
-                "bit": 8,
+            "10": {
+                "bit": 10,
                 "code": "YDSCH",
                 "label": "Year Day Access Schedules"
             },
-            "9": {
-                "bit": 9,
+            "11": {
+                "bit": 11,
                 "code": "HDSCH",
                 "label": "Holiday Schedules"
             },
-            "10": {
-                "bit": 10,
+            "12": {
+                "bit": 12,
                 "code": "UBOLT",
                 "label": "Unbolting"
             },
-            "11": {
-                "bit": 11,
+            "13": {
+                "bit": 13,
                 "code": "ALIRO",
                 "label": "Aliro Provisioning"
             },
-            "12": {
-                "bit": 12,
+            "14": {
+                "bit": 14,
                 "code": "ALBU",
                 "label": "Aliro Bleuwb"
             }
@@ -10481,8 +10486,8 @@ export const clusters: Record<number, ClusterDescription> = {
                 "code": "PA_LF",
                 "label": "Position Aware Lift"
             },
-            "3": {
-                "bit": 3,
+            "4": {
+                "bit": 4,
                 "code": "PA_TL",
                 "label": "Position Aware Tilt"
             }
@@ -11736,38 +11741,38 @@ export const clusters: Record<number, ClusterDescription> = {
                 "code": "OCC",
                 "label": "Occupancy"
             },
-            "3": {
-                "bit": 3,
+            "4": {
+                "bit": 4,
                 "code": "SB",
                 "label": "Setback"
             },
-            "4": {
-                "bit": 4,
+            "5": {
+                "bit": 5,
                 "code": "AUTO",
                 "label": "Auto Mode"
             },
-            "5": {
-                "bit": 5,
+            "6": {
+                "bit": 6,
                 "code": "LTNE",
                 "label": "Local Temperature Not Exposed"
             },
-            "6": {
-                "bit": 6,
+            "7": {
+                "bit": 7,
                 "code": "MSCH",
                 "label": "Matter Schedule Configuration"
             },
-            "7": {
-                "bit": 7,
+            "8": {
+                "bit": 8,
                 "code": "PRES",
                 "label": "Presets"
             },
-            "8": {
-                "bit": 8,
+            "9": {
+                "bit": 9,
                 "code": "TEVT",
                 "label": "Events"
             },
-            "9": {
-                "bit": 9,
+            "10": {
+                "bit": 10,
                 "code": "TSUGGEST",
                 "label": "Thermostat Suggestions"
             }
@@ -13196,8 +13201,8 @@ export const clusters: Record<number, ClusterDescription> = {
                 "code": "VIS",
                 "label": "Vision"
             },
-            "8": {
-                "bit": 8,
+            "9": {
+                "bit": 9,
                 "code": "OCCEVENT",
                 "label": "Occupancy Event"
             }

--- a/packages/dashboard/test/ClusterFeaturesTest.ts
+++ b/packages/dashboard/test/ClusterFeaturesTest.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ClusterFeatureDescription } from "../src/client/models/descriptions.js";
+import { clusters, type ClusterFeatureDescription } from "../src/client/models/descriptions.js";
 import { computeActiveClusterFeatures } from "../src/util/cluster-features.js";
 
 // CameraAvStreamManagement's real feature set (spec §11.2.4), used in the FeatureMap=39 case below.
@@ -43,5 +43,36 @@ describe("computeActiveClusterFeatures", () => {
     it("coerces bigint FeatureMap values", () => {
         const active = computeActiveClusterFeatures(16n, AVSM_FEATURES);
         expect(active.map(f => f.code)).to.deep.equal(["SPKR"]);
+    });
+});
+
+describe("generated cluster feature bits", () => {
+    it("preserves the reserved-bit gap in the Thermostat feature table", () => {
+        const bitsByCode = Object.fromEntries(Object.values(clusters[0x201].features).map(f => [f.code, f.bit]));
+        expect(bitsByCode).to.include({
+            HEAT: 0,
+            COOL: 1,
+            OCC: 2,
+            SB: 4,
+            AUTO: 5,
+            LTNE: 6,
+            MSCH: 7,
+            PRES: 8,
+            TEVT: 9,
+            TSUGGEST: 10,
+        });
+    });
+
+    it("keeps a lone high feature bit at its spec position", () => {
+        expect(clusters[0x39].features["20"]).to.deep.equal({
+            bit: 20,
+            code: "BIS",
+            label: "Bridged Icd Support",
+        });
+    });
+
+    it("decodes a real Thermostat FeatureMap against the generated table", () => {
+        const active = computeActiveClusterFeatures(1955, Object.values(clusters[0x201].features));
+        expect(active.map(f => f.code)).to.deep.equal(["HEAT", "COOL", "AUTO", "MSCH", "PRES", "TEVT", "TSUGGEST"]);
     });
 });


### PR DESCRIPTION
## Summary
- The dashboard's generated cluster feature table (`packages/dashboard/src/client/models/descriptions.ts`) indexed FeatureMap bits by `feature.effectiveId`, which falls back to a field's sibling position when no explicit `id` is set.
- For clusters whose FeatureMap definition skips a bit (e.g. Thermostat's unused/reserved bit 3), positional indexing collapses the gap and shifts every subsequent feature down by one bit — silently mislabeling active features and dropping the last one entirely.
- Concretely: for a Thermostat FeatureMap value of 1955 (bits HEAT, COOL, AUTO, MSCH, PRES, TEVT, TSUGGEST), the dashboard rendered MSCH as "Presets", PRES as "Events", TEVT as "Thermostat Suggestions", and dropped TSUGGEST entirely.
- Fix: `scripts/generate-descriptions.ts` now keys/stores each feature by `feature.key` (matter.js's bitmap-aware getter that resolves to the field's actual `constraint`), instead of `effectiveId`. Regenerated `descriptions.ts` accordingly.

## Test plan
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `PRIMARY_INTERFACE=ens33 MATTER_MDNS_NETWORKINTERFACE=ens33 npm test` (255/255 passing)
- [x] Verified `computeActiveClusterFeatures(1955, …)` for the Thermostat cluster now returns HEAT, COOL, AUTO, MSCH, PRES, TEVT, TSUGGEST correctly labeled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)