### PR TITLE
feat(dashboard): add Schedule panel for Thermostat (MSCH)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
-- Enhancement: (lboue) Dashboard Thermostat cluster view shows a Schedule Configuration panel (MSCH feature) visualizing schedules as a weekly setpoint grid with legend and transition list
 - Enhancement: Introduces Websocket Schema version 13 (backward compatible)
     - (MindFreeze) Adds Websocket command `get_network_topology` and event `network_topology_updated` to expose the Thread and WiFi network details for external visualization
 - Enhancement: (lboue) Dashboard endpoint view shows "Client Clusters" of an endpoint and their binding status when also a Binding cluster is available
+- Enhancement: (lboue) Added a Schedule Configuration panel (Thermostat cluster MSCH feature) to Dashboard visualizing schedules
 - Enhancement: Dashboard dev mode adds a second read button per attribute that reads across all fabrics and shows the result without caching it
 - Fix: Dashboard endpoint view refreshes its cluster list when a cluster appears or disappears on the node, or the viewed endpoint changes
 - Fix: Dashboard attribute reads are fabric-filtered like the subscription; only a read that needs to see other fabrics' data is non-fabric-filtered, and its result is not cached

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
+- Enhancement: (lboue) Dashboard Thermostat cluster view shows a Schedule Configuration panel (MSCH feature) visualizing schedules as a weekly setpoint grid with legend and transition list
 - Enhancement: Introduces Websocket Schema version 13 (backward compatible)
     - (MindFreeze) Adds Websocket command `get_network_topology` and event `network_topology_updated` to expose the Thread and WiFi network details for external visualization
 - Enhancement: (lboue) Dashboard endpoint view shows "Client Clusters" of an endpoint and their binding status when also a Binding cluster is available

--- a/packages/dashboard/public/index.html
+++ b/packages/dashboard/public/index.html
@@ -72,6 +72,10 @@
     --graph-node-fallback: #999999;
     --monospace-font: "Roboto Mono", ui-monospace, monospace;
 
+    /* Thermostat schedule setpoint gradient (cold -> hot) */
+    --schedule-color-cold: #1e88e5;
+    --schedule-color-hot: #fb8c00;
+
     --md-sys-typescale-headline-font: var(--roboto-font);
     --md-sys-typescale-title-font: var(--roboto-font);
 
@@ -133,6 +137,8 @@
     --graph-font-color: #e0e0e0;
     --graph-edge-dimmed: #555555;
     --graph-node-fallback: #999999;
+    --schedule-color-cold: #64b5f6;
+    --schedule-color-hot: #ffb74d;
     --text-color: rgba(255, 255, 255, 0.6);
     --danger-color: #ff7961;
     --success-color: #66bb6a;

--- a/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
@@ -1,0 +1,506 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mdiCheck, mdiClockOutline, mdiFire, mdiSnowflake } from "@mdi/js";
+import { css, html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import "../../../components/ha-svg-icon.js";
+import {
+    assignDaysToSchedules,
+    buildDaySegments,
+    computeSetpointRange,
+    DAY_LABELS,
+    type DaySegment,
+    formatHandleShort,
+    formatSetpoint,
+    isMSCHActive,
+    readActiveScheduleHandle,
+    readPresets,
+    pickSetpointForMode,
+    readSchedules,
+    resolveTransitionLabel,
+    type ScheduleColorMode,
+    setpointColorMixPercent,
+    THERMOSTAT_CLUSTER_ID,
+    type ThermostatSchedule,
+} from "../../../util/thermostat-schedule.js";
+import { BaseClusterCommands } from "../base-cluster-commands.js";
+import { registerClusterCommands } from "../registry.js";
+
+const HOUR_TICKS = [0, 4, 8, 12, 16, 20, 24];
+
+function formatMinutes(min: number): string {
+    return `${String(Math.floor(min / 60)).padStart(2, "0")}:${String(min % 60).padStart(2, "0")}`;
+}
+
+@customElement("thermostat-cluster-commands")
+class ThermostatClusterCommands extends BaseClusterCommands {
+    @state() private _selectedHandle: string | null = null;
+    @state() private _colorMode: ScheduleColorMode = "heat";
+    private _scheduleContext?: string;
+
+    override willUpdate(changedProperties: Map<string, unknown>) {
+        super.willUpdate(changedProperties);
+        if (!this.node) return;
+        const context = `${String(this.node.node_id)}/${this.endpoint}/${this.cluster}`;
+        if (this._scheduleContext !== undefined && this._scheduleContext !== context) {
+            this._selectedHandle = null;
+        }
+        this._scheduleContext = context;
+    }
+
+    override render() {
+        if (!this.node || this.cluster !== THERMOSTAT_CLUSTER_ID || !isMSCHActive(this.node, this.endpoint)) {
+            return nothing;
+        }
+
+        const schedules = readSchedules(this.node, this.endpoint);
+        const activeHandle = readActiveScheduleHandle(this.node, this.endpoint);
+        const presets = readPresets(this.node, this.endpoint);
+        const owners = assignDaysToSchedules(schedules);
+
+        const selectedSchedule: ThermostatSchedule | undefined =
+            (this._selectedHandle !== null ? schedules.find(s => s.handle === this._selectedHandle) : undefined) ??
+            (activeHandle !== null ? schedules.find(s => s.handle === activeHandle) : undefined) ??
+            schedules[0];
+
+        const ownerSchedules = owners.filter((s): s is ThermostatSchedule => s !== undefined);
+        const ranges = ownerSchedules
+            .map(computeSetpointRange)
+            .filter((r): r is { min: number; max: number } => r !== undefined);
+        const range =
+            ranges.length > 0
+                ? { min: Math.min(...ranges.map(r => r.min)), max: Math.max(...ranges.map(r => r.max)) }
+                : undefined;
+        const hasDualSetpoints = ownerSchedules.some(s =>
+            s.transitions.some(t => t.heatingSetpoint !== null && t.coolingSetpoint !== null),
+        );
+
+        return html`
+            <details class="command-panel" open>
+                <summary>
+                    <ha-svg-icon .path=${mdiClockOutline}></ha-svg-icon>
+                    Schedule Configuration
+                    <span class="feature-map-badge">FeatureMap: MSCH</span>
+                </summary>
+                <div class="command-content">
+                    ${
+                        schedules.length === 0
+                            ? html`<p class="empty">No schedules configured.</p>`
+                            : html`
+                                  <ul class="schedule-chips">
+                                      ${schedules.map((s, index) => {
+                                          const isActive = s.handle !== null && s.handle === activeHandle;
+                                          return html`
+                                              <li>
+                                                  <button
+                                                      class="schedule-chip ${isActive ? "active" : ""} ${
+                                                          selectedSchedule === s ? "selected" : ""
+                                                      }"
+                                                      @click=${() => {
+                                                          this._selectedHandle = s.handle;
+                                                      }}
+                                                  >
+                                                      <span>${s.name ?? `Schedule ${index + 1}`}</span>
+                                                      <span class="chip-handle">${formatHandleShort(s.handle)}</span>
+                                                      ${
+                                                          isActive
+                                                              ? html`<span class="active-badge">
+                                                                    <ha-svg-icon .path=${mdiCheck}></ha-svg-icon>
+                                                                    Active
+                                                                </span>`
+                                                              : nothing
+                                                      }
+                                                  </button>
+                                              </li>
+                                          `;
+                                      })}
+                                  </ul>
+
+                                  ${
+                                      selectedSchedule
+                                          ? html`
+                                                ${
+                                                    hasDualSetpoints
+                                                        ? html`
+                                                              <div class="grid-toolbar">
+                                                                  <span class="grid-toolbar-label">Color by</span>
+                                                                  <button
+                                                                      class="mode-toggle ${
+                                                                          this._colorMode === "heat" ? "active" : ""
+                                                                      }"
+                                                                      @click=${() => {
+                                                                          this._colorMode = "heat";
+                                                                      }}
+                                                                  >
+                                                                      <ha-svg-icon .path=${mdiFire}></ha-svg-icon>
+                                                                      Heat
+                                                                  </button>
+                                                                  <button
+                                                                      class="mode-toggle ${
+                                                                          this._colorMode === "cool" ? "active" : ""
+                                                                      }"
+                                                                      @click=${() => {
+                                                                          this._colorMode = "cool";
+                                                                      }}
+                                                                  >
+                                                                      <ha-svg-icon .path=${mdiSnowflake}></ha-svg-icon>
+                                                                      Cool
+                                                                  </button>
+                                                              </div>
+                                                          `
+                                                        : nothing
+                                                }
+                                                <div class="schedule-grid">
+                                                    <div class="grid-ticks">
+                                                        ${HOUR_TICKS.map(
+                                                            h => html`<span>${String(h).padStart(2, "0")}:00</span>`,
+                                                        )}
+                                                    </div>
+                                                    ${DAY_LABELS.map((label, day) => {
+                                                        const owner = owners[day];
+                                                        const isSelectedDay = owner === selectedSchedule;
+                                                        const segments = owner ? buildDaySegments(owner, day) : [];
+                                                        return html`
+                                                            <div class="grid-row ${isSelectedDay ? "" : "dimmed"}">
+                                                                <span class="day-label">${label}</span>
+                                                                <div class="day-timeline">
+                                                                    ${segments.map(
+                                                                        seg => html`
+                                                                            <span
+                                                                                class="segment"
+                                                                                style=${`left:${(seg.startMin / 1440) * 100}%;width:${
+                                                                                    ((seg.endMin - seg.startMin) /
+                                                                                        1440) *
+                                                                                    100
+                                                                                }%;background:${this._segmentColor(
+                                                                                    seg,
+                                                                                    range,
+                                                                                    this._colorMode,
+                                                                                )}`}
+                                                                            ></span>
+                                                                        `,
+                                                                    )}
+                                                                </div>
+                                                            </div>
+                                                        `;
+                                                    })}
+                                                </div>
+
+                                                ${
+                                                    range
+                                                        ? html`
+                                                              <div class="legend">
+                                                                  <ha-svg-icon .path=${mdiSnowflake}></ha-svg-icon>
+                                                                  <span>${formatSetpoint(range.min)}</span>
+                                                                  <span class="legend-bar"></span>
+                                                                  <span>${formatSetpoint(range.max)}</span>
+                                                                  <ha-svg-icon .path=${mdiFire}></ha-svg-icon>
+                                                              </div>
+                                                          `
+                                                        : nothing
+                                                }
+
+                                                <div class="transitions">
+                                                    <div class="transitions-header">
+                                                        TRANSITIONS ·
+                                                        ${
+                                                            selectedSchedule.name ??
+                                                            formatHandleShort(selectedSchedule.handle)
+                                                        }
+                                                    </div>
+                                                    <ul class="transitions-list">
+                                                        ${[...selectedSchedule.transitions]
+                                                            .sort((a, b) => a.transitionTimeMin - b.transitionTimeMin)
+                                                            .map(
+                                                                t => html`
+                                                                    <li class="transition-row">
+                                                                        <span class="transition-time">
+                                                                            ${formatMinutes(t.transitionTimeMin)}
+                                                                        </span>
+                                                                        <span class="transition-label">
+                                                                            ${resolveTransitionLabel(t, presets)}
+                                                                        </span>
+                                                                        <span class="transition-setpoint">
+                                                                            ${
+                                                                                t.heatingSetpoint !== null
+                                                                                    ? html`<ha-svg-icon
+                                                                                              .path=${mdiFire}
+                                                                                          ></ha-svg-icon>
+                                                                                          ${formatSetpoint(
+                                                                                              t.heatingSetpoint,
+                                                                                          )}`
+                                                                                    : nothing
+                                                                            }
+                                                                            ${
+                                                                                t.coolingSetpoint !== null
+                                                                                    ? html`<ha-svg-icon
+                                                                                              .path=${mdiSnowflake}
+                                                                                          ></ha-svg-icon>
+                                                                                          ${formatSetpoint(
+                                                                                              t.coolingSetpoint,
+                                                                                          )}`
+                                                                                    : nothing
+                                                                            }
+                                                                        </span>
+                                                                    </li>
+                                                                `,
+                                                            )}
+                                                    </ul>
+                                                </div>
+                                            `
+                                          : nothing
+                                  }
+                              `
+                    }
+                </div>
+            </details>
+        `;
+    }
+
+    private _segmentColor(
+        seg: DaySegment,
+        range: { min: number; max: number } | undefined,
+        mode: ScheduleColorMode,
+    ): string {
+        const value = pickSetpointForMode(seg, mode);
+        if (value === null || !range) return "var(--md-sys-color-surface-container-high)";
+        const pct = setpointColorMixPercent(value, range.min, range.max);
+        return `color-mix(in srgb, var(--schedule-color-cold), var(--schedule-color-hot) ${pct}%)`;
+    }
+
+    static override styles = [
+        ...(Array.isArray(BaseClusterCommands.styles) ? BaseClusterCommands.styles : [BaseClusterCommands.styles]),
+        css`
+            .feature-map-badge {
+                margin-left: auto;
+                font-size: 0.75rem;
+                font-weight: 400;
+                color: var(--md-sys-color-on-surface-variant);
+            }
+
+            .schedule-chips {
+                list-style: none;
+                margin: 0 0 16px 0;
+                padding: 0;
+                display: flex;
+                flex-wrap: wrap;
+                gap: 8px;
+            }
+
+            .schedule-chip {
+                display: inline-flex;
+                align-items: center;
+                gap: 6px;
+                padding: 6px 12px;
+                border-radius: 8px;
+                border: 1px solid var(--md-sys-color-outline);
+                background: transparent;
+                color: var(--md-sys-color-on-surface);
+                font: inherit;
+                cursor: pointer;
+            }
+
+            .schedule-chip.active {
+                background: var(--md-sys-color-secondary-container);
+                color: var(--md-sys-color-on-secondary-container);
+                border-color: transparent;
+            }
+
+            .schedule-chip.selected {
+                outline: 2px solid var(--md-sys-color-primary);
+                outline-offset: 1px;
+            }
+
+            .chip-handle {
+                font-family: var(--monospace-font);
+                font-size: 0.75rem;
+                color: var(--md-sys-color-on-surface-variant);
+            }
+
+            .active-badge {
+                display: inline-flex;
+                align-items: center;
+                gap: 2px;
+                font-size: 0.75rem;
+                color: var(--success-color);
+            }
+
+            .active-badge ha-svg-icon {
+                --mdc-icon-size: 14px;
+            }
+
+            .grid-toolbar {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                margin-bottom: 8px;
+            }
+
+            .grid-toolbar-label {
+                font-size: 0.75rem;
+                color: var(--md-sys-color-on-surface-variant);
+            }
+
+            .mode-toggle {
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+                padding: 4px 10px;
+                border-radius: 8px;
+                border: 1px solid var(--md-sys-color-outline);
+                background: transparent;
+                color: var(--md-sys-color-on-surface-variant);
+                font: inherit;
+                font-size: 0.8rem;
+                cursor: pointer;
+            }
+
+            .mode-toggle ha-svg-icon {
+                --mdc-icon-size: 14px;
+            }
+
+            .mode-toggle.active {
+                background: var(--md-sys-color-secondary-container);
+                color: var(--md-sys-color-on-secondary-container);
+                border-color: transparent;
+            }
+
+            .schedule-grid {
+                margin-bottom: 12px;
+            }
+
+            .grid-ticks {
+                display: flex;
+                justify-content: space-between;
+                font-size: 0.7rem;
+                color: var(--md-sys-color-on-surface-variant);
+                padding: 0 0 4px 48px;
+            }
+
+            .grid-row {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                padding: 2px 0;
+            }
+
+            .grid-row.dimmed {
+                opacity: 0.45;
+            }
+
+            .day-label {
+                width: 40px;
+                flex-shrink: 0;
+                font-size: 0.8rem;
+                font-weight: 500;
+            }
+
+            .grid-row:not(.dimmed) .day-label {
+                font-weight: 700;
+                color: var(--md-sys-color-primary);
+            }
+
+            .day-timeline {
+                position: relative;
+                flex: 1;
+                height: 18px;
+                border-radius: 4px;
+                overflow: hidden;
+                background: var(--md-sys-color-surface-container-high);
+            }
+
+            .segment {
+                position: absolute;
+                top: 0;
+                bottom: 0;
+            }
+
+            .legend {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                font-size: 0.8rem;
+                color: var(--md-sys-color-on-surface-variant);
+                padding: 8px 0 16px 48px;
+            }
+
+            .legend ha-svg-icon {
+                --mdc-icon-size: 16px;
+            }
+
+            .legend-bar {
+                flex: 1;
+                max-width: 240px;
+                height: 8px;
+                border-radius: 4px;
+                background: linear-gradient(to right, var(--schedule-color-cold), var(--schedule-color-hot));
+            }
+
+            .transitions-header {
+                font-weight: 500;
+                font-size: 0.8rem;
+                letter-spacing: 0.04em;
+                color: var(--md-sys-color-on-surface-variant);
+                text-transform: uppercase;
+                margin-bottom: 8px;
+            }
+
+            .transitions-list {
+                list-style: none;
+                margin: 0;
+                padding: 0;
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+            }
+
+            .transition-row {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+                padding: 8px 12px;
+                border-radius: 8px;
+                background: var(--md-sys-color-surface-container-high);
+            }
+
+            .transition-time {
+                font-family: var(--monospace-font);
+                font-weight: 500;
+                width: 48px;
+            }
+
+            .transition-label {
+                flex: 1;
+                color: var(--md-sys-color-on-surface-variant);
+            }
+
+            .transition-setpoint {
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+                font-weight: 500;
+            }
+
+            .transition-setpoint ha-svg-icon {
+                --mdc-icon-size: 16px;
+            }
+
+            .empty {
+                color: var(--md-sys-color-on-surface-variant);
+                margin: 0;
+            }
+        `,
+    ];
+}
+
+registerClusterCommands(THERMOSTAT_CLUSTER_ID, "thermostat-cluster-commands");
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "thermostat-cluster-commands": ThermostatClusterCommands;
+    }
+}

