### PR TITLE
fix(matter-server): unwedge shutdown and deliver the OTA size rejection

### DIFF
--- a/packages/matter-server/src/server/OtaUploadHandler.ts
+++ b/packages/matter-server/src/server/OtaUploadHandler.ts
@@ -14,6 +14,9 @@ const logger = Logger.get("OtaUploadHandler");
 
 const UPLOAD_PATH = /^\/ota-upload\/([0-9a-f]{32})$/;
 
+/** How long a rejected body may keep its socket busy before the connection is taken down. */
+const DISCARD_TIMEOUT_MS = 30_000;
+
 /** Thrown once the streamed body passes the configured limit, to distinguish it from I/O failures. */
 class UploadTooLargeError extends Error {}
 
@@ -199,8 +202,17 @@ export class OtaUploadHandler implements WebServerHandler {
             return;
         }
         if (discardBody) {
-            res.setHeader("Connection", "close");
-            res.once("finish", () => req.destroy());
+            res.once("finish", () => {
+                if (req.destroyed || req.readableEnded) {
+                    return;
+                }
+                // Tearing the socket down while the peer is still writing resets it, and the
+                // rejection it has not read yet goes with it. `Connection: close` counts as tearing
+                // it down: Node destroys the socket as soon as such a response is flushed.
+                const deadline = setTimeout(() => req.destroy(), DISCARD_TIMEOUT_MS).unref();
+                req.once("end", () => req.destroy());
+                req.once("close", () => clearTimeout(deadline));
+            });
         }
         req.resume();
         this.#respondJson(res, status, body);

--- a/packages/matter-server/src/server/OtaUploadHandler.ts
+++ b/packages/matter-server/src/server/OtaUploadHandler.ts
@@ -15,7 +15,7 @@ const logger = Logger.get("OtaUploadHandler");
 const UPLOAD_PATH = /^\/ota-upload\/([0-9a-f]{32})$/;
 
 /** How long a rejected body may keep its socket busy before the connection is taken down. */
-const DISCARD_TIMEOUT_MS = 30_000;
+const DISCARD_TIMEOUT_MS = 10_000;
 
 /** Thrown once the streamed body passes the configured limit, to distinguish it from I/O failures. */
 class UploadTooLargeError extends Error {}

--- a/packages/matter-server/src/server/WebServer.ts
+++ b/packages/matter-server/src/server/WebServer.ts
@@ -111,6 +111,9 @@ export class WebServer {
                                 resolve();
                             }
                         });
+                        // Node <=22 leaks the connection count of a socket the peer reset while a
+                        // response was being written, and `close()` then never calls back.
+                        server.closeAllConnections();
                     }),
             ),
         );

--- a/packages/matter-server/test/IntegrationTest.ts
+++ b/packages/matter-server/test/IntegrationTest.ts
@@ -14,6 +14,7 @@
 import { ServerErrorCode } from "@matter-server/ws-controller";
 import { ChildProcess } from "child_process";
 import { stat } from "node:fs/promises";
