### PR TITLE
feat(dashboard): add CommodityTariff and MeterIdentification decoding panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
-- Enhancement: (lboue) Dashboard cluster view shows read-only panels for the CommodityTariff and MeterIdentification clusters, decoding tariff label and provider, the current and upcoming price with their time ranges, today's and tomorrow's tariff schedule, and the meter's identification and power thresholds
 - Enhancement: Introduces Websocket Schema version 13 (backward compatible)
     - (MindFreeze) Adds Websocket command `get_network_topology` and event `network_topology_updated` to expose the Thread and WiFi network details for external visualization
 - Enhancement: (lboue) Dashboard endpoint view shows "Client Clusters" of an endpoint and their binding status when also a Binding cluster is available
 - Enhancement: (lboue) Added a Schedule Configuration panel (Thermostat cluster MSCH feature) to Dashboard visualizing schedules
+- Enhancement: (lboue) Added read-only panels for the CommodityTariff and MeterIdentification clusters to Dashboard
 - Enhancement: Dashboard dev mode adds a second read button per attribute that reads across all fabrics and shows the result without caching it
 - Fix: Dashboard endpoint view refreshes its cluster list when a cluster appears or disappears on the node, or the viewed endpoint changes
 - Fix: Dashboard attribute reads are fabric-filtered like the subscription; only a read that needs to see other fabrics' data is non-fabric-filtered, and its result is not cached

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
+- Enhancement: (lboue) Dashboard cluster view shows read-only panels for the CommodityTariff and MeterIdentification clusters, decoding tariff label and provider, the current and upcoming price with their time ranges, today's and tomorrow's tariff schedule, and the meter's identification and power thresholds
 - Enhancement: Introduces Websocket Schema version 13 (backward compatible)
     - (MindFreeze) Adds Websocket command `get_network_topology` and event `network_topology_updated` to expose the Thread and WiFi network details for external visualization
 - Enhancement: (lboue) Dashboard endpoint view shows "Client Clusters" of an endpoint and their binding status when also a Binding cluster is available

--- a/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
@@ -422,7 +422,7 @@ class AccessControlClusterCommands extends BaseClusterCommands {
     ];
 }
 
-registerClusterCommands(CLUSTER_ID, "access-control-cluster-commands");
+registerClusterCommands(CLUSTER_ID, "access-control-cluster-commands", { renderWhenOffline: true });
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/binding-commands.ts
@@ -285,7 +285,7 @@ class BindingClusterCommands extends BaseClusterCommands {
     ];
 }
 