--- a/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
@@ -5,15 +5,16 @@
  */
 
 import { mdiCheck, mdiClockOutline, mdiFire, mdiSnowflake } from "@mdi/js";
-import { css, html, nothing } from "lit";
+import { css, type CSSResultGroup, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import "../../../components/ha-svg-icon.js";
 import {
-    assignDaysToSchedules,
     buildDaySegments,
+    compareTransitionsForDisplay,
     computeSetpointRange,
     DAY_LABELS,
     type DaySegment,
+    formatDayOfWeek,
     formatHandleShort,
     formatMinutes,
     formatSegmentTooltip,
@@ -23,11 +24,11 @@ import {
     readPresets,
     pickSetpointForMode,
     readSchedules,
+    resolveScheduleDefaults,
     resolveTransitionLabel,
     type ScheduleColorMode,
     setpointColorMixPercent,
     THERMOSTAT_CLUSTER_ID,
-    type ThermostatSchedule,
 } from "../../../util/thermostat-schedule.js";
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
@@ -46,6 +47,7 @@ class ThermostatClusterCommands extends BaseClusterCommands {
         const context = `${String(this.node.node_id)}/${this.endpoint}/${this.cluster}`;
         if (this._scheduleContext !== undefined && this._scheduleContext !== context) {
             this._selectedHandle = null;
+            this._colorMode = "heat";
         }
         this._scheduleContext = context;
     }
@@ -58,24 +60,22 @@ class ThermostatClusterCommands extends BaseClusterCommands {
         const schedules = readSchedules(this.node, this.endpoint);
         const activeHandle = readActiveScheduleHandle(this.node, this.endpoint);
         const presets = readPresets(this.node, this.endpoint);
-        const owners = assignDaysToSchedules(schedules);
 
-        const selectedSchedule: ThermostatSchedule | undefined =
-            (this._selectedHandle !== null ? schedules.find(s => s.handle === this._selectedHandle) : undefined) ??
-            (activeHandle !== null ? schedules.find(s => s.handle === activeHandle) : undefined) ??
-            schedules[0];
+        const pickedSchedule =
+            (this._selectedHandle !== null ? schedules?.find(s => s.handle === this._selectedHandle) : undefined) ??
+            (activeHandle !== null ? schedules?.find(s => s.handle === activeHandle) : undefined) ??
+            schedules?.[0];
+        const selectedSchedule =
+            pickedSchedule !== undefined ? resolveScheduleDefaults(pickedSchedule, presets) : undefined;
+        const resolvedTransitions = selectedSchedule?.transitions ?? [];
+        const transitionRows = resolvedTransitions
+            .map((resolved, index) => ({ resolved, reported: pickedSchedule?.transitions[index] }))
+            .sort((a, b) => compareTransitionsForDisplay(a.resolved, b.resolved));
 
-        const ownerSchedules = owners.filter((s): s is ThermostatSchedule => s !== undefined);
-        const ranges = ownerSchedules
-            .map(s => computeSetpointRange(s, this._colorMode))
-            .filter((r): r is { min: number; max: number } => r !== undefined);
-        const range =
-            ranges.length > 0
-                ? { min: Math.min(...ranges.map(r => r.min)), max: Math.max(...ranges.map(r => r.max)) }
-                : undefined;
-        const hasDualSetpoints = ownerSchedules.some(s =>
-            s.transitions.some(t => t.heatingSetpoint !== null && t.coolingSetpoint !== null),
-        );
+        const range = selectedSchedule ? computeSetpointRange(selectedSchedule, this._colorMode) : undefined;
+        const hasDualSetpoints =
+            resolvedTransitions.some(t => t.heatingSetpoint !== null) &&
+            resolvedTransitions.some(t => t.coolingSetpoint !== null);
 
         return html`
             <details class="command-panel" open>
@@ -86,181 +86,191 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                 </summary>
                 <div class="command-content">
                     ${
-                        schedules.length === 0
-                            ? html`<p class="empty">No schedules configured.</p>`
-                            : html`
-                                  <ul class="schedule-chips">
-                                      ${schedules.map((s, index) => {
-                                          const isActive = s.handle !== null && s.handle === activeHandle;
-                                          return html`
-                                              <li>
-                                                  <button
-                                                      class="schedule-chip ${isActive ? "active" : ""} ${
-                                                          selectedSchedule === s ? "selected" : ""
-                                                      }"
-                                                      @click=${() => {
-                                                          this._selectedHandle = s.handle;
-                                                      }}
-                                                  >
-                                                      <span>${s.name ?? `Schedule ${index + 1}`}</span>
-                                                      <span class="chip-handle">${formatHandleShort(s.handle)}</span>
-                                                      ${
-                                                          isActive
-                                                              ? html`<span class="active-badge">
-                                                                    <ha-svg-icon .path=${mdiCheck}></ha-svg-icon>
-                                                                    Active
-                                                                </span>`
-                                                              : nothing
-                                                      }
-                                                  </button>
-                                              </li>
-                                          `;
-                                      })}
-                                  </ul>
-
-                                  ${
-                                      selectedSchedule
-                                          ? html`
-                                                ${
-                                                    hasDualSetpoints
-                                                        ? html`
-                                                              <div class="grid-toolbar">
-                                                                  <span class="grid-toolbar-label">Color by</span>
-                                                                  <button
-                                                                      class="mode-toggle ${
-                                                                          this._colorMode === "heat" ? "active" : ""
-                                                                      }"
-                                                                      @click=${() => {
-                                                                          this._colorMode = "heat";
-                                                                      }}
-                                                                  >
-                                                                      <ha-svg-icon .path=${mdiFire}></ha-svg-icon>
-                                                                      Heat
-                                                                  </button>
-                                                                  <button
-                                                                      class="mode-toggle ${
-                                                                          this._colorMode === "cool" ? "active" : ""
-                                                                      }"
-                                                                      @click=${() => {
-                                                                          this._colorMode = "cool";
-                                                                      }}
-                                                                  >
-                                                                      <ha-svg-icon .path=${mdiSnowflake}></ha-svg-icon>
-                                                                      Cool
-                                                                  </button>
-                                                              </div>
-                                                          `
-                                                        : nothing
-                                                }
-                                                <div class="schedule-grid">
-                                                    <div class="grid-ticks">
-                                                        ${HOUR_TICKS.map(
-                                                            h => html`<span>${String(h).padStart(2, "0")}:00</span>`,
-                                                        )}
-                                                    </div>
-                                                    ${DAY_LABELS.map((label, day) => {
-                                                        const owner = owners[day];
-                                                        const isSelectedDay = owner === selectedSchedule;
-                                                        const segments = owner ? buildDaySegments(owner, day) : [];
-                                                        return html`
-                                                            <div class="grid-row ${isSelectedDay ? "" : "dimmed"}">
-                                                                <span class="day-label">${label}</span>
-                                                                <div class="day-timeline">
-                                                                    ${segments.map(
-                                                                        seg => html`
-                                                                            <span
-                                                                                class="segment"
-                                                                                style=${`left:${(seg.startMin / 1440) * 100}%;width:${
-                                                                                    ((seg.endMin - seg.startMin) /
-                                                                                        1440) *
-                                                                                    100
-                                                                                }%;background:${this._segmentColor(
-                                                                                    seg,
-                                                                                    range,
-                                                                                    this._colorMode,
-                                                                                )}`}
-                                                                                title=${formatSegmentTooltip(
-                                                                                    seg,
-                                                                                    presets,
-                                                                                )}
-                                                                            ></span>
-                                                                        `,
-                                                                    )}
-                                                                </div>
-                                                            </div>
-                                                        `;
-                                                    })}
-                                                </div>
-
-                                                ${
-                                                    range
-                                                        ? html`
-                                                              <div class="legend">
-                                                                  <ha-svg-icon .path=${mdiSnowflake}></ha-svg-icon>
-                                                                  <span>${formatSetpoint(range.min)}</span>
-                                                                  <span class="legend-bar"></span>
-                                                                  <span>${formatSetpoint(range.max)}</span>
-                                                                  <ha-svg-icon .path=${mdiFire}></ha-svg-icon>
-                                                              </div>
-                                                          `
-                                                        : nothing
-                                                }
-
-                                                <div class="transitions">
-                                                    <div class="transitions-header">
-                                                        TRANSITIONS ·
+                        schedules === undefined
+                            ? html`<p class="empty">Schedules attribute not available.</p>`
+                            : schedules.length === 0
+                              ? html`<p class="empty">No schedules configured.</p>`
+                              : html`
+                                    <ul class="schedule-chips">
+                                        ${schedules.map((s, index) => {
+                                            const isActive = s.handle === activeHandle;
+                                            return html`
+                                                <li>
+                                                    <button
+                                                        class="schedule-chip ${isActive ? "active" : ""} ${
+                                                            selectedSchedule?.handle === s.handle ? "selected" : ""
+                                                        }"
+                                                        @click=${() => {
+                                                            this._selectedHandle = s.handle;
+                                                        }}
+                                                    >
+                                                        <span>${s.name ?? `Schedule ${index + 1}`}</span>
+                                                        <span class="chip-handle">${formatHandleShort(s.handle)}</span>
                                                         ${
-                                                            selectedSchedule.name ??
-                                                            formatHandleShort(selectedSchedule.handle)
+                                                            isActive
+                                                                ? html`<span class="active-badge">
+                                                                      <ha-svg-icon .path=${mdiCheck}></ha-svg-icon>
+                                                                      Active
+                                                                  </span>`
+                                                                : nothing
                                                         }
-                                                    </div>
-                                                    <ul class="transitions-list">
-                                                        ${[...selectedSchedule.transitions]
-                                                            .sort((a, b) => a.transitionTimeMin - b.transitionTimeMin)
-                                                            .map(
-                                                                t => html`
-                                                                    <li class="transition-row">
-                                                                        <span class="transition-time">
-                                                                            ${formatMinutes(t.transitionTimeMin)}
-                                                                        </span>
-                                                                        <span class="transition-label">
-                                                                            ${resolveTransitionLabel(t, presets)}
-                                                                        </span>
-                                                                        <span class="transition-setpoint">
-                                                                            ${
-                                                                                t.heatingSetpoint !== null
-                                                                                    ? html`<ha-svg-icon
-                                                                                              .path=${mdiFire}
-                                                                                          ></ha-svg-icon>
-                                                                                          ${formatSetpoint(
-                                                                                              t.heatingSetpoint,
-                                                                                          )}`
-                                                                                    : nothing
-                                                                            }
-                                                                            ${
-                                                                                t.coolingSetpoint !== null
-                                                                                    ? html`<ha-svg-icon
-                                                                                              .path=${mdiSnowflake}
-                                                                                          ></ha-svg-icon>
-                                                                                          ${formatSetpoint(
-                                                                                              t.coolingSetpoint,
-                                                                                          )}`
-                                                                                    : nothing
-                                                                            }
-                                                                        </span>
-                                                                    </li>
-                                                                `,
-                                                            )}
-                                                    </ul>
-                                                </div>
-                                            `
-                                          : nothing
-                                  }
-                              `
+                                                    </button>
+                                                </li>
+                                            `;
+                                        })}
+                                    </ul>
+
+                                    ${
+                                        selectedSchedule
+                                            ? html`
+                                                  ${
+                                                      hasDualSetpoints
+                                                          ? html`
+                                                                <div class="grid-toolbar">
+                                                                    <span class="grid-toolbar-label">Color by</span>
+                                                                    <button
+                                                                        class="mode-toggle ${
+                                                                            this._colorMode === "heat" ? "active" : ""
+                                                                        }"
+                                                                        @click=${() => {
+                                                                            this._colorMode = "heat";
+                                                                        }}
+                                                                    >
+                                                                        <ha-svg-icon .path=${mdiFire}></ha-svg-icon>
+                                                                        Heat
+                                                                    </button>
+                                                                    <button
+                                                                        class="mode-toggle ${
+                                                                            this._colorMode === "cool" ? "active" : ""
+                                                                        }"
+                                                                        @click=${() => {
+                                                                            this._colorMode = "cool";
+                                                                        }}
+                                                                    >
+                                                                        <ha-svg-icon
+                                                                            .path=${mdiSnowflake}
+                                                                        ></ha-svg-icon>
+                                                                        Cool
+                                                                    </button>
+                                                                </div>
+                                                            `
+                                                          : nothing
+                                                  }
+                                                  <div class="schedule-grid">
+                                                      <div class="grid-ticks">
+                                                          ${HOUR_TICKS.map(
+                                                              h => html`<span>${String(h).padStart(2, "0")}:00</span>`,
+                                                          )}
+                                                      </div>
+                                                      ${DAY_LABELS.map((label, day) => {
+                                                          const segments = buildDaySegments(selectedSchedule, day);
+                                                          return html`
+                                                              <div
+                                                                  class="grid-row ${segments.length > 0 ? "" : "dimmed"}"
+                                                              >
+                                                                  <span class="day-label">${label}</span>
+                                                                  <div class="day-timeline">
+                                                                      ${segments.map(
+                                                                          seg => html`
+                                                                              <span
+                                                                                  class="segment"
+                                                                                  style=${`left:${(seg.startMin / 1440) * 100}%;width:${
+                                                                                      ((seg.endMin - seg.startMin) /
+                                                                                          1440) *
+                                                                                      100
+                                                                                  }%;background:${this._segmentColor(
+                                                                                      seg,
+                                                                                      range,
+                                                                                      this._colorMode,
+                                                                                  )}`}
+                                                                                  title=${formatSegmentTooltip(seg, presets)}
+                                                                              ></span>
+                                                                          `,
+                                                                      )}
+                                                                  </div>
+                                                              </div>
+                                                          `;
+                                                      })}
+                                                  </div>
+
+                                                  ${
+                                                      range
+                                                          ? html`
+                                                                <div class="legend">
+                                                                    ${
+                                                                        range.min === range.max
+                                                                            ? html`<span>
+                                                                                  ${formatSetpoint(range.min)}
+                                                                              </span>`
+                                                                            : html`<span>
+                                                                                      ${formatSetpoint(range.min)}
+                                                                                  </span>
+                                                                                  <span class="legend-bar"></span>
+                                                                                  <span>
+                                                                                      ${formatSetpoint(range.max)}
+                                                                                  </span>`
+                                                                    }
+                                                                </div>
+                                                            `
+                                                          : nothing
+                                                  }
+
+                                                  <div class="transitions">
+                                                      <div class="transitions-header">
+                                                          TRANSITIONS ·
+                                                          ${selectedSchedule.name ?? formatHandleShort(selectedSchedule.handle)}
+                                                      </div>
+                                                      <ul class="transitions-list">
+                                                          ${transitionRows.map(
+                                                              ({ resolved: t, reported }) => html`
+                                                                  <li class="transition-row">
+                                                                      <span class="transition-days">
+                                                                          ${formatDayOfWeek(t.dayOfWeek)}
+                                                                      </span>
+                                                                      <span class="transition-time">
+                                                                          ${formatMinutes(t.transitionTimeMin)}
+                                                                      </span>
+                                                                      <span class="transition-label">
+                                                                          ${resolveTransitionLabel(t, presets)}
+                                                                      </span>
+                                                                      <span class="transition-setpoint">
+                                                                          ${this._setpointCell(
+                                                                              mdiFire,
+                                                                              t.heatingSetpoint,
+                                                                              reported?.heatingSetpoint ?? null,
+                                                                          )}
+                                                                          ${this._setpointCell(
+                                                                              mdiSnowflake,
+                                                                              t.coolingSetpoint,
+                                                                              reported?.coolingSetpoint ?? null,
+                                                                          )}
+                                                                      </span>
+                                                                  </li>
+                                                              `,
+                                                          )}
+                                                      </ul>
+                                                  </div>
+                                              `
+                                            : nothing
+                                    }
+                                `
                     }
                 </div>
             </details>
         `;