+import { request as httpRequest, type IncomingMessage } from "node:http";
 import {
     cleanupTempStorage,
     createTempStoragePaths,
@@ -316,12 +317,36 @@ describe("Integration Test", function () {
             it("should reject an OTA upload larger than the configured limit", async function () {
                 const ticket = await client.sendCommand("initiate_ota_upload", 13, {});
 
-                const response = await fetch(`http://localhost:${SERVER_PORT}/ota-upload/${ticket.upload_id}`, {
+                // The rejection lands on the declared length, so the body must stay unsent: a client
+                // still writing when the socket goes down reads a broken pipe, not the answer.
+                const request = httpRequest({
+                    host: "localhost",
+                    port: SERVER_PORT,
+                    path: `/ota-upload/${ticket.upload_id}`,
                     method: "POST",
-                    body: Buffer.alloc(ticket.max_size + 1),
+                    headers: { "Content-Length": String(ticket.max_size + 1) },
                 });
+                request.on("error", () => {});
 
-                expect(response.status).to.equal(413);
+                try {
+                    const response = await new Promise<IncomingMessage>((resolve, reject) => {
+                        request.on("response", resolve);
+                        request.on("error", reject);
+                        request.write("x");
+                    });
+                    response.resume();
+
+                    expect(response.statusCode).to.equal(413);
+                } finally {
+                    request.destroy();
+                }
+
+                const replay = await fetch(`http://localhost:${SERVER_PORT}/ota-upload/${ticket.upload_id}`, {
+                    method: "POST",
+                    body: Buffer.from("not a real ota file"),
+                });
+                expect(replay.status).to.equal(400);
+                expect((await replay.json()).error_code).to.equal(ServerErrorCode.OtaUploadError);
             });
 
             it("should reject an OTA upload POST without a valid id", async function () {

--- a/packages/matter-server/test/OtaUploadHandlerTest.ts
+++ b/packages/matter-server/test/OtaUploadHandlerTest.ts
@@ -8,7 +8,7 @@ import { ServerError, ServerErrorCode, UpdateSource, type MatterSoftwareVersion 
 import { Logger, LogLevel } from "@matter/main";
 import type { Diagnostic } from "@matter/main";
 import { chmod, mkdtemp, readdir, rm } from "node:fs/promises";
-import { createServer, type Server } from "node:http";
+import { createServer, request as httpRequest, type IncomingMessage, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { OtaUploadHandler } from "../src/server/OtaUploadHandler.js";
@@ -58,10 +58,22 @@ class TestStaging {
 
 const UPLOAD_ID = "0123456789abcdef0123456789abcdef";
 
+/**
+ * Node <=22 leaks the connection count of a socket the peer reset while a response was being
+ * written, and `close()` then never calls back.
+ */
+function closeServer(server: Server): Promise<void> {
+    return new Promise<void>(resolve => {
+        server.close(() => resolve());
+        server.closeAllConnections();
+    });
+}
+
 describe("OtaUploadHandler", () => {
     let stagingDir: string;
     let staging: TestStaging;
     let server: Server;
+    let port: number;
     let baseUrl: string;
     let logged: Diagnostic.Message[];
     let restoreLog: () => void;
@@ -85,12 +97,13 @@ describe("OtaUploadHandler", () => {
         if (address === null || typeof address === "string") {
             throw new Error("Expected a TCP address");
         }
-        baseUrl = `http://127.0.0.1:${address.port}`;
+        port = address.port;
+        baseUrl = `http://127.0.0.1:${port}`;
     });
 
     afterEach(async () => {
         restoreLog();
-        await new Promise<void>(resolve => server.close(() => resolve()));
+        await closeServer(server);
         await rm(stagingDir, { recursive: true, force: true });
     });
 
@@ -165,6 +178,35 @@ describe("OtaUploadHandler", () => {
         // client for the reservation lifetime, since a reservation cannot be handed back.
         expect(staging.released).to.deep.equal([UPLOAD_ID]);
         expect(await readdir(stagingDir)).to.be.empty;
+    });
+
+    it("delivers the rejection to a client still writing the body it declared", async () => {
+        const declared = 4 * 1024 * 1024;
+
+        const request = httpRequest({
+            host: "127.0.0.1",
+            port,
+            path: `/ota-upload/${UPLOAD_ID}`,
+            method: "POST",
+            headers: { "Content-Length": String(declared) },
+        });
+        // The rest of the body is still in flight once the answer is in, so the socket goes down
+        // under it either way; only a failure before the answer is a test failure.
+        request.on("error", () => {});
+
+        try {
+            const response = await new Promise<IncomingMessage>((resolve, reject) => {
+                request.on("response", resolve);
+                request.on("error", reject);
+                request.end(Buffer.alloc(declared));
+            });
+            response.resume();
+
+            expect(response.statusCode).to.equal(413);
+            expect(staging.completed).to.be.empty;
+        } finally {
+            request.destroy();
+        }
     });
 
     it("rejects a body that outgrows the limit without declaring its length", async () => {
@@ -258,7 +300,7 @@ describe("OtaUploadHandler", () => {
             expect(staging.completed).to.be.empty;
         } finally {
             await handler.unregister();
-            await new Promise<void>(resolve => shuttingDown.close(() => resolve()));
+            await closeServer(shuttingDown);
         }
     });
 

--- a/packages/matter-server/test/OtaUploadHandlerTest.ts
+++ b/packages/matter-server/test/OtaUploadHandlerTest.ts
@@ -195,13 +195,20 @@ describe("OtaUploadHandler", () => {
         request.on("error", () => {});
 
         try {
+            let stillWriting: boolean | undefined;
             const response = await new Promise<IncomingMessage>((resolve, reject) => {
-                request.on("response", resolve);
+                request.on("response", message => {
+                    stillWriting = !request.writableFinished;
+                    resolve(message);
+                });
                 request.on("error", reject);
                 request.end(Buffer.alloc(declared));
             });
             response.resume();
 
+            // A body that drained before the answer arrived would leave nothing for the socket
+            // teardown to discard, and the test would pass without exercising the race at all.
+            expect(stillWriting).to.be.true;
             expect(response.statusCode).to.equal(413);
             expect(staging.completed).to.be.empty;
         } finally {


### PR DESCRIPTION
## Why

CI on #978 failed intermittently in the node 22.x job:

```
✗ Failure 1 of 1: OtaUploadHandler ➡ "after each" hook for "survives a client that hangs up while the image is being imported"
Test timeout: Timeout of 2000ms exceeded
```

Two separate defects, both reachable through the OTA upload path added in #939.

### 1. `server.close()` never calls back on Node <= 22

When a client aborts a request and the server then writes its response, Node <= 22 keeps counting the connection even though the socket is destroyed. `http.Server.close()` waits for that phantom connection forever.

Minimal reproduction, same script on both runtimes:

| runtime | `getConnections` after the abort | `server.close()` |
| --- | --- | --- |
| v22.23.2 | 1 | never calls back |
| v24.18.0 | 0 | returns in 0 ms |

`closeIdleConnections()` does not clear it; `closeAllConnections()` does.

This is not test-only. `engines` allows `>=22.13.0`, so a single aborted OTA upload wedged `WebServer.stop()` for the life of the process.

### 2. The 413 for an oversized upload was rarely delivered

`OtaUploadHandler` rejects on the declared `Content-Length`, which is meant to be the one path where the client reliably reads the answer. It was not: both `Connection: close` and the explicit `req.destroy()` on `finish` tear the socket down while the peer is still writing its body, and the resulting RST discards the response the client has not read yet. Clients saw a broken pipe instead of "Firmware image exceeds the 64 MB limit".

The oversized-upload integration test hit the same reset and fails intermittently on `main` today (2 of 6 runs locally, `write EPIPE`), independent of this branch.

## What changed

- `WebServer.stop()` calls `closeAllConnections()` alongside `close()`.
- `OtaUploadHandler` discards a rejected body until the peer stops writing, bounded by a 10 s deadline, rather than resetting the socket immediately. A ticket holder still cannot keep the server reading indefinitely.
- `OtaUploadHandlerTest` gains coverage for the rejection actually reaching a client that is still writing, and a teardown helper that survives the Node <= 22 leak.
- The integration test drives the declared-length path over `node:http` with an oversized `Content-Length` and a one-byte body, so it tests the rejection without racing a 64 MB write, and asserts the ticket is spent afterwards.

## Verification

- `OtaUploadHandlerTest` on Node 22.23.2: 30/30 failures before, 40/40 green after.
- Full `npm test` green on Node 24.18.0; `matter-server` suite green x3 on Node 22.23.2.
- Both handler hunks mutation-tested separately. Restoring the immediate `req.destroy()` fails the new test with `write EPIPE`; re-adding only `Connection: close` while keeping the discard also fails it.
- `npm run format`, `npm run lint`, `npm run build` clean.

## Note for review

Dropping `Connection: close` means a rejected upload's connection stays keep-alive until the handler tears it down on body end or at the 10 s deadline. Net exposure is unchanged, since the header did not bound anything the discard does not, but it is a behaviour change on that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
