### PR TITLE
Add WAGO custom cluster (0x1534fc00)

### DIFF
--- a/packages/custom-clusters/README.md
+++ b/packages/custom-clusters/README.md
@@ -16,6 +16,7 @@ Custom clusters are used by device manufacturers to expose proprietary functiona
 | `NeoCluster`                        | 0x125dfc11 | Neo (0x125d/4991)          | Power metering                             |
 | `HeimanCluster`                     | 0x120bfc01 | Heiman (0x120b/4619)       | Sensor states, alarms                      |
 | `ThirdRealityMeteringCluster`       | 0x130dfc02 | ThirdReality (0x130d/4877) | Power metering                             |
+| `WagoCluster`                       | 0x1534fc00 | WAGO (0x1534/5428)         | Relay switch input configuration           |
 | `DraftElectricalMeasurementCluster` | 0x00000b04 | Various                    | Draft Matter 1.0 electrical measurement    |
 
 ## Adding a New Custom Cluster

--- a/packages/custom-clusters/src/clusters/index.ts
+++ b/packages/custom-clusters/src/clusters/index.ts
@@ -11,3 +11,4 @@ export * from "./inovelli.js";
 export * from "./neo.js";
 export * from "./tcl.js";
 export * from "./thirdreality.js";
+export * from "./wago.js";

--- a/packages/custom-clusters/src/clusters/wago.ts
+++ b/packages/custom-clusters/src/clusters/wago.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { attribute, bool, cluster, uint8, writable } from "@matter/main/model";
+
+@cluster(0x1534fc00)
+export class WagoCluster {
+    /**
+     * Connection option: when true the local button input directly controls
+     * the relay output ("Directly connected"), when false the button and
+     * output are decoupled and only linked via Matter ("Matter only").
+     */
+    @attribute(0x00000000, bool, writable)
+    directlyConnected?: boolean;
+
+    /**
+     * Bipolar/Unipolar switching: type of switch connected to the input.
+     * 0 = button (momentary), 1 = switch (bistable).
+     */
+    @attribute(0x00000001, uint8, writable)
+    switchType?: number;
+}

--- a/packages/dashboard/src/client/models/descriptions.ts
+++ b/packages/dashboard/src/client/models/descriptions.ts
@@ -19812,6 +19812,70 @@ export const clusters: Record<number, ClusterDescription> = {
         },
         "commands": {},
         "features": {}
+    },
+    "355793920": {
+        "id": 355793920,
+        "label": "WagoCluster",
+        "attributes": {
+            "0": {
+                "id": 0,
+                "cluster_id": 355793920,
+                "label": "DirectlyConnected",
+                "type": "Optional[bool]",
+                "writable": true
+            },
+            "1": {
+                "id": 1,
+                "cluster_id": 355793920,
+                "label": "SwitchType",
+                "type": "Optional[unknown]",
+                "writable": true
+            },
+            "65528": {
+                "id": 65528,
+                "cluster_id": 355793920,
+                "label": "GeneratedCommandList",
+                "type": "List[command-id]",
+                "writable": false
+            },
+            "65529": {
+                "id": 65529,
+                "cluster_id": 355793920,
+                "label": "AcceptedCommandList",
+                "type": "List[command-id]",
+                "writable": false
+            },
+            "65530": {
+                "id": 65530,
+                "cluster_id": 355793920,
+                "label": "EventList",
+                "type": "Optional[unknown]",
+                "writable": true
+            },
+            "65531": {
+                "id": 65531,
+                "cluster_id": 355793920,
+                "label": "AttributeList",
+                "type": "List[attrib-id]",
+                "writable": false
+            },
+            "65532": {
+                "id": 65532,
+                "cluster_id": 355793920,
+                "label": "FeatureMap",
+                "type": "map32",
+                "writable": false
+            },
+            "65533": {
+                "id": 65533,
+                "cluster_id": 355793920,
+                "label": "ClusterRevision",
+                "type": "uint16",
+                "writable": false
+            }
+        },
+        "commands": {},
+        "features": {}
     }
 };
 