+    }
+
+    /** A value the device did not report for this transition comes from its preset, so it is marked as derived. */
+    private _setpointCell(icon: string, resolved: number | null, reported: number | null) {
+        if (resolved === null) return nothing;
+        const fromPreset = resolved !== reported;
+        return html`<span
+            class="setpoint-value ${fromPreset ? "inherited" : ""}"
+            title=${fromPreset ? "From preset" : nothing}
+        >
+            <ha-svg-icon .path=${icon}></ha-svg-icon>
+            ${formatSetpoint(resolved)}
+        </span>`;
     }
 
     private _segmentColor(
@@ -269,13 +279,15 @@ class ThermostatClusterCommands extends BaseClusterCommands {
         mode: ScheduleColorMode,
     ): string {
         const value = pickSetpointForMode(seg, mode);
-        if (value === null || !range) return "var(--md-sys-color-surface-container-high)";
+        if (value === null || !range) {
+            return "repeating-linear-gradient(45deg, var(--md-sys-color-outline) 0 3px, transparent 3px 7px)";
+        }
         const pct = setpointColorMixPercent(value, range.min, range.max);
         return `color-mix(in srgb, var(--schedule-color-cold), var(--schedule-color-hot) ${pct}%)`;
     }
 
-    static override styles = [
-        ...(Array.isArray(BaseClusterCommands.styles) ? BaseClusterCommands.styles : [BaseClusterCommands.styles]),
+    static override styles: CSSResultGroup = [
+        BaseClusterCommands.styles,
         css`
             .feature-map-badge {
                 margin-left: auto;
@@ -328,11 +340,12 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                 align-items: center;
                 gap: 2px;
                 font-size: 0.75rem;
-                color: var(--success-color);
+                color: var(--md-sys-color-on-secondary-container);
             }
 
             .active-badge ha-svg-icon {
                 --mdc-icon-size: 14px;
+                --icon-primary-color: var(--success-color, #2e7d32);
             }
 
             .grid-toolbar {
@@ -403,7 +416,7 @@ class ThermostatClusterCommands extends BaseClusterCommands {
 
             .grid-row:not(.dimmed) .day-label {
                 font-weight: 700;
-                color: var(--md-sys-color-primary);
+                color: var(--md-sys-color-on-surface);
             }
 
             .day-timeline {
@@ -412,13 +425,14 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                 height: 18px;
                 border-radius: 4px;
                 overflow: hidden;
-                background: var(--md-sys-color-surface-container-high);
+                background: var(--md-sys-color-surface-container-highest);
             }
 
             .segment {
                 position: absolute;
                 top: 0;
                 bottom: 0;
+                min-width: 2px;
             }
 
             .legend {
@@ -428,10 +442,6 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                 font-size: 0.8rem;
                 color: var(--md-sys-color-on-surface-variant);
                 padding: 8px 0 16px 48px;
-            }
-
-            .legend ha-svg-icon {
-                --mdc-icon-size: 16px;
             }
 
             .legend-bar {
@@ -466,7 +476,15 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                 gap: 12px;
                 padding: 8px 12px;
                 border-radius: 8px;
-                background: var(--md-sys-color-surface-container-high);
+                background: var(--md-sys-color-surface-container-highest);
+            }
+
+            .transition-days {
+                min-width: 104px;
+                flex-shrink: 0;
+                font-size: 0.8rem;
+                font-weight: 500;
+                color: var(--md-sys-color-on-surface-variant);
             }
 
             .transition-time {
@@ -489,6 +507,18 @@ class ThermostatClusterCommands extends BaseClusterCommands {
 
             .transition-setpoint ha-svg-icon {
                 --mdc-icon-size: 16px;
+            }
+
+            .setpoint-value {
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+            }
+
+            .setpoint-value.inherited {
+                font-style: italic;
+                font-weight: 400;
+                color: var(--md-sys-color-on-surface-variant);
             }
 
             .empty {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
@@ -15,6 +15,8 @@ import {
     DAY_LABELS,
     type DaySegment,
     formatHandleShort,
+    formatMinutes,
+    formatSegmentTooltip,
     formatSetpoint,
     isMSCHActive,
     readActiveScheduleHandle,
@@ -31,10 +33,6 @@ import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
 
 const HOUR_TICKS = [0, 4, 8, 12, 16, 20, 24];
-
-function formatMinutes(min: number): string {
-    return `${String(Math.floor(min / 60)).padStart(2, "0")}:${String(min % 60).padStart(2, "0")}`;
-}
 
 @customElement("thermostat-cluster-commands")
 class ThermostatClusterCommands extends BaseClusterCommands {
@@ -69,7 +67,7 @@ class ThermostatClusterCommands extends BaseClusterCommands {
 
         const ownerSchedules = owners.filter((s): s is ThermostatSchedule => s !== undefined);
         const ranges = ownerSchedules
-            .map(computeSetpointRange)
+            .map(s => computeSetpointRange(s, this._colorMode))
             .filter((r): r is { min: number; max: number } => r !== undefined);
         const range =
             ranges.length > 0
@@ -181,6 +179,10 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                                                                                     range,
                                                                                     this._colorMode,
                                                                                 )}`}
+                                                                                title=${formatSegmentTooltip(
+                                                                                    seg,
+                                                                                    presets,
+                                                                                )}
                                                                             ></span>
                                                                         `,
                                                                     )}

--- a/packages/dashboard/src/pages/cluster-commands/index.ts
+++ b/packages/dashboard/src/pages/cluster-commands/index.ts
@@ -25,3 +25,4 @@ import "./clusters/closure-control-commands.js";
 import "./clusters/icd-management-commands.js";
 import "./clusters/level-control-commands.js";
 import "./clusters/on-off-commands.js";
+import "./clusters/thermostat-commands.js";

--- a/packages/dashboard/src/util/attribute-shapes.ts
+++ b/packages/dashboard/src/util/attribute-shapes.ts
@@ -21,6 +21,16 @@ export function pickString(obj: Record<string, unknown>, key: string): string | 
     return typeof v === "string" ? v : null;
 }
 
+export function pickBoolean(obj: Record<string, unknown>, key: string): boolean | null {
+    const v = obj[key];
+    return typeof v === "boolean" ? v : null;
+}
+
+export function pickArray(obj: Record<string, unknown>, key: string): unknown[] {
+    const v = obj[key];
+    return Array.isArray(v) ? v : [];
+}
+
 export function extractAttributeValue(attributesData: unknown): unknown {
     const obj = asObject(attributesData);
     if (!obj) return attributesData;

--- a/packages/dashboard/src/util/thermostat-schedule.ts
+++ b/packages/dashboard/src/util/thermostat-schedule.ts
@@ -169,8 +169,13 @@ export function readPresets(node: MatterNode, endpoint: number): ThermostatPrese
     return raw.map(decodePreset).filter((p): p is ThermostatPreset => p !== null);
 }
 
-/** Resolves a transition's human label: matching preset name, else SystemMode, else a generic fallback. */
-export function resolveTransitionLabel(transition: ThermostatScheduleTransition, presets: ThermostatPreset[]): string {
+interface ModeLabelSource {
+    presetHandle: string | null;
+    systemMode: number | null;
+}
+
+/** Resolves a transition's (or day segment's) human label: matching preset name, else SystemMode, else a generic fallback. */
+export function resolveTransitionLabel(transition: ModeLabelSource, presets: ThermostatPreset[]): string {
     if (transition.presetHandle) {
         const preset = presets.find(p => p.handle === transition.presetHandle);
         if (preset?.name) return preset.name;
@@ -233,21 +238,26 @@ export function formatSetpoint(centidegrees: number | undefined | null): string 
     return `${(centidegrees / 100).toFixed(1)}°C`;
 }
 
-export function computeSetpointRange(schedule: ThermostatSchedule): { min: number; max: number } | undefined {
-    const values = schedule.transitions
-        .flatMap(t => [t.heatingSetpoint, t.coolingSetpoint])
-        .filter((v): v is number => v !== null);
-    if (values.length === 0) return undefined;
-    return { min: Math.min(...values), max: Math.max(...values) };
+export function formatMinutes(min: number): string {
+    return `${String(Math.floor(min / 60)).padStart(2, "0")}:${String(min % 60).padStart(2, "0")}`;
 }
 
-/** Clamped 0-100 position of `value` within [min, max], for driving a cold->hot color-mix gradient. */
-export function setpointColorMixPercent(value: number, min: number, max: number): number {
-    if (max <= min) return 50;
-    return Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100));
+/** Hover text for a grid segment: its time span, label, and any setpoints — for a native `title` tooltip. */
+export function formatSegmentTooltip(seg: DaySegment, presets: ThermostatPreset[]): string {
+    const lines = [
+        `${formatMinutes(seg.startMin)}–${formatMinutes(seg.endMin)} · ${resolveTransitionLabel(seg, presets)}`,
+    ];
+    if (seg.heatingSetpoint !== null) lines.push(`Heat ${formatSetpoint(seg.heatingSetpoint)}`);
+    if (seg.coolingSetpoint !== null) lines.push(`Cool ${formatSetpoint(seg.coolingSetpoint)}`);
+    return lines.join("\n");
 }
 
 export type ScheduleColorMode = "heat" | "cool";
+
+interface SetpointPair {
+    heatingSetpoint: number | null;
+    coolingSetpoint: number | null;
+}
 
 /**
  * The setpoint driving a segment's color for the given mode. In Auto mode (both heat and cool
@@ -256,10 +266,30 @@ export type ScheduleColorMode = "heat" | "cool";
  * preserves the actual variation instead. Falls back to whichever setpoint is present when the
  * selected mode's isn't (e.g. a Cool-only schedule while in "heat" mode).
  */
-export function pickSetpointForMode(seg: DaySegment, mode: ScheduleColorMode): number | null {
+export function pickSetpointForMode(seg: SetpointPair, mode: ScheduleColorMode): number | null {
     return mode === "heat"
         ? (seg.heatingSetpoint ?? seg.coolingSetpoint)
         : (seg.coolingSetpoint ?? seg.heatingSetpoint);
+}
+
+/**
+ * Min/max for the given mode's setpoints only. Heat and cool setpoints sit in disjoint
+ * bands (e.g. heat 17-21°C, cool 24-27°C) — pooling them into one range would compress
+ * each mode's gradient into a narrow slice instead of using the full color scale.
+ */
+export function computeSetpointRange(
+    schedule: ThermostatSchedule,
+    mode: ScheduleColorMode,
+): { min: number; max: number } | undefined {
+    const values = schedule.transitions.map(t => pickSetpointForMode(t, mode)).filter((v): v is number => v !== null);
+    if (values.length === 0) return undefined;
+    return { min: Math.min(...values), max: Math.max(...values) };
+}
+
+/** Clamped 0-100 position of `value` within [min, max], for driving a cold->hot color-mix gradient. */
+export function setpointColorMixPercent(value: number, min: number, max: number): number {
+    if (max <= min) return 50;
+    return Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100));
 }
 
 function decodeHandleBytes(base64: string): Uint8Array {

--- a/packages/dashboard/src/util/thermostat-schedule.ts
+++ b/packages/dashboard/src/util/thermostat-schedule.ts
@@ -94,7 +94,18 @@ function decodeTransition(raw: unknown): ThermostatScheduleTransition | null {
     if (!obj) return null;
     const dayOfWeek = pickNum(obj, "DayOfWeek", "0");
     const transitionTimeMin = pickNum(obj, "TransitionTime", "1");
-    if (dayOfWeek === null || transitionTimeMin === null) return null;
+    if (
+        dayOfWeek === null ||
+        transitionTimeMin === null ||
+        !Number.isInteger(dayOfWeek) ||
+        dayOfWeek < 0 ||
+        dayOfWeek > 0x7f ||
+        !Number.isInteger(transitionTimeMin) ||
+        transitionTimeMin < 0 ||
+        transitionTimeMin >= 1440
+    ) {
+        return null;
+    }
     return {
         dayOfWeek,
         transitionTimeMin,
@@ -108,13 +119,14 @@ function decodeTransition(raw: unknown): ThermostatScheduleTransition | null {
 function decodeSchedule(raw: unknown): ThermostatSchedule | null {
     const obj = asObject(raw);
     if (!obj) return null;
+    const handle = pickStr(obj, "ScheduleHandle", "0");
     const systemMode = pickNum(obj, "SystemMode", "1");
-    if (systemMode === null) return null;
+    if (handle === null || systemMode === null) return null;
     const transitions = pickArr(obj, "Transitions", "4")
         .map(decodeTransition)
         .filter((t): t is ThermostatScheduleTransition => t !== null);
     return {
-        handle: pickStr(obj, "ScheduleHandle", "0"),
+        handle,
         systemMode,
         name: pickStr(obj, "Name", "2"),
         presetHandle: pickStr(obj, "PresetHandle", "3"),

--- a/packages/dashboard/src/util/thermostat-schedule.ts
+++ b/packages/dashboard/src/util/thermostat-schedule.ts
@@ -6,10 +6,10 @@
 
 import type { MatterNode } from "@matter-server/ws-client";
 import { clusters } from "../client/models/descriptions.js";
-import { asObject } from "./attribute-shapes.js";
+import { asObject, pickArray, pickBoolean, pickNumber, pickString } from "./attribute-shapes.js";
 import { computeActiveClusterFeatures } from "./cluster-features.js";
 
-/** Thermostat cluster (Matter spec §4.4). */
+/** Thermostat cluster (Matter spec §4.3). */
 export const THERMOSTAT_CLUSTER_ID = 513; // 0x0201
 
 const ATTR_PRESETS = 0x50;
@@ -43,7 +43,7 @@ export interface ThermostatScheduleTransition {
 }
 
 export interface ThermostatSchedule {
-    handle: string | null;
+    handle: string;
     systemMode: number;
     name: string | null;
     presetHandle: string | null;
@@ -54,6 +54,8 @@ export interface ThermostatSchedule {
 export interface ThermostatPreset {
     handle: string;
     name: string | null;
+    coolingSetpoint: number | null;
+    heatingSetpoint: number | null;
 }
 
 export interface DaySegment {
@@ -69,31 +71,13 @@ function readAttr(node: MatterNode, endpoint: number, attrId: number): unknown {
     return node.attributes[`${endpoint}/${THERMOSTAT_CLUSTER_ID}/${attrId}`];
 }
 
-function pickStr(obj: Record<string, unknown>, name: string, tag: string): string | null {
-    const v = obj[name] ?? obj[tag];
-    return typeof v === "string" ? v : null;
-}
-
-function pickNum(obj: Record<string, unknown>, name: string, tag: string): number | null {
-    const v = obj[name] ?? obj[tag];
-    return typeof v === "number" && Number.isFinite(v) ? v : null;
-}
-
-function pickBool(obj: Record<string, unknown>, name: string, tag: string): boolean | null {
-    const v = obj[name] ?? obj[tag];
-    return typeof v === "boolean" ? v : null;
-}
-
-function pickArr(obj: Record<string, unknown>, name: string, tag: string): unknown[] {
-    const v = obj[name] ?? obj[tag];
-    return Array.isArray(v) ? v : [];
-}
-
+// Struct attributes reach the dashboard through convertMatterToWebSocketTagBased, so fields are keyed
+// by numeric field tag only — never by name, unlike the invoke/event converters.
 function decodeTransition(raw: unknown): ThermostatScheduleTransition | null {
     const obj = asObject(raw);
     if (!obj) return null;
-    const dayOfWeek = pickNum(obj, "DayOfWeek", "0");
-    const transitionTimeMin = pickNum(obj, "TransitionTime", "1");
+    const dayOfWeek = pickNumber(obj, "0");
+    const transitionTimeMin = pickNumber(obj, "1");
     if (
         dayOfWeek === null ||
         transitionTimeMin === null ||
@@ -109,38 +93,43 @@ function decodeTransition(raw: unknown): ThermostatScheduleTransition | null {
     return {
         dayOfWeek,
         transitionTimeMin,
-        presetHandle: pickStr(obj, "PresetHandle", "2"),
-        systemMode: pickNum(obj, "SystemMode", "3"),
-        coolingSetpoint: pickNum(obj, "CoolingSetpoint", "4"),
-        heatingSetpoint: pickNum(obj, "HeatingSetpoint", "5"),
+        presetHandle: pickString(obj, "2"),
+        systemMode: pickNumber(obj, "3"),
+        coolingSetpoint: pickNumber(obj, "4"),
+        heatingSetpoint: pickNumber(obj, "5"),
     };
 }
 
 function decodeSchedule(raw: unknown): ThermostatSchedule | null {
     const obj = asObject(raw);
     if (!obj) return null;
-    const handle = pickStr(obj, "ScheduleHandle", "0");
-    const systemMode = pickNum(obj, "SystemMode", "1");
+    const handle = pickString(obj, "0");
+    const systemMode = pickNumber(obj, "1");
     if (handle === null || systemMode === null) return null;
-    const transitions = pickArr(obj, "Transitions", "4")
+    const transitions = pickArray(obj, "4")
         .map(decodeTransition)
         .filter((t): t is ThermostatScheduleTransition => t !== null);
     return {
         handle,
         systemMode,
-        name: pickStr(obj, "Name", "2"),
-        presetHandle: pickStr(obj, "PresetHandle", "3"),
+        name: pickString(obj, "2"),
+        presetHandle: pickString(obj, "3"),
         transitions,
-        builtIn: pickBool(obj, "BuiltIn", "5"),
+        builtIn: pickBoolean(obj, "5"),
     };
 }
 
 function decodePreset(raw: unknown): ThermostatPreset | null {
     const obj = asObject(raw);
     if (!obj) return null;
-    const handle = pickStr(obj, "PresetHandle", "0");
+    const handle = pickString(obj, "0");
     if (handle === null) return null;
-    return { handle, name: pickStr(obj, "Name", "2") };
+    return {
+        handle,
+        name: pickString(obj, "2"),
+        coolingSetpoint: pickNumber(obj, "3"),
+        heatingSetpoint: pickNumber(obj, "4"),
+    };
 }
 
 /** Whether the Thermostat cluster's FeatureMap includes MatterScheduleConfiguration (MSCH). */
@@ -156,9 +145,10 @@ export function readActiveScheduleHandle(node: MatterNode, endpoint: number): st
     return typeof v === "string" ? v : null;
 }
 
-export function readSchedules(node: MatterNode, endpoint: number): ThermostatSchedule[] {
+/** Decoded Schedules, or undefined when the attribute is not in the node's attribute cache. */
+export function readSchedules(node: MatterNode, endpoint: number): ThermostatSchedule[] | undefined {
     const raw = readAttr(node, endpoint, ATTR_SCHEDULES);
-    if (!Array.isArray(raw)) return [];
+    if (!Array.isArray(raw)) return undefined;
     return raw.map(decodeSchedule).filter((s): s is ThermostatSchedule => s !== null);
 }
 
@@ -187,47 +177,112 @@ export function resolveTransitionLabel(transition: ModeLabelSource, presets: The
 }
 
 /**
- * For each day (Mon..Sun), finds the first schedule whose DayOfWeek bitmap claims it.
- * A schedule "claims" a day if any of its transitions include that day.
+ * Resolves each transition's effective preset and setpoints by the §4.3.10.27 order of precedence: an own
+ * PresetHandle wins, else the transition's own setpoints, and only a transition providing neither falls
+ * through to the schedule's default PresetHandle. SystemMode always defaults to the schedule's (§4.3.10.26.2).
  */
-export function assignDaysToSchedules(schedules: ThermostatSchedule[]): (ThermostatSchedule | undefined)[] {
-    return DAY_BIT.map(bit => schedules.find(s => s.transitions.some(t => (t.dayOfWeek & (1 << bit)) !== 0)));
+export function resolveScheduleDefaults(schedule: ThermostatSchedule, presets: ThermostatPreset[]): ThermostatSchedule {
+    return {
+        ...schedule,
+        transitions: schedule.transitions.map(t => {
+            const reportsSetpoint = t.heatingSetpoint !== null || t.coolingSetpoint !== null;
+            const presetHandle = t.presetHandle ?? (reportsSetpoint ? null : schedule.presetHandle);
+            const preset = presetHandle !== null ? presets.find(p => p.handle === presetHandle) : undefined;
+            return {
+                ...t,
+                presetHandle,
+                systemMode: t.systemMode ?? schedule.systemMode,
+                coolingSetpoint: preset?.coolingSetpoint ?? t.coolingSetpoint,
+                heatingSetpoint: preset?.heatingSetpoint ?? t.heatingSetpoint,
+            };
+        }),
+    };
+}
+
+/** Display-order (Mon..Sun) day indices a ScheduleDayOfWeekBitmap claims. */
+function claimedDays(dayOfWeek: number): number[] {
+    return DAY_BIT.map((bit, day) => ((dayOfWeek & (1 << bit)) !== 0 ? day : -1)).filter(day => day >= 0);
+}
+
+/** First claimed day in Mon..Sun display order; 7 when the bitmap claims none, so unclaimed rows sort last. */
+export function firstClaimedDay(dayOfWeek: number): number {
+    return claimedDays(dayOfWeek)[0] ?? 7;
+}
+
+/** Mon..Sun day labels for a ScheduleDayOfWeekBitmap, consecutive runs compressed (e.g. "Mon–Wed, Fri"). */
+export function formatDayOfWeek(dayOfWeek: number): string {
+    const days = claimedDays(dayOfWeek);
+    if (days.length === 0) return "—";
+    if (days.length === DAY_LABELS.length) return "Every day";
+    const parts = new Array<string>();
+    for (let start = 0; start < days.length;) {
+        let end = start;
+        while (end + 1 < days.length && days[end + 1] === days[end] + 1) end++;
+        if (end - start >= 2) {
+            parts.push(`${DAY_LABELS[days[start]]}–${DAY_LABELS[days[end]]}`);
+        } else {
+            for (let i = start; i <= end; i++) parts.push(DAY_LABELS[days[i]]);
+        }
+        start = end + 1;
+    }
+    return parts.join(", ");
+}
+
+/** Row order for the transitions list: by first claimed day in Mon..Sun display order, then by time. */
+export function compareTransitionsForDisplay(a: ThermostatScheduleTransition, b: ThermostatScheduleTransition): number {
+    return firstClaimedDay(a.dayOfWeek) - firstClaimedDay(b.dayOfWeek) || a.transitionTimeMin - b.transitionTimeMin;
+}
+
+function transitionsForDay(schedule: ThermostatSchedule, day: number): ThermostatScheduleTransition[] {
+    const bit = DAY_BIT[day];
+    return schedule.transitions
+        .filter(t => (t.dayOfWeek & (1 << bit)) !== 0)
+        .sort((a, b) => a.transitionTimeMin - b.transitionTimeMin);
+}
+
+function segmentOf(t: ThermostatScheduleTransition, startMin: number, endMin: number): DaySegment {
+    return {
+        startMin,
+        endMin,
+        heatingSetpoint: t.heatingSetpoint,
+        coolingSetpoint: t.coolingSetpoint,
+        presetHandle: t.presetHandle,
+        systemMode: t.systemMode,
+    };
+}
+
+function findCarryOverTransition(schedule: ThermostatSchedule, day: number): ThermostatScheduleTransition | undefined {
+    for (let back = 1; back < DAY_LABELS.length; back++) {
+        const previous = transitionsForDay(schedule, (day + DAY_LABELS.length - back) % DAY_LABELS.length);
+        if (previous.length > 0) return previous[previous.length - 1];
+    }
+    return undefined;
 }
 
 /**
- * Builds the ordered, gap-free list of setpoint segments covering a full day (0-1440 min) for one schedule.
- * The period before the day's first transition carries the *last* transition's setpoint, since Matter
- * schedules apply until the next transition — including across the midnight boundary.
+ * Ordered, gap-free setpoint segments covering one day (0-1440 min) of a schedule. Per cluster
+ * §4.3.10.26.5 the band before the day's first transition carries the last transition of the most
+ * recent earlier day the schedule covers.
  */
 export function buildDaySegments(schedule: ThermostatSchedule, day: number): DaySegment[] {
-    const bit = DAY_BIT[day];
-    const dayTransitions = schedule.transitions
-        .filter(t => (t.dayOfWeek & (1 << bit)) !== 0)
-        .sort((a, b) => a.transitionTimeMin - b.transitionTimeMin);
-    if (dayTransitions.length === 0) return [];
+    const dayTransitions = transitionsForDay(schedule, day);
+    const segments = new Array<DaySegment>();
+    if (dayTransitions.length === 0) return segments;
 
-    const segments: DaySegment[] = [];
-    const last = dayTransitions[dayTransitions.length - 1];
-    if (dayTransitions[0].transitionTimeMin > 0) {
-        segments.push({
-            startMin: 0,
-            endMin: dayTransitions[0].transitionTimeMin,
-            heatingSetpoint: last.heatingSetpoint,
-            coolingSetpoint: last.coolingSetpoint,
-            presetHandle: last.presetHandle,
-            systemMode: last.systemMode,
-        });
+    const first = dayTransitions[0];
+    if (first.transitionTimeMin > 0) {
+        const carried = findCarryOverTransition(schedule, day) ?? dayTransitions[dayTransitions.length - 1];
+        segments.push(segmentOf(carried, 0, first.transitionTimeMin));
     }
     for (let i = 0; i < dayTransitions.length; i++) {
         const t = dayTransitions[i];
-        segments.push({
-            startMin: t.transitionTimeMin,
-            endMin: i + 1 < dayTransitions.length ? dayTransitions[i + 1].transitionTimeMin : 1440,
-            heatingSetpoint: t.heatingSetpoint,
-            coolingSetpoint: t.coolingSetpoint,
-            presetHandle: t.presetHandle,
-            systemMode: t.systemMode,
-        });
+        segments.push(
+            segmentOf(
+                t,
+                t.transitionTimeMin,
+                i + 1 < dayTransitions.length ? dayTransitions[i + 1].transitionTimeMin : 1440,
+            ),
+        );
     }
     return segments;
 }
@@ -259,24 +314,14 @@ interface SetpointPair {
     coolingSetpoint: number | null;
 }
 
-/**
- * The setpoint driving a segment's color for the given mode. In Auto mode (both heat and cool
- * present), averaging the two would flatten the gradient to a single muddy blend whenever the
- * band is centered on the same setpoint all day — showing one bound at a time (user-toggleable)
- * preserves the actual variation instead. Falls back to whichever setpoint is present when the
- * selected mode's isn't (e.g. a Cool-only schedule while in "heat" mode).
- */
+/** The setpoint driving a segment's color, falling back to the other mode's when the selected one is absent. */
 export function pickSetpointForMode(seg: SetpointPair, mode: ScheduleColorMode): number | null {
     return mode === "heat"
         ? (seg.heatingSetpoint ?? seg.coolingSetpoint)
         : (seg.coolingSetpoint ?? seg.heatingSetpoint);
 }
 
-/**
- * Min/max for the given mode's setpoints only. Heat and cool setpoints sit in disjoint
- * bands (e.g. heat 17-21°C, cool 24-27°C) — pooling them into one range would compress
- * each mode's gradient into a narrow slice instead of using the full color scale.
- */
+/** Heat and cool setpoints occupy disjoint value bands, so the range covers only the selected mode's setpoints. */
 export function computeSetpointRange(
     schedule: ThermostatSchedule,
     mode: ScheduleColorMode,

--- a/packages/dashboard/src/util/thermostat-schedule.ts
+++ b/packages/dashboard/src/util/thermostat-schedule.ts
@@ -1,0 +1,272 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MatterNode } from "@matter-server/ws-client";
+import { clusters } from "../client/models/descriptions.js";
+import { asObject } from "./attribute-shapes.js";
+import { computeActiveClusterFeatures } from "./cluster-features.js";
+
+/** Thermostat cluster (Matter spec §4.4). */
+export const THERMOSTAT_CLUSTER_ID = 513; // 0x0201
+
+const ATTR_PRESETS = 0x50;
+const ATTR_SCHEDULES = 0x51;
+const ATTR_ACTIVE_SCHEDULE_HANDLE = 0x4f;
+const ATTR_FEATURE_MAP = 0xfffc;
+
+/** Days in display order (Mon..Sun) mapped to their ScheduleDayOfWeekBitmap bit (Sunday=0 .. Saturday=6). */
+const DAY_BIT = [1, 2, 3, 4, 5, 6, 0];
+export const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+const SYSTEM_MODE_LABELS: Record<number, string> = {
+    0: "Off",
+    1: "Auto",
+    3: "Cool",
+    4: "Heat",
+    5: "Emergency Heat",
+    6: "Precooling",
+    7: "Fan Only",
+    8: "Dry",
+    9: "Sleep",
+};
+
+export interface ThermostatScheduleTransition {
+    dayOfWeek: number;
+    transitionTimeMin: number;
+    presetHandle: string | null;
+    systemMode: number | null;
+    coolingSetpoint: number | null;
+    heatingSetpoint: number | null;
+}
+
+export interface ThermostatSchedule {
+    handle: string | null;
+    systemMode: number;
+    name: string | null;
+    presetHandle: string | null;
+    transitions: ThermostatScheduleTransition[];
+    builtIn: boolean | null;
+}
+
+export interface ThermostatPreset {
+    handle: string;
+    name: string | null;
+}
+
+export interface DaySegment {
+    startMin: number;
+    endMin: number;
+    heatingSetpoint: number | null;
+    coolingSetpoint: number | null;
+    presetHandle: string | null;
+    systemMode: number | null;
+}
+
+function readAttr(node: MatterNode, endpoint: number, attrId: number): unknown {
+    return node.attributes[`${endpoint}/${THERMOSTAT_CLUSTER_ID}/${attrId}`];
+}
+
+function pickStr(obj: Record<string, unknown>, name: string, tag: string): string | null {
+    const v = obj[name] ?? obj[tag];
+    return typeof v === "string" ? v : null;
+}
+
+function pickNum(obj: Record<string, unknown>, name: string, tag: string): number | null {
+    const v = obj[name] ?? obj[tag];
+    return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function pickBool(obj: Record<string, unknown>, name: string, tag: string): boolean | null {
+    const v = obj[name] ?? obj[tag];
+    return typeof v === "boolean" ? v : null;
+}
+
+function pickArr(obj: Record<string, unknown>, name: string, tag: string): unknown[] {
+    const v = obj[name] ?? obj[tag];
+    return Array.isArray(v) ? v : [];
+}
+
+function decodeTransition(raw: unknown): ThermostatScheduleTransition | null {
+    const obj = asObject(raw);
+    if (!obj) return null;
+    const dayOfWeek = pickNum(obj, "DayOfWeek", "0");
+    const transitionTimeMin = pickNum(obj, "TransitionTime", "1");
+    if (dayOfWeek === null || transitionTimeMin === null) return null;
+    return {
+        dayOfWeek,
+        transitionTimeMin,
+        presetHandle: pickStr(obj, "PresetHandle", "2"),
+        systemMode: pickNum(obj, "SystemMode", "3"),
+        coolingSetpoint: pickNum(obj, "CoolingSetpoint", "4"),
+        heatingSetpoint: pickNum(obj, "HeatingSetpoint", "5"),
+    };
+}
+
+function decodeSchedule(raw: unknown): ThermostatSchedule | null {
+    const obj = asObject(raw);
+    if (!obj) return null;
+    const systemMode = pickNum(obj, "SystemMode", "1");
+    if (systemMode === null) return null;
+    const transitions = pickArr(obj, "Transitions", "4")
+        .map(decodeTransition)
+        .filter((t): t is ThermostatScheduleTransition => t !== null);
+    return {
+        handle: pickStr(obj, "ScheduleHandle", "0"),
+        systemMode,
+        name: pickStr(obj, "Name", "2"),
+        presetHandle: pickStr(obj, "PresetHandle", "3"),
+        transitions,
+        builtIn: pickBool(obj, "BuiltIn", "5"),
+    };
+}
+
+function decodePreset(raw: unknown): ThermostatPreset | null {
+    const obj = asObject(raw);
+    if (!obj) return null;
+    const handle = pickStr(obj, "PresetHandle", "0");
+    if (handle === null) return null;
+    return { handle, name: pickStr(obj, "Name", "2") };
+}
+
+/** Whether the Thermostat cluster's FeatureMap includes MatterScheduleConfiguration (MSCH). */
+export function isMSCHActive(node: MatterNode, endpoint: number): boolean {
+    const knownFeatures = Object.values(clusters[THERMOSTAT_CLUSTER_ID]?.features ?? {});
+    const featureMapValue = node.attributes[`${endpoint}/${THERMOSTAT_CLUSTER_ID}/${ATTR_FEATURE_MAP}`];
+    if (featureMapValue === undefined) return false;
+    return computeActiveClusterFeatures(featureMapValue, knownFeatures).some(feature => feature.code === "MSCH");
+}
+
+export function readActiveScheduleHandle(node: MatterNode, endpoint: number): string | null {
+    const v = readAttr(node, endpoint, ATTR_ACTIVE_SCHEDULE_HANDLE);
+    return typeof v === "string" ? v : null;
+}
+
+export function readSchedules(node: MatterNode, endpoint: number): ThermostatSchedule[] {
+    const raw = readAttr(node, endpoint, ATTR_SCHEDULES);
+    if (!Array.isArray(raw)) return [];
+    return raw.map(decodeSchedule).filter((s): s is ThermostatSchedule => s !== null);
+}
+
+/** Best-effort: only meaningful when the Presets (PRES) feature is supported, but harmless to read regardless. */
+export function readPresets(node: MatterNode, endpoint: number): ThermostatPreset[] {
+    const raw = readAttr(node, endpoint, ATTR_PRESETS);
+    if (!Array.isArray(raw)) return [];
+    return raw.map(decodePreset).filter((p): p is ThermostatPreset => p !== null);
+}
+
+/** Resolves a transition's human label: matching preset name, else SystemMode, else a generic fallback. */
+export function resolveTransitionLabel(transition: ThermostatScheduleTransition, presets: ThermostatPreset[]): string {
+    if (transition.presetHandle) {
+        const preset = presets.find(p => p.handle === transition.presetHandle);
+        if (preset?.name) return preset.name;
+    }
+    if (transition.systemMode !== null) {
+        return SYSTEM_MODE_LABELS[transition.systemMode] ?? `Mode ${transition.systemMode}`;
+    }
+    return "Setpoint";
+}
+
+/**
+ * For each day (Mon..Sun), finds the first schedule whose DayOfWeek bitmap claims it.
+ * A schedule "claims" a day if any of its transitions include that day.
+ */
+export function assignDaysToSchedules(schedules: ThermostatSchedule[]): (ThermostatSchedule | undefined)[] {
+    return DAY_BIT.map(bit => schedules.find(s => s.transitions.some(t => (t.dayOfWeek & (1 << bit)) !== 0)));
+}
+
+/**
+ * Builds the ordered, gap-free list of setpoint segments covering a full day (0-1440 min) for one schedule.
+ * The period before the day's first transition carries the *last* transition's setpoint, since Matter
+ * schedules apply until the next transition — including across the midnight boundary.
+ */
+export function buildDaySegments(schedule: ThermostatSchedule, day: number): DaySegment[] {
+    const bit = DAY_BIT[day];
+    const dayTransitions = schedule.transitions
+        .filter(t => (t.dayOfWeek & (1 << bit)) !== 0)
+        .sort((a, b) => a.transitionTimeMin - b.transitionTimeMin);
+    if (dayTransitions.length === 0) return [];
+
+    const segments: DaySegment[] = [];
+    const last = dayTransitions[dayTransitions.length - 1];
+    if (dayTransitions[0].transitionTimeMin > 0) {
+        segments.push({
+            startMin: 0,
+            endMin: dayTransitions[0].transitionTimeMin,
+            heatingSetpoint: last.heatingSetpoint,
+            coolingSetpoint: last.coolingSetpoint,
+            presetHandle: last.presetHandle,
+            systemMode: last.systemMode,
+        });
+    }
+    for (let i = 0; i < dayTransitions.length; i++) {
+        const t = dayTransitions[i];
+        segments.push({
+            startMin: t.transitionTimeMin,
+            endMin: i + 1 < dayTransitions.length ? dayTransitions[i + 1].transitionTimeMin : 1440,
+            heatingSetpoint: t.heatingSetpoint,
+            coolingSetpoint: t.coolingSetpoint,
+            presetHandle: t.presetHandle,
+            systemMode: t.systemMode,
+        });
+    }
+    return segments;
+}
+
+/** Matter "temperature" values are int16 hundredths of a degree Celsius. */
+export function formatSetpoint(centidegrees: number | undefined | null): string | undefined {
+    if (centidegrees === undefined || centidegrees === null) return undefined;
+    return `${(centidegrees / 100).toFixed(1)}°C`;
+}
+
+export function computeSetpointRange(schedule: ThermostatSchedule): { min: number; max: number } | undefined {
+    const values = schedule.transitions
+        .flatMap(t => [t.heatingSetpoint, t.coolingSetpoint])
+        .filter((v): v is number => v !== null);
+    if (values.length === 0) return undefined;
+    return { min: Math.min(...values), max: Math.max(...values) };
+}
+
+/** Clamped 0-100 position of `value` within [min, max], for driving a cold->hot color-mix gradient. */
+export function setpointColorMixPercent(value: number, min: number, max: number): number {
+    if (max <= min) return 50;
+    return Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100));
+}
+
+export type ScheduleColorMode = "heat" | "cool";
+
+/**
+ * The setpoint driving a segment's color for the given mode. In Auto mode (both heat and cool
+ * present), averaging the two would flatten the gradient to a single muddy blend whenever the
+ * band is centered on the same setpoint all day — showing one bound at a time (user-toggleable)
+ * preserves the actual variation instead. Falls back to whichever setpoint is present when the
+ * selected mode's isn't (e.g. a Cool-only schedule while in "heat" mode).
+ */
+export function pickSetpointForMode(seg: DaySegment, mode: ScheduleColorMode): number | null {
+    return mode === "heat"
+        ? (seg.heatingSetpoint ?? seg.coolingSetpoint)
+        : (seg.coolingSetpoint ?? seg.heatingSetpoint);
+}
+
+function decodeHandleBytes(base64: string): Uint8Array {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+}
+
+/** Short hex label for a base64-encoded schedule/preset handle (e.g. a single-byte handle -> "0x01"). */
+export function formatHandleShort(handle: string | null): string {
+    if (!handle) return "";
+    try {
+        const bytes = decodeHandleBytes(handle);
+        return `0x${Array.from(bytes)
+            .map(b => b.toString(16).padStart(2, "0"))
+            .join("")
+            .toUpperCase()}`;
+    } catch {
+        return handle.slice(0, 8);
+    }
+}

--- a/packages/dashboard/test/ThermostatScheduleUtilTest.ts
+++ b/packages/dashboard/test/ThermostatScheduleUtilTest.ts
@@ -6,11 +6,12 @@
 
 import { MatterNode, type MatterNodeData } from "@matter-server/ws-client";
 import {
-    assignDaysToSchedules,
     buildDaySegments,
+    compareTransitionsForDisplay,
     computeSetpointRange,
-    DAY_LABELS,
     type DaySegment,
+    firstClaimedDay,
+    formatDayOfWeek,
     formatHandleShort,
     formatMinutes,
     formatSegmentTooltip,
@@ -20,9 +21,12 @@ import {
     readActiveScheduleHandle,
     readPresets,
     readSchedules,
+    resolveScheduleDefaults,
     resolveTransitionLabel,
     setpointColorMixPercent,
+    type ThermostatPreset,
     type ThermostatSchedule,
+    type ThermostatScheduleTransition,
 } from "../src/util/thermostat-schedule.js";
 
 function node(attributes: Record<string, unknown>, node_id: number | bigint = 1): MatterNode {
@@ -42,6 +46,50 @@ function node(attributes: Record<string, unknown>, node_id: number | bigint = 1)
 // Single-byte schedule handles, base64-encoded (0x01 -> "AQ==", 0x02 -> "Ag==").
 const HANDLE_1 = "AQ==";
 const HANDLE_2 = "Ag==";
+
+// ScheduleDayOfWeekBitmap bits (Sunday = bit 0 .. Saturday = bit 6).
+const SUN = 1 << 0;
+const MON = 1 << 1;
+const TUE = 1 << 2;
+const WED = 1 << 3;
+const THU = 1 << 4;
+const FRI = 1 << 5;
+const SAT = 1 << 6;
+
+function transition(
+    dayOfWeek: number,
+    transitionTimeMin: number,
+    overrides: Partial<ThermostatScheduleTransition> = {},
+): ThermostatScheduleTransition {
+    return {
+        dayOfWeek,
+        transitionTimeMin,
+        presetHandle: null,
+        systemMode: null,
+        coolingSetpoint: null,
+        heatingSetpoint: null,
+        ...overrides,
+    };
+}
+
+function schedule(
+    transitions: ThermostatScheduleTransition[],
+    overrides: Partial<ThermostatSchedule> = {},
+): ThermostatSchedule {
+    return {
+        handle: HANDLE_1,
+        systemMode: 4,
+        name: null,
+        presetHandle: null,
+        builtIn: null,
+        transitions,
+        ...overrides,
+    };
+}
+
+function preset(handle: string, overrides: Partial<ThermostatPreset> = {}): ThermostatPreset {
+    return { handle, name: null, coolingSetpoint: null, heatingSetpoint: null, ...overrides };
+}
 
 describe("thermostat-schedule util", () => {
     describe("isMSCHActive", () => {
@@ -67,15 +115,17 @@ describe("thermostat-schedule util", () => {
     });
 
     describe("readSchedules", () => {
-        it("decodes named-keyed struct fields, including nested transitions", () => {
+        it("decodes field-tag-keyed structs, including nested transitions", () => {
             const schedules = readSchedules(
                 node({
                     "6/513/81": [
                         {
-                            ScheduleHandle: HANDLE_1,
-                            SystemMode: 4,
-                            Name: "Weekdays",
-                            Transitions: [{ DayOfWeek: 0b0111110, TransitionTime: 480, HeatingSetpoint: 2100 }],
+                            "0": HANDLE_1,
+                            "1": 4,
+                            "2": "Weekdays",
+                            "3": HANDLE_2,
+                            "4": [{ "0": 0b0111110, "1": 480, "2": HANDLE_2, "3": 4, "4": 2600, "5": 2100 }],
+                            "5": true,
                         },
                     ],
                 }),
@@ -86,64 +136,78 @@ describe("thermostat-schedule util", () => {
                     handle: HANDLE_1,
                     systemMode: 4,
                     name: "Weekdays",
-                    presetHandle: null,
-                    builtIn: null,
+                    presetHandle: HANDLE_2,
+                    builtIn: true,
                     transitions: [
                         {
                             dayOfWeek: 0b0111110,
                             transitionTimeMin: 480,
-                            presetHandle: null,
-                            systemMode: null,
-                            coolingSetpoint: null,
+                            presetHandle: HANDLE_2,
+                            systemMode: 4,
+                            coolingSetpoint: 2600,
                             heatingSetpoint: 2100,
                         },
                     ],
                 },
             ]);
         });
-        it("decodes field-tag-keyed wire entries", () => {
+        it("leaves optional fields null when the struct omits them", () => {
             const schedules = readSchedules(
-                node({
-                    "6/513/81": [
-                        {
-                            "0": HANDLE_2,
-                            "1": 4,
-                            "4": [{ "0": 0b1000001, "1": 0, "5": 1750 }],
-                        },
-                    ],
-                }),
+                node({ "6/513/81": [{ "0": HANDLE_2, "1": 4, "4": [{ "0": SAT | SUN, "1": 0, "5": 1750 }] }] }),
                 6,
             );
-            expect(schedules[0].handle).to.equal(HANDLE_2);
-            expect(schedules[0].transitions[0]).to.deep.equal({
-                dayOfWeek: 0b1000001,
-                transitionTimeMin: 0,
+            expect(schedules?.[0]).to.deep.equal({
+                handle: HANDLE_2,
+                systemMode: 4,
+                name: null,
                 presetHandle: null,
-                systemMode: null,
-                coolingSetpoint: null,
-                heatingSetpoint: 1750,
+                builtIn: null,
+                transitions: [
+                    {
+                        dayOfWeek: SAT | SUN,
+                        transitionTimeMin: 0,
+                        presetHandle: null,
+                        systemMode: null,
+                        coolingSetpoint: null,
+                        heatingSetpoint: 1750,
+                    },
+                ],
             });
         });
-        it("drops entries missing a required field and returns empty for a non-array attribute", () => {
-            expect(readSchedules(node({ "6/513/81": [{ Name: "no mode or handle" }] }), 6)).to.deep.equal([]);
-            expect(readSchedules(node({}), 6)).to.deep.equal([]);
+        it("drops entries missing a required field, including name-keyed structs", () => {
+            expect(readSchedules(node({ "6/513/81": [{ "1": 4 }] }), 6)).to.deep.equal([]);
+            expect(readSchedules(node({ "6/513/81": [{ ScheduleHandle: HANDLE_1, SystemMode: 4 }] }), 6)).to.deep.equal(
+                [],
+            );
+        });
+        it("drops a transition whose DayOfWeek sets the reserved Vacation bit", () => {
+            const schedules = readSchedules(
+                node({ "6/513/81": [{ "0": HANDLE_1, "1": 4, "4": [{ "0": 0x80 | MON, "1": 0 }] }] }),
+                6,
+            );
+            expect(schedules?.[0].transitions).to.deep.equal([]);
+        });
+        it("distinguishes an absent attribute from an empty list", () => {
+            expect(readSchedules(node({}), 6)).to.equal(undefined);
+            expect(readSchedules(node({ "6/513/81": null }), 6)).to.equal(undefined);
+            expect(readSchedules(node({ "6/513/81": [] }), 6)).to.deep.equal([]);
         });
     });
 
     describe("readPresets", () => {
-        it("decodes named- and tag-keyed presets", () => {
+        it("decodes tag-keyed presets including their setpoints", () => {
             const presets = readPresets(
                 node({
                     "6/513/80": [
-                        { PresetHandle: HANDLE_1, PresetScenario: 4, Name: "Night" },
-                        { "0": HANDLE_2, "1": 4, "2": "Morning" },
+                        { "0": HANDLE_1, "1": 4, "2": "Night", "4": 1700 },
+                        { "0": HANDLE_2, "1": 1, "2": "Morning", "3": 2600, "4": 2100 },
                     ],
                 }),
                 6,
             );
             expect(presets).to.deep.equal([
-                { handle: HANDLE_1, name: "Night" },
-                { handle: HANDLE_2, name: "Morning" },
+                { handle: HANDLE_1, name: "Night", coolingSetpoint: null, heatingSetpoint: 1700 },
+                { handle: HANDLE_2, name: "Morning", coolingSetpoint: 2600, heatingSetpoint: 2100 },
             ]);
         });
         it("returns empty when absent", () => {
@@ -152,7 +216,7 @@ describe("thermostat-schedule util", () => {
     });
 
     describe("resolveTransitionLabel", () => {
-        const presets = [{ handle: HANDLE_1, name: "Night" }];
+        const presets = [preset(HANDLE_1, { name: "Night" })];
         it("prefers a matching preset name", () => {
             const label = resolveTransitionLabel({ presetHandle: HANDLE_1, systemMode: 4 }, presets);
             expect(label).to.equal("Night");
@@ -167,93 +231,183 @@ describe("thermostat-schedule util", () => {
         });
     });
 
-    describe("assignDaysToSchedules", () => {
-        it("assigns Mon-Fri to Weekdays and Sat-Sun to Weekend", () => {
-            const weekdays: ThermostatSchedule = {
-                handle: HANDLE_1,
-                systemMode: 4,
-                name: "Weekdays",
-                presetHandle: null,
-                builtIn: null,
-                transitions: [
-                    {
-                        dayOfWeek: 0b0111110, // Mon..Fri
-                        transitionTimeMin: 0,
-                        presetHandle: null,
-                        systemMode: null,
-                        coolingSetpoint: null,
-                        heatingSetpoint: 1750,
-                    },
-                ],
-            };
-            const weekend: ThermostatSchedule = {
-                handle: HANDLE_2,
-                systemMode: 4,
-                name: "Weekend",
-                presetHandle: null,
-                builtIn: null,
-                transitions: [
-                    {
-                        dayOfWeek: 0b1000001, // Sat + Sun
-                        transitionTimeMin: 0,
-                        presetHandle: null,
-                        systemMode: null,
-                        coolingSetpoint: null,
-                        heatingSetpoint: 1750,
-                    },
-                ],
-            };
-            const owners = assignDaysToSchedules([weekdays, weekend]);
-            expect(owners.map(s => s?.name)).to.deep.equal(
-                DAY_LABELS.map(d => (d === "Sat" || d === "Sun" ? "Weekend" : "Weekdays")),
+    describe("resolveScheduleDefaults", () => {
+        const presets = [preset(HANDLE_2, { name: "Night", coolingSetpoint: 2600, heatingSetpoint: 1700 })];
+
+        it("fills absent setpoints from the referenced preset", () => {
+            const resolved = resolveScheduleDefaults(
+                schedule([transition(MON, 480, { presetHandle: HANDLE_2 })]),
+                presets,
             );
+            expect(resolved.transitions[0].heatingSetpoint).to.equal(1700);
+            expect(resolved.transitions[0].coolingSetpoint).to.equal(2600);
         });
-        it("leaves a day unowned when no schedule claims it", () => {
-            const owners = assignDaysToSchedules([]);
-            expect(owners).to.deep.equal(new Array(7).fill(undefined));
+        it("resolves setpoints through the schedule's default PresetHandle", () => {
+            const resolved = resolveScheduleDefaults(
+                schedule([transition(MON, 480)], { presetHandle: HANDLE_2 }),
+                presets,
+            );
+            expect(resolved.transitions[0].presetHandle).to.equal(HANDLE_2);
+            expect(resolved.transitions[0].heatingSetpoint).to.equal(1700);
+            expect(resolved.transitions[0].coolingSetpoint).to.equal(2600);
+        });
+        it("prefers the transition's own PresetHandle over the schedule default", () => {
+            const resolved = resolveScheduleDefaults(
+                schedule([transition(MON, 480, { presetHandle: HANDLE_1 })], { presetHandle: HANDLE_2 }),
+                [...presets, preset(HANDLE_1, { name: "Day", heatingSetpoint: 2100 })],
+            );
+            expect(resolved.transitions[0].heatingSetpoint).to.equal(2100);
+            expect(resolved.transitions[0].coolingSetpoint).to.equal(null);
+        });
+        it("defaults a transition's SystemMode to the schedule's", () => {
+            const resolved = resolveScheduleDefaults(
+                schedule([transition(MON, 0), transition(TUE, 0, { systemMode: 3 })], { systemMode: 4 }),
+                presets,
+            );
+            expect(resolved.transitions.map(t => t.systemMode)).to.deep.equal([4, 3]);
+        });
+        it("lets the transition's own preset win over setpoints a device sent alongside it", () => {
+            const resolved = resolveScheduleDefaults(
+                schedule([transition(MON, 480, { presetHandle: HANDLE_2, heatingSetpoint: 2100 })]),
+                presets,
+            );
+            expect(resolved.transitions[0].heatingSetpoint).to.equal(1700);
+            expect(resolved.transitions[0].coolingSetpoint).to.equal(2600);
+        });
+        it("uses a reported setpoint only for a bound its own preset leaves unset", () => {
+            const resolved = resolveScheduleDefaults(
+                schedule([transition(MON, 480, { presetHandle: HANDLE_1, coolingSetpoint: 2400 })]),
+                [preset(HANDLE_1, { name: "Day", heatingSetpoint: 2100 })],
+            );
+            expect(resolved.transitions[0].heatingSetpoint).to.equal(2100);
+            expect(resolved.transitions[0].coolingSetpoint).to.equal(2400);
+        });
+        it("keeps reported setpoints out of the schedule's default preset and off its label", () => {
+            const resolved = resolveScheduleDefaults(
+                schedule([transition(MON, 480, { heatingSetpoint: 2100 })], {
+                    presetHandle: HANDLE_2,
+                    systemMode: 4,
+                }),
+                presets,
+            );
+            expect(resolved.transitions[0].presetHandle).to.equal(null);
+            expect(resolved.transitions[0].heatingSetpoint).to.equal(2100);
+            expect(resolved.transitions[0].coolingSetpoint).to.equal(null);
+            expect(resolveTransitionLabel(resolved.transitions[0], presets)).to.equal("Heat");
+        });
+        it("leaves setpoints null when neither the transition nor the schedule references a known preset", () => {
+            const resolved = resolveScheduleDefaults(
+                schedule([transition(MON, 0), transition(TUE, 0, { presetHandle: HANDLE_1 })]),
+                presets,
+            );
+            expect(resolved.transitions.map(t => t.heatingSetpoint)).to.deep.equal([null, null]);
+        });
+        it("does not mutate the input schedule", () => {
+            const original = schedule([transition(MON, 480, { presetHandle: HANDLE_2 })]);
+            resolveScheduleDefaults(original, presets);
+            expect(original.transitions[0].heatingSetpoint).to.equal(null);
+        });
+    });
+
+    describe("compareTransitionsForDisplay", () => {
+        it("orders by first claimed display day before time", () => {
+            const rows = [
+                transition(SAT, 360),
+                transition(MON | TUE | WED | THU | FRI, 1320),
+                transition(SUN, 0),
+                transition(MON, 480),
+            ].sort(compareTransitionsForDisplay);
+            expect(rows.map(t => [firstClaimedDay(t.dayOfWeek), t.transitionTimeMin])).to.deep.equal([
+                [0, 480],
+                [0, 1320],
+                [5, 360],
+                [6, 0],
+            ]);
+        });
+        it("sorts a transition claiming no day last", () => {
+            const rows = [transition(0, 0), transition(SUN, 1320)].sort(compareTransitionsForDisplay);
+            expect(rows[0].dayOfWeek).to.equal(SUN);
+        });
+    });
+
+    describe("formatDayOfWeek", () => {
+        it("compresses runs of three or more days with a dash", () => {
+            expect(formatDayOfWeek(MON | TUE | WED | THU | FRI)).to.equal("Mon–Fri");
+            expect(formatDayOfWeek(MON | TUE | WED | FRI)).to.equal("Mon–Wed, Fri");
+        });
+        it("lists short runs and single days separately", () => {
+            expect(formatDayOfWeek(SAT | SUN)).to.equal("Sat, Sun");
+            expect(formatDayOfWeek(WED)).to.equal("Wed");
+            expect(formatDayOfWeek(MON | WED | FRI)).to.equal("Mon, Wed, Fri");
+        });
+        it("labels the full week, and a bitmap claiming no day with a dash", () => {
+            expect(formatDayOfWeek(0x7f)).to.equal("Every day");
+            expect(formatDayOfWeek(0)).to.equal("—");
+        });
+    });
+
+    describe("firstClaimedDay", () => {
+        it("returns the first claimed day in Mon..Sun display order", () => {
+            expect(firstClaimedDay(MON)).to.equal(0);
+            expect(firstClaimedDay(SAT | SUN)).to.equal(5);
+            expect(firstClaimedDay(SUN)).to.equal(6);
+        });
+        it("sorts an empty bitmap last", () => {
+            expect(firstClaimedDay(0)).to.equal(7);
         });
     });
 
     describe("buildDaySegments", () => {
         it("returns no segments when the schedule has no transitions for that day", () => {
-            const schedule: ThermostatSchedule = {
-                handle: null,
-                systemMode: 4,
-                name: null,
-                presetHandle: null,
-                builtIn: null,
-                transitions: [],
-            };
-            expect(buildDaySegments(schedule, 0)).to.deep.equal([]);
+            expect(buildDaySegments(schedule([]), 0)).to.deep.equal([]);
         });
-        it("carries the last transition's setpoint into the wraparound segment before the first transition", () => {
-            const schedule: ThermostatSchedule = {
-                handle: null,
-                systemMode: 4,
-                name: null,
-                presetHandle: null,
-                builtIn: null,
-                transitions: [
-                    // Monday = bit 1
-                    {
-                        dayOfWeek: 0b10,
-                        transitionTimeMin: 480,
-                        presetHandle: null,
-                        systemMode: null,
-                        coolingSetpoint: null,
-                        heatingSetpoint: 1800,
-                    },
-                    {
-                        dayOfWeek: 0b10,
-                        transitionTimeMin: 1320,
-                        presetHandle: null,
-                        systemMode: null,
-                        coolingSetpoint: null,
-                        heatingSetpoint: 2100,
-                    },
-                ],
-            };
-            expect(buildDaySegments(schedule, 0)).to.deep.equal([
+        it("carries the previous day's last transition across midnight", () => {
+            const monday = buildDaySegments(
+                schedule([
+                    transition(MON, 480, { heatingSetpoint: 2100 }),
+                    transition(SUN, 1320, { heatingSetpoint: 1700 }),
+                ]),
+                0,
+            );
+            expect(monday).to.deep.equal([
+                {
+                    startMin: 0,
+                    endMin: 480,
+                    heatingSetpoint: 1700,
+                    coolingSetpoint: null,
+                    presetHandle: null,
+                    systemMode: null,
+                },
+                {
+                    startMin: 480,
+                    endMin: 1440,
+                    heatingSetpoint: 2100,
+                    coolingSetpoint: null,
+                    presetHandle: null,
+                    systemMode: null,
+                },
+            ]);
+        });
+        it("uses the nearest earlier covered day when several are covered", () => {
+            const tuesday = buildDaySegments(
+                schedule([
+                    transition(SUN, 1320, { heatingSetpoint: 1700 }),
+                    transition(MON, 1320, { heatingSetpoint: 1800 }),
+                    transition(TUE, 480, { heatingSetpoint: 2100 }),
+                ]),
+                1,
+            );
+            expect(tuesday[0].heatingSetpoint).to.equal(1800);
+        });
+        it("falls back to the day's own last transition when the schedule covers no other day", () => {
+            const monday = buildDaySegments(
+                schedule([
+                    transition(MON, 480, { heatingSetpoint: 1800 }),
+                    transition(MON, 1320, { heatingSetpoint: 2100 }),
+                ]),
+                0,
+            );
+            expect(monday).to.deep.equal([
                 {
                     startMin: 0,
                     endMin: 480,
@@ -281,24 +435,7 @@ describe("thermostat-schedule util", () => {
             ]);
         });
         it("skips the wraparound segment when the first transition is already at midnight", () => {
-            const schedule: ThermostatSchedule = {
-                handle: null,
-                systemMode: 4,
-                name: null,
-                presetHandle: null,
-                builtIn: null,
-                transitions: [
-                    {
-                        dayOfWeek: 0b10,
-                        transitionTimeMin: 0,
-                        presetHandle: null,
-                        systemMode: null,
-                        coolingSetpoint: null,
-                        heatingSetpoint: 1750,
-                    },
-                ],
-            };
-            expect(buildDaySegments(schedule, 0)).to.deep.equal([
+            expect(buildDaySegments(schedule([transition(MON, 0, { heatingSetpoint: 1750 })]), 0)).to.deep.equal([
                 {
                     startMin: 0,
                     endMin: 1440,
@@ -308,6 +445,12 @@ describe("thermostat-schedule util", () => {
                     systemMode: null,
                 },
             ]);
+        });
+        it("carries preset-resolved setpoints when the schedule is resolved first", () => {
+            const resolved = resolveScheduleDefaults(schedule([transition(MON, 480, { presetHandle: HANDLE_2 })]), [
+                preset(HANDLE_2, { heatingSetpoint: 1900 }),
+            ]);
+            expect(buildDaySegments(resolved, 0).map(s => s.heatingSetpoint)).to.deep.equal([1900, 1900]);
         });
     });
 
@@ -323,56 +466,27 @@ describe("thermostat-schedule util", () => {
     });
 
     describe("computeSetpointRange", () => {
-        const schedule: ThermostatSchedule = {
-            handle: null,
-            systemMode: 1,
-            name: null,
-            presetHandle: null,
-            builtIn: null,
-            transitions: [
-                {
-                    dayOfWeek: 0,
-                    transitionTimeMin: 0,
-                    presetHandle: null,
-                    systemMode: null,
-                    coolingSetpoint: 2600,
-                    heatingSetpoint: 1750,
-                },
-                {
-                    dayOfWeek: 0,
-                    transitionTimeMin: 480,
-                    presetHandle: null,
-                    systemMode: null,
-                    coolingSetpoint: null,
-                    heatingSetpoint: 2100,
-                },
+        const dual = schedule(
+            [
+                transition(0, 0, { coolingSetpoint: 2600, heatingSetpoint: 1750 }),
+                transition(0, 480, { heatingSetpoint: 2100 }),
             ],
-        };
+            { systemMode: 1 },
+        );
         it("scopes the range to heating setpoints in heat mode", () => {
-            expect(computeSetpointRange(schedule, "heat")).to.deep.equal({ min: 1750, max: 2100 });
+            expect(computeSetpointRange(dual, "heat")).to.deep.equal({ min: 1750, max: 2100 });
         });
         it("scopes the range to cooling setpoints in cool mode, falling back where cooling is absent", () => {
-            expect(computeSetpointRange(schedule, "cool")).to.deep.equal({ min: 2100, max: 2600 });
+            expect(computeSetpointRange(dual, "cool")).to.deep.equal({ min: 2100, max: 2600 });
         });
         it("returns undefined when no numeric setpoints exist", () => {
-            const empty: ThermostatSchedule = {
-                handle: null,
-                systemMode: 0,
-                name: null,
-                presetHandle: null,
-                builtIn: null,
-                transitions: [
-                    {
-                        dayOfWeek: 0,
-                        transitionTimeMin: 0,
-                        presetHandle: null,
-                        systemMode: null,
-                        coolingSetpoint: null,
-                        heatingSetpoint: null,
-                    },
-                ],
-            };
-            expect(computeSetpointRange(empty, "heat")).to.equal(undefined);
+            expect(computeSetpointRange(schedule([transition(0, 0)], { systemMode: 0 }), "heat")).to.equal(undefined);
+        });
+        it("covers setpoints that only a preset supplies", () => {
+            const resolved = resolveScheduleDefaults(schedule([transition(MON, 0, { presetHandle: HANDLE_2 })]), [
+                preset(HANDLE_2, { heatingSetpoint: 1900 }),
+            ]);
+            expect(computeSetpointRange(resolved, "heat")).to.deep.equal({ min: 1900, max: 1900 });
         });
     });
 

--- a/packages/dashboard/test/ThermostatScheduleUtilTest.ts
+++ b/packages/dashboard/test/ThermostatScheduleUtilTest.ts
@@ -1,0 +1,453 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MatterNode, type MatterNodeData } from "@matter-server/ws-client";
+import {
+    assignDaysToSchedules,
+    buildDaySegments,
+    computeSetpointRange,
+    DAY_LABELS,
+    type DaySegment,
+    formatHandleShort,
+    formatSetpoint,
+    isMSCHActive,
+    pickSetpointForMode,
+    readActiveScheduleHandle,
+    readPresets,
+    readSchedules,
+    resolveTransitionLabel,
+    setpointColorMixPercent,
+    type ThermostatSchedule,
+} from "../src/util/thermostat-schedule.js";
+
+function node(attributes: Record<string, unknown>, node_id: number | bigint = 1): MatterNode {
+    const data: MatterNodeData = {
+        node_id,
+        date_commissioned: "",
+        last_interview: "",
+        interview_version: 1,
+        available: true,
+        is_bridge: false,
+        attributes,
+        attribute_subscriptions: [],
+    };
+    return new MatterNode(data);
+}
+
+// Single-byte schedule handles, base64-encoded (0x01 -> "AQ==", 0x02 -> "Ag==").
+const HANDLE_1 = "AQ==";
+const HANDLE_2 = "Ag==";
+
+describe("thermostat-schedule util", () => {
+    describe("isMSCHActive", () => {
+        it("is true when the MSCH bit is set on the real Thermostat FeatureMap", () => {
+            expect(isMSCHActive(node({ "6/513/65532": 1 << 7 }), 6)).to.equal(true);
+        });
+        it("is false when MSCH is not set", () => {
+            expect(isMSCHActive(node({ "6/513/65532": 0b1 }), 6)).to.equal(false);
+        });
+        it("is false when FeatureMap is absent", () => {
+            expect(isMSCHActive(node({}), 6)).to.equal(false);
+        });
+    });
+
+    describe("readActiveScheduleHandle", () => {
+        it("reads the handle string", () => {
+            expect(readActiveScheduleHandle(node({ "6/513/79": HANDLE_1 }), 6)).to.equal(HANDLE_1);
+        });
+        it("returns null when null/absent", () => {
+            expect(readActiveScheduleHandle(node({ "6/513/79": null }), 6)).to.equal(null);
+            expect(readActiveScheduleHandle(node({}), 6)).to.equal(null);
+        });
+    });
+
+    describe("readSchedules", () => {
+        it("decodes named-keyed struct fields, including nested transitions", () => {
+            const schedules = readSchedules(
+                node({
+                    "6/513/81": [
+                        {
+                            ScheduleHandle: HANDLE_1,
+                            SystemMode: 4,
+                            Name: "Weekdays",
+                            Transitions: [{ DayOfWeek: 0b0111110, TransitionTime: 480, HeatingSetpoint: 2100 }],
+                        },
+                    ],
+                }),
+                6,
+            );
+            expect(schedules).to.deep.equal([
+                {
+                    handle: HANDLE_1,
+                    systemMode: 4,
+                    name: "Weekdays",
+                    presetHandle: null,
+                    builtIn: null,
+                    transitions: [
+                        {
+                            dayOfWeek: 0b0111110,
+                            transitionTimeMin: 480,
+                            presetHandle: null,
+                            systemMode: null,
+                            coolingSetpoint: null,
+                            heatingSetpoint: 2100,
+                        },
+                    ],
+                },
+            ]);
+        });
+        it("decodes field-tag-keyed wire entries", () => {
+            const schedules = readSchedules(
+                node({
+                    "6/513/81": [
+                        {
+                            "0": HANDLE_2,
+                            "1": 4,
+                            "4": [{ "0": 0b1000001, "1": 0, "5": 1750 }],
+                        },
+                    ],
+                }),
+                6,
+            );
+            expect(schedules[0].handle).to.equal(HANDLE_2);
+            expect(schedules[0].transitions[0]).to.deep.equal({
+                dayOfWeek: 0b1000001,
+                transitionTimeMin: 0,
+                presetHandle: null,
+                systemMode: null,
+                coolingSetpoint: null,
+                heatingSetpoint: 1750,
+            });
+        });
+        it("drops entries missing a required field and returns empty for a non-array attribute", () => {
+            expect(readSchedules(node({ "6/513/81": [{ Name: "no mode or handle" }] }), 6)).to.deep.equal([]);
+            expect(readSchedules(node({}), 6)).to.deep.equal([]);
+        });
+    });
+
+    describe("readPresets", () => {
+        it("decodes named- and tag-keyed presets", () => {
+            const presets = readPresets(
+                node({
+                    "6/513/80": [
+                        { PresetHandle: HANDLE_1, PresetScenario: 4, Name: "Night" },
+                        { "0": HANDLE_2, "1": 4, "2": "Morning" },
+                    ],
+                }),
+                6,
+            );
+            expect(presets).to.deep.equal([
+                { handle: HANDLE_1, name: "Night" },
+                { handle: HANDLE_2, name: "Morning" },
+            ]);
+        });
+        it("returns empty when absent", () => {
+            expect(readPresets(node({}), 6)).to.deep.equal([]);
+        });
+    });
+
+    describe("resolveTransitionLabel", () => {
+        const presets = [{ handle: HANDLE_1, name: "Night" }];
+        it("prefers a matching preset name", () => {
+            const label = resolveTransitionLabel(
+                {
+                    dayOfWeek: 0,
+                    transitionTimeMin: 0,
+                    presetHandle: HANDLE_1,
+                    systemMode: 4,
+                    coolingSetpoint: null,
+                    heatingSetpoint: 1750,
+                },
+                presets,
+            );
+            expect(label).to.equal("Night");
+        });
+        it("falls back to the SystemMode label when no preset matches", () => {
+            const label = resolveTransitionLabel(
+                {
+                    dayOfWeek: 0,
+                    transitionTimeMin: 0,
+                    presetHandle: null,
+                    systemMode: 4,
+                    coolingSetpoint: null,
+                    heatingSetpoint: 1750,
+                },
+                presets,
+            );
+            expect(label).to.equal("Heat");
+        });
+        it("falls back to a generic label when neither is available", () => {
+            const label = resolveTransitionLabel(
+                {
+                    dayOfWeek: 0,
+                    transitionTimeMin: 0,
+                    presetHandle: null,
+                    systemMode: null,
+                    coolingSetpoint: null,
+                    heatingSetpoint: 1750,
+                },
+                presets,
+            );
+            expect(label).to.equal("Setpoint");
+        });
+    });
+
+    describe("assignDaysToSchedules", () => {
+        it("assigns Mon-Fri to Weekdays and Sat-Sun to Weekend", () => {
+            const weekdays: ThermostatSchedule = {
+                handle: HANDLE_1,
+                systemMode: 4,
+                name: "Weekdays",
+                presetHandle: null,
+                builtIn: null,
+                transitions: [
+                    {
+                        dayOfWeek: 0b0111110, // Mon..Fri
+                        transitionTimeMin: 0,
+                        presetHandle: null,
+                        systemMode: null,
+                        coolingSetpoint: null,
+                        heatingSetpoint: 1750,
+                    },
+                ],
+            };
+            const weekend: ThermostatSchedule = {
+                handle: HANDLE_2,
+                systemMode: 4,
+                name: "Weekend",
+                presetHandle: null,
+                builtIn: null,
+                transitions: [
+                    {
+                        dayOfWeek: 0b1000001, // Sat + Sun
+                        transitionTimeMin: 0,
+                        presetHandle: null,
+                        systemMode: null,
+                        coolingSetpoint: null,
+                        heatingSetpoint: 1750,
+                    },
+                ],
+            };
+            const owners = assignDaysToSchedules([weekdays, weekend]);
+            expect(owners.map(s => s?.name)).to.deep.equal(
+                DAY_LABELS.map(d => (d === "Sat" || d === "Sun" ? "Weekend" : "Weekdays")),
+            );
+        });
+        it("leaves a day unowned when no schedule claims it", () => {
+            const owners = assignDaysToSchedules([]);
+            expect(owners).to.deep.equal(new Array(7).fill(undefined));
+        });
+    });
+
+    describe("buildDaySegments", () => {
+        it("returns no segments when the schedule has no transitions for that day", () => {
+            const schedule: ThermostatSchedule = {
+                handle: null,
+                systemMode: 4,
+                name: null,
+                presetHandle: null,
+                builtIn: null,
+                transitions: [],
+            };
+            expect(buildDaySegments(schedule, 0)).to.deep.equal([]);
+        });
+        it("carries the last transition's setpoint into the wraparound segment before the first transition", () => {
+            const schedule: ThermostatSchedule = {
+                handle: null,
+                systemMode: 4,
+                name: null,
+                presetHandle: null,
+                builtIn: null,
+                transitions: [
+                    // Monday = bit 1
+                    {
+                        dayOfWeek: 0b10,
+                        transitionTimeMin: 480,
+                        presetHandle: null,
+                        systemMode: null,
+                        coolingSetpoint: null,
+                        heatingSetpoint: 1800,
+                    },
+                    {
+                        dayOfWeek: 0b10,
+                        transitionTimeMin: 1320,
+                        presetHandle: null,
+                        systemMode: null,
+                        coolingSetpoint: null,
+                        heatingSetpoint: 2100,
+                    },
+                ],
+            };
+            expect(buildDaySegments(schedule, 0)).to.deep.equal([
+                {
+                    startMin: 0,
+                    endMin: 480,
+                    heatingSetpoint: 2100,
+                    coolingSetpoint: null,
+                    presetHandle: null,
+                    systemMode: null,
+                },
+                {
+                    startMin: 480,
+                    endMin: 1320,
+                    heatingSetpoint: 1800,
+                    coolingSetpoint: null,
+                    presetHandle: null,
+                    systemMode: null,
+                },
+                {
+                    startMin: 1320,
+                    endMin: 1440,
+                    heatingSetpoint: 2100,
+                    coolingSetpoint: null,
+                    presetHandle: null,
+                    systemMode: null,
+                },
+            ]);
+        });
+        it("skips the wraparound segment when the first transition is already at midnight", () => {
+            const schedule: ThermostatSchedule = {
+                handle: null,
+                systemMode: 4,
+                name: null,
+                presetHandle: null,
+                builtIn: null,
+                transitions: [
+                    {
+                        dayOfWeek: 0b10,
+                        transitionTimeMin: 0,
+                        presetHandle: null,
+                        systemMode: null,
+                        coolingSetpoint: null,
+                        heatingSetpoint: 1750,
+                    },
+                ],
+            };
+            expect(buildDaySegments(schedule, 0)).to.deep.equal([
+                {
+                    startMin: 0,
+                    endMin: 1440,
+                    heatingSetpoint: 1750,
+                    coolingSetpoint: null,
+                    presetHandle: null,
+                    systemMode: null,
+                },
+            ]);
+        });
+    });
+
+    describe("formatSetpoint", () => {
+        it("divides by 100 and appends the unit", () => {
+            expect(formatSetpoint(1750)).to.equal("17.5°C");
+            expect(formatSetpoint(2100)).to.equal("21.0°C");
+        });
+        it("returns undefined for null/undefined", () => {
+            expect(formatSetpoint(null)).to.equal(undefined);
+            expect(formatSetpoint(undefined)).to.equal(undefined);
+        });
+    });
+
+    describe("computeSetpointRange", () => {
+        it("returns the min/max across heating and cooling setpoints", () => {
+            const schedule: ThermostatSchedule = {
+                handle: null,
+                systemMode: 1,
+                name: null,
+                presetHandle: null,
+                builtIn: null,
+                transitions: [
+                    {
+                        dayOfWeek: 0,
+                        transitionTimeMin: 0,
+                        presetHandle: null,
+                        systemMode: null,
+                        coolingSetpoint: 2600,
+                        heatingSetpoint: 1750,
+                    },
+                    {
+                        dayOfWeek: 0,
+                        transitionTimeMin: 480,
+                        presetHandle: null,
+                        systemMode: null,
+                        coolingSetpoint: null,
+                        heatingSetpoint: 2100,
+                    },
+                ],
+            };
+            expect(computeSetpointRange(schedule)).to.deep.equal({ min: 1750, max: 2600 });
+        });
+        it("returns undefined when no numeric setpoints exist", () => {
+            const schedule: ThermostatSchedule = {
+                handle: null,
+                systemMode: 0,
+                name: null,
+                presetHandle: null,
+                builtIn: null,
+                transitions: [
+                    {
+                        dayOfWeek: 0,
+                        transitionTimeMin: 0,
+                        presetHandle: null,
+                        systemMode: null,
+                        coolingSetpoint: null,
+                        heatingSetpoint: null,
+                    },
+                ],
+            };
+            expect(computeSetpointRange(schedule)).to.equal(undefined);
+        });
+    });
+
+    describe("setpointColorMixPercent", () => {
+        it("clamps to 0-100 within range", () => {
+            expect(setpointColorMixPercent(1750, 1750, 2100)).to.equal(0);
+            expect(setpointColorMixPercent(2100, 1750, 2100)).to.equal(100);
+            expect(setpointColorMixPercent(1925, 1750, 2100)).to.be.closeTo(50, 0.01);
+        });
+        it("clamps values outside the range", () => {
+            expect(setpointColorMixPercent(1000, 1750, 2100)).to.equal(0);
+            expect(setpointColorMixPercent(3000, 1750, 2100)).to.equal(100);
+        });
+        it("returns 50 when min === max", () => {
+            expect(setpointColorMixPercent(1750, 1750, 1750)).to.equal(50);
+        });
+    });
+
+    describe("pickSetpointForMode", () => {
+        const segment = (heatingSetpoint: number | null, coolingSetpoint: number | null): DaySegment => ({
+            startMin: 0,
+            endMin: 1440,
+            heatingSetpoint,
+            coolingSetpoint,
+            presetHandle: null,
+            systemMode: null,
+        });
+
+        it("picks the heating setpoint in heat mode", () => {
+            expect(pickSetpointForMode(segment(2000, 2400), "heat")).to.equal(2000);
+        });
+        it("picks the cooling setpoint in cool mode", () => {
+            expect(pickSetpointForMode(segment(2000, 2400), "cool")).to.equal(2400);
+        });
+        it("falls back to whichever setpoint is present when the selected mode's is absent", () => {
+            expect(pickSetpointForMode(segment(null, 2400), "heat")).to.equal(2400);
+            expect(pickSetpointForMode(segment(1750, null), "cool")).to.equal(1750);
+        });
+        it("returns null when neither is present", () => {
+            expect(pickSetpointForMode(segment(null, null), "heat")).to.equal(null);
+        });
+    });
+
+    describe("formatHandleShort", () => {
+        it("formats a single-byte handle as hex", () => {
+            expect(formatHandleShort(HANDLE_1)).to.equal("0x01");
+            expect(formatHandleShort(HANDLE_2)).to.equal("0x02");
+        });
+        it("returns an empty string for null", () => {
+            expect(formatHandleShort(null)).to.equal("");
+        });
+    });
+});

--- a/packages/dashboard/test/ThermostatScheduleUtilTest.ts
+++ b/packages/dashboard/test/ThermostatScheduleUtilTest.ts
@@ -12,6 +12,8 @@ import {
     DAY_LABELS,
     type DaySegment,
     formatHandleShort,
+    formatMinutes,
+    formatSegmentTooltip,
     formatSetpoint,
     isMSCHActive,
     pickSetpointForMode,
@@ -152,45 +154,15 @@ describe("thermostat-schedule util", () => {
     describe("resolveTransitionLabel", () => {
         const presets = [{ handle: HANDLE_1, name: "Night" }];
         it("prefers a matching preset name", () => {
-            const label = resolveTransitionLabel(
-                {
-                    dayOfWeek: 0,
-                    transitionTimeMin: 0,
-                    presetHandle: HANDLE_1,
-                    systemMode: 4,
-                    coolingSetpoint: null,
-                    heatingSetpoint: 1750,
-                },
-                presets,
-            );
+            const label = resolveTransitionLabel({ presetHandle: HANDLE_1, systemMode: 4 }, presets);
             expect(label).to.equal("Night");
         });
         it("falls back to the SystemMode label when no preset matches", () => {
-            const label = resolveTransitionLabel(
-                {
-                    dayOfWeek: 0,
-                    transitionTimeMin: 0,
-                    presetHandle: null,
-                    systemMode: 4,
-                    coolingSetpoint: null,
-                    heatingSetpoint: 1750,
-                },
-                presets,
-            );
+            const label = resolveTransitionLabel({ presetHandle: null, systemMode: 4 }, presets);
             expect(label).to.equal("Heat");
         });
         it("falls back to a generic label when neither is available", () => {
-            const label = resolveTransitionLabel(
-                {
-                    dayOfWeek: 0,
-                    transitionTimeMin: 0,
-                    presetHandle: null,
-                    systemMode: null,
-                    coolingSetpoint: null,
-                    heatingSetpoint: 1750,
-                },
-                presets,
-            );
+            const label = resolveTransitionLabel({ presetHandle: null, systemMode: null }, presets);
             expect(label).to.equal("Setpoint");
         });
     });
@@ -351,36 +323,39 @@ describe("thermostat-schedule util", () => {
     });
 
     describe("computeSetpointRange", () => {
-        it("returns the min/max across heating and cooling setpoints", () => {
-            const schedule: ThermostatSchedule = {
-                handle: null,
-                systemMode: 1,
-                name: null,
-                presetHandle: null,
-                builtIn: null,
-                transitions: [
-                    {
-                        dayOfWeek: 0,
-                        transitionTimeMin: 0,
-                        presetHandle: null,
-                        systemMode: null,
-                        coolingSetpoint: 2600,
-                        heatingSetpoint: 1750,
-                    },
-                    {
-                        dayOfWeek: 0,
-                        transitionTimeMin: 480,
-                        presetHandle: null,
-                        systemMode: null,
-                        coolingSetpoint: null,
-                        heatingSetpoint: 2100,
-                    },
-                ],
-            };
-            expect(computeSetpointRange(schedule)).to.deep.equal({ min: 1750, max: 2600 });
+        const schedule: ThermostatSchedule = {
+            handle: null,
+            systemMode: 1,
+            name: null,
+            presetHandle: null,
+            builtIn: null,
+            transitions: [
+                {
+                    dayOfWeek: 0,
+                    transitionTimeMin: 0,
+                    presetHandle: null,
+                    systemMode: null,
+                    coolingSetpoint: 2600,
+                    heatingSetpoint: 1750,
+                },
+                {
+                    dayOfWeek: 0,
+                    transitionTimeMin: 480,
+                    presetHandle: null,
+                    systemMode: null,
+                    coolingSetpoint: null,
+                    heatingSetpoint: 2100,
+                },
+            ],
+        };
+        it("scopes the range to heating setpoints in heat mode", () => {
+            expect(computeSetpointRange(schedule, "heat")).to.deep.equal({ min: 1750, max: 2100 });
+        });
+        it("scopes the range to cooling setpoints in cool mode, falling back where cooling is absent", () => {
+            expect(computeSetpointRange(schedule, "cool")).to.deep.equal({ min: 2100, max: 2600 });
         });
         it("returns undefined when no numeric setpoints exist", () => {
-            const schedule: ThermostatSchedule = {
+            const empty: ThermostatSchedule = {
                 handle: null,
                 systemMode: 0,
                 name: null,
@@ -397,7 +372,7 @@ describe("thermostat-schedule util", () => {
                     },
                 ],
             };
-            expect(computeSetpointRange(schedule)).to.equal(undefined);
+            expect(computeSetpointRange(empty, "heat")).to.equal(undefined);
         });
     });
 
@@ -448,6 +423,34 @@ describe("thermostat-schedule util", () => {
         });
         it("returns an empty string for null", () => {
             expect(formatHandleShort(null)).to.equal("");
+        });
+    });
+
+    describe("formatMinutes", () => {
+        it("formats minutes-since-midnight as HH:MM", () => {
+            expect(formatMinutes(0)).to.equal("00:00");
+            expect(formatMinutes(90)).to.equal("01:30");
+            expect(formatMinutes(1439)).to.equal("23:59");
+        });
+    });
+
+    describe("formatSegmentTooltip", () => {
+        const segment = (heatingSetpoint: number | null, coolingSetpoint: number | null): DaySegment => ({
+            startMin: 360,
+            endMin: 480,
+            heatingSetpoint,
+            coolingSetpoint,
+            presetHandle: null,
+            systemMode: 4,
+        });
+
+        it("includes the time span, label, and both setpoints when both are present", () => {
+            expect(formatSegmentTooltip(segment(1900, 2500), [])).to.equal(
+                "06:00–08:00 · Heat\nHeat 19.0°C\nCool 25.0°C",
+            );
+        });
+        it("omits the setpoint line for whichever mode is absent", () => {
+            expect(formatSegmentTooltip(segment(1900, null), [])).to.equal("06:00–08:00 · Heat\nHeat 19.0°C");
         });
     });
 });


### PR DESCRIPTION
## Summary
- Adds a Schedule Configuration panel to the Thermostat cluster view, gated on the FeatureMap's MSCH bit (same conditional pattern as the existing Active Features panel), closing #962.
- Visualizes the `Schedules` / `ActiveScheduleHandle` attributes as schedule chips (with an Active badge), a 7-day × 24h color-coded grid, a setpoint gradient legend, and a transition list — instead of raw attribute JSON — so MSCH support can be exercised before Home Assistant's own integration adds it.
- Adds a Heat/Cool color toggle for Auto-mode schedules: averaging heat+cool setpoints into a single color flattened the gradient into an uninformative blend whenever both bands shared the same center setpoint (found while testing against a real device), so the grid now colors by whichever bound the user selects instead.
- Read-only for this first iteration; `SetActiveScheduleRequest` is intentionally deferred to a follow-up per the issue.

## Test plan
- [x] `npm run format` / `npm run lint` / `npm run build`
- [x] `npm test -w @matter-server/dashboard` — 215/215 passing, including new `ThermostatScheduleUtilTest.ts` coverage of the decode/format/color-mapping logic (tag- and name-keyed wire formats, day-of-week bitmap assignment, midnight wraparound, preset-name resolution, setpoint formatting/clamping)
- [x] Full `npm test` — only pre-existing, unrelated `ws-controller` failure (`ConvertersTest.ts`), reproducible in isolation on code untouched by this branch
- [x] Manually verified against a real MSCH-capable Thermostat device via the local dev server (chips, grid, legend, transitions, Heat/Cool toggle)

<img width="737" height="535" alt="image" src="https://github.com/user-attachments/assets/5ec0c82b-ca0d-4bb1-907a-a3040be5deb6" />