-registerClusterCommands(CLUSTER_ID, "binding-cluster-commands");
+registerClusterCommands(CLUSTER_ID, "binding-cluster-commands", { renderWhenOffline: true });
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/commodity-tariff-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/commodity-tariff-commands.ts
@@ -18,18 +18,6 @@ import {
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
 
-const FEATURE_LABELS: [
-    key: "pricing" | "friendlyCredit" | "auxiliaryLoad" | "peakPeriod" | "powerThreshold" | "randomization",
-    text: string,
-][] = [
-    ["pricing", "Pricing"],
-    ["friendlyCredit", "Friendly Credit"],
-    ["auxiliaryLoad", "Auxiliary Load"],
-    ["peakPeriod", "Peak Period"],
-    ["powerThreshold", "Power Threshold"],
-    ["randomization", "Randomization"],
-];
-
 /**
  * Read-only decoding panel for the CommodityTariff cluster (ID: 0x700 / 1792).
  */
@@ -40,17 +28,17 @@ export class CommodityTariffClusterCommands extends BaseClusterCommands {
         const info = commodityTariffInfo(this.node.attributes, this.endpoint);
         if (!info.supported) return nothing;
 
-        const features = FEATURE_LABELS.filter(([key]) => info.features[key]).map(([, text]) => text);
+        const { label, providerName } = info.tariffInfo ?? {};
 
         return html`
             <details class="command-panel" open>
                 <summary>Commodity Tariff</summary>
                 <div class="command-content">
                     ${
-                        info.tariffInfo?.label || info.tariffInfo?.providerName
+                        label !== undefined || providerName !== undefined
                             ? html`<p class="tariff-header">
-                                  ${info.tariffInfo.label ? html`<b>${info.tariffInfo.label}</b>` : nothing}
-                                  ${info.tariffInfo.providerName ? html` — ${info.tariffInfo.providerName}` : nothing}
+                                  ${label !== undefined ? html`<b>${label}</b>` : nothing}
+                                  ${providerName !== undefined ? html` — ${providerName}` : nothing}
                               </p>`
                             : nothing
                     }
@@ -60,22 +48,8 @@ export class CommodityTariffClusterCommands extends BaseClusterCommands {
                         ${this._renderPriceLine("next", info.nextComponent, info.nextRange)}
                     </div>
 
-                    ${
-                        info.todaySchedule.length > 0
-                            ? html`<details class="schedule">
-                                  <summary>Today's schedule</summary>
-                                  ${this._renderScheduleTable(info.todaySchedule)}
-                              </details>`
-                            : nothing
-                    }
-                    ${
-                        info.tomorrowSchedule.length > 0
-                            ? html`<details class="schedule">
-                                  <summary>Tomorrow's schedule</summary>
-                                  ${this._renderScheduleTable(info.tomorrowSchedule)}
-                              </details>`
-                            : nothing
-                    }
+                    ${this._renderSchedule("Today", info.todaySchedule, info.todayType)}
+                    ${this._renderSchedule("Tomorrow", info.tomorrowSchedule, info.tomorrowType)}
 
                     <dl class="info-grid">
                         ${
@@ -96,12 +70,6 @@ export class CommodityTariffClusterCommands extends BaseClusterCommands {
                                       <dd title=${info.tariffInfo.blockModeDescription ?? nothing}>
                                           ${info.tariffInfo.blockMode}
                                       </dd>`
-                                : nothing
-                        }
-                        ${
-                            features.length > 0
-                                ? html`<dt>Features</dt>
-                                      <dd>${features.join(", ")}</dd>`
                                 : nothing
                         }
                     </dl>
@@ -129,6 +97,20 @@ export class CommodityTariffClusterCommands extends BaseClusterCommands {
                 <span class="text">${text}${amount ? html` — ${amount}` : nothing}</span>
                 <span class="range">${rangeText}</span>
             </div>
+        `;
+    }
+
+    private _renderSchedule(
+        day: string,
+        rows: ScheduleRow[],
+        dayType: string | undefined,
+    ): TemplateResult | typeof nothing {
+        if (rows.length === 0) return nothing;
+        return html`
+            <details class="schedule">
+                <summary>${day}'s schedule${dayType ? html` — ${dayType}` : nothing}</summary>
+                ${this._renderScheduleTable(rows)}
+            </details>
         `;
     }
 

--- a/packages/dashboard/src/pages/cluster-commands/clusters/commodity-tariff-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/commodity-tariff-commands.ts
@@ -213,7 +213,9 @@ export class CommodityTariffClusterCommands extends BaseClusterCommands {
     ];
 }
 
-registerClusterCommands(COMMODITY_TARIFF_CLUSTER_ID, "commodity-tariff-cluster-commands");
+registerClusterCommands(COMMODITY_TARIFF_CLUSTER_ID, "commodity-tariff-cluster-commands", {
+    renderWhenOffline: true,
+});
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/commodity-tariff-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/commodity-tariff-commands.ts
@@ -1,0 +1,240 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { css, html, nothing, type CSSResultGroup, type TemplateResult } from "lit";
+import { customElement } from "lit/decorators.js";
+import {
+    COMMODITY_TARIFF_CLUSTER_ID,
+    commodityTariffInfo,
+    formatEpochTime,
+    formatMinutesOfDay,
+    type ScheduleRow,
+    type TariffComponentInfo,
+    type TariffRange,
+} from "../../../util/commodity-tariff.js";
+import { BaseClusterCommands } from "../base-cluster-commands.js";
+import { registerClusterCommands } from "../registry.js";
+
+const FEATURE_LABELS: [
+    key: "pricing" | "friendlyCredit" | "auxiliaryLoad" | "peakPeriod" | "powerThreshold" | "randomization",
+    text: string,
+][] = [
+    ["pricing", "Pricing"],
+    ["friendlyCredit", "Friendly Credit"],
+    ["auxiliaryLoad", "Auxiliary Load"],
+    ["peakPeriod", "Peak Period"],
+    ["powerThreshold", "Power Threshold"],
+    ["randomization", "Randomization"],
+];
+
+/**
+ * Read-only decoding panel for the CommodityTariff cluster (ID: 0x700 / 1792).
+ */
+@customElement("commodity-tariff-cluster-commands")
+export class CommodityTariffClusterCommands extends BaseClusterCommands {
+    override render() {
+        if (!this.node || this.cluster !== COMMODITY_TARIFF_CLUSTER_ID) return nothing;
+        const info = commodityTariffInfo(this.node.attributes, this.endpoint);
+        if (!info.supported) return nothing;
+
+        const features = FEATURE_LABELS.filter(([key]) => info.features[key]).map(([, text]) => text);
+
+        return html`
+            <details class="command-panel" open>
+                <summary>Commodity Tariff</summary>
+                <div class="command-content">
+                    ${
+                        info.tariffInfo?.label || info.tariffInfo?.providerName
+                            ? html`<p class="tariff-header">
+                                  ${info.tariffInfo.label ? html`<b>${info.tariffInfo.label}</b>` : nothing}
+                                  ${info.tariffInfo.providerName ? html` — ${info.tariffInfo.providerName}` : nothing}
+                              </p>`
+                            : nothing
+                    }
+
+                    <div class="now-next">
+                        ${this._renderPriceLine("current", info.currentComponent, info.currentRange)}
+                        ${this._renderPriceLine("next", info.nextComponent, info.nextRange)}
+                    </div>
+
+                    ${
+                        info.todaySchedule.length > 0
+                            ? html`<details class="schedule">
+                                  <summary>Today's schedule</summary>
+                                  ${this._renderScheduleTable(info.todaySchedule)}
+                              </details>`
+                            : nothing
+                    }
+                    ${
+                        info.tomorrowSchedule.length > 0
+                            ? html`<details class="schedule">
+                                  <summary>Tomorrow's schedule</summary>
+                                  ${this._renderScheduleTable(info.tomorrowSchedule)}
+                              </details>`
+                            : nothing
+                    }
+
+                    <dl class="info-grid">
+                        ${
+                            info.startDate !== undefined
+                                ? html`<dt>Valid since</dt>
+                                      <dd>${formatEpochTime(info.startDate)}</dd>`
+                                : nothing
+                        }
+                        ${
+                            info.tariffUnit
+                                ? html`<dt>Unit</dt>
+                                      <dd>${info.tariffUnit}</dd>`
+                                : nothing
+                        }
+                        ${
+                            info.tariffInfo?.blockMode
+                                ? html`<dt>Block mode</dt>
+                                      <dd title=${info.tariffInfo.blockModeDescription ?? nothing}>
+                                          ${info.tariffInfo.blockMode}
+                                      </dd>`
+                                : nothing
+                        }
+                        ${
+                            features.length > 0
+                                ? html`<dt>Features</dt>
+                                      <dd>${features.join(", ")}</dd>`
+                                : nothing
+                        }
+                    </dl>
+                </div>
+            </details>
+        `;
+    }
+
+    private _renderPriceLine(
+        kind: "current" | "next",
+        component: TariffComponentInfo | undefined,
+        range: TariffRange | undefined,
+    ): TemplateResult {
+        if (!component && !range) return html``;
+        const text = component?.label ?? component?.price?.priceType ?? "Unknown period";
+        const amount = component?.price?.amount;
+        const rangeText = range
+            ? range.end !== undefined
+                ? html`${formatEpochTime(range.start)}–${formatEpochTime(range.end)}`
+                : html`from ${formatEpochTime(range.start)}`
+            : nothing;
+        return html`
+            <div class="tariff-row ${kind}">
+                <span class="tag">${kind === "current" ? "Now" : "Next"}</span>
+                <span class="text">${text}${amount ? html` — ${amount}` : nothing}</span>
+                <span class="range">${rangeText}</span>
+            </div>
+        `;
+    }
+
+    private _renderScheduleTable(rows: ScheduleRow[]): TemplateResult {
+        return html`
+            <table class="tariff-schedule">
+                <thead>
+                    <tr>
+                        <th>Time</th>
+                        <th>Period</th>
+                        <th>Price</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    ${rows.map(
+                        row => html`
+                            <tr>
+                                <td>${formatMinutesOfDay(row.startMinutes)}–${formatMinutesOfDay(row.endMinutes)}</td>
+                                <td>${row.label ?? "—"}</td>
+                                <td>${row.price?.amount ?? "—"}</td>
+                            </tr>
+                        `,
+                    )}
+                </tbody>
+            </table>
+        `;
+    }
+
+    static override styles: CSSResultGroup = [
+        BaseClusterCommands.styles,
+        css`
+            .command-content {
+                font-size: 14px;
+            }
+            .tariff-header {
+                margin: 0 0 12px 0;
+                color: var(--text-color, rgba(0, 0, 0, 0.6));
+            }
+            .now-next {
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+                margin-bottom: 12px;
+            }
+            .tariff-row {
+                display: flex;
+                align-items: baseline;
+                gap: 8px;
+            }
+            .tariff-row.current {
+                font-weight: 700;
+            }
+            .tariff-row .tag {
+                min-width: 40px;
+                text-transform: uppercase;
+                opacity: 0.6;
+                font-weight: 500;
+            }
+            .tariff-row .range {
+                color: var(--text-color, rgba(0, 0, 0, 0.6));
+                font-weight: 400;
+            }
+            details.schedule {
+                margin-bottom: 12px;
+            }
+            details.schedule summary {
+                cursor: pointer;
+                color: var(--md-sys-color-primary);
+            }
+            .tariff-schedule {
+                width: 100%;
+                border-collapse: collapse;
+                margin-top: 8px;
+            }
+            .tariff-schedule th {
+                text-align: left;
+                text-transform: uppercase;
+                opacity: 0.6;
+                padding: 6px 10px;
+                border-bottom: 1px solid var(--md-sys-color-outline-variant);
+            }
+            .tariff-schedule td {
+                padding: 6px 10px;
+                border-bottom: 1px solid var(--md-sys-color-outline-variant);
+            }
+            .info-grid {
+                display: grid;
+                grid-template-columns: auto 1fr;
+                gap: 6px 16px;
+                margin: 0;
+            }
+            .info-grid dt {
+                color: var(--text-color, rgba(0, 0, 0, 0.6));
+            }
+            .info-grid dd {
+                margin: 0;
+                font-weight: 500;
+            }
+        `,
+    ];
+}
+
+registerClusterCommands(COMMODITY_TARIFF_CLUSTER_ID, "commodity-tariff-cluster-commands");
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "commodity-tariff-cluster-commands": CommodityTariffClusterCommands;
+    }
+}

--- a/packages/dashboard/src/pages/cluster-commands/clusters/icd-management-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/icd-management-commands.ts
@@ -558,7 +558,8 @@ export class IcdManagementClusterCommands extends BaseClusterCommands {
     ];
 }
 
-registerClusterCommands(ICD_CLUSTER_ID, "icd-management-cluster-commands");
+// Commands here target a sleeping device, so they stay actionable while it counts as unreachable.
+registerClusterCommands(ICD_CLUSTER_ID, "icd-management-cluster-commands", { renderWhenOffline: true });
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/meter-identification-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/meter-identification-commands.ts
@@ -100,7 +100,9 @@ export class MeterIdentificationClusterCommands extends BaseClusterCommands {
     ];
 }
 
-registerClusterCommands(METER_IDENTIFICATION_CLUSTER_ID, "meter-identification-cluster-commands");
+registerClusterCommands(METER_IDENTIFICATION_CLUSTER_ID, "meter-identification-cluster-commands", {
+    renderWhenOffline: true,
+});
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/meter-identification-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/meter-identification-commands.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { css, html, nothing, type CSSResultGroup } from "lit";
+import { customElement } from "lit/decorators.js";
+import { METER_IDENTIFICATION_CLUSTER_ID, meterIdentificationInfo } from "../../../util/meter-identification.js";
+import { BaseClusterCommands } from "../base-cluster-commands.js";
+import { registerClusterCommands } from "../registry.js";
+
+/**
+ * Read-only decoding panel for the MeterIdentification cluster (ID: 0xB06 / 2822).
+ */
+@customElement("meter-identification-cluster-commands")
+export class MeterIdentificationClusterCommands extends BaseClusterCommands {
+    override render() {
+        if (!this.node || this.cluster !== METER_IDENTIFICATION_CLUSTER_ID) return nothing;
+        const info = meterIdentificationInfo(this.node.attributes, this.endpoint);
+        if (!info.supported) return nothing;
+
+        return html`
+            <details class="command-panel" open>
+                <summary>Meter Identification</summary>
+                <div class="command-content">
+                    <dl class="info-grid">
+                        ${
+                            info.meterType
+                                ? html`<dt>Meter type</dt>
+                                      <dd>${info.meterType}</dd>`
+                                : nothing
+                        }
+                        ${
+                            info.pointOfDelivery
+                                ? html`<dt>Point of delivery</dt>
+                                      <dd>${info.pointOfDelivery}</dd>`
+                                : nothing
+                        }
+                        ${
+                            info.meterSerialNumber
+                                ? html`<dt>Serial number</dt>
+                                      <dd>${info.meterSerialNumber}</dd>`
+                                : nothing
+                        }
+                        ${
+                            info.protocolVersion
+                                ? html`<dt>Protocol version</dt>
+                                      <dd>${info.protocolVersion}</dd>`
+                                : nothing
+                        }
+                        ${
+                            info.powerThresholdSupported && info.powerThreshold
+                                ? html`
+                                      ${
+                                          info.powerThreshold.powerThresholdW !== undefined
+                                              ? html`<dt>Power threshold</dt>
+                                                    <dd>${info.powerThreshold.powerThresholdW} W</dd>`
+                                              : nothing
+                                      }
+                                      ${
+                                          info.powerThreshold.apparentPowerThresholdVA !== undefined
+                                              ? html`<dt>Apparent power threshold</dt>
+                                                    <dd>${info.powerThreshold.apparentPowerThresholdVA} VA</dd>`
+                                              : nothing
+                                      }
+                                      ${
+                                          info.powerThreshold.source
+                                              ? html`<dt>Threshold source</dt>
+                                                    <dd>${info.powerThreshold.source}</dd>`
+                                              : nothing
+                                      }
+                                  `
+                                : nothing
+                        }
+                    </dl>
+                </div>
+            </details>
+        `;
+    }
+
+    static override styles: CSSResultGroup = [
+        BaseClusterCommands.styles,
+        css`
+            .info-grid {
+                display: grid;
+                grid-template-columns: auto 1fr;
+                gap: 6px 16px;
+                margin: 0;
+            }
+            .info-grid dt {
+                color: var(--text-color, rgba(0, 0, 0, 0.6));
+                font-size: 13px;
+            }
+            .info-grid dd {
+                margin: 0;
+                font-weight: 500;
+            }
+        `,
+    ];
+}
+
+registerClusterCommands(METER_IDENTIFICATION_CLUSTER_ID, "meter-identification-cluster-commands");
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "meter-identification-cluster-commands": MeterIdentificationClusterCommands;
+    }
+}

--- a/packages/dashboard/src/pages/cluster-commands/index.ts
+++ b/packages/dashboard/src/pages/cluster-commands/index.ts
@@ -10,7 +10,13 @@
  */
 
 // Registry exports
-export { getClusterCommandsTag, hasClusterCommands, registerClusterCommands } from "./registry.js";
+export {
+    getClusterCommandsTag,
+    hasClusterCommands,
+    registerClusterCommands,
+    rendersClusterCommandsWhenOffline,
+    type ClusterCommandsRegistration,
+} from "./registry.js";
 
 // Base class for creating new cluster commands
 export { BaseClusterCommands } from "./base-cluster-commands.js";

--- a/packages/dashboard/src/pages/cluster-commands/index.ts
+++ b/packages/dashboard/src/pages/cluster-commands/index.ts
@@ -22,6 +22,8 @@ import "./clusters/basic-information-commands.js";
 import "./clusters/binding-commands.js";
 import "./clusters/chime-commands.js";
 import "./clusters/closure-control-commands.js";
+import "./clusters/commodity-tariff-commands.js";
 import "./clusters/icd-management-commands.js";
 import "./clusters/level-control-commands.js";
+import "./clusters/meter-identification-commands.js";
 import "./clusters/on-off-commands.js";

--- a/packages/dashboard/src/pages/cluster-commands/registry.ts
+++ b/packages/dashboard/src/pages/cluster-commands/registry.ts
@@ -10,15 +10,29 @@
  * rendered in the cluster view when viewing that cluster.
  */
 
-const clusterCommandRegistry = new Map<number, string>();
+export interface ClusterCommandsRegistration {
+    tagName: string;
+    /**
+     * Whether the panel stays visible while the node is unreachable. Set it for panels that only decode
+     * cached attributes, or whose commands target a sleeping device; the cluster view hides the rest.
+     */
+    renderWhenOffline?: boolean;
+}
+
+const clusterCommandRegistry = new Map<number, ClusterCommandsRegistration>();
 
 /**
  * Register a cluster command panel component.
  * @param clusterId - The Matter cluster ID (e.g., 6 for OnOff, 8 for LevelControl)
  * @param tagName - The custom element tag name (e.g., "on-off-cluster-commands")
+ * @param options - Rendering behaviour the cluster view needs before it creates the element
  */
-export function registerClusterCommands(clusterId: number, tagName: string): void {
-    clusterCommandRegistry.set(clusterId, tagName);
+export function registerClusterCommands(
+    clusterId: number,
+    tagName: string,
+    options: Omit<ClusterCommandsRegistration, "tagName"> = {},
+): void {
+    clusterCommandRegistry.set(clusterId, { tagName, ...options });
 }
 
 /**
@@ -27,7 +41,7 @@ export function registerClusterCommands(clusterId: number, tagName: string): voi
  * @returns The custom element tag name, or undefined if not registered
  */
 export function getClusterCommandsTag(clusterId: number): string | undefined {
-    return clusterCommandRegistry.get(clusterId);
+    return clusterCommandRegistry.get(clusterId)?.tagName;
 }
 
 /**
@@ -37,4 +51,13 @@ export function getClusterCommandsTag(clusterId: number): string | undefined {
  */
 export function hasClusterCommands(clusterId: number): boolean {
     return clusterCommandRegistry.has(clusterId);
+}
+
+/**
+ * Whether a cluster's panel is shown while the node is unreachable.
+ * @param clusterId - The Matter cluster ID
+ * @returns true when the panel declared itself usable offline
+ */
+export function rendersClusterCommandsWhenOffline(clusterId: number): boolean {
+    return clusterCommandRegistry.get(clusterId)?.renderWhenOffline === true;
 }

--- a/packages/dashboard/src/pages/matter-cluster-view.ts
+++ b/packages/dashboard/src/pages/matter-cluster-view.ts
@@ -34,7 +34,11 @@ import {
     TAG_LIST_ATTR,
 } from "../util/semantic-tags.js";
 import { infoPanelStyles, notFoundStyles } from "../util/shared-styles.js";
-import { BaseClusterCommands, getClusterCommandsTag } from "./cluster-commands/index.js";
+import {
+    BaseClusterCommands,
+    getClusterCommandsTag,
+    rendersClusterCommandsWhenOffline,
+} from "./cluster-commands/index.js";
 import { bindingContext } from "./components/context.js";
 
 declare global {
@@ -499,12 +503,7 @@ class MatterClusterView extends LitElement {
 
     private _renderClusterCommands() {
         if (this.cluster === undefined) return html``;
-        // ACL (31), Binding (30), CommodityTariff (1792) and MeterIdentification (2822) panels only decode
-        // cached attributes, so they stay visible read-only for offline nodes; ICD management (70) stays
-        // visible and actionable since its commands target sleeping devices. Commands for other clusters
-        // are hidden while the device is unreachable.
-        const RENDER_WHEN_OFFLINE = new Set<number>([30, 31, 70, 1792, 2822]);
-        if (!this.node?.available && !RENDER_WHEN_OFFLINE.has(this.cluster)) return html``;
+        if (!this.node?.available && !rendersClusterCommandsWhenOffline(this.cluster)) return html``;
 
         const tagName = getClusterCommandsTag(this.cluster);
         if (!tagName) return html``;

--- a/packages/dashboard/src/pages/matter-cluster-view.ts
+++ b/packages/dashboard/src/pages/matter-cluster-view.ts
@@ -499,10 +499,11 @@ class MatterClusterView extends LitElement {
 
     private _renderClusterCommands() {
         if (this.cluster === undefined) return html``;
-        // ACL (31) and Binding (30) panels stay visible read-only for offline nodes; ICD management (70)
-        // stays visible and actionable since its commands target sleeping devices. Commands for other
-        // clusters are hidden while the device is unreachable.
-        const RENDER_WHEN_OFFLINE = new Set<number>([30, 31, 70]);
+        // ACL (31), Binding (30), CommodityTariff (1792) and MeterIdentification (2822) panels only decode
+        // cached attributes, so they stay visible read-only for offline nodes; ICD management (70) stays
+        // visible and actionable since its commands target sleeping devices. Commands for other clusters
+        // are hidden while the device is unreachable.
+        const RENDER_WHEN_OFFLINE = new Set<number>([30, 31, 70, 1792, 2822]);
         if (!this.node?.available && !RENDER_WHEN_OFFLINE.has(this.cluster)) return html``;
 
         const tagName = getClusterCommandsTag(this.cluster);

--- a/packages/dashboard/src/util/attribute-shapes.ts
+++ b/packages/dashboard/src/util/attribute-shapes.ts
@@ -21,6 +21,22 @@ export function pickString(obj: Record<string, unknown>, key: string): string | 
     return typeof v === "string" ? v : null;
 }
 
+/** Struct attributes reach the dashboard field-tag keyed (`{"0": …}`) via convertMatterToWebSocketTagBased. */
+export function tagField(value: unknown, tag: number): unknown {
+    return asObject(value)?.[String(tag)];
+}
+
+/** int64/uint64 fields arrive as bigint, smaller ones as number. */
+export function toNumber(value: unknown): number | undefined {
+    return typeof value === "number" || typeof value === "bigint" ? Number(value) : undefined;
+}
+
+/** A blank string carries no display value, so it reads as absent. */
+export function toText(value: unknown): string | undefined {
+    const text = typeof value === "string" ? value.trim() : "";
+    return text.length > 0 ? text : undefined;
+}
+
 export function extractAttributeValue(attributesData: unknown): unknown {
     const obj = asObject(attributesData);
     if (!obj) return attributesData;

--- a/packages/dashboard/src/util/attribute-shapes.ts
+++ b/packages/dashboard/src/util/attribute-shapes.ts
@@ -26,9 +26,17 @@ export function tagField(value: unknown, tag: number): unknown {
     return asObject(value)?.[String(tag)];
 }
 
-/** int64/uint64 fields arrive as bigint, smaller ones as number. */
+/**
+ * int64/uint64 fields arrive as bigint, smaller ones as number. parseBigIntAwareJson only yields a bigint
+ * beyond the safe integer range, so converting one there would round it: such a value reads as absent
+ * rather than as a wrong number.
+ */
 export function toNumber(value: unknown): number | undefined {
-    return typeof value === "number" || typeof value === "bigint" ? Number(value) : undefined;
+    if (typeof value === "number") return value;
+    if (typeof value !== "bigint") return undefined;
+    return value >= BigInt(Number.MIN_SAFE_INTEGER) && value <= BigInt(Number.MAX_SAFE_INTEGER)
+        ? Number(value)
+        : undefined;
 }
 
 /** A blank string carries no display value, so it reads as absent. */

--- a/packages/dashboard/src/util/commodity-tariff.ts
+++ b/packages/dashboard/src/util/commodity-tariff.ts
@@ -1,0 +1,407 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const COMMODITY_TARIFF_CLUSTER_ID = 1792;
+
+const BLOCK_MODE_NAMES: Record<number, string> = {
+    0: "No usage blocks",
+    1: "Combined usage blocks",
+    2: "Individual usage blocks",
+};
+
+/** Matter 1.6 §9.12.5.6: what a tariff component's Threshold field(s) actually meter. */
+const BLOCK_MODE_DESCRIPTIONS: Record<number, string> = {
+    0: "This tariff has no usage-based price tiers.",
+    1: "Price tiers apply to total usage combined across all tariff components during the billing period.",
+    2: "Price tiers apply separately to usage during each tariff component's own active period.",
+};
+const DAY_TYPE_NAMES: Record<number, string> = { 0: "Standard", 1: "Holiday", 2: "Dynamic", 3: "Event" };
+const TARIFF_PRICE_TYPE_NAMES: Record<number, string> = {
+    0: "Standard",
+    1: "Critical Peak",
+    2: "Virtual Power Plant",
+    3: "Incentive",
+    4: "Incentive Signal",
+};
+const TARIFF_UNIT_NAMES: Record<number, string> = { 0: "kWh", 1: "kVAh" };
+
+/** ISO 4217 numeric currency codes; falls back to the raw code when not listed here. */
+const CURRENCY_SYMBOLS: Record<number, string> = { 978: "€", 840: "$", 826: "£", 756: "CHF" };
+
+/** Matter epoch-s values count seconds since 2000-01-01T00:00:00Z, not the Unix epoch. */
+const MATTER_EPOCH_OFFSET_SECONDS = 946_684_800;
+
+/** CommodityTariff FeatureMap bits per Matter 1.6 §9.12.4. */
+const FEATURE_BITS = {
+    pricing: 0b1,
+    friendlyCredit: 0b10,
+    auxiliaryLoad: 0b100,
+    peakPeriod: 0b1000,
+    powerThreshold: 0b10000,
+    randomization: 0b100000,
+} as const;
+
+export interface CurrencyInfo {
+    code: number;
+    decimalPoints: number;
+    symbol?: string;
+}
+
+export interface TariffInfo {
+    label?: string;
+    providerName?: string;
+    currency?: CurrencyInfo;
+    blockMode?: string;
+    blockModeDescription?: string;
+}
+
+export interface TariffPriceInfo {
+    priceType: string;
+    amount?: string;
+    priceLevel?: number;
+}
+
+export interface TariffComponentInfo {
+    id: number;
+    label?: string;
+    price?: TariffPriceInfo;
+    threshold?: number;
+}
+
+export interface DayEntryInfo {
+    id: number;
+    startMinutes: number;
+    durationMinutes?: number;
+}
+
+export interface TariffPeriodInfo {
+    label?: string;
+    dayEntryIds: number[];
+    tariffComponentIds: number[];
+}
+
+export interface DayInfo {
+    date?: number;
+    dayType?: string;
+    dayEntryIds: number[];
+}
+
+export interface ScheduleRow {
+    entryId: number;
+    startMinutes: number;
+    endMinutes: number;
+    label?: string;
+    price?: TariffPriceInfo;
+}
+
+export interface TariffRange {
+    /** Epoch seconds the range starts at. */
+    start: number;
+    /** Epoch seconds the range ends at, when known. */
+    end?: number;
+}
+
+export interface CommodityTariffFeatures {
+    pricing: boolean;
+    friendlyCredit: boolean;
+    auxiliaryLoad: boolean;
+    peakPeriod: boolean;
+    powerThreshold: boolean;
+    randomization: boolean;
+}
+
+export interface CommodityTariffInfo {
+    supported: boolean;
+    features: CommodityTariffFeatures;
+    tariffInfo?: TariffInfo;
+    tariffUnit?: string;
+    startDate?: number;
+    currentComponent?: TariffComponentInfo;
+    nextComponent?: TariffComponentInfo;
+    currentRange?: TariffRange;
+    nextRange?: TariffRange;
+    todaySchedule: ScheduleRow[];
+    tomorrowSchedule: ScheduleRow[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+/** Wire-format structs are field-tag keyed (e.g. `{"0": ..., "1": ...}`), not camelCase field names. */
+function field(value: unknown, tag: number): unknown {
+    return isRecord(value) ? value[String(tag)] : undefined;
+}
+
+function attr(attributes: Record<string, unknown>, endpoint: number, attributeId: number): unknown {
+    return attributes[`${endpoint}/${COMMODITY_TARIFF_CLUSTER_ID}/${attributeId}`];
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+    return typeof value === "number" || typeof value === "bigint" ? Number(value) : undefined;
+}
+
+function stringOrUndefined(value: unknown): string | undefined {
+    return typeof value === "string" ? value : undefined;
+}
+
+function numberList(value: unknown): number[] {
+    return Array.isArray(value) ? value.filter((v): v is number => typeof v === "number") : [];
+}
+
+function decodeCurrency(value: unknown): CurrencyInfo | undefined {
+    const code = field(value, 0);
+    const decimalPoints = field(value, 1);
+    if (typeof code !== "number" || typeof decimalPoints !== "number") return undefined;
+    return { code, decimalPoints, symbol: CURRENCY_SYMBOLS[code] };
+}
+
+/** Formats a raw tariff price integer using the currency's decimal point scale (e.g. 1579 @ 4dp -> "0.1579 €"). */
+export function formatPrice(price: unknown, currency: CurrencyInfo | undefined): string | undefined {
+    const raw = numberOrUndefined(price);
+    if (raw === undefined) return undefined;
+    const decimalPoints = currency?.decimalPoints ?? 0;
+    const amount = (raw / 10 ** decimalPoints).toFixed(decimalPoints);
+    if (!currency) return amount;
+    return currency.symbol ? `${amount} ${currency.symbol}` : `${amount} (ISO 4217 #${currency.code})`;
+}
+
+function decodeTariffInfo(value: unknown): TariffInfo | undefined {
+    if (!isRecord(value)) return undefined;
+    const blockMode = field(value, 3);
+    return {
+        label: stringOrUndefined(field(value, 0)),
+        providerName: stringOrUndefined(field(value, 1)),
+        currency: decodeCurrency(field(value, 2)),
+        blockMode:
+            typeof blockMode === "number" ? (BLOCK_MODE_NAMES[blockMode] ?? `Unknown (${blockMode})`) : undefined,
+        blockModeDescription: typeof blockMode === "number" ? BLOCK_MODE_DESCRIPTIONS[blockMode] : undefined,
+    };
+}
+
+function decodeTariffPrice(value: unknown, currency: CurrencyInfo | undefined): TariffPriceInfo | undefined {
+    if (!isRecord(value)) return undefined;
+    const priceType = field(value, 0);
+    return {
+        priceType:
+            typeof priceType === "number"
+                ? (TARIFF_PRICE_TYPE_NAMES[priceType] ?? `Unknown (${priceType})`)
+                : "Unknown",
+        amount: formatPrice(field(value, 1), currency),
+        priceLevel: numberOrUndefined(field(value, 2)),
+    };
+}
+
+function decodeTariffComponent(value: unknown, currency: CurrencyInfo | undefined): TariffComponentInfo | undefined {
+    if (!isRecord(value)) return undefined;
+    const id = field(value, 0);
+    if (typeof id !== "number") return undefined;
+    return {
+        id,
+        label: stringOrUndefined(field(value, 7)),
+        price: decodeTariffPrice(field(value, 1), currency),
+        threshold: numberOrUndefined(field(value, 6)),
+    };
+}
+
+function decodeTariffComponents(value: unknown, currency: CurrencyInfo | undefined): TariffComponentInfo[] {
+    return Array.isArray(value)
+        ? value
+              .map(entry => decodeTariffComponent(entry, currency))
+              .filter((c): c is TariffComponentInfo => c !== undefined)
+        : [];
+}
+
+function decodeDayEntry(value: unknown): DayEntryInfo | undefined {
+    const id = field(value, 0);
+    const startTime = field(value, 1);
+    if (typeof id !== "number" || typeof startTime !== "number") return undefined;
+    return { id, startMinutes: startTime, durationMinutes: numberOrUndefined(field(value, 2)) };
+}
+
+function decodeDayEntries(value: unknown): DayEntryInfo[] {
+    return Array.isArray(value) ? value.map(decodeDayEntry).filter((e): e is DayEntryInfo => e !== undefined) : [];
+}
+
+function decodeTariffPeriod(value: unknown): TariffPeriodInfo | undefined {
+    if (!isRecord(value)) return undefined;
+    return {
+        label: stringOrUndefined(field(value, 0)),
+        dayEntryIds: numberList(field(value, 1)),
+        tariffComponentIds: numberList(field(value, 2)),
+    };
+}
+
+function decodeTariffPeriods(value: unknown): TariffPeriodInfo[] {
+    return Array.isArray(value)
+        ? value.map(decodeTariffPeriod).filter((p): p is TariffPeriodInfo => p !== undefined)
+        : [];
+}
+
+function decodeDay(value: unknown): DayInfo | undefined {
+    if (!isRecord(value)) return undefined;
+    const dayType = field(value, 1);
+    return {
+        date: numberOrUndefined(field(value, 0)),
+        dayType: typeof dayType === "number" ? (DAY_TYPE_NAMES[dayType] ?? `Unknown (${dayType})`) : undefined,
+        dayEntryIds: numberList(field(value, 2)),
+    };
+}
+
+/** CommodityTariff FeatureMap is a raw bitmap integer on the wire, not a named-boolean object. */
+function decodeFeatures(value: unknown): CommodityTariffFeatures {
+    const bits = typeof value === "number" ? value : 0;
+    return {
+        pricing: (bits & FEATURE_BITS.pricing) !== 0,
+        friendlyCredit: (bits & FEATURE_BITS.friendlyCredit) !== 0,
+        auxiliaryLoad: (bits & FEATURE_BITS.auxiliaryLoad) !== 0,
+        peakPeriod: (bits & FEATURE_BITS.peakPeriod) !== 0,
+        powerThreshold: (bits & FEATURE_BITS.powerThreshold) !== 0,
+        randomization: (bits & FEATURE_BITS.randomization) !== 0,
+    };
+}
+
+/** Resolves a day's entry ids into time-ordered rows, each showing the period label and price active during it. */
+function buildDailySchedule(
+    day: DayInfo | undefined,
+    dayEntries: DayEntryInfo[],
+    tariffPeriods: TariffPeriodInfo[],
+    tariffComponents: TariffComponentInfo[],
+): ScheduleRow[] {
+    if (!day) return [];
+    const entries = day.dayEntryIds
+        .map(id => dayEntries.find(entry => entry.id === id))
+        .filter((entry): entry is DayEntryInfo => entry !== undefined)
+        .sort((a, b) => a.startMinutes - b.startMinutes);
+
+    return entries.map((entry, index) => {
+        const next = entries[index + 1];
+        const endMinutes = next ? next.startMinutes : 24 * 60;
+        const period = tariffPeriods.find(p => p.dayEntryIds.includes(entry.id));
+        const component = tariffComponents.find(c => c.id === period?.tariffComponentIds[0]);
+        return {
+            entryId: entry.id,
+            startMinutes: entry.startMinutes,
+            endMinutes,
+            label: period?.label ?? component?.label,
+            price: component?.price,
+        };
+    });
+}
+
+function resolveEntryPeriod(
+    entryId: number,
+    tariffPeriods: TariffPeriodInfo[],
+    tariffComponents: TariffComponentInfo[],
+): { label?: string; componentId?: number } {
+    const period = tariffPeriods.find(p => p.dayEntryIds.includes(entryId));
+    const componentId = period?.tariffComponentIds[0];
+    return { label: period?.label ?? tariffComponents.find(c => c.id === componentId)?.label, componentId };
+}
+
+/**
+ * A period active at day-end and resumed at day-start (e.g. an off-peak block spanning midnight) is
+ * modeled as two separate DayEntry records because DayEntry.startTime can't cross midnight. Finds when
+ * `fromEntryId`'s period actually ends by walking the daily entry cycle forward (wrapping past midnight)
+ * until the resolved period changes; returns the offset in minutes from `fromEntryId`'s own start, or
+ * undefined if the cycle never changes period (e.g. a single entry, or all entries share one period).
+ */
+function minutesUntilNextTransition(
+    fromEntryId: number,
+    dayEntries: DayEntryInfo[],
+    tariffPeriods: TariffPeriodInfo[],
+    tariffComponents: TariffComponentInfo[],
+): number | undefined {
+    if (dayEntries.length < 2) return undefined;
+    const sorted = [...dayEntries].sort((a, b) => a.startMinutes - b.startMinutes);
+    const fromIndex = sorted.findIndex(entry => entry.id === fromEntryId);
+    if (fromIndex === -1) return undefined;
+    const fromPeriod = resolveEntryPeriod(fromEntryId, tariffPeriods, tariffComponents);
+
+    for (let step = 1; step <= sorted.length; step++) {
+        const position = fromIndex + step;
+        const entry = sorted[position % sorted.length];
+        const period = resolveEntryPeriod(entry.id, tariffPeriods, tariffComponents);
+        if (period.label !== fromPeriod.label || period.componentId !== fromPeriod.componentId) {
+            const wraps = Math.floor(position / sorted.length);
+            return entry.startMinutes + wraps * 24 * 60 - sorted[fromIndex].startMinutes;
+        }
+    }
+    return undefined;
+}
+
+/** Formats minutes-since-midnight as "HH:MM"; 1440 (end of day) renders as "24:00". */
+export function formatMinutesOfDay(minutes: number): string {
+    if (minutes >= 24 * 60) return "24:00";
+    const hours = Math.floor(minutes / 60);
+    const mins = minutes % 60;
+    return `${String(hours).padStart(2, "0")}:${String(mins).padStart(2, "0")}`;
+}
+
+/** Formats a Matter epoch-s instant as a local time, prefixed with the date when it isn't today. */
+export function formatEpochTime(matterEpochSeconds: number, relativeTo: Date = new Date()): string {
+    const date = new Date((matterEpochSeconds + MATTER_EPOCH_OFFSET_SECONDS) * 1000);
+    const time = date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+    if (date.toDateString() === relativeTo.toDateString()) return time;
+    const tomorrow = new Date(relativeTo);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    if (date.toDateString() === tomorrow.toDateString()) return `tomorrow ${time}`;
+    return `${date.toLocaleDateString(undefined, { month: "2-digit", day: "2-digit" })} ${time}`;
+}
+
+export function commodityTariffInfo(attributes: Record<string, unknown>, endpoint: number): CommodityTariffInfo {
+    const featureMap = attr(attributes, endpoint, 65532);
+    const tariffInfo = decodeTariffInfo(attr(attributes, endpoint, 0));
+    const currency = tariffInfo?.currency;
+    const tariffUnitRaw = attr(attributes, endpoint, 1);
+    const dayEntries = decodeDayEntries(attr(attributes, endpoint, 3));
+    const tariffPeriods = decodeTariffPeriods(attr(attributes, endpoint, 14));
+    const tariffComponents = decodeTariffComponents(attr(attributes, endpoint, 13), currency);
+    const currentComponents = decodeTariffComponents(attr(attributes, endpoint, 15), currency);
+    const nextComponents = decodeTariffComponents(attr(attributes, endpoint, 16), currency);
+    const currentDayEntryDate = numberOrUndefined(attr(attributes, endpoint, 10));
+    const nextDayEntryDate = numberOrUndefined(attr(attributes, endpoint, 12));
+    const nextDayEntry = decodeDayEntry(attr(attributes, endpoint, 11));
+    const nextEndOffsetMinutes =
+        nextDayEntry !== undefined
+            ? minutesUntilNextTransition(nextDayEntry.id, dayEntries, tariffPeriods, tariffComponents)
+            : undefined;
+
+    return {
+        supported: featureMap !== undefined,
+        features: decodeFeatures(featureMap),
+        tariffInfo,
+        tariffUnit:
+            typeof tariffUnitRaw === "number"
+                ? (TARIFF_UNIT_NAMES[tariffUnitRaw] ?? `Unknown (${tariffUnitRaw})`)
+                : undefined,
+        startDate: numberOrUndefined(attr(attributes, endpoint, 2)),
+        currentComponent: currentComponents[0],
+        nextComponent: nextComponents[0],
+        currentRange:
+            currentDayEntryDate !== undefined ? { start: currentDayEntryDate, end: nextDayEntryDate } : undefined,
+        nextRange:
+            nextDayEntryDate !== undefined
+                ? {
+                      start: nextDayEntryDate,
+                      end:
+                          nextEndOffsetMinutes !== undefined ? nextDayEntryDate + nextEndOffsetMinutes * 60 : undefined,
+                  }
+                : undefined,
+        todaySchedule: buildDailySchedule(
+            decodeDay(attr(attributes, endpoint, 7)),
+            dayEntries,
+            tariffPeriods,
+            tariffComponents,
+        ),
+        tomorrowSchedule: buildDailySchedule(
+            decodeDay(attr(attributes, endpoint, 8)),
+            dayEntries,
+            tariffPeriods,
+            tariffComponents,
+        ),
+    };
+}

--- a/packages/dashboard/src/util/commodity-tariff.ts
+++ b/packages/dashboard/src/util/commodity-tariff.ts
@@ -149,7 +149,11 @@ function stringOrUndefined(value: unknown): string | undefined {
 }
 
 function numberList(value: unknown): number[] {
-    return Array.isArray(value) ? value.filter((v): v is number => typeof v === "number") : [];
+    return Array.isArray(value)
+        ? value
+              .map(v => (typeof v === "number" || typeof v === "bigint" ? Number(v) : NaN))
+              .filter((v): v is number => Number.isFinite(v))
+        : [];
 }
 
 function decodeCurrency(value: unknown): CurrencyInfo | undefined {
@@ -279,7 +283,12 @@ function buildDailySchedule(
 
     return entries.map((entry, index) => {
         const next = entries[index + 1];
-        const endMinutes = next ? next.startMinutes : 24 * 60;
+        const endMinutes =
+            entry.durationMinutes !== undefined
+                ? Math.min(entry.startMinutes + entry.durationMinutes, 24 * 60)
+                : next
+                  ? next.startMinutes
+                  : 24 * 60;
         const period = tariffPeriods.find(p => p.dayEntryIds.includes(entry.id));
         const component = tariffComponents.find(c => c.id === period?.tariffComponentIds[0]);
         return {

--- a/packages/dashboard/src/util/commodity-tariff.ts
+++ b/packages/dashboard/src/util/commodity-tariff.ts
@@ -4,7 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { tagField as field, toNumber, toText } from "./attribute-shapes.js";
+
 export const COMMODITY_TARIFF_CLUSTER_ID = 1792;
+
+const ATTR_TARIFF_INFO = 0;
+const ATTR_TARIFF_UNIT = 1;
+const ATTR_START_DATE = 2;
+const ATTR_DAY_ENTRIES = 3;
+const ATTR_CURRENT_DAY = 7;
+const ATTR_NEXT_DAY = 8;
+const ATTR_CURRENT_DAY_ENTRY = 9;
+const ATTR_CURRENT_DAY_ENTRY_DATE = 10;
+const ATTR_NEXT_DAY_ENTRY = 11;
+const ATTR_NEXT_DAY_ENTRY_DATE = 12;
+const ATTR_TARIFF_COMPONENTS = 13;
+const ATTR_TARIFF_PERIODS = 14;
+const ATTR_CURRENT_TARIFF_COMPONENTS = 15;
+const ATTR_NEXT_TARIFF_COMPONENTS = 16;
+const ATTR_FEATURE_MAP = 0xfffc;
+
+const MINUTES_PER_DAY = 24 * 60;
 
 const BLOCK_MODE_NAMES: Record<number, string> = {
     0: "No usage blocks",
@@ -33,16 +53,6 @@ const CURRENCY_SYMBOLS: Record<number, string> = { 978: "€", 840: "$", 826: "�
 
 /** Matter epoch-s values count seconds since 2000-01-01T00:00:00Z, not the Unix epoch. */
 const MATTER_EPOCH_OFFSET_SECONDS = 946_684_800;
-
-/** CommodityTariff FeatureMap bits per Matter 1.6 §9.12.4. */
-const FEATURE_BITS = {
-    pricing: 0b1,
-    friendlyCredit: 0b10,
-    auxiliaryLoad: 0b100,
-    peakPeriod: 0b1000,
-    powerThreshold: 0b10000,
-    randomization: 0b100000,
-} as const;
 
 export interface CurrencyInfo {
     code: number;
@@ -78,6 +88,8 @@ export interface DayEntryInfo {
 }
 
 export interface TariffPeriodInfo {
+    /** Position in the TariffPeriods list; identifies a period, since labels are neither unique nor mandatory. */
+    index: number;
     label?: string;
     dayEntryIds: number[];
     tariffComponentIds: number[];
@@ -104,18 +116,8 @@ export interface TariffRange {
     end?: number;
 }
 
-export interface CommodityTariffFeatures {
-    pricing: boolean;
-    friendlyCredit: boolean;
-    auxiliaryLoad: boolean;
-    peakPeriod: boolean;
-    powerThreshold: boolean;
-    randomization: boolean;
-}
-
 export interface CommodityTariffInfo {
     supported: boolean;
-    features: CommodityTariffFeatures;
     tariffInfo?: TariffInfo;
     tariffUnit?: string;
     startDate?: number;
@@ -123,49 +125,38 @@ export interface CommodityTariffInfo {
     nextComponent?: TariffComponentInfo;
     currentRange?: TariffRange;
     nextRange?: TariffRange;
+    todayType?: string;
+    tomorrowType?: string;
     todaySchedule: ScheduleRow[];
     tomorrowSchedule: ScheduleRow[];
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null;
-}
-
-/** Wire-format structs are field-tag keyed (e.g. `{"0": ..., "1": ...}`), not camelCase field names. */
-function field(value: unknown, tag: number): unknown {
-    return isRecord(value) ? value[String(tag)] : undefined;
 }
 
 function attr(attributes: Record<string, unknown>, endpoint: number, attributeId: number): unknown {
     return attributes[`${endpoint}/${COMMODITY_TARIFF_CLUSTER_ID}/${attributeId}`];
 }
 
-function numberOrUndefined(value: unknown): number | undefined {
-    return typeof value === "number" || typeof value === "bigint" ? Number(value) : undefined;
-}
-
-function stringOrUndefined(value: unknown): string | undefined {
-    return typeof value === "string" ? value : undefined;
-}
-
 function numberList(value: unknown): number[] {
     return Array.isArray(value)
-        ? value
-              .map(v => (typeof v === "number" || typeof v === "bigint" ? Number(v) : NaN))
-              .filter((v): v is number => Number.isFinite(v))
+        ? value.map(toNumber).filter((v): v is number => v !== undefined && Number.isFinite(v))
         : [];
 }
 
+function enumName(value: unknown, names: Record<number, string>): string | undefined {
+    const raw = toNumber(value);
+    if (raw === undefined) return undefined;
+    return names[raw] ?? `Unknown (${raw})`;
+}
+
 function decodeCurrency(value: unknown): CurrencyInfo | undefined {
-    const code = field(value, 0);
-    const decimalPoints = field(value, 1);
-    if (typeof code !== "number" || typeof decimalPoints !== "number") return undefined;
+    const code = toNumber(field(value, 0));
+    const decimalPoints = toNumber(field(value, 1));
+    if (code === undefined || decimalPoints === undefined) return undefined;
     return { code, decimalPoints, symbol: CURRENCY_SYMBOLS[code] };
 }
 
 /** Formats a raw tariff price integer using the currency's decimal point scale (e.g. 1579 @ 4dp -> "0.1579 €"). */
 export function formatPrice(price: unknown, currency: CurrencyInfo | undefined): string | undefined {
-    const raw = numberOrUndefined(price);
+    const raw = toNumber(price);
     if (raw === undefined) return undefined;
     const decimalPoints = currency?.decimalPoints ?? 0;
     const amount = (raw / 10 ** decimalPoints).toFixed(decimalPoints);
@@ -174,40 +165,36 @@ export function formatPrice(price: unknown, currency: CurrencyInfo | undefined):
 }
 
 function decodeTariffInfo(value: unknown): TariffInfo | undefined {
-    if (!isRecord(value)) return undefined;
-    const blockMode = field(value, 3);
+    const blockMode = toNumber(field(value, 3));
+    if (blockMode === undefined && field(value, 0) === undefined && field(value, 1) === undefined) return undefined;
     return {
-        label: stringOrUndefined(field(value, 0)),
-        providerName: stringOrUndefined(field(value, 1)),
+        label: toText(field(value, 0)),
+        providerName: toText(field(value, 1)),
         currency: decodeCurrency(field(value, 2)),
-        blockMode:
-            typeof blockMode === "number" ? (BLOCK_MODE_NAMES[blockMode] ?? `Unknown (${blockMode})`) : undefined,
-        blockModeDescription: typeof blockMode === "number" ? BLOCK_MODE_DESCRIPTIONS[blockMode] : undefined,
+        blockMode: enumName(blockMode, BLOCK_MODE_NAMES),
+        blockModeDescription: blockMode !== undefined ? BLOCK_MODE_DESCRIPTIONS[blockMode] : undefined,
     };
 }
 
 function decodeTariffPrice(value: unknown, currency: CurrencyInfo | undefined): TariffPriceInfo | undefined {
-    if (!isRecord(value)) return undefined;
-    const priceType = field(value, 0);
+    const priceType = toNumber(field(value, 0));
+    const price = field(value, 1);
+    if (priceType === undefined && price === undefined) return undefined;
     return {
-        priceType:
-            typeof priceType === "number"
-                ? (TARIFF_PRICE_TYPE_NAMES[priceType] ?? `Unknown (${priceType})`)
-                : "Unknown",
-        amount: formatPrice(field(value, 1), currency),
-        priceLevel: numberOrUndefined(field(value, 2)),
+        priceType: enumName(priceType, TARIFF_PRICE_TYPE_NAMES) ?? "Unknown",
+        amount: formatPrice(price, currency),
+        priceLevel: toNumber(field(value, 2)),
     };
 }
 
 function decodeTariffComponent(value: unknown, currency: CurrencyInfo | undefined): TariffComponentInfo | undefined {
-    if (!isRecord(value)) return undefined;
-    const id = field(value, 0);
-    if (typeof id !== "number") return undefined;
+    const id = toNumber(field(value, 0));
+    if (id === undefined) return undefined;
     return {
         id,
-        label: stringOrUndefined(field(value, 7)),
+        label: toText(field(value, 7)),
         price: decodeTariffPrice(field(value, 1), currency),
-        threshold: numberOrUndefined(field(value, 6)),
+        threshold: toNumber(field(value, 6)),
     };
 }
 
@@ -220,52 +207,104 @@ function decodeTariffComponents(value: unknown, currency: CurrencyInfo | undefin
 }
 
 function decodeDayEntry(value: unknown): DayEntryInfo | undefined {
-    const id = field(value, 0);
-    const startTime = field(value, 1);
-    if (typeof id !== "number" || typeof startTime !== "number") return undefined;
-    return { id, startMinutes: startTime, durationMinutes: numberOrUndefined(field(value, 2)) };
+    const id = toNumber(field(value, 0));
+    const startMinutes = toNumber(field(value, 1));
+    if (id === undefined || startMinutes === undefined) return undefined;
+    return { id, startMinutes, durationMinutes: toNumber(field(value, 2)) };
 }
 
 function decodeDayEntries(value: unknown): DayEntryInfo[] {
     return Array.isArray(value) ? value.map(decodeDayEntry).filter((e): e is DayEntryInfo => e !== undefined) : [];
 }
 
-function decodeTariffPeriod(value: unknown): TariffPeriodInfo | undefined {
-    if (!isRecord(value)) return undefined;
-    return {
-        label: stringOrUndefined(field(value, 0)),
-        dayEntryIds: numberList(field(value, 1)),
-        tariffComponentIds: numberList(field(value, 2)),
-    };
-}
-
 function decodeTariffPeriods(value: unknown): TariffPeriodInfo[] {
     return Array.isArray(value)
-        ? value.map(decodeTariffPeriod).filter((p): p is TariffPeriodInfo => p !== undefined)
+        ? value.map((entry, index) => ({
+              index,
+              label: toText(field(entry, 0)),
+              dayEntryIds: numberList(field(entry, 1)),
+              tariffComponentIds: numberList(field(entry, 2)),
+          }))
         : [];
 }
 
 function decodeDay(value: unknown): DayInfo | undefined {
-    if (!isRecord(value)) return undefined;
-    const dayType = field(value, 1);
-    return {
-        date: numberOrUndefined(field(value, 0)),
-        dayType: typeof dayType === "number" ? (DAY_TYPE_NAMES[dayType] ?? `Unknown (${dayType})`) : undefined,
-        dayEntryIds: numberList(field(value, 2)),
-    };
+    const dayEntryIds = numberList(field(value, 2));
+    const date = toNumber(field(value, 0));
+    const dayType = enumName(field(value, 1), DAY_TYPE_NAMES);
+    if (dayEntryIds.length === 0 && date === undefined && dayType === undefined) return undefined;
+    return { date, dayType, dayEntryIds };
 }
 
-/** CommodityTariff FeatureMap is a raw bitmap integer on the wire, not a named-boolean object. */
-function decodeFeatures(value: unknown): CommodityTariffFeatures {
-    const bits = typeof value === "number" ? value : 0;
-    return {
-        pricing: (bits & FEATURE_BITS.pricing) !== 0,
-        friendlyCredit: (bits & FEATURE_BITS.friendlyCredit) !== 0,
-        auxiliaryLoad: (bits & FEATURE_BITS.auxiliaryLoad) !== 0,
-        peakPeriod: (bits & FEATURE_BITS.peakPeriod) !== 0,
-        powerThreshold: (bits & FEATURE_BITS.powerThreshold) !== 0,
-        randomization: (bits & FEATURE_BITS.randomization) !== 0,
-    };
+/** The day's entries in time order; ids the DayEntries attribute doesn't describe are dropped. */
+function orderedDayEntries(day: DayInfo | undefined, dayEntries: DayEntryInfo[]): DayEntryInfo[] {
+    if (!day) return [];
+    return day.dayEntryIds
+        .map(id => dayEntries.find(entry => entry.id === id))
+        .filter((entry): entry is DayEntryInfo => entry !== undefined)
+        .sort((a, b) => a.startMinutes - b.startMinutes);
+}
+
+function periodOf(entryId: number, tariffPeriods: TariffPeriodInfo[]): TariffPeriodInfo | undefined {
+    return tariffPeriods.find(period => period.dayEntryIds.includes(entryId));
+}
+
+/** A period lists every component that applies to it (price, friendly credit, thresholds); price is what a panel shows. */
+function resolveComponent(
+    period: TariffPeriodInfo | undefined,
+    tariffComponents: TariffComponentInfo[],
+): TariffComponentInfo | undefined {
+    const candidates =
+        period?.tariffComponentIds
+            .map(id => tariffComponents.find(component => component.id === id))
+            .filter((component): component is TariffComponentInfo => component !== undefined) ?? [];
+    return candidates.find(component => component.price !== undefined) ?? candidates[0];
+}
+
+interface TimelineSlot {
+    entryId: number;
+    /** Minutes since the start of the timeline's first day, so a slot on the following day is >= 1440. */
+    startMinutes: number;
+    periodIndex?: number;
+}
+
+/**
+ * Lays consecutive days' entries onto one minute axis. A period active at day-end and resumed at day-start
+ * (e.g. an off-peak block spanning midnight) is modeled as two DayEntry records because DayEntry.startTime
+ * can't cross midnight, so spotting where a period really ends needs the following day's entries too.
+ */
+function buildTimeline(
+    days: (DayInfo | undefined)[],
+    dayEntries: DayEntryInfo[],
+    tariffPeriods: TariffPeriodInfo[],
+): TimelineSlot[] {
+    return days.flatMap((day, dayOffset) =>
+        orderedDayEntries(day, dayEntries).map(entry => ({
+            entryId: entry.id,
+            startMinutes: entry.startMinutes + dayOffset * MINUTES_PER_DAY,
+            periodIndex: periodOf(entry.id, tariffPeriods)?.index,
+        })),
+    );
+}
+
+function findSlot(timeline: TimelineSlot[], entryId: number, afterPosition: number): number {
+    return timeline.findIndex((slot, position) => position > afterPosition && slot.entryId === entryId);
+}
+
+/**
+ * Epoch seconds at which the period starting at `position` gives way to another one, or undefined when the
+ * timeline doesn't reach that far. Offsets are wall-clock minutes, so a DST change inside the range shifts
+ * the computed end by an hour.
+ */
+function rangeEnd(startEpochSeconds: number, timeline: TimelineSlot[], position: number): number | undefined {
+    const from = timeline[position];
+    if (from === undefined) return undefined;
+    for (const slot of timeline.slice(position + 1)) {
+        if (slot.periodIndex !== from.periodIndex) {
+            return startEpochSeconds + (slot.startMinutes - from.startMinutes) * 60;
+        }
+    }
+    return undefined;
 }
 
 /** Resolves a day's entry ids into time-ordered rows, each showing the period label and price active during it. */
@@ -275,76 +314,27 @@ function buildDailySchedule(
     tariffPeriods: TariffPeriodInfo[],
     tariffComponents: TariffComponentInfo[],
 ): ScheduleRow[] {
-    if (!day) return [];
-    const entries = day.dayEntryIds
-        .map(id => dayEntries.find(entry => entry.id === id))
-        .filter((entry): entry is DayEntryInfo => entry !== undefined)
-        .sort((a, b) => a.startMinutes - b.startMinutes);
-
+    const entries = orderedDayEntries(day, dayEntries);
     return entries.map((entry, index) => {
-        const next = entries[index + 1];
-        const endMinutes =
-            entry.durationMinutes !== undefined
-                ? Math.min(entry.startMinutes + entry.durationMinutes, 24 * 60)
-                : next
-                  ? next.startMinutes
-                  : 24 * 60;
-        const period = tariffPeriods.find(p => p.dayEntryIds.includes(entry.id));
-        const component = tariffComponents.find(c => c.id === period?.tariffComponentIds[0]);
+        const nextStart = entries[index + 1]?.startMinutes ?? MINUTES_PER_DAY;
+        const period = periodOf(entry.id, tariffPeriods);
+        const component = resolveComponent(period, tariffComponents);
         return {
             entryId: entry.id,
             startMinutes: entry.startMinutes,
-            endMinutes,
+            endMinutes:
+                entry.durationMinutes !== undefined
+                    ? Math.min(entry.startMinutes + entry.durationMinutes, nextStart)
+                    : nextStart,
             label: period?.label ?? component?.label,
             price: component?.price,
         };
     });
 }
 
-function resolveEntryPeriod(
-    entryId: number,
-    tariffPeriods: TariffPeriodInfo[],
-    tariffComponents: TariffComponentInfo[],
-): { label?: string; componentId?: number } {
-    const period = tariffPeriods.find(p => p.dayEntryIds.includes(entryId));
-    const componentId = period?.tariffComponentIds[0];
-    return { label: period?.label ?? tariffComponents.find(c => c.id === componentId)?.label, componentId };
-}
-
-/**
- * A period active at day-end and resumed at day-start (e.g. an off-peak block spanning midnight) is
- * modeled as two separate DayEntry records because DayEntry.startTime can't cross midnight. Finds when
- * `fromEntryId`'s period actually ends by walking the daily entry cycle forward (wrapping past midnight)
- * until the resolved period changes; returns the offset in minutes from `fromEntryId`'s own start, or
- * undefined if the cycle never changes period (e.g. a single entry, or all entries share one period).
- */
-function minutesUntilNextTransition(
-    fromEntryId: number,
-    dayEntries: DayEntryInfo[],
-    tariffPeriods: TariffPeriodInfo[],
-    tariffComponents: TariffComponentInfo[],
-): number | undefined {
-    if (dayEntries.length < 2) return undefined;
-    const sorted = [...dayEntries].sort((a, b) => a.startMinutes - b.startMinutes);
-    const fromIndex = sorted.findIndex(entry => entry.id === fromEntryId);
-    if (fromIndex === -1) return undefined;
-    const fromPeriod = resolveEntryPeriod(fromEntryId, tariffPeriods, tariffComponents);
-
-    for (let step = 1; step <= sorted.length; step++) {
-        const position = fromIndex + step;
-        const entry = sorted[position % sorted.length];
-        const period = resolveEntryPeriod(entry.id, tariffPeriods, tariffComponents);
-        if (period.label !== fromPeriod.label || period.componentId !== fromPeriod.componentId) {
-            const wraps = Math.floor(position / sorted.length);
-            return entry.startMinutes + wraps * 24 * 60 - sorted[fromIndex].startMinutes;
-        }
-    }
-    return undefined;
-}
-
 /** Formats minutes-since-midnight as "HH:MM"; 1440 (end of day) renders as "24:00". */
 export function formatMinutesOfDay(minutes: number): string {
-    if (minutes >= 24 * 60) return "24:00";
+    if (minutes >= MINUTES_PER_DAY) return "24:00";
     const hours = Math.floor(minutes / 60);
     const mins = minutes % 60;
     return `${String(hours).padStart(2, "0")}:${String(mins).padStart(2, "0")}`;
@@ -362,55 +352,46 @@ export function formatEpochTime(matterEpochSeconds: number, relativeTo: Date = n
 }
 
 export function commodityTariffInfo(attributes: Record<string, unknown>, endpoint: number): CommodityTariffInfo {
-    const featureMap = attr(attributes, endpoint, 65532);
-    const tariffInfo = decodeTariffInfo(attr(attributes, endpoint, 0));
+    const featureMap = attr(attributes, endpoint, ATTR_FEATURE_MAP);
+    const tariffInfo = decodeTariffInfo(attr(attributes, endpoint, ATTR_TARIFF_INFO));
     const currency = tariffInfo?.currency;
-    const tariffUnitRaw = attr(attributes, endpoint, 1);
-    const dayEntries = decodeDayEntries(attr(attributes, endpoint, 3));
-    const tariffPeriods = decodeTariffPeriods(attr(attributes, endpoint, 14));
-    const tariffComponents = decodeTariffComponents(attr(attributes, endpoint, 13), currency);
-    const currentComponents = decodeTariffComponents(attr(attributes, endpoint, 15), currency);
-    const nextComponents = decodeTariffComponents(attr(attributes, endpoint, 16), currency);
-    const currentDayEntryDate = numberOrUndefined(attr(attributes, endpoint, 10));
-    const nextDayEntryDate = numberOrUndefined(attr(attributes, endpoint, 12));
-    const nextDayEntry = decodeDayEntry(attr(attributes, endpoint, 11));
-    const nextEndOffsetMinutes =
-        nextDayEntry !== undefined
-            ? minutesUntilNextTransition(nextDayEntry.id, dayEntries, tariffPeriods, tariffComponents)
-            : undefined;
+    const dayEntries = decodeDayEntries(attr(attributes, endpoint, ATTR_DAY_ENTRIES));
+    const tariffPeriods = decodeTariffPeriods(attr(attributes, endpoint, ATTR_TARIFF_PERIODS));
+    const tariffComponents = decodeTariffComponents(attr(attributes, endpoint, ATTR_TARIFF_COMPONENTS), currency);
+    const currentComponents = decodeTariffComponents(
+        attr(attributes, endpoint, ATTR_CURRENT_TARIFF_COMPONENTS),
+        currency,
+    );
+    const nextComponents = decodeTariffComponents(attr(attributes, endpoint, ATTR_NEXT_TARIFF_COMPONENTS), currency);
+    const today = decodeDay(attr(attributes, endpoint, ATTR_CURRENT_DAY));
+    const tomorrow = decodeDay(attr(attributes, endpoint, ATTR_NEXT_DAY));
+
+    const timeline = buildTimeline([today, tomorrow], dayEntries, tariffPeriods);
+    const currentDayEntry = decodeDayEntry(attr(attributes, endpoint, ATTR_CURRENT_DAY_ENTRY));
+    const currentPosition = currentDayEntry !== undefined ? findSlot(timeline, currentDayEntry.id, -1) : -1;
+    const nextDayEntry = decodeDayEntry(attr(attributes, endpoint, ATTR_NEXT_DAY_ENTRY));
+    const nextPosition = nextDayEntry !== undefined ? findSlot(timeline, nextDayEntry.id, currentPosition) : -1;
+    const currentDayEntryDate = toNumber(attr(attributes, endpoint, ATTR_CURRENT_DAY_ENTRY_DATE));
+    const nextDayEntryDate = toNumber(attr(attributes, endpoint, ATTR_NEXT_DAY_ENTRY_DATE));
 
     return {
         supported: featureMap !== undefined,
-        features: decodeFeatures(featureMap),
         tariffInfo,
-        tariffUnit:
-            typeof tariffUnitRaw === "number"
-                ? (TARIFF_UNIT_NAMES[tariffUnitRaw] ?? `Unknown (${tariffUnitRaw})`)
-                : undefined,
-        startDate: numberOrUndefined(attr(attributes, endpoint, 2)),
+        tariffUnit: enumName(attr(attributes, endpoint, ATTR_TARIFF_UNIT), TARIFF_UNIT_NAMES),
+        startDate: toNumber(attr(attributes, endpoint, ATTR_START_DATE)),
         currentComponent: currentComponents[0],
         nextComponent: nextComponents[0],
         currentRange:
-            currentDayEntryDate !== undefined ? { start: currentDayEntryDate, end: nextDayEntryDate } : undefined,
+            currentDayEntryDate !== undefined
+                ? { start: currentDayEntryDate, end: rangeEnd(currentDayEntryDate, timeline, currentPosition) }
+                : undefined,
         nextRange:
             nextDayEntryDate !== undefined
-                ? {
-                      start: nextDayEntryDate,
-                      end:
-                          nextEndOffsetMinutes !== undefined ? nextDayEntryDate + nextEndOffsetMinutes * 60 : undefined,
-                  }
+                ? { start: nextDayEntryDate, end: rangeEnd(nextDayEntryDate, timeline, nextPosition) }
                 : undefined,
-        todaySchedule: buildDailySchedule(
-            decodeDay(attr(attributes, endpoint, 7)),
-            dayEntries,
-            tariffPeriods,
-            tariffComponents,
-        ),
-        tomorrowSchedule: buildDailySchedule(
-            decodeDay(attr(attributes, endpoint, 8)),
-            dayEntries,
-            tariffPeriods,
-            tariffComponents,
-        ),
+        todayType: today?.dayType,
+        tomorrowType: tomorrow?.dayType,
+        todaySchedule: buildDailySchedule(today, dayEntries, tariffPeriods, tariffComponents),
+        tomorrowSchedule: buildDailySchedule(tomorrow, dayEntries, tariffPeriods, tariffComponents),
     };
 }

--- a/packages/dashboard/src/util/commodity-tariff.ts
+++ b/packages/dashboard/src/util/commodity-tariff.ts
@@ -26,6 +26,12 @@ const ATTR_FEATURE_MAP = 0xfffc;
 
 const MINUTES_PER_DAY = 24 * 60;
 
+/** DayEntry.StartTime reaches 1499: Matter's day axis carries the extra hour of a DST fall-back day. */
+const MAX_DAY_MINUTES = 1500;
+
+/** ISO 4217 allows at most 4 minor units; toFixed rejects more than 100 digits. */
+const MAX_DECIMAL_POINTS = 6;
+
 const BLOCK_MODE_NAMES: Record<number, string> = {
     0: "No usage blocks",
     1: "Combined usage blocks",
@@ -151,22 +157,25 @@ function decodeCurrency(value: unknown): CurrencyInfo | undefined {
     const code = toNumber(field(value, 0));
     const decimalPoints = toNumber(field(value, 1));
     if (code === undefined || decimalPoints === undefined) return undefined;
+    if (decimalPoints < 0 || decimalPoints > MAX_DECIMAL_POINTS) return undefined;
     return { code, decimalPoints, symbol: CURRENCY_SYMBOLS[code] };
 }
 
-/** Formats a raw tariff price integer using the currency's decimal point scale (e.g. 1579 @ 4dp -> "0.1579 €"). */
+/**
+ * Formats a raw tariff price integer using the currency's decimal point scale (e.g. 1579 @ 4dp -> "0.1579 €").
+ * Without a currency the scale is unknown, and a raw integer would read as a price it is not.
+ */
 export function formatPrice(price: unknown, currency: CurrencyInfo | undefined): string | undefined {
     const raw = toNumber(price);
-    if (raw === undefined) return undefined;
-    const decimalPoints = currency?.decimalPoints ?? 0;
-    const amount = (raw / 10 ** decimalPoints).toFixed(decimalPoints);
-    if (!currency) return amount;
+    if (raw === undefined || currency === undefined) return undefined;
+    const amount = (raw / 10 ** currency.decimalPoints).toFixed(currency.decimalPoints);
     return currency.symbol ? `${amount} ${currency.symbol}` : `${amount} (ISO 4217 #${currency.code})`;
 }
 
 function decodeTariffInfo(value: unknown): TariffInfo | undefined {
     const blockMode = toNumber(field(value, 3));
-    if (blockMode === undefined && field(value, 0) === undefined && field(value, 1) === undefined) return undefined;
+    const present = [0, 1, 2].some(tag => field(value, tag) !== undefined) || blockMode !== undefined;
+    if (!present) return undefined;
     return {
         label: toText(field(value, 0)),
         providerName: toText(field(value, 1)),
@@ -245,27 +254,40 @@ function orderedDayEntries(day: DayInfo | undefined, dayEntries: DayEntryInfo[])
         .sort((a, b) => a.startMinutes - b.startMinutes);
 }
 
-function periodOf(entryId: number, tariffPeriods: TariffPeriodInfo[]): TariffPeriodInfo | undefined {
-    return tariffPeriods.find(period => period.dayEntryIds.includes(entryId));
+/** A day entry may appear in several periods, each contributing its own components. */
+function periodsOf(entryId: number, tariffPeriods: TariffPeriodInfo[]): TariffPeriodInfo[] {
+    return tariffPeriods.filter(period => period.dayEntryIds.includes(entryId));
 }
 
-/** A period lists every component that applies to it (price, friendly credit, thresholds); price is what a panel shows. */
+/** Periods list every component that applies (price, friendly credit, thresholds); price is what a panel shows. */
 function resolveComponent(
-    period: TariffPeriodInfo | undefined,
+    periods: TariffPeriodInfo[],
     tariffComponents: TariffComponentInfo[],
 ): TariffComponentInfo | undefined {
-    const candidates =
-        period?.tariffComponentIds
-            .map(id => tariffComponents.find(component => component.id === id))
-            .filter((component): component is TariffComponentInfo => component !== undefined) ?? [];
-    return candidates.find(component => component.price !== undefined) ?? candidates[0];
+    const ids = new Set(periods.flatMap(period => period.tariffComponentIds));
+    return pickPricedComponent(tariffComponents.filter(component => ids.has(component.id)));
+}
+
+function pickPricedComponent(components: TariffComponentInfo[]): TariffComponentInfo | undefined {
+    return components.find(component => component.price !== undefined) ?? components[0];
+}
+
+/** The set of periods an entry belongs to, since one period changing is what starts a new price range. */
+function periodKey(periods: TariffPeriodInfo[]): string | undefined {
+    return periods.length > 0 ? periods.map(period => period.index).join(",") : undefined;
+}
+
+/** A day that uses the 25th hour spans further than midnight. */
+function daySpanMinutes(entries: DayEntryInfo[]): number {
+    const lastStart = entries[entries.length - 1]?.startMinutes ?? 0;
+    return lastStart >= MINUTES_PER_DAY ? MAX_DAY_MINUTES : MINUTES_PER_DAY;
 }
 
 interface TimelineSlot {
     entryId: number;
-    /** Minutes since the start of the timeline's first day, so a slot on the following day is >= 1440. */
+    /** Minutes since the start of the timeline's first day, so a slot on the following day is >= that day's span. */
     startMinutes: number;
-    periodIndex?: number;
+    periodKey?: string;
 }
 
 /**
@@ -278,13 +300,20 @@ function buildTimeline(
     dayEntries: DayEntryInfo[],
     tariffPeriods: TariffPeriodInfo[],
 ): TimelineSlot[] {
-    return days.flatMap((day, dayOffset) =>
-        orderedDayEntries(day, dayEntries).map(entry => ({
-            entryId: entry.id,
-            startMinutes: entry.startMinutes + dayOffset * MINUTES_PER_DAY,
-            periodIndex: periodOf(entry.id, tariffPeriods)?.index,
-        })),
-    );
+    const timeline = new Array<TimelineSlot>();
+    let dayStartMinutes = 0;
+    for (const day of days) {
+        const entries = orderedDayEntries(day, dayEntries);
+        for (const entry of entries) {
+            timeline.push({
+                entryId: entry.id,
+                startMinutes: entry.startMinutes + dayStartMinutes,
+                periodKey: periodKey(periodsOf(entry.id, tariffPeriods)),
+            });
+        }
+        dayStartMinutes += daySpanMinutes(entries);
+    }
+    return timeline;
 }
 
 function findSlot(timeline: TimelineSlot[], entryId: number, afterPosition: number): number {
@@ -300,7 +329,8 @@ function rangeEnd(startEpochSeconds: number, timeline: TimelineSlot[], position:
     const from = timeline[position];
     if (from === undefined) return undefined;
     for (const slot of timeline.slice(position + 1)) {
-        if (slot.periodIndex !== from.periodIndex) {
+        if (slot.startMinutes <= from.startMinutes) continue;
+        if (slot.periodKey !== from.periodKey) {
             return startEpochSeconds + (slot.startMinutes - from.startMinutes) * 60;
         }
     }
@@ -315,26 +345,26 @@ function buildDailySchedule(
     tariffComponents: TariffComponentInfo[],
 ): ScheduleRow[] {
     const entries = orderedDayEntries(day, dayEntries);
+    const dayEnd = daySpanMinutes(entries);
     return entries.map((entry, index) => {
-        const nextStart = entries[index + 1]?.startMinutes ?? MINUTES_PER_DAY;
-        const period = periodOf(entry.id, tariffPeriods);
-        const component = resolveComponent(period, tariffComponents);
+        const nextStart = entries[index + 1]?.startMinutes ?? dayEnd;
+        const periods = periodsOf(entry.id, tariffPeriods);
+        const component = resolveComponent(periods, tariffComponents);
         return {
             entryId: entry.id,
             startMinutes: entry.startMinutes,
             endMinutes:
                 entry.durationMinutes !== undefined
-                    ? Math.min(entry.startMinutes + entry.durationMinutes, nextStart)
-                    : nextStart,
-            label: period?.label ?? component?.label,
+                    ? Math.min(entry.startMinutes + entry.durationMinutes, Math.max(nextStart, entry.startMinutes))
+                    : Math.max(nextStart, entry.startMinutes),
+            label: periods.find(period => period.label !== undefined)?.label ?? component?.label,
             price: component?.price,
         };
     });
 }
 
-/** Formats minutes-since-midnight as "HH:MM"; 1440 (end of day) renders as "24:00". */
+/** Formats minutes on Matter's day axis as "HH:MM"; the hours past midnight of a 25-hour day read as 24:xx. */
 export function formatMinutesOfDay(minutes: number): string {
-    if (minutes >= MINUTES_PER_DAY) return "24:00";
     const hours = Math.floor(minutes / 60);
     const mins = minutes % 60;
     return `${String(hours).padStart(2, "0")}:${String(mins).padStart(2, "0")}`;
@@ -348,7 +378,11 @@ export function formatEpochTime(matterEpochSeconds: number, relativeTo: Date = n
     const tomorrow = new Date(relativeTo);
     tomorrow.setDate(tomorrow.getDate() + 1);
     if (date.toDateString() === tomorrow.toDateString()) return `tomorrow ${time}`;
-    return `${date.toLocaleDateString(undefined, { month: "2-digit", day: "2-digit" })} ${time}`;
+    const dateOptions: Intl.DateTimeFormatOptions =
+        date.getFullYear() === relativeTo.getFullYear()
+            ? { month: "2-digit", day: "2-digit" }
+            : { year: "numeric", month: "2-digit", day: "2-digit" };
+    return `${date.toLocaleDateString(undefined, dateOptions)} ${time}`;
 }
 
 export function commodityTariffInfo(attributes: Record<string, unknown>, endpoint: number): CommodityTariffInfo {
@@ -379,8 +413,8 @@ export function commodityTariffInfo(attributes: Record<string, unknown>, endpoin
         tariffInfo,
         tariffUnit: enumName(attr(attributes, endpoint, ATTR_TARIFF_UNIT), TARIFF_UNIT_NAMES),
         startDate: toNumber(attr(attributes, endpoint, ATTR_START_DATE)),
-        currentComponent: currentComponents[0],
-        nextComponent: nextComponents[0],
+        currentComponent: pickPricedComponent(currentComponents),
+        nextComponent: pickPricedComponent(nextComponents),
         currentRange:
             currentDayEntryDate !== undefined
                 ? { start: currentDayEntryDate, end: rangeEnd(currentDayEntryDate, timeline, currentPosition) }

--- a/packages/dashboard/src/util/meter-identification.ts
+++ b/packages/dashboard/src/util/meter-identification.ts
@@ -77,15 +77,14 @@ export function meterIdentificationInfo(
     endpoint: number,
 ): MeterIdentificationInfo {
     const featureMap = attr(attributes, endpoint, 65532);
-    const powerThresholdSupported = typeof featureMap === "number" && (featureMap & POWER_THRESHOLD_FEATURE_BIT) !== 0;
-    const meterTypeRaw = attr(attributes, endpoint, 0);
+    const featureBits = numberOrUndefined(featureMap) ?? 0;
+    const powerThresholdSupported = (featureBits & POWER_THRESHOLD_FEATURE_BIT) !== 0;
+    const meterTypeRaw = numberOrUndefined(attr(attributes, endpoint, 0));
 
     return {
         supported: featureMap !== undefined,
         meterType:
-            typeof meterTypeRaw === "number"
-                ? (METER_TYPE_NAMES[meterTypeRaw] ?? `Unknown (${meterTypeRaw})`)
-                : undefined,
+            meterTypeRaw !== undefined ? (METER_TYPE_NAMES[meterTypeRaw] ?? `Unknown (${meterTypeRaw})`) : undefined,
         pointOfDelivery: stringAttr(attributes, endpoint, 1),
         meterSerialNumber: stringAttr(attributes, endpoint, 2),
         protocolVersion: stringAttr(attributes, endpoint, 3),

--- a/packages/dashboard/src/util/meter-identification.ts
+++ b/packages/dashboard/src/util/meter-identification.ts
@@ -4,7 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { tagField as field, toNumber, toText } from "./attribute-shapes.js";
+
 export const METER_IDENTIFICATION_CLUSTER_ID = 2822;
+
+const ATTR_METER_TYPE = 0;
+const ATTR_POINT_OF_DELIVERY = 1;
+const ATTR_METER_SERIAL_NUMBER = 2;
+const ATTR_PROTOCOL_VERSION = 3;
+const ATTR_POWER_THRESHOLD = 4;
+const ATTR_FEATURE_MAP = 0xfffc;
 
 const METER_TYPE_NAMES: Record<number, string> = {
     0: "Utility",
@@ -37,38 +46,25 @@ export interface MeterIdentificationInfo {
     powerThreshold?: PowerThresholdInfo;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === "object" && value !== null;
-}
-
-/** Wire-format structs are field-tag keyed (e.g. `{"0": ..., "1": ...}`), not camelCase field names. */
-function field(value: unknown, tag: number): unknown {
-    return isRecord(value) ? value[String(tag)] : undefined;
-}
-
 function attr(attributes: Record<string, unknown>, endpoint: number, attributeId: number): unknown {
     return attributes[`${endpoint}/${METER_IDENTIFICATION_CLUSTER_ID}/${attributeId}`];
 }
 
-function stringAttr(attributes: Record<string, unknown>, endpoint: number, attributeId: number): string | undefined {
-    const value = attr(attributes, endpoint, attributeId);
-    return typeof value === "string" ? value : undefined;
-}
-
-function numberOrUndefined(value: unknown): number | undefined {
-    return typeof value === "number" || typeof value === "bigint" ? Number(value) : undefined;
+function enumName(value: unknown, names: Record<number, string>): string | undefined {
+    const raw = toNumber(value);
+    if (raw === undefined) return undefined;
+    return names[raw] ?? `Unknown (${raw})`;
 }
 
 function decodePowerThreshold(value: unknown): PowerThresholdInfo | undefined {
-    if (!isRecord(value)) return undefined;
-    const powerThreshold = numberOrUndefined(field(value, 0));
-    const apparentPowerThreshold = numberOrUndefined(field(value, 1));
-    const source = field(value, 2);
+    const powerThreshold = toNumber(field(value, 0));
+    const apparentPowerThreshold = toNumber(field(value, 1));
+    const source = enumName(field(value, 2), POWER_THRESHOLD_SOURCE_NAMES);
+    if (powerThreshold === undefined && apparentPowerThreshold === undefined && source === undefined) return undefined;
     return {
         powerThresholdW: powerThreshold !== undefined ? powerThreshold / 1000 : undefined,
         apparentPowerThresholdVA: apparentPowerThreshold !== undefined ? apparentPowerThreshold / 1000 : undefined,
-        source:
-            typeof source === "number" ? (POWER_THRESHOLD_SOURCE_NAMES[source] ?? `Unknown (${source})`) : undefined,
+        source,
     };
 }
 
@@ -76,19 +72,15 @@ export function meterIdentificationInfo(
     attributes: Record<string, unknown>,
     endpoint: number,
 ): MeterIdentificationInfo {
-    const featureMap = attr(attributes, endpoint, 65532);
-    const featureBits = numberOrUndefined(featureMap) ?? 0;
-    const powerThresholdSupported = (featureBits & POWER_THRESHOLD_FEATURE_BIT) !== 0;
-    const meterTypeRaw = numberOrUndefined(attr(attributes, endpoint, 0));
+    const featureMap = attr(attributes, endpoint, ATTR_FEATURE_MAP);
 
     return {
         supported: featureMap !== undefined,
-        meterType:
-            meterTypeRaw !== undefined ? (METER_TYPE_NAMES[meterTypeRaw] ?? `Unknown (${meterTypeRaw})`) : undefined,
-        pointOfDelivery: stringAttr(attributes, endpoint, 1),
-        meterSerialNumber: stringAttr(attributes, endpoint, 2),
-        protocolVersion: stringAttr(attributes, endpoint, 3),
-        powerThresholdSupported,
-        powerThreshold: decodePowerThreshold(attr(attributes, endpoint, 4)),
+        meterType: enumName(attr(attributes, endpoint, ATTR_METER_TYPE), METER_TYPE_NAMES),
+        pointOfDelivery: toText(attr(attributes, endpoint, ATTR_POINT_OF_DELIVERY)),
+        meterSerialNumber: toText(attr(attributes, endpoint, ATTR_METER_SERIAL_NUMBER)),
+        protocolVersion: toText(attr(attributes, endpoint, ATTR_PROTOCOL_VERSION)),
+        powerThresholdSupported: ((toNumber(featureMap) ?? 0) & POWER_THRESHOLD_FEATURE_BIT) !== 0,
+        powerThreshold: decodePowerThreshold(attr(attributes, endpoint, ATTR_POWER_THRESHOLD)),
     };
 }

--- a/packages/dashboard/src/util/meter-identification.ts
+++ b/packages/dashboard/src/util/meter-identification.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const METER_IDENTIFICATION_CLUSTER_ID = 2822;
+
+const METER_TYPE_NAMES: Record<number, string> = {
+    0: "Utility",
+    1: "Private",
+    2: "Generic",
+};
+
+const POWER_THRESHOLD_SOURCE_NAMES: Record<number, string> = {
+    0: "Contract",
+    1: "Legal regulator",
+    2: "Meter equipment limit",
+};
+
+/** MeterIdentification FeatureMap bits per Matter 1.6 §2.13.4. */
+const POWER_THRESHOLD_FEATURE_BIT = 0b1;
+
+export interface PowerThresholdInfo {
+    powerThresholdW?: number;
+    apparentPowerThresholdVA?: number;
+    source?: string;
+}
+
+export interface MeterIdentificationInfo {
+    supported: boolean;
+    meterType?: string;
+    pointOfDelivery?: string;
+    meterSerialNumber?: string;
+    protocolVersion?: string;
+    powerThresholdSupported: boolean;
+    powerThreshold?: PowerThresholdInfo;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+/** Wire-format structs are field-tag keyed (e.g. `{"0": ..., "1": ...}`), not camelCase field names. */
+function field(value: unknown, tag: number): unknown {
+    return isRecord(value) ? value[String(tag)] : undefined;
+}
+
+function attr(attributes: Record<string, unknown>, endpoint: number, attributeId: number): unknown {
+    return attributes[`${endpoint}/${METER_IDENTIFICATION_CLUSTER_ID}/${attributeId}`];
+}
+
+function stringAttr(attributes: Record<string, unknown>, endpoint: number, attributeId: number): string | undefined {
+    const value = attr(attributes, endpoint, attributeId);
+    return typeof value === "string" ? value : undefined;
+}
+
+function numberOrUndefined(value: unknown): number | undefined {
+    return typeof value === "number" || typeof value === "bigint" ? Number(value) : undefined;
+}
+
+function decodePowerThreshold(value: unknown): PowerThresholdInfo | undefined {
+    if (!isRecord(value)) return undefined;
+    const powerThreshold = numberOrUndefined(field(value, 0));
+    const apparentPowerThreshold = numberOrUndefined(field(value, 1));
+    const source = field(value, 2);
+    return {
+        powerThresholdW: powerThreshold !== undefined ? powerThreshold / 1000 : undefined,
+        apparentPowerThresholdVA: apparentPowerThreshold !== undefined ? apparentPowerThreshold / 1000 : undefined,
+        source:
+            typeof source === "number" ? (POWER_THRESHOLD_SOURCE_NAMES[source] ?? `Unknown (${source})`) : undefined,
+    };
+}
+
+export function meterIdentificationInfo(
+    attributes: Record<string, unknown>,
+    endpoint: number,
+): MeterIdentificationInfo {
+    const featureMap = attr(attributes, endpoint, 65532);
+    const powerThresholdSupported = typeof featureMap === "number" && (featureMap & POWER_THRESHOLD_FEATURE_BIT) !== 0;
+    const meterTypeRaw = attr(attributes, endpoint, 0);
+
+    return {
+        supported: featureMap !== undefined,
+        meterType:
+            typeof meterTypeRaw === "number"
+                ? (METER_TYPE_NAMES[meterTypeRaw] ?? `Unknown (${meterTypeRaw})`)
+                : undefined,
+        pointOfDelivery: stringAttr(attributes, endpoint, 1),
+        meterSerialNumber: stringAttr(attributes, endpoint, 2),
+        protocolVersion: stringAttr(attributes, endpoint, 3),
+        powerThresholdSupported,
+        powerThreshold: decodePowerThreshold(attr(attributes, endpoint, 4)),
+    };
+}

--- a/packages/dashboard/test/ClusterCommandsRegistryTest.ts
+++ b/packages/dashboard/test/ClusterCommandsRegistryTest.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    getClusterCommandsTag,
+    hasClusterCommands,
+    registerClusterCommands,
+    rendersClusterCommandsWhenOffline,
+} from "../src/pages/cluster-commands/registry.js";
+
+/** Out of the Matter cluster id range, so the real panel registrations stay untouched. */
+const ONLINE_ONLY_CLUSTER = 0xf000_0001;
+const OFFLINE_CAPABLE_CLUSTER = 0xf000_0002;
+
+describe("cluster commands registry", () => {
+    before(() => {
+        registerClusterCommands(ONLINE_ONLY_CLUSTER, "online-only-cluster-commands");
+        registerClusterCommands(OFFLINE_CAPABLE_CLUSTER, "offline-capable-cluster-commands", {
+            renderWhenOffline: true,
+        });
+    });
+
+    it("resolves a registered panel's tag name", () => {
+        expect(getClusterCommandsTag(ONLINE_ONLY_CLUSTER)).to.equal("online-only-cluster-commands");
+        expect(hasClusterCommands(ONLINE_ONLY_CLUSTER)).to.equal(true);
+    });
+
+    it("reports nothing for a cluster without a panel", () => {
+        expect(getClusterCommandsTag(0xf000_00ff)).to.equal(undefined);
+        expect(hasClusterCommands(0xf000_00ff)).to.equal(false);
+        expect(rendersClusterCommandsWhenOffline(0xf000_00ff)).to.equal(false);
+    });
+
+    it("hides a panel offline unless it declares otherwise", () => {
+        expect(rendersClusterCommandsWhenOffline(ONLINE_ONLY_CLUSTER)).to.equal(false);
+        expect(rendersClusterCommandsWhenOffline(OFFLINE_CAPABLE_CLUSTER)).to.equal(true);
+    });
+
+    it("replaces a re-registered panel wholesale, dropping its previous options", () => {
+        registerClusterCommands(OFFLINE_CAPABLE_CLUSTER, "replacement-cluster-commands");
+        expect(getClusterCommandsTag(OFFLINE_CAPABLE_CLUSTER)).to.equal("replacement-cluster-commands");
+        expect(rendersClusterCommandsWhenOffline(OFFLINE_CAPABLE_CLUSTER)).to.equal(false);
+    });
+});

--- a/packages/dashboard/test/CommodityTariffUtilTest.ts
+++ b/packages/dashboard/test/CommodityTariffUtilTest.ts
@@ -100,6 +100,9 @@ describe("commodity tariff util", () => {
         it("is absent without a currency, since the scale is then unknown", () => {
             expect(formatPrice(1579, undefined)).to.equal(undefined);
         });
+        it("is absent for a money value no number can hold exactly", () => {
+            expect(formatPrice(9_007_199_254_740_993n, EUR)).to.equal(undefined);
+        });
     });
 
     describe("formatMinutesOfDay", () => {

--- a/packages/dashboard/test/CommodityTariffUtilTest.ts
+++ b/packages/dashboard/test/CommodityTariffUtilTest.ts
@@ -44,8 +44,10 @@ const TARIFF_COMPONENTS = [
 
 const DAY_ENTRY_IDS = [1, 2, 4, 3];
 
-/** 2026-08-05 07:00 UTC, day entry 2 active, day entry 4 (12:00) next. */
-const CURRENT_DAY_ENTRY_DATE = 838_339_200;
+/** Matter epoch-s midnight the CurrentDay struct reports; entry start times are offsets from it. */
+const TODAY_DATE = 838_339_200;
+/** Day entry 2 (07:00) is active, day entry 4 (12:00) comes next. */
+const CURRENT_DAY_ENTRY_DATE = TODAY_DATE + 420 * 60;
 const NEXT_DAY_ENTRY_DATE = CURRENT_DAY_ENTRY_DATE + 5 * 3600;
 /** The period the 22:00 off-peak entry starts ends at 07:00 the following day. */
 const OFF_PEAK_START = CURRENT_DAY_ENTRY_DATE + 15 * 3600;
@@ -55,8 +57,8 @@ const TARIFF_ATTRS: Record<string, unknown> = {
     "1/1792/1": 0, // TariffUnit kWh
     "1/1792/2": 820_454_400, // StartDate
     "1/1792/3": DAY_ENTRIES,
-    "1/1792/7": { "0": 838_339_200, "1": 0, "2": DAY_ENTRY_IDS }, // CurrentDay, Standard
-    "1/1792/8": { "0": 838_425_600, "1": 1, "2": DAY_ENTRY_IDS }, // NextDay, Holiday
+    "1/1792/7": { "0": TODAY_DATE, "1": 0, "2": DAY_ENTRY_IDS }, // CurrentDay, Standard
+    "1/1792/8": { "0": TODAY_DATE + 86_400, "1": 1, "2": DAY_ENTRY_IDS }, // NextDay, Holiday
     "1/1792/9": { "0": 2, "1": 420 }, // CurrentDayEntry
     "1/1792/10": CURRENT_DAY_ENTRY_DATE,
     "1/1792/11": { "0": 4, "1": 720 }, // NextDayEntry
@@ -95,6 +97,9 @@ describe("commodity tariff util", () => {
         it("is absent without a price", () => {
             expect(formatPrice(undefined, EUR)).to.equal(undefined);
         });
+        it("is absent without a currency, since the scale is then unknown", () => {
+            expect(formatPrice(1579, undefined)).to.equal(undefined);
+        });
     });
 
     describe("formatMinutesOfDay", () => {
@@ -104,22 +109,48 @@ describe("commodity tariff util", () => {
         it("renders end of day as 24:00", () => {
             expect(formatMinutesOfDay(1440)).to.equal("24:00");
         });
+        it("keeps the 25th hour of a DST fall-back day readable", () => {
+            expect(formatMinutesOfDay(1470)).to.equal("24:30");
+        });
     });
 
     describe("formatEpochTime", () => {
-        it("omits the date for the same day", () => {
-            const now = new Date((CURRENT_DAY_ENTRY_DATE + MATTER_EPOCH_OFFSET_SECONDS) * 1000);
-            expect(formatEpochTime(CURRENT_DAY_ENTRY_DATE, now)).to.not.contain("tomorrow");
-            expect(formatEpochTime(CURRENT_DAY_ENTRY_DATE, now)).to.match(/^\d{1,2}[.:]\d{2}/);
+        const localTime = (matterEpochSeconds: number) =>
+            new Date((matterEpochSeconds + MATTER_EPOCH_OFFSET_SECONDS) * 1000).toLocaleTimeString(undefined, {
+                hour: "2-digit",
+                minute: "2-digit",
+            });
+        const at = (matterEpochSeconds: number) => new Date((matterEpochSeconds + MATTER_EPOCH_OFFSET_SECONDS) * 1000);
+
+        it("shows only the time for the same day", () => {
+            expect(formatEpochTime(CURRENT_DAY_ENTRY_DATE, at(CURRENT_DAY_ENTRY_DATE))).to.equal(
+                localTime(CURRENT_DAY_ENTRY_DATE),
+            );
         });
         it("marks the following day", () => {
-            const now = new Date((CURRENT_DAY_ENTRY_DATE + MATTER_EPOCH_OFFSET_SECONDS - 86_400) * 1000);
-            expect(formatEpochTime(CURRENT_DAY_ENTRY_DATE, now)).to.contain("tomorrow");
+            expect(formatEpochTime(CURRENT_DAY_ENTRY_DATE, at(CURRENT_DAY_ENTRY_DATE - 86_400))).to.equal(
+                `tomorrow ${localTime(CURRENT_DAY_ENTRY_DATE)}`,
+            );
         });
-        it("prefixes a date further out", () => {
-            const now = new Date((CURRENT_DAY_ENTRY_DATE + MATTER_EPOCH_OFFSET_SECONDS - 5 * 86_400) * 1000);
-            expect(formatEpochTime(CURRENT_DAY_ENTRY_DATE, now)).to.not.contain("tomorrow");
-            expect(formatEpochTime(CURRENT_DAY_ENTRY_DATE, now)).to.match(/\d{2}[./-]\d{2}/);
+        it("prefixes the date further out in the same year", () => {
+            const now = at(CURRENT_DAY_ENTRY_DATE - 5 * 86_400);
+            const date = at(CURRENT_DAY_ENTRY_DATE).toLocaleDateString(undefined, {
+                month: "2-digit",
+                day: "2-digit",
+            });
+            expect(formatEpochTime(CURRENT_DAY_ENTRY_DATE, now)).to.equal(
+                `${date} ${localTime(CURRENT_DAY_ENTRY_DATE)}`,
+            );
+        });
+        it("includes the year for another year, as the StartDate row needs", () => {
+            const now = at(CURRENT_DAY_ENTRY_DATE);
+            const startDate = CURRENT_DAY_ENTRY_DATE - 3 * 365 * 86_400;
+            const expected = at(startDate).toLocaleDateString(undefined, {
+                year: "numeric",
+                month: "2-digit",
+                day: "2-digit",
+            });
+            expect(formatEpochTime(startDate, now)).to.equal(`${expected} ${localTime(startDate)}`);
         });
     });
 
@@ -152,6 +183,113 @@ describe("commodity tariff util", () => {
             expect(info.tariffUnit).to.equal("Unknown (7)");
         });
 
+        it("keeps the currency of a TariffInfo struct that carries nothing else", () => {
+            const info = commodityTariffInfo({ ...TARIFF_ATTRS, "1/1792/0": { "2": { "0": 840, "1": 2 } } }, 1);
+            expect(info.tariffInfo?.currency).to.deep.equal({ code: 840, decimalPoints: 2, symbol: "$" });
+            expect(info.currentComponent?.price?.amount).to.equal("35.00 $");
+        });
+
+        it("drops a decimal point count that no currency uses instead of throwing", () => {
+            const info = commodityTariffInfo(
+                { ...TARIFF_ATTRS, "1/1792/0": { "0": "Tempo", "2": { "0": 978, "1": 200 }, "3": 0 } },
+                1,
+            );
+            expect(info.tariffInfo?.currency).to.equal(undefined);
+            expect(info.currentComponent?.price?.amount).to.equal(undefined);
+        });
+
+        it("prefers the priced entry of CurrentTariffComponents", () => {
+            const info = commodityTariffInfo(
+                { ...TARIFF_ATTRS, "1/1792/15": [TARIFF_COMPONENTS[0], TARIFF_COMPONENTS[2]] },
+                1,
+            );
+            expect(info.currentComponent?.label).to.equal("Peak");
+            expect(info.currentComponent?.price?.amount).to.equal("0.3500 €");
+        });
+
+        it("collects the components of every period a day entry belongs to", () => {
+            const attrs = {
+                ...TARIFF_ATTRS,
+                "1/1792/14": [
+                    { "0": "Peak thresholds", "1": [2, 4], "2": [100] },
+                    { "0": "Peak price", "1": [2, 4], "2": [200] },
+                    { "0": "Off-peak", "1": [1, 3], "2": [101] },
+                ],
+            };
+            const info = commodityTariffInfo(attrs, 1);
+            const peak = info.todaySchedule.find(row => row.entryId === 2);
+            expect(peak?.label).to.equal("Peak thresholds");
+            expect(peak?.price?.amount).to.equal("0.3500 €");
+        });
+
+        it("resolves the next day entry to its occurrence after the current one", () => {
+            const attrs = {
+                ...TARIFF_ATTRS,
+                "1/1792/9": { "0": 4, "1": 720 },
+                "1/1792/10": TODAY_DATE + 720 * 60,
+                "1/1792/11": { "0": 1, "1": 0 }, // day entry 1 recurs tomorrow at 00:00
+                "1/1792/12": TODAY_DATE + 86_400,
+                "1/1792/8": { "0": TODAY_DATE + 86_400, "1": 0, "2": [1, 4] }, // tomorrow skips the 07:00 entry
+                "1/1792/14": [
+                    { "0": "Off-peak", "1": [1], "2": [101] },
+                    { "0": "Peak", "1": [2, 4], "2": [200] },
+                    { "0": "Evening", "1": [3], "2": [200] },
+                ],
+            };
+            const info = commodityTariffInfo(attrs, 1);
+            // Tomorrow off-peak runs 00:00–12:00; today's occurrence of the same entry would end after 7 h.
+            expect(info.nextRange?.end).to.equal(TODAY_DATE + 86_400 + 12 * 3600);
+        });
+
+        it("reports no end rather than a backwards one for a start time past the day axis", () => {
+            const attrs = {
+                ...TARIFF_ATTRS,
+                "1/1792/3": [
+                    { "0": 1, "1": 0 },
+                    { "0": 5, "1": 2000 }, // beyond the 1499 the spec allows
+                ],
+                "1/1792/7": { "0": TODAY_DATE, "1": 0, "2": [1, 5] },
+                "1/1792/8": { "0": TODAY_DATE + 86_400, "1": 0, "2": [1] },
+                "1/1792/9": { "0": 5, "1": 2000 },
+                "1/1792/10": TODAY_DATE + 2000 * 60,
+                "1/1792/14": [
+                    { "0": "Off-peak", "1": [1], "2": [101] },
+                    { "0": "Peak", "1": [5], "2": [200] },
+                ],
+            };
+            const info = commodityTariffInfo(attrs, 1);
+            expect(info.currentRange?.end).to.equal(undefined);
+        });
+
+        it("keeps ranges forward-running on a 25-hour day", () => {
+            const attrs = {
+                ...TARIFF_ATTRS,
+                "1/1792/3": [
+                    { "0": 1, "1": 0 },
+                    { "0": 2, "1": 420 },
+                    { "0": 3, "1": 1470 }, // the extra hour of a DST fall-back day
+                ],
+                "1/1792/7": { "0": TODAY_DATE, "1": 0, "2": [1, 2, 3] },
+                "1/1792/8": { "0": TODAY_DATE + 90_000, "1": 0, "2": [1, 2, 3] },
+                "1/1792/9": { "0": 3, "1": 1470 },
+                "1/1792/10": TODAY_DATE + 1470 * 60,
+                "1/1792/11": { "0": 1, "1": 0 },
+                "1/1792/12": TODAY_DATE + 1500 * 60,
+                "1/1792/14": [
+                    { "0": "Off-peak", "1": [1, 3], "2": [101] },
+                    { "0": "Peak", "1": [2], "2": [200] },
+                ],
+            };
+            const info = commodityTariffInfo(attrs, 1);
+            const end = info.currentRange?.end;
+            expect(end === undefined || end > (info.currentRange?.start ?? 0)).to.equal(true);
+            expect(info.todaySchedule.map(row => [row.startMinutes, row.endMinutes])).to.deep.equal([
+                [0, 420],
+                [420, 1470],
+                [1470, 1500],
+            ]);
+        });
+
         it("ends the current range when the period changes, not when the next day entry starts", () => {
             const info = commodityTariffInfo(TARIFF_ATTRS, 1);
             expect(info.currentRange?.start).to.equal(CURRENT_DAY_ENTRY_DATE);
@@ -164,12 +302,6 @@ describe("commodity tariff util", () => {
             // Off-peak starts 22:00 today and ends 07:00 tomorrow: 9 h, not 2 h to midnight.
             expect(info.nextRange?.start).to.equal(OFF_PEAK_START);
             expect(info.nextRange?.end).to.equal(OFF_PEAK_START + 9 * 3600);
-        });
-
-        it("ignores day entries from a day pattern this day does not use", () => {
-            // Weekend entry 10 sits at 23:00 in another period; the off-peak block must not end there.
-            const info = commodityTariffInfo(OFF_PEAK_NEXT_ATTRS, 1);
-            expect(info.nextRange?.end).to.not.equal(OFF_PEAK_START + 3600);
         });
 
         it("leaves the range end unknown when the next day is not cached", () => {
@@ -213,8 +345,14 @@ describe("commodity tariff util", () => {
             expect(info.todaySchedule.map(row => row.endMinutes)).to.deep.equal([420, 720, 1320, 1440]);
         });
 
+        it("sorts a day whose entry ids arrive out of order", () => {
+            const attrs = { ...TARIFF_ATTRS, "1/1792/7": { "0": TODAY_DATE, "1": 0, "2": [3, 4, 1, 2] } };
+            const info = commodityTariffInfo(attrs, 1);
+            expect(info.todaySchedule.map(row => row.startMinutes)).to.deep.equal([0, 420, 720, 1320]);
+        });
+
         it("skips day entry ids the DayEntries attribute does not describe", () => {
-            const attrs = { ...TARIFF_ATTRS, "1/1792/7": { "0": 838_339_200, "1": 0, "2": [...DAY_ENTRY_IDS, 99] } };
+            const attrs = { ...TARIFF_ATTRS, "1/1792/7": { "0": TODAY_DATE, "1": 0, "2": [...DAY_ENTRY_IDS, 99] } };
             const info = commodityTariffInfo(attrs, 1);
             expect(info.todaySchedule).to.have.lengthOf(4);
         });

--- a/packages/dashboard/test/CommodityTariffUtilTest.ts
+++ b/packages/dashboard/test/CommodityTariffUtilTest.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+    commodityTariffInfo,
+    formatEpochTime,
+    formatMinutesOfDay,
+    formatPrice,
+    type CurrencyInfo,
+} from "../src/util/commodity-tariff.js";
+
+const MATTER_EPOCH_OFFSET_SECONDS = 946_684_800;
+
+const EUR: CurrencyInfo = { code: 978, decimalPoints: 4, symbol: "€" };
+
+/**
+ * A two-period tariff: peak 07:00–22:00 split across day entries 2 and 4, off-peak 22:00–07:00 modeled as
+ * entries 3 (22:00) and 1 (00:00) because DayEntry.startTime cannot cross midnight. Entries 10 and 11 come
+ * from a second day pattern (weekend) that neither today nor tomorrow uses.
+ */
+const DAY_ENTRIES = [
+    { "0": 1, "1": 0 }, // 00:00 off-peak, continues yesterday's block
+    { "0": 2, "1": 420 }, // 07:00 peak
+    { "0": 4, "1": 720 }, // 12:00 peak, second block
+    { "0": 3, "1": 1320 }, // 22:00 off-peak
+    { "0": 10, "1": 1380 }, // weekend pattern only
+    { "0": 11, "1": 600 }, // weekend pattern only
+];
+
+/** Both periods carry the same label, so period identity cannot be derived from labels. */
+const TARIFF_PERIODS = [
+    { "0": "Tariff", "1": [1, 3], "2": [100, 101] },
+    { "0": "Tariff", "1": [2, 4, 10, 11], "2": [200] },
+];
+
+const TARIFF_COMPONENTS = [
+    { "0": 100, "6": 0, "7": "Off-peak threshold" }, // no Price field
+    { "0": 101, "1": { "0": 0, "1": 1200 }, "6": 0, "7": "Off-peak" },
+    { "0": 200, "1": { "0": 1, "1": 3500 }, "6": 0, "7": "Peak" },
+];
+
+const DAY_ENTRY_IDS = [1, 2, 4, 3];
+
+/** 2026-08-05 07:00 UTC, day entry 2 active, day entry 4 (12:00) next. */
+const CURRENT_DAY_ENTRY_DATE = 838_339_200;
+const NEXT_DAY_ENTRY_DATE = CURRENT_DAY_ENTRY_DATE + 5 * 3600;
+/** The period the 22:00 off-peak entry starts ends at 07:00 the following day. */
+const OFF_PEAK_START = CURRENT_DAY_ENTRY_DATE + 15 * 3600;
+
+const TARIFF_ATTRS: Record<string, unknown> = {
+    "1/1792/0": { "0": "Tempo", "1": "EDF", "2": { "0": 978, "1": 4 }, "3": 1 },
+    "1/1792/1": 0, // TariffUnit kWh
+    "1/1792/2": 820_454_400, // StartDate
+    "1/1792/3": DAY_ENTRIES,
+    "1/1792/7": { "0": 838_339_200, "1": 0, "2": DAY_ENTRY_IDS }, // CurrentDay, Standard
+    "1/1792/8": { "0": 838_425_600, "1": 1, "2": DAY_ENTRY_IDS }, // NextDay, Holiday
+    "1/1792/9": { "0": 2, "1": 420 }, // CurrentDayEntry
+    "1/1792/10": CURRENT_DAY_ENTRY_DATE,
+    "1/1792/11": { "0": 4, "1": 720 }, // NextDayEntry
+    "1/1792/12": NEXT_DAY_ENTRY_DATE,
+    "1/1792/13": TARIFF_COMPONENTS,
+    "1/1792/14": TARIFF_PERIODS,
+    "1/1792/15": [TARIFF_COMPONENTS[2]],
+    "1/1792/16": [TARIFF_COMPONENTS[2]],
+    "1/1792/65532": 0b100001, // PRICE | RNDM
+};
+
+/** Same tariff, but the 22:00 off-peak entry is the one coming up next. */
+const OFF_PEAK_NEXT_ATTRS: Record<string, unknown> = {
+    ...TARIFF_ATTRS,
+    "1/1792/9": { "0": 4, "1": 720 },
+    "1/1792/10": NEXT_DAY_ENTRY_DATE,
+    "1/1792/11": { "0": 3, "1": 1320 },
+    "1/1792/12": OFF_PEAK_START,
+    "1/1792/16": [TARIFF_COMPONENTS[1]],
+};
+
+describe("commodity tariff util", () => {
+    describe("formatPrice", () => {
+        it("scales by the currency's decimal points", () => {
+            expect(formatPrice(1579, EUR)).to.equal("0.1579 €");
+        });
+        it("names the ISO code when the symbol is unknown", () => {
+            expect(formatPrice(1579, { code: 949, decimalPoints: 2 })).to.equal("15.79 (ISO 4217 #949)");
+        });
+        it("reads a bigint money field", () => {
+            expect(formatPrice(12345n, EUR)).to.equal("1.2345 €");
+        });
+        it("keeps a negative price (export tariff)", () => {
+            expect(formatPrice(-500, EUR)).to.equal("-0.0500 €");
+        });
+        it("is absent without a price", () => {
+            expect(formatPrice(undefined, EUR)).to.equal(undefined);
+        });
+    });
+
+    describe("formatMinutesOfDay", () => {
+        it("pads hours and minutes", () => {
+            expect(formatMinutesOfDay(425)).to.equal("07:05");
+        });
+        it("renders end of day as 24:00", () => {
+            expect(formatMinutesOfDay(1440)).to.equal("24:00");
+        });
+    });
+
+    describe("formatEpochTime", () => {
+        it("omits the date for the same day", () => {
+            const now = new Date((CURRENT_DAY_ENTRY_DATE + MATTER_EPOCH_OFFSET_SECONDS) * 1000);
+            expect(formatEpochTime(CURRENT_DAY_ENTRY_DATE, now)).to.not.contain("tomorrow");
+            expect(formatEpochTime(CURRENT_DAY_ENTRY_DATE, now)).to.match(/^\d{1,2}[.:]\d{2}/);
+        });
+        it("marks the following day", () => {
+            const now = new Date((CURRENT_DAY_ENTRY_DATE + MATTER_EPOCH_OFFSET_SECONDS - 86_400) * 1000);
+            expect(formatEpochTime(CURRENT_DAY_ENTRY_DATE, now)).to.contain("tomorrow");
+        });
+        it("prefixes a date further out", () => {
+            const now = new Date((CURRENT_DAY_ENTRY_DATE + MATTER_EPOCH_OFFSET_SECONDS - 5 * 86_400) * 1000);
+            expect(formatEpochTime(CURRENT_DAY_ENTRY_DATE, now)).to.not.contain("tomorrow");
+            expect(formatEpochTime(CURRENT_DAY_ENTRY_DATE, now)).to.match(/\d{2}[./-]\d{2}/);
+        });
+    });
+
+    describe("commodityTariffInfo", () => {
+        it("reports unsupported when the cluster is absent", () => {
+            const info = commodityTariffInfo({ "1/40/5": "label" }, 1);
+            expect(info.supported).to.equal(false);
+            expect(info.todaySchedule).to.have.lengthOf(0);
+        });
+
+        it("decodes tariff header, unit and block mode", () => {
+            const info = commodityTariffInfo(TARIFF_ATTRS, 1);
+            expect(info.supported).to.equal(true);
+            expect(info.tariffInfo?.label).to.equal("Tempo");
+            expect(info.tariffInfo?.providerName).to.equal("EDF");
+            expect(info.tariffInfo?.currency).to.deep.equal({ code: 978, decimalPoints: 4, symbol: "€" });
+            expect(info.tariffInfo?.blockMode).to.equal("Combined usage blocks");
+            expect(info.tariffUnit).to.equal("kWh");
+            expect(info.startDate).to.equal(820_454_400);
+        });
+
+        it("treats a blank label as absent", () => {
+            const info = commodityTariffInfo({ ...TARIFF_ATTRS, "1/1792/0": { "0": "  ", "1": "EDF", "3": 0 } }, 1);
+            expect(info.tariffInfo?.label).to.equal(undefined);
+            expect(info.tariffInfo?.providerName).to.equal("EDF");
+        });
+
+        it("names unknown enum values", () => {
+            const info = commodityTariffInfo({ ...TARIFF_ATTRS, "1/1792/1": 7 }, 1);
+            expect(info.tariffUnit).to.equal("Unknown (7)");
+        });
+
+        it("ends the current range when the period changes, not when the next day entry starts", () => {
+            const info = commodityTariffInfo(TARIFF_ATTRS, 1);
+            expect(info.currentRange?.start).to.equal(CURRENT_DAY_ENTRY_DATE);
+            // Peak continues across the 12:00 day entry and ends at 22:00, 15 h after 07:00.
+            expect(info.currentRange?.end).to.equal(CURRENT_DAY_ENTRY_DATE + 15 * 3600);
+        });
+
+        it("merges an off-peak block spanning midnight into one next range", () => {
+            const info = commodityTariffInfo(OFF_PEAK_NEXT_ATTRS, 1);
+            // Off-peak starts 22:00 today and ends 07:00 tomorrow: 9 h, not 2 h to midnight.
+            expect(info.nextRange?.start).to.equal(OFF_PEAK_START);
+            expect(info.nextRange?.end).to.equal(OFF_PEAK_START + 9 * 3600);
+        });
+
+        it("ignores day entries from a day pattern this day does not use", () => {
+            // Weekend entry 10 sits at 23:00 in another period; the off-peak block must not end there.
+            const info = commodityTariffInfo(OFF_PEAK_NEXT_ATTRS, 1);
+            expect(info.nextRange?.end).to.not.equal(OFF_PEAK_START + 3600);
+        });
+
+        it("leaves the range end unknown when the next day is not cached", () => {
+            const attrs = { ...OFF_PEAK_NEXT_ATTRS };
+            delete attrs["1/1792/8"];
+            const info = commodityTariffInfo(attrs, 1);
+            expect(info.nextRange?.start).to.equal(OFF_PEAK_START);
+            expect(info.nextRange?.end).to.equal(undefined);
+        });
+
+        it("picks the priced component of a period", () => {
+            const info = commodityTariffInfo(TARIFF_ATTRS, 1);
+            const offPeak = info.todaySchedule.find(row => row.entryId === 3);
+            expect(offPeak?.price?.amount).to.equal("0.1200 €");
+            expect(offPeak?.price?.priceType).to.equal("Standard");
+        });
+
+        it("orders the day's schedule and closes the last row at 24:00", () => {
+            const info = commodityTariffInfo(TARIFF_ATTRS, 1);
+            expect(info.todaySchedule.map(row => [row.startMinutes, row.endMinutes])).to.deep.equal([
+                [0, 420],
+                [420, 720],
+                [720, 1320],
+                [1320, 1440],
+            ]);
+            expect(info.todayType).to.equal("Standard");
+            expect(info.tomorrowType).to.equal("Holiday");
+        });
+
+        it("clamps a duration that overruns the next entry", () => {
+            const attrs = {
+                ...TARIFF_ATTRS,
+                "1/1792/3": [
+                    { "0": 1, "1": 0, "2": 600 }, // claims 10 h but the next entry starts after 7 h
+                    { "0": 2, "1": 420 },
+                    { "0": 4, "1": 720 },
+                    { "0": 3, "1": 1320, "2": 300 }, // claims 5 h, i.e. past midnight
+                ],
+            };
+            const info = commodityTariffInfo(attrs, 1);
+            expect(info.todaySchedule.map(row => row.endMinutes)).to.deep.equal([420, 720, 1320, 1440]);
+        });
+
+        it("skips day entry ids the DayEntries attribute does not describe", () => {
+            const attrs = { ...TARIFF_ATTRS, "1/1792/7": { "0": 838_339_200, "1": 0, "2": [...DAY_ENTRY_IDS, 99] } };
+            const info = commodityTariffInfo(attrs, 1);
+            expect(info.todaySchedule).to.have.lengthOf(4);
+        });
+    });
+});

--- a/packages/dashboard/test/MeterIdentificationUtilTest.ts
+++ b/packages/dashboard/test/MeterIdentificationUtilTest.ts
@@ -52,6 +52,18 @@ describe("meter identification util", () => {
         expect(info.powerThresholdSupported).to.equal(false);
     });
 
+    it("reads the number form of the threshold fields, which is what the wire carries", () => {
+        const info = meterIdentificationInfo({ ...METER_ATTRS, "1/2822/4": { "0": 4600, "1": 5000, "2": 2 } }, 1);
+        expect(info.powerThreshold?.powerThresholdW).to.equal(4.6);
+        expect(info.powerThreshold?.apparentPowerThresholdVA).to.equal(5);
+        expect(info.powerThreshold?.source).to.equal("Meter equipment limit");
+    });
+
+    it("treats a struct whose fields are all null as absent", () => {
+        const info = meterIdentificationInfo({ ...METER_ATTRS, "1/2822/4": { "0": null, "1": null, "2": null } }, 1);
+        expect(info.powerThreshold).to.equal(undefined);
+    });
+
     it("treats a null threshold struct and blank strings as absent", () => {
         const info = meterIdentificationInfo(
             { ...METER_ATTRS, "1/2822/3": "  ", "1/2822/4": null, "1/2822/0": null },

--- a/packages/dashboard/test/MeterIdentificationUtilTest.ts
+++ b/packages/dashboard/test/MeterIdentificationUtilTest.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { meterIdentificationInfo } from "../src/util/meter-identification.js";
+
+/** PowerThresholdStruct is field-tag keyed: "0" PowerThreshold (mW), "1" ApparentPowerThreshold (mVA), "2" Source. */
+const METER_ATTRS: Record<string, unknown> = {
+    "1/2822/0": 0, // MeterType Utility
+    "1/2822/1": "POD-12345",
+    "1/2822/2": "SN-98765",
+    "1/2822/3": "1.0",
+    "1/2822/4": { "0": 9_000_000n, "1": 9_500_000n, "2": 0 },
+    "1/2822/65532": 0b1, // PWRTHLD
+};
+
+describe("meter identification util", () => {
+    it("reports unsupported when the cluster is absent", () => {
+        const info = meterIdentificationInfo({ "1/40/5": "label" }, 1);
+        expect(info.supported).to.equal(false);
+        expect(info.powerThresholdSupported).to.equal(false);
+    });
+
+    it("decodes identification strings and the meter type", () => {
+        const info = meterIdentificationInfo(METER_ATTRS, 1);
+        expect(info.supported).to.equal(true);
+        expect(info.meterType).to.equal("Utility");
+        expect(info.pointOfDelivery).to.equal("POD-12345");
+        expect(info.meterSerialNumber).to.equal("SN-98765");
+        expect(info.protocolVersion).to.equal("1.0");
+    });
+
+    it("converts mW and mVA thresholds to W and VA", () => {
+        const info = meterIdentificationInfo(METER_ATTRS, 1);
+        expect(info.powerThresholdSupported).to.equal(true);
+        expect(info.powerThreshold?.powerThresholdW).to.equal(9000);
+        expect(info.powerThreshold?.apparentPowerThresholdVA).to.equal(9500);
+        expect(info.powerThreshold?.source).to.equal("Contract");
+    });
+
+    it("names an unknown threshold source", () => {
+        const info = meterIdentificationInfo({ ...METER_ATTRS, "1/2822/4": { "0": 1000, "2": 9 } }, 1);
+        expect(info.powerThreshold?.source).to.equal("Unknown (9)");
+        expect(info.powerThreshold?.apparentPowerThresholdVA).to.equal(undefined);
+    });
+
+    it("reports the feature as unsupported when the bit is clear", () => {
+        const info = meterIdentificationInfo({ ...METER_ATTRS, "1/2822/65532": 0 }, 1);
+        expect(info.supported).to.equal(true);
+        expect(info.powerThresholdSupported).to.equal(false);
+    });
+
+    it("treats a null threshold struct and blank strings as absent", () => {
+        const info = meterIdentificationInfo(
+            { ...METER_ATTRS, "1/2822/3": "  ", "1/2822/4": null, "1/2822/0": null },
+            1,
+        );
+        expect(info.protocolVersion).to.equal(undefined);
+        expect(info.meterType).to.equal(undefined);
+        expect(info.powerThreshold).to.equal(undefined);
+    });
+});

--- a/packages/dashboard/test/MeterIdentificationUtilTest.ts
+++ b/packages/dashboard/test/MeterIdentificationUtilTest.ts
@@ -59,6 +59,15 @@ describe("meter identification util", () => {
         expect(info.powerThreshold?.source).to.equal("Meter equipment limit");
     });
 
+    it("drops a threshold no number can hold exactly instead of rounding it", () => {
+        const info = meterIdentificationInfo(
+            { ...METER_ATTRS, "1/2822/4": { "0": 9_007_199_254_740_993n, "1": 5000, "2": 0 } },
+            1,
+        );
+        expect(info.powerThreshold?.powerThresholdW).to.equal(undefined);
+        expect(info.powerThreshold?.apparentPowerThresholdVA).to.equal(5);
+    });
+
     it("treats a struct whose fields are all null as absent", () => {
         const info = meterIdentificationInfo({ ...METER_ATTRS, "1/2822/4": { "0": null, "1": null, "2": null } }, 1);
         expect(info.powerThreshold).to.equal(undefined);


### PR DESCRIPTION
## Summary
- Adds a read-only cluster panel for `CommodityTariff` (0x0700) showing tariff label/provider, a Now/Next price view with time ranges, an optional today/tomorrow schedule table, and supported features.
- Adds a read-only cluster panel for `MeterIdentification` (0x0B06) showing meter type, point of delivery, serial number, protocol version, and power threshold.
- Both decode the wire-format attributes directly: field-tag-keyed structs (`{"0": ..., "1": ...}`), raw FeatureMap bitmaps, and Matter epoch-s timestamps — none of this is exposed as named/camelCase objects over the WebSocket API.
- The "Next" time range accounts for periods that span midnight: Matter's `DayEntry.startTime` can't cross midnight, so a period active at day-end and resumed at day-start is modeled as two separate `DayEntry` records; the panel merges these back into one continuous range when computing when "Next" ends.

## Test plan
- [x] `npm run format`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test -w @matter-server/dashboard` (184/184 passing)
- [x] Verified against a live device via direct WebSocket queries and in the running dashboard