--- a/python_client/chip/clusters/Objects.py
+++ b/python_client/chip/clusters/Objects.py
@@ -165,6 +165,7 @@ __all__ = [
     "UnitLocalization",
     "UserLabel",
     "ValveConfigurationAndControl",
+    "WagoCluster",
     "WakeOnLan",
     "WaterHeaterManagement",
     "WaterHeaterMode",

--- a/python_client/chip/clusters/cluster_defs/WagoCluster.py
+++ b/python_client/chip/clusters/cluster_defs/WagoCluster.py
@@ -1,0 +1,171 @@
+"""WagoCluster cluster definition (auto-generated, DO NOT edit)."""
+
+from __future__ import annotations
+
+import typing
+from dataclasses import dataclass, field
+from enum import IntFlag
+
+from ... import ChipUtility
+from ...clusters.enum import MatterIntEnum
+from ...tlv import float32, uint
+from ..ClusterObjects import (Cluster, ClusterAttributeDescriptor, ClusterCommand, ClusterEvent, ClusterObject,
+                              ClusterObjectDescriptor, ClusterObjectFieldDescriptor)
+from ..Types import Nullable, NullValue
+
+
+@dataclass
+class WagoCluster(Cluster):
+    id: typing.ClassVar[int] = 0x1534FC00
+
+    @ChipUtility.classproperty
+    def descriptor(cls) -> ClusterObjectDescriptor:
+        return ClusterObjectDescriptor(
+            Fields=[
+                ClusterObjectFieldDescriptor(Label="directlyConnected", Tag=0x00000000, Type=typing.Optional[bool]),
+                ClusterObjectFieldDescriptor(Label="switchType", Tag=0x00000001, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="generatedCommandList", Tag=0x0000FFF8, Type=typing.List[uint]),
+                ClusterObjectFieldDescriptor(Label="acceptedCommandList", Tag=0x0000FFF9, Type=typing.List[uint]),
+                ClusterObjectFieldDescriptor(Label="eventList", Tag=0x0000FFFA, Type=typing.List[uint]),
+                ClusterObjectFieldDescriptor(Label="attributeList", Tag=0x0000FFFB, Type=typing.List[uint]),
+                ClusterObjectFieldDescriptor(Label="featureMap", Tag=0x0000FFFC, Type=uint),
+                ClusterObjectFieldDescriptor(Label="clusterRevision", Tag=0x0000FFFD, Type=uint),
+            ])
+
+    directlyConnected: typing.Optional[bool] = None
+    switchType: typing.Optional[uint] = None
+    generatedCommandList: typing.List[uint] = field(default_factory=lambda: [])
+    acceptedCommandList: typing.List[uint] = field(default_factory=lambda: [])
+    eventList: typing.List[uint] = field(default_factory=lambda: [])
+    attributeList: typing.List[uint] = field(default_factory=lambda: [])
+    featureMap: uint = 0
+    clusterRevision: uint = 0
+
+    class Attributes:
+        @dataclass
+        class DirectlyConnected(ClusterAttributeDescriptor):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x1534FC00
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                return 0x00000000
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[bool])
+
+            value: typing.Optional[bool] = None
+
+        @dataclass
+        class SwitchType(ClusterAttributeDescriptor):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x1534FC00
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                return 0x00000001
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+
+            value: typing.Optional[uint] = None
+
+        @dataclass
+        class GeneratedCommandList(ClusterAttributeDescriptor):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x1534FC00
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                return 0x0000FFF8
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                return ClusterObjectFieldDescriptor(Type=typing.List[uint])
+
+            value: typing.List[uint] = field(default_factory=lambda: [])
+
+        @dataclass
+        class AcceptedCommandList(ClusterAttributeDescriptor):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x1534FC00
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                return 0x0000FFF9
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                return ClusterObjectFieldDescriptor(Type=typing.List[uint])
+
+            value: typing.List[uint] = field(default_factory=lambda: [])
+
+        @dataclass
+        class EventList(ClusterAttributeDescriptor):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x1534FC00
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                return 0x0000FFFA
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                return ClusterObjectFieldDescriptor(Type=typing.List[uint])
+
+            value: typing.List[uint] = field(default_factory=lambda: [])
+
+        @dataclass
+        class AttributeList(ClusterAttributeDescriptor):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x1534FC00
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                return 0x0000FFFB
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                return ClusterObjectFieldDescriptor(Type=typing.List[uint])
+
+            value: typing.List[uint] = field(default_factory=lambda: [])
+
+        @dataclass
+        class FeatureMap(ClusterAttributeDescriptor):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x1534FC00
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                return 0x0000FFFC
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                return ClusterObjectFieldDescriptor(Type=uint)
+
+            value: uint = 0
+
+        @dataclass
+        class ClusterRevision(ClusterAttributeDescriptor):
+            @ChipUtility.classproperty
+            def cluster_id(cls) -> int:
+                return 0x1534FC00
+
+            @ChipUtility.classproperty
+            def attribute_id(cls) -> int:
+                return 0x0000FFFD
+
+            @ChipUtility.classproperty
+            def attribute_type(cls) -> ClusterObjectFieldDescriptor:
+                return ClusterObjectFieldDescriptor(Type=uint)
+
+            value: uint = 0

