### PR TITLE
fix(ws-controller): pin Casablanca time-zone tests to historical dates

### DIFF
--- a/packages/ws-controller/test/HostTimeZoneTest.ts
+++ b/packages/ws-controller/test/HostTimeZoneTest.ts
@@ -333,25 +333,25 @@ describe("hostTimeZone", () => {
             this.timeout(20_000);
             // One zone per behaviour: each plan day-steps its whole scan range, so breadth across
             // every IANA zone and year belongs to the offline sweep.
-            const zones = [
-                "Europe/Berlin", // northern seasonal DST
-                "Australia/Sydney", // southern, window spans New Year
-                "America/Phoenix", // no DST
-                "Asia/Kolkata", // half-hour offset, no DST
-                "Pacific/Chatham", // 45-minute DST delta
-                "Africa/Casablanca", // recurring dip below the base
+            const cases: Array<[string, number]> = [
+                ["Europe/Berlin", 2026], // northern seasonal DST
+                ["Australia/Sydney", 2026], // southern, window spans New Year
+                ["America/Phoenix", 2026], // no DST
+                ["Asia/Kolkata", 2026], // half-hour offset, no DST
+                ["Pacific/Chatham", 2026], // 45-minute DST delta
+                ["Africa/Casablanca", 2022], // recurring dip below the base (historical under every tzdata)
+                ["Africa/Casablanca", 2026], // dip, or pending permanent +00, depending on tzdata
             ];
-            // 2022: a year Casablanca's dip recurs under every tzdata in circulation (see above)
             let checked = 0;
-            for (const zone of zones) {
+            for (const [zone, year] of cases) {
                 for (const month of [0, 3, 6, 9]) {
                     for (const maxWindows of [1, 2]) {
-                        expectPlanMatchesZone(zone, Date.UTC(2022, month, 5, 6), { maxRegimes: 2, maxWindows });
+                        expectPlanMatchesZone(zone, Date.UTC(year, month, 5, 6), { maxRegimes: 2, maxWindows });
                         checked++;
                     }
                 }
             }
-            expect(checked).to.equal(zones.length * 4 * 2);
+            expect(checked).to.equal(cases.length * 4 * 2);
         });
 
         it("produces lists SetTimeZone and SetDstOffset accept", function () {

--- a/packages/ws-controller/test/HostTimeZoneTest.ts
+++ b/packages/ws-controller/test/HostTimeZoneTest.ts
@@ -239,11 +239,17 @@ describe("hostTimeZone", () => {
         });
 
         it("does not split an ordinary DST zone or a recurring seasonal dip", () => {
-            for (const zone of ["Europe/Berlin", "America/New_York", "Africa/Casablanca"]) {
+            for (const zone of ["Europe/Berlin", "America/New_York"]) {
                 for (const month of [0, 3, 6, 9]) {
                     const plan = timeZonePlan(zone, Date.UTC(2026, month, 10), BOTH_MAX);
                     expect(plan.regimes.length, `${zone} month ${month}`).to.equal(1);
                 }
+            }
+            // Morocco's Ramadan dip only recurs historically: newer tzdata moves the zone
+            // permanently to +00 on 2026-09-21, making 2026 a pending-permanent-change case.
+            for (const month of [0, 3, 6, 9]) {
+                const plan = timeZonePlan("Africa/Casablanca", Date.UTC(2022, month, 10), BOTH_MAX);
+                expect(plan.regimes.length, `Africa/Casablanca month ${month}`).to.equal(1);
             }
         });
 
@@ -335,11 +341,12 @@ describe("hostTimeZone", () => {
                 "Pacific/Chatham", // 45-minute DST delta
                 "Africa/Casablanca", // recurring dip below the base
             ];
+            // 2022: a year Casablanca's dip recurs under every tzdata in circulation (see above)
             let checked = 0;
             for (const zone of zones) {
                 for (const month of [0, 3, 6, 9]) {
                     for (const maxWindows of [1, 2]) {
-                        expectPlanMatchesZone(zone, Date.UTC(2026, month, 5, 6), { maxRegimes: 2, maxWindows });
+                        expectPlanMatchesZone(zone, Date.UTC(2022, month, 5, 6), { maxRegimes: 2, maxWindows });
                         checked++;
                     }
                 }
@@ -358,7 +365,7 @@ describe("hostTimeZone", () => {
                 ["Asia/Almaty", Date.UTC(2024, 0, 10)], // pending permanent reduction
                 ["Europe/Istanbul", Date.UTC(2016, 0, 10)], // pending permanent adoption
                 ["America/Asuncion", Date.UTC(2024, 0, 10)], // real DST plus a pending change
-                ["Africa/Casablanca", Date.UTC(2026, 3, 10)], // recurring dip below the base
+                ["Africa/Casablanca", Date.UTC(2022, 3, 10)], // recurring dip below the base
             ];
             let checked = 0;
             for (const [zone, atMs] of cases) {


### PR DESCRIPTION
## Type of change

- [x] 🐛 **Fix** — corrects a defect or wrong behavior
- [ ] ✨ **Feature** — adds new functionality or capability

## Description

CI is red on every branch since 2026-08-05 ~02:05 UTC: `hostTimeZone ➡ timeZonePlan standard-offset regimes ➡ does not split an ordinary DST zone or a recurring seasonal dip` fails with `Africa/Casablanca month 3: expected 2 to equal 1` (e.g. [this run on PR #958](https://github.com/matter-js/matterjs-server/actions/runs/31005001697/job/92302924224), and identically on [unrelated dependabot branches](https://github.com/matter-js/matterjs-server/actions/runs/30968321965) hours earlier).

Root cause: the Node releases picked up by `setup-node` that morning (e.g. 26.6.0) bundle a tzdata where **Africa/Casablanca moves permanently to +00 on 2026-09-21** — no transitions afterwards (probed ~950 days via `Intl`). Older tzdata (e.g. local Node 24.18/ICU 78) still projects recurring Ramadan dips through 2028+. `timeZonePlan` behaves correctly under both: with the new data it legitimately reports a pending permanent regime (the designed Istanbul-style split). The test premise "Casablanca 2026 = recurring seasonal dip" is what went stale.

Fix (test-only): pin the three test sites whose premise is "recurring dip" to 2022 sync instants — the dips there are historical fact, deterministic under every tzdata generation. Premise-free property assertions (plan-matches-zone breadth checks) keep their 2026 dates; under the new tzdata they now additionally cover the zone-in-transition shape.

## Backing evidence

- Failing CI job log (byte-identical failure reproduced locally under downloaded Node 26.6.0): https://github.com/matter-js/matterjs-server/actions/runs/31005001697/job/92302924224
- Transition scan comparison, same `Intl` probing as `hostTimeZone.ts`:
  - Node 24.18 (old tzdata): dips `2026-02-16→03-23`, `2027-02-08→03-15`, `2028-01-24→03-06` …
  - Node 26.6.0 (new tzdata): dip `2026-02-16→03-23`, then `2026-09-21 +01→+00` and **nothing after** (≥950 days)

## Checklist

- [x] I understand the code I am submitting and can explain how it works ([AI policy](https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md))
- [x] Tests added or updated to cover the change (test-only change; suite verified green under both Node 26.6.0 — previously failing — and Node 24.18)
- [x] `npm test` passes (full suite, incl. integration)
- [x] `npm run format-verify` and `npm run lint` pass
- [ ] CHANGELOG updated — not applicable, test-only change with no user-facing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)