--- a/python_client/chip/clusters/cluster_defs/__init__.py
+++ b/python_client/chip/clusters/cluster_defs/__init__.py
@@ -133,6 +133,7 @@ from .TotalVolatileOrganicCompoundsConcentrationMeasurement import TotalVolatile
 from .UnitLocalization import UnitLocalization
 from .UserLabel import UserLabel
 from .ValveConfigurationAndControl import ValveConfigurationAndControl
+from .WagoCluster import WagoCluster
 from .WakeOnLan import WakeOnLan
 from .WaterHeaterManagement import WaterHeaterManagement
 from .WaterHeaterMode import WaterHeaterMode
@@ -279,6 +280,7 @@ __all__ = [
     "UnitLocalization",
     "UserLabel",
     "ValveConfigurationAndControl",
+    "WagoCluster",
     "WakeOnLan",
     "WaterHeaterManagement",
     "WaterHeaterMode",

--- a/python_client/matter_server/common/custom_clusters.py
+++ b/python_client/matter_server/common/custom_clusters.py
@@ -7,6 +7,7 @@ from chip.clusters.cluster_defs.InovelliCluster import InovelliCluster
 from chip.clusters.cluster_defs.NeoCluster import NeoCluster
 from chip.clusters.cluster_defs.TclDehumidifierCluster import TclDehumidifierCluster
 from chip.clusters.cluster_defs.ThirdRealityMeteringCluster import ThirdRealityMeteringCluster
+from chip.clusters.cluster_defs.WagoCluster import WagoCluster
 
 ALL_CUSTOM_CLUSTERS: dict = {
     DraftElectricalMeasurementCluster.id: DraftElectricalMeasurementCluster,
@@ -16,6 +17,7 @@ ALL_CUSTOM_CLUSTERS: dict = {
     NeoCluster.id: NeoCluster,
     TclDehumidifierCluster.id: TclDehumidifierCluster,
     ThirdRealityMeteringCluster.id: ThirdRealityMeteringCluster,
+    WagoCluster.id: WagoCluster,
 }
 
 __all__ = [
@@ -27,4 +29,5 @@ __all__ = [
     "NeoCluster",
     "TclDehumidifierCluster",
     "ThirdRealityMeteringCluster",
+    "WagoCluster",
 ]

--- a/python_client/tests/test_imports.py
+++ b/python_client/tests/test_imports.py
@@ -75,6 +75,7 @@ def test_custom_cluster_imports():
         InovelliCluster,
         NeoCluster,
         ThirdRealityMeteringCluster,
+        WagoCluster,
     )
 
     assert EveCluster is not None
@@ -83,6 +84,9 @@ def test_custom_cluster_imports():
     assert NeoCluster is not None
     assert ThirdRealityMeteringCluster is not None
     assert DraftElectricalMeasurementCluster is not None
+    assert WagoCluster is not None
+    assert hasattr(WagoCluster.Attributes, "DirectlyConnected")
+    assert hasattr(WagoCluster.Attributes, "SwitchType")
 
 
 def test_eve_new_attributes_exist():


### PR DESCRIPTION
## Summary

Adds a custom cluster definition for WAGO devices (vendor ID `0x1534`/5428), as found on the **WAGO Home Relay 16A Thread** (2757-1102). The cluster (`0x1534fc00`, root endpoint) exposes the two configuration options the WAGO Home app offers:

- `directlyConnected` (`0x0000`, bool, writable): "Connection options" — when `true` the local button/switch input directly controls the relay output; when `false` they are decoupled and only linked via Matter ("Matter only").
- `switchType` (`0x0001`, uint8, writable): "Bipolar/Unipolar switching" — type of switch wired to the input, `0` = button (momentary), `1` = switch (bistable).

Attribute semantics were determined by diffing diagnostics dumps of the node taken with each of the four setting combinations in the WAGO Home app.

Python cluster definitions were regenerated with `npm run python:generate`, and the import test extended to cover the new cluster.

Tested against the real device with a locally running server: the cluster decodes with proper labels and both attributes are writable from the controller.

A follow-up PR for Home Assistant Core adds config select entities on top of these attributes.

## Testing

- `npm run format-verify`, `npm run lint`
- `python_client`: 67 tests pass (`pytest tests/ --ignore=tests/test_integration.py`)
- Verified on hardware (WAGO Home Relay 16A Thread, firmware 3.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)