### PR TITLE
Add Presets and Thermostat Suggestions panels to Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
-- Enhancement: (lboue) Added Presets and Thermostat Suggestions (Thermostat cluster PRES/TSUGGEST features) read-only panels to Dashboard
+- Enhancement: (lboue) Added Presets and Thermostat Suggestions (Thermostat cluster PRES/TSUGGEST features) panels to Dashboard, including adding and removing suggestions
 
 ## 1.4.0 (2026-08-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This page shows a detailed overview of the changes between versions without the 
 	## **WORK IN PROGRESS**
 -->
 
+## **WORK IN PROGRESS**
+
+- Enhancement: (lboue) Added Presets and Thermostat Suggestions (Thermostat cluster PRES/TSUGGEST features) read-only panels to Dashboard
+
 ## 1.4.0 (2026-08-07)
 
 - Enhancement: Introduces Websocket Schema version 13 (backward compatible)

--- a/packages/dashboard/src/pages/cluster-commands/clusters/commodity-tariff-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/commodity-tariff-commands.ts
@@ -9,12 +9,12 @@ import { customElement } from "lit/decorators.js";
 import {
     COMMODITY_TARIFF_CLUSTER_ID,
     commodityTariffInfo,
-    formatEpochTime,
     formatMinutesOfDay,
     type ScheduleRow,
     type TariffComponentInfo,
     type TariffRange,
 } from "../../../util/commodity-tariff.js";
+import { formatEpochTime } from "../../../util/time.js";
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
 

--- a/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
@@ -15,7 +15,7 @@ import {
 import { css, type CSSResultGroup, html, nothing, type TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import "../../../components/ha-svg-icon.js";
-import { formatEpochTime } from "../../../util/commodity-tariff.js";
+import { formatEpochTime } from "../../../util/time.js";
 import {
     buildDaySegments,
     compareTransitionsForDisplay,

--- a/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
@@ -437,7 +437,6 @@ class ThermostatClusterCommands extends BaseClusterCommands {
         isCurrent: boolean,
         presets: ThermostatPreset[],
     ): TemplateResult {
-        const online = this.node?.available === true;
         const busy = this._removeOperations[suggestion.uniqueId] !== undefined;
         return html`
             <li class="preset-row">
@@ -457,7 +456,7 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                 <md-outlined-icon-button
                     title="Remove suggestion"
                     aria-label="Remove suggestion"
-                    ?disabled=${!online || busy}
+                    ?disabled=${busy}
                     @click=${handleAsync(() => this._handleRemoveSuggestion(suggestion.uniqueId))}
                 >
                     <ha-svg-icon .path=${mdiTrashCanOutline}></ha-svg-icon>
@@ -467,7 +466,6 @@ class ThermostatClusterCommands extends BaseClusterCommands {
     }
 
     private _renderAddSuggestionForm(presets: ThermostatPreset[], atCapacity: boolean): TemplateResult {
-        const online = this.node?.available === true;
         // The device rewrites Presets at will, so a handle picked earlier may no longer exist.
         const selectedHandle =
             (presets.some(p => p.handle === this._addPresetHandle) ? this._addPresetHandle : presets[0]?.handle) ??
@@ -514,9 +512,7 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                                   }}
                               />
                               <md-outlined-button
-                                  ?disabled=${
-                                      !online || this._addOperation !== null || atCapacity || selectedHandle === null
-                                  }
+                                  ?disabled=${this._addOperation !== null || atCapacity || selectedHandle === null}
                                   @click=${handleAsync(() => this._handleAddSuggestion(selectedHandle))}
                               >
                                   <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
@@ -942,8 +938,9 @@ class ThermostatClusterCommands extends BaseClusterCommands {
     ];
 }
 
-// The panels visualise cached attributes, so they stay useful offline; the invoke controls guard on `available`.
-registerClusterCommands(THERMOSTAT_CLUSTER_ID, "thermostat-cluster-commands", { renderWhenOffline: true });
+// Without renderWhenOffline the parent unmounts this panel when the node drops, which is what lets the
+// suggestion invoke controls omit an `available` check. Adding it means adding those checks back.
+registerClusterCommands(THERMOSTAT_CLUSTER_ID, "thermostat-cluster-commands");
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
@@ -4,10 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { mdiCheck, mdiClockOutline, mdiFire, mdiSnowflake } from "@mdi/js";
-import { css, type CSSResultGroup, html, nothing } from "lit";
+import {
+    mdiCheck,
+    mdiClockOutline,
+    mdiFire,
+    mdiLightbulbOnOutline,
+    mdiPaletteSwatchOutline,
+    mdiSnowflake,
+} from "@mdi/js";
+import { css, type CSSResultGroup, html, nothing, type TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import "../../../components/ha-svg-icon.js";
+import { formatEpochTime } from "../../../util/commodity-tariff.js";
 import {
     buildDaySegments,
     compareTransitionsForDisplay,
@@ -17,9 +25,11 @@ import {
     formatDayOfWeek,
     formatHandleShort,
     formatMinutes,
+    formatPresetLabel,
     formatSegmentTooltip,
     formatSetpoint,
-    isMSCHActive,
+    isFeatureActive,
+    readActivePresetHandle,
     readActiveScheduleHandle,
     readPresets,
     pickSetpointForMode,
@@ -29,7 +39,17 @@ import {
     type ScheduleColorMode,
     setpointColorMixPercent,
     THERMOSTAT_CLUSTER_ID,
+    type ThermostatPreset,
 } from "../../../util/thermostat-schedule.js";
+import {
+    isTSUGGESTActive,
+    readCurrentThermostatSuggestion,
+    readMaxThermostatSuggestions,
+    readThermostatSuggestionNotFollowingReasons,
+    readThermostatSuggestions,
+    resolveSuggestionLabel,
+    type ThermostatSuggestion,
+} from "../../../util/thermostat-suggestions.js";
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
 
@@ -53,10 +73,16 @@ class ThermostatClusterCommands extends BaseClusterCommands {
     }
 
     override render() {
-        if (!this.node || this.cluster !== THERMOSTAT_CLUSTER_ID || !isMSCHActive(this.node, this.endpoint)) {
-            return nothing;
-        }
+        if (!this.node || this.cluster !== THERMOSTAT_CLUSTER_ID) return nothing;
 
+        return html`
+            ${isFeatureActive(this.node, this.endpoint, "MSCH") ? this._renderSchedulePanel() : nothing}
+            ${isFeatureActive(this.node, this.endpoint, "PRES") ? this._renderPresetsPanel() : nothing}
+            ${isTSUGGESTActive(this.node, this.endpoint) ? this._renderSuggestionsPanel() : nothing}
+        `;
+    }
+
+    private _renderSchedulePanel(): TemplateResult {
         const schedules = readSchedules(this.node, this.endpoint);
         const activeHandle = readActiveScheduleHandle(this.node, this.endpoint);
         const presets = readPresets(this.node, this.endpoint);
@@ -257,6 +283,142 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                     }
                 </div>
             </details>
+        `;
+    }
+
+    private _renderPresetsPanel(): TemplateResult {
+        const presets = readPresets(this.node, this.endpoint);
+        const activeHandle = readActivePresetHandle(this.node, this.endpoint);
+
+        return html`
+            <details class="command-panel" open>
+                <summary>
+                    <ha-svg-icon .path=${mdiPaletteSwatchOutline}></ha-svg-icon>
+                    Presets
+                    <span class="feature-map-badge">FeatureMap: PRES</span>
+                </summary>
+                <div class="command-content">
+                    ${
+                        presets.length === 0
+                            ? html`<p class="empty">No presets configured.</p>`
+                            : html`
+                                  <ul class="preset-list">
+                                      ${presets.map(p => this._renderPresetRow(p, p.handle === activeHandle))}
+                                  </ul>
+                              `
+                    }
+                </div>
+            </details>
+        `;
+    }
+
+    private _renderPresetRow(preset: ThermostatPreset, isActive: boolean): TemplateResult {
+        return html`
+            <li class="preset-row">
+                <span class="preset-label">${formatPresetLabel(preset)}</span>
+                <span class="preset-setpoints">
+                    ${this._setpointCell(mdiFire, preset.heatingSetpoint, preset.heatingSetpoint)}
+                    ${this._setpointCell(mdiSnowflake, preset.coolingSetpoint, preset.coolingSetpoint)}
+                </span>
+                ${preset.builtIn ? html`<span class="chip-handle">Built-in</span>` : nothing}
+                ${
+                    isActive
+                        ? html`<span class="active-badge">
+                              <ha-svg-icon .path=${mdiCheck}></ha-svg-icon>
+                              Active
+                          </span>`
+                        : nothing
+                }
+            </li>
+        `;
+    }
+
+    private _renderSuggestionsPanel(): TemplateResult {
+        const maxSuggestions = readMaxThermostatSuggestions(this.node, this.endpoint);
+        const suggestions = readThermostatSuggestions(this.node, this.endpoint);
+        const current = readCurrentThermostatSuggestion(this.node, this.endpoint);
+        const notFollowingReasons = readThermostatSuggestionNotFollowingReasons(this.node, this.endpoint);
+        const presets = readPresets(this.node, this.endpoint);
+
+        return html`
+            <details class="command-panel" open>
+                <summary>
+                    <ha-svg-icon .path=${mdiLightbulbOnOutline}></ha-svg-icon>
+                    Thermostat Suggestions
+                    <span class="feature-map-badge">FeatureMap: TSUGGEST</span>
+                </summary>
+                <div class="command-content">
+                    ${
+                        current
+                            ? html`
+                                  <div class="current-suggestion">
+                                      <span class="suggestion-current-label">Current suggestion</span>
+                                      <span class="preset-label">${resolveSuggestionLabel(current, presets)}</span>
+                                      <span class="suggestion-window">
+                                          ${formatEpochTime(current.effectiveTime)} –
+                                          ${formatEpochTime(current.expirationTime)}
+                                      </span>
+                                      ${
+                                          notFollowingReasons.length > 0
+                                              ? html`<span class="suggestion-not-following">
+                                                    Not followed: ${notFollowingReasons.map(r => r.label).join(", ")}
+                                                </span>`
+                                              : nothing
+                                      }
+                                  </div>
+                              `
+                            : html`<p class="empty">No current suggestion.</p>`
+                    }
+                    ${
+                        suggestions === undefined
+                            ? nothing
+                            : html`
+                                  <div class="transitions-header">
+                                      QUEUE
+                                      ${maxSuggestions !== null ? html`· ${suggestions.length}/${maxSuggestions}` : nothing}
+                                  </div>
+                                  ${
+                                      suggestions.length === 0
+                                          ? html`<p class="empty">No suggestions queued.</p>`
+                                          : html`
+                                                <ul class="preset-list">
+                                                    ${suggestions.map(s =>
+                                                        this._renderSuggestionRow(
+                                                            s,
+                                                            s.uniqueId === current?.uniqueId,
+                                                            presets,
+                                                        ),
+                                                    )}
+                                                </ul>
+                                            `
+                                  }
+                              `
+                    }
+                </div>
+            </details>
+        `;
+    }
+
+    private _renderSuggestionRow(
+        suggestion: ThermostatSuggestion,
+        isCurrent: boolean,
+        presets: ThermostatPreset[],
+    ): TemplateResult {
+        return html`
+            <li class="preset-row">
+                <span class="preset-label">${resolveSuggestionLabel(suggestion, presets)}</span>
+                <span class="suggestion-window">
+                    ${formatEpochTime(suggestion.effectiveTime)} – ${formatEpochTime(suggestion.expirationTime)}
+                </span>
+                ${
+                    isCurrent
+                        ? html`<span class="active-badge">
+                              <ha-svg-icon .path=${mdiCheck}></ha-svg-icon>
+                              Current
+                          </span>`
+                        : nothing
+                }
+            </li>
         `;
     }
 
@@ -519,6 +681,66 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                 font-style: italic;
                 font-weight: 400;
                 color: var(--md-sys-color-on-surface-variant);
+            }
+
+            .preset-list {
+                list-style: none;
+                margin: 0;
+                padding: 0;
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+            }
+
+            .preset-row {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+                padding: 8px 12px;
+                border-radius: 8px;
+                background: var(--md-sys-color-surface-container-highest);
+            }
+
+            .preset-label {
+                flex: 1;
+                font-weight: 500;
+            }
+
+            .preset-setpoints {
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+            }
+
+            .current-suggestion {
+                display: flex;
+                flex-wrap: wrap;
+                align-items: baseline;
+                gap: 8px 12px;
+                padding: 8px 12px;
+                margin-bottom: 12px;
+                border-radius: 8px;
+                background: var(--md-sys-color-secondary-container);
+                color: var(--md-sys-color-on-secondary-container);
+            }
+
+            .suggestion-current-label {
+                text-transform: uppercase;
+                font-size: 0.75rem;
+                letter-spacing: 0.04em;
+                opacity: 0.8;
+            }
+
+            .suggestion-window {
+                font-family: var(--monospace-font);
+                font-size: 0.8rem;
+                opacity: 0.8;
+            }
+
+            .suggestion-not-following {
+                flex-basis: 100%;
+                font-size: 0.8rem;
+                color: var(--danger-color);
             }
 
             .empty {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import "@material/web/button/outlined-button";
 import "@material/web/iconbutton/outlined-icon-button";
+import type { MatterNode } from "@matter-server/ws-client";
 import {
     mdiCheck,
     mdiClockOutline,
@@ -17,6 +19,7 @@ import {
 } from "@mdi/js";
 import { css, type CSSResultGroup, html, nothing, type TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import { live } from "lit/directives/live.js";
 import "../../../components/ha-svg-icon.js";
 import { showAlertDialog } from "../../../components/dialog-box/show-dialog-box.js";
 import { handleAsync } from "../../../util/async-handler.js";
@@ -46,7 +49,9 @@ import {
     type ThermostatPreset,
 } from "../../../util/thermostat-schedule.js";
 import {
-    isTSUGGESTActive,
+    clampExpirationMinutes,
+    MAX_EXPIRATION_MINUTES,
+    MIN_EXPIRATION_MINUTES,
     readCurrentThermostatSuggestion,
     readMaxThermostatSuggestions,
     readThermostatSuggestionNotFollowingReasons,
@@ -60,9 +65,7 @@ import { registerClusterCommands } from "../registry.js";
 
 const HOUR_TICKS = [0, 4, 8, 12, 16, 20, 24];
 
-// AddThermostatSuggestion's ExpirationInMinutes constraint (Matter spec §4.3.7.9).
-const MIN_EXPIRATION_MINUTES = 30;
-const MAX_EXPIRATION_MINUTES = 1440;
+const DEFAULT_EXPIRATION_MINUTES = 60;
 
 @customElement("thermostat-cluster-commands")
 class ThermostatClusterCommands extends BaseClusterCommands {
@@ -71,9 +74,16 @@ class ThermostatClusterCommands extends BaseClusterCommands {
     private _scheduleContext?: string;
 
     @state() private _addPresetHandle: string | null = null;
-    @state() private _addExpirationMinutes = 60;
-    @state() private _addBusy = false;
-    @state() private _removeBusy: Record<number, boolean> = {};
+    @state() private _addExpirationMinutes = DEFAULT_EXPIRATION_MINUTES;
+    @state() private _addExpirationInput = String(DEFAULT_EXPIRATION_MINUTES);
+
+    /**
+     * In-flight invokes, identified by operation id rather than a boolean: the panel is reused across
+     * navigations, so a settling promise must only clear the flag it set itself.
+     */
+    @state() private _addOperation: number | null = null;
+    @state() private _removeOperations: Record<number, number> = {};
+    private _operationCounter = 0;
 
     override willUpdate(changedProperties: Map<string, unknown>) {
         super.willUpdate(changedProperties);
@@ -83,8 +93,10 @@ class ThermostatClusterCommands extends BaseClusterCommands {
             this._selectedHandle = null;
             this._colorMode = "heat";
             this._addPresetHandle = null;
-            this._addExpirationMinutes = 60;
-            this._removeBusy = {};
+            this._addExpirationMinutes = DEFAULT_EXPIRATION_MINUTES;
+            this._addExpirationInput = String(DEFAULT_EXPIRATION_MINUTES);
+            this._addOperation = null;
+            this._removeOperations = {};
         }
         this._scheduleContext = context;
     }
@@ -95,14 +107,14 @@ class ThermostatClusterCommands extends BaseClusterCommands {
         return html`
             ${isFeatureActive(this.node, this.endpoint, "MSCH") ? this._renderSchedulePanel() : nothing}
             ${isFeatureActive(this.node, this.endpoint, "PRES") ? this._renderPresetsPanel() : nothing}
-            ${isTSUGGESTActive(this.node, this.endpoint) ? this._renderSuggestionsPanel() : nothing}
+            ${isFeatureActive(this.node, this.endpoint, "TSUGGEST") ? this._renderSuggestionsPanel() : nothing}
         `;
     }
 
     private _renderSchedulePanel(): TemplateResult {
         const schedules = readSchedules(this.node, this.endpoint);
         const activeHandle = readActiveScheduleHandle(this.node, this.endpoint);
-        const presets = readPresets(this.node, this.endpoint);
+        const presets = readPresets(this.node, this.endpoint) ?? [];
 
         const pickedSchedule =
             (this._selectedHandle !== null ? schedules?.find(s => s.handle === this._selectedHandle) : undefined) ??
@@ -316,13 +328,15 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                 </summary>
                 <div class="command-content">
                     ${
-                        presets.length === 0
-                            ? html`<p class="empty">No presets configured.</p>`
-                            : html`
-                                  <ul class="preset-list">
-                                      ${presets.map(p => this._renderPresetRow(p, p.handle === activeHandle))}
-                                  </ul>
-                              `
+                        presets === undefined
+                            ? html`<p class="empty">Presets attribute not available.</p>`
+                            : presets.length === 0
+                              ? html`<p class="empty">No presets configured.</p>`
+                              : html`
+                                    <ul class="preset-list">
+                                        ${presets.map(p => this._renderPresetRow(p, p.handle === activeHandle))}
+                                    </ul>
+                                `
                     }
                 </div>
             </details>
@@ -355,7 +369,8 @@ class ThermostatClusterCommands extends BaseClusterCommands {
         const suggestions = readThermostatSuggestions(this.node, this.endpoint);
         const current = readCurrentThermostatSuggestion(this.node, this.endpoint);
         const notFollowingReasons = readThermostatSuggestionNotFollowingReasons(this.node, this.endpoint);
-        const presets = readPresets(this.node, this.endpoint);
+        const presets = readPresets(this.node, this.endpoint) ?? [];
+        const atCapacity = maxSuggestions !== null && suggestions !== undefined && suggestions.length >= maxSuggestions;
 
         return html`
             <details class="command-panel" open>
@@ -388,7 +403,7 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                     }
                     ${
                         suggestions === undefined
-                            ? nothing
+                            ? html`<p class="empty">ThermostatSuggestions attribute not available.</p>`
                             : html`
                                   <div class="transitions-header">
                                       QUEUE
@@ -411,7 +426,7 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                                   }
                               `
                     }
-                    ${this._renderAddSuggestionForm(presets)}
+                    ${this._renderAddSuggestionForm(presets, atCapacity)}
                 </div>
             </details>
         `;
@@ -423,9 +438,10 @@ class ThermostatClusterCommands extends BaseClusterCommands {
         presets: ThermostatPreset[],
     ): TemplateResult {
         const online = this.node?.available === true;
-        const busy = this._removeBusy[suggestion.uniqueId] === true;
+        const busy = this._removeOperations[suggestion.uniqueId] !== undefined;
         return html`
             <li class="preset-row">
+                <span class="chip-handle">#${suggestion.uniqueId}</span>
                 <span class="preset-label">${resolveSuggestionLabel(suggestion, presets)}</span>
                 <span class="suggestion-window">
                     ${formatEpochTime(suggestion.effectiveTime)} – ${formatEpochTime(suggestion.expirationTime)}
@@ -450,9 +466,12 @@ class ThermostatClusterCommands extends BaseClusterCommands {
         `;
     }
 
-    private _renderAddSuggestionForm(presets: ThermostatPreset[]): TemplateResult {
+    private _renderAddSuggestionForm(presets: ThermostatPreset[], atCapacity: boolean): TemplateResult {
         const online = this.node?.available === true;
-        const selectedHandle = this._addPresetHandle ?? presets[0]?.handle ?? null;
+        // The device rewrites Presets at will, so a handle picked earlier may no longer exist.
+        const selectedHandle =
+            (presets.some(p => p.handle === this._addPresetHandle) ? this._addPresetHandle : presets[0]?.handle) ??
+            null;
         return html`
             <div class="transitions-header">ADD SUGGESTION</div>
             ${
@@ -469,7 +488,7 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                               >
                                   ${presets.map(
                                       p => html`
-                                          <option value=${p.handle} ?selected=${p.handle === selectedHandle}>
+                                          <option value=${p.handle} .selected=${p.handle === selectedHandle}>
                                               ${formatPresetLabel(p)}
                                           </option>
                                       `,
@@ -481,14 +500,23 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                                   type="number"
                                   min=${MIN_EXPIRATION_MINUTES}
                                   max=${MAX_EXPIRATION_MINUTES}
-                                  .value=${String(this._addExpirationMinutes)}
+                                  .value=${live(this._addExpirationInput)}
                                   @input=${(e: Event) => {
-                                      const value = parseInt((e.target as HTMLInputElement).value, 10);
-                                      if (!Number.isNaN(value)) this._addExpirationMinutes = value;
+                                      this._addExpirationInput = (e.target as HTMLInputElement).value;
+                                  }}
+                                  @change=${(e: Event) => {
+                                      const raw = (e.target as HTMLInputElement).value.trim();
+                                      this._addExpirationMinutes = clampExpirationMinutes(
+                                          raw === "" ? NaN : Number(raw),
+                                          this._addExpirationMinutes,
+                                      );
+                                      this._addExpirationInput = String(this._addExpirationMinutes);
                                   }}
                               />
                               <md-outlined-button
-                                  ?disabled=${!online || this._addBusy || selectedHandle === null}
+                                  ?disabled=${
+                                      !online || this._addOperation !== null || atCapacity || selectedHandle === null
+                                  }
                                   @click=${handleAsync(() => this._handleAddSuggestion(selectedHandle))}
                               >
                                   <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
@@ -500,15 +528,13 @@ class ThermostatClusterCommands extends BaseClusterCommands {
         `;
     }
 
-    private async _handleAddSuggestion(presetHandle: string) {
+    private async _handleAddSuggestion(presetHandle: string | null) {
         const node = this.node;
         const endpoint = this.endpoint;
-        if (!node) return;
-        const expirationInMinutes = Math.min(
-            MAX_EXPIRATION_MINUTES,
-            Math.max(MIN_EXPIRATION_MINUTES, this._addExpirationMinutes),
-        );
-        this._addBusy = true;
+        if (!node || presetHandle === null || this._addOperation !== null) return;
+        const expirationInMinutes = clampExpirationMinutes(this._addExpirationMinutes, DEFAULT_EXPIRATION_MINUTES);
+        const operation = ++this._operationCounter;
+        this._addOperation = operation;
         try {
             await this.client.deviceCommand(node.node_id, endpoint, THERMOSTAT_CLUSTER_ID, "AddThermostatSuggestion", {
                 presetHandle,
@@ -516,20 +542,18 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                 expirationInMinutes,
             });
         } catch (err) {
-            showAlertDialog({
-                title: "Add suggestion failed",
-                text: err instanceof Error ? err.message : String(err),
-            }).catch(alertErr => console.error("Failed to show the add-suggestion error", alertErr));
+            this._reportInvokeFailure("Add suggestion failed", err, node, endpoint);
         } finally {
-            if (this.isSameContext(node, endpoint)) this._addBusy = false;
+            if (this._addOperation === operation) this._addOperation = null;
         }
     }
 
     private async _handleRemoveSuggestion(uniqueId: number) {
         const node = this.node;
         const endpoint = this.endpoint;
-        if (!node) return;
-        this._removeBusy = { ...this._removeBusy, [uniqueId]: true };
+        if (!node || this._removeOperations[uniqueId] !== undefined) return;
+        const operation = ++this._operationCounter;
+        this._removeOperations = { ...this._removeOperations, [uniqueId]: operation };
         try {
             await this.client.deviceCommand(
                 node.node_id,
@@ -541,15 +565,26 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                 },
             );
         } catch (err) {
-            showAlertDialog({
-                title: "Remove suggestion failed",
-                text: err instanceof Error ? err.message : String(err),
-            }).catch(alertErr => console.error("Failed to show the remove-suggestion error", alertErr));
+            this._reportInvokeFailure("Remove suggestion failed", err, node, endpoint);
         } finally {
-            if (this.isSameContext(node, endpoint)) {
-                this._removeBusy = { ...this._removeBusy, [uniqueId]: false };
+            if (this._removeOperations[uniqueId] === operation) {
+                const pending = { ...this._removeOperations };
+                delete pending[uniqueId];
+                this._removeOperations = pending;
             }
         }
+    }
+
+    /** Only alerts while the panel still shows the node the invoke was sent to; the dialog names no device. */
+    private _reportInvokeFailure(title: string, err: unknown, node: MatterNode, endpoint: number) {
+        if (!this.isSameContext(node, endpoint)) {
+            console.error(`${title} (panel moved on)`, err);
+            return;
+        }
+        showAlertDialog({
+            title,
+            text: err instanceof Error ? err.message : String(err),
+        }).catch(alertErr => console.error(`Failed to show the "${title}" dialog`, alertErr));
     }
 
     /** A value the device did not report for this transition comes from its preset, so it is marked as derived. */
@@ -581,6 +616,12 @@ class ThermostatClusterCommands extends BaseClusterCommands {
     static override styles: CSSResultGroup = [
         BaseClusterCommands.styles,
         css`
+            :host {
+                display: flex;
+                flex-direction: column;
+                gap: 12px;
+            }
+
             .feature-map-badge {
                 margin-left: auto;
                 font-size: 0.75rem;
@@ -842,8 +883,13 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                 gap: 4px;
             }
 
+            .preset-setpoints ha-svg-icon {
+                --mdc-icon-size: 16px;
+            }
+
             .preset-row md-outlined-icon-button {
-                --md-outlined-icon-button-container-size: 32px;
+                --md-outlined-icon-button-container-height: 32px;
+                --md-outlined-icon-button-container-width: 32px;
                 --md-outlined-icon-button-icon-size: 16px;
                 flex-shrink: 0;
             }
@@ -896,7 +942,8 @@ class ThermostatClusterCommands extends BaseClusterCommands {
     ];
 }
 
-registerClusterCommands(THERMOSTAT_CLUSTER_ID, "thermostat-cluster-commands");
+// The panels visualise cached attributes, so they stay useful offline; the invoke controls guard on `available`.
+registerClusterCommands(THERMOSTAT_CLUSTER_ID, "thermostat-cluster-commands", { renderWhenOffline: true });
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/thermostat-commands.ts
@@ -4,18 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import "@material/web/iconbutton/outlined-icon-button";
 import {
     mdiCheck,
     mdiClockOutline,
     mdiFire,
     mdiLightbulbOnOutline,
     mdiPaletteSwatchOutline,
+    mdiPlus,
     mdiSnowflake,
+    mdiTrashCanOutline,
 } from "@mdi/js";
 import { css, type CSSResultGroup, html, nothing, type TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import "../../../components/ha-svg-icon.js";
-import { formatEpochTime } from "../../../util/time.js";
+import { showAlertDialog } from "../../../components/dialog-box/show-dialog-box.js";
+import { handleAsync } from "../../../util/async-handler.js";
 import {
     buildDaySegments,
     compareTransitionsForDisplay,
@@ -50,16 +54,26 @@ import {
     resolveSuggestionLabel,
     type ThermostatSuggestion,
 } from "../../../util/thermostat-suggestions.js";
+import { formatEpochTime } from "../../../util/time.js";
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
 
 const HOUR_TICKS = [0, 4, 8, 12, 16, 20, 24];
+
+// AddThermostatSuggestion's ExpirationInMinutes constraint (Matter spec §4.3.7.9).
+const MIN_EXPIRATION_MINUTES = 30;
+const MAX_EXPIRATION_MINUTES = 1440;
 
 @customElement("thermostat-cluster-commands")
 class ThermostatClusterCommands extends BaseClusterCommands {
     @state() private _selectedHandle: string | null = null;
     @state() private _colorMode: ScheduleColorMode = "heat";
     private _scheduleContext?: string;
+
+    @state() private _addPresetHandle: string | null = null;
+    @state() private _addExpirationMinutes = 60;
+    @state() private _addBusy = false;
+    @state() private _removeBusy: Record<number, boolean> = {};
 
     override willUpdate(changedProperties: Map<string, unknown>) {
         super.willUpdate(changedProperties);
@@ -68,6 +82,9 @@ class ThermostatClusterCommands extends BaseClusterCommands {
         if (this._scheduleContext !== undefined && this._scheduleContext !== context) {
             this._selectedHandle = null;
             this._colorMode = "heat";
+            this._addPresetHandle = null;
+            this._addExpirationMinutes = 60;
+            this._removeBusy = {};
         }
         this._scheduleContext = context;
     }
@@ -394,6 +411,7 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                                   }
                               `
                     }
+                    ${this._renderAddSuggestionForm(presets)}
                 </div>
             </details>
         `;
@@ -404,6 +422,8 @@ class ThermostatClusterCommands extends BaseClusterCommands {
         isCurrent: boolean,
         presets: ThermostatPreset[],
     ): TemplateResult {
+        const online = this.node?.available === true;
+        const busy = this._removeBusy[suggestion.uniqueId] === true;
         return html`
             <li class="preset-row">
                 <span class="preset-label">${resolveSuggestionLabel(suggestion, presets)}</span>
@@ -418,8 +438,118 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                           </span>`
                         : nothing
                 }
+                <md-outlined-icon-button
+                    title="Remove suggestion"
+                    aria-label="Remove suggestion"
+                    ?disabled=${!online || busy}
+                    @click=${handleAsync(() => this._handleRemoveSuggestion(suggestion.uniqueId))}
+                >
+                    <ha-svg-icon .path=${mdiTrashCanOutline}></ha-svg-icon>
+                </md-outlined-icon-button>
             </li>
         `;
+    }
+
+    private _renderAddSuggestionForm(presets: ThermostatPreset[]): TemplateResult {
+        const online = this.node?.available === true;
+        const selectedHandle = this._addPresetHandle ?? presets[0]?.handle ?? null;
+        return html`
+            <div class="transitions-header">ADD SUGGESTION</div>
+            ${
+                presets.length === 0
+                    ? html`<p class="empty">No presets available to suggest.</p>`
+                    : html`
+                          <div class="command-row">
+                              <label for="addSuggestionPreset">Preset:</label>
+                              <select
+                                  id="addSuggestionPreset"
+                                  @change=${(e: Event) => {
+                                      this._addPresetHandle = (e.target as HTMLSelectElement).value;
+                                  }}
+                              >
+                                  ${presets.map(
+                                      p => html`
+                                          <option value=${p.handle} ?selected=${p.handle === selectedHandle}>
+                                              ${formatPresetLabel(p)}
+                                          </option>
+                                      `,
+                                  )}
+                              </select>
+                              <label for="addSuggestionExpiration">Expires in (min):</label>
+                              <input
+                                  id="addSuggestionExpiration"
+                                  type="number"
+                                  min=${MIN_EXPIRATION_MINUTES}
+                                  max=${MAX_EXPIRATION_MINUTES}
+                                  .value=${String(this._addExpirationMinutes)}
+                                  @input=${(e: Event) => {
+                                      const value = parseInt((e.target as HTMLInputElement).value, 10);
+                                      if (!Number.isNaN(value)) this._addExpirationMinutes = value;
+                                  }}
+                              />
+                              <md-outlined-button
+                                  ?disabled=${!online || this._addBusy || selectedHandle === null}
+                                  @click=${handleAsync(() => this._handleAddSuggestion(selectedHandle))}
+                              >
+                                  <ha-svg-icon slot="icon" .path=${mdiPlus}></ha-svg-icon>
+                                  Add
+                              </md-outlined-button>
+                          </div>
+                      `
+            }
+        `;
+    }
+
+    private async _handleAddSuggestion(presetHandle: string) {
+        const node = this.node;
+        const endpoint = this.endpoint;
+        if (!node) return;
+        const expirationInMinutes = Math.min(
+            MAX_EXPIRATION_MINUTES,
+            Math.max(MIN_EXPIRATION_MINUTES, this._addExpirationMinutes),
+        );
+        this._addBusy = true;
+        try {
+            await this.client.deviceCommand(node.node_id, endpoint, THERMOSTAT_CLUSTER_ID, "AddThermostatSuggestion", {
+                presetHandle,
+                effectiveTime: null,
+                expirationInMinutes,
+            });
+        } catch (err) {
+            showAlertDialog({
+                title: "Add suggestion failed",
+                text: err instanceof Error ? err.message : String(err),
+            }).catch(alertErr => console.error("Failed to show the add-suggestion error", alertErr));
+        } finally {
+            if (this.isSameContext(node, endpoint)) this._addBusy = false;
+        }
+    }
+
+    private async _handleRemoveSuggestion(uniqueId: number) {
+        const node = this.node;
+        const endpoint = this.endpoint;
+        if (!node) return;
+        this._removeBusy = { ...this._removeBusy, [uniqueId]: true };
+        try {
+            await this.client.deviceCommand(
+                node.node_id,
+                endpoint,
+                THERMOSTAT_CLUSTER_ID,
+                "RemoveThermostatSuggestion",
+                {
+                    uniqueId,
+                },
+            );
+        } catch (err) {
+            showAlertDialog({
+                title: "Remove suggestion failed",
+                text: err instanceof Error ? err.message : String(err),
+            }).catch(alertErr => console.error("Failed to show the remove-suggestion error", alertErr));
+        } finally {
+            if (this.isSameContext(node, endpoint)) {
+                this._removeBusy = { ...this._removeBusy, [uniqueId]: false };
+            }
+        }
     }
 
     /** A value the device did not report for this transition comes from its preset, so it is marked as derived. */
@@ -710,6 +840,21 @@ class ThermostatClusterCommands extends BaseClusterCommands {
                 display: inline-flex;
                 align-items: center;
                 gap: 4px;
+            }
+
+            .preset-row md-outlined-icon-button {
+                --md-outlined-icon-button-container-size: 32px;
+                --md-outlined-icon-button-icon-size: 16px;
+                flex-shrink: 0;
+            }
+
+            .command-row select {
+                padding: 8px;
+                border: 1px solid var(--md-sys-color-outline);
+                border-radius: 4px;
+                background: var(--md-sys-color-surface);
+                color: var(--md-sys-color-on-surface);
+                font: inherit;
             }
 
             .current-suggestion {

--- a/packages/dashboard/src/util/commodity-tariff.ts
+++ b/packages/dashboard/src/util/commodity-tariff.ts
@@ -57,9 +57,6 @@ const TARIFF_UNIT_NAMES: Record<number, string> = { 0: "kWh", 1: "kVAh" };
 /** ISO 4217 numeric currency codes; falls back to the raw code when not listed here. */
 const CURRENCY_SYMBOLS: Record<number, string> = { 978: "€", 840: "$", 826: "£", 756: "CHF" };
 
-/** Matter epoch-s values count seconds since 2000-01-01T00:00:00Z, not the Unix epoch. */
-const MATTER_EPOCH_OFFSET_SECONDS = 946_684_800;
-
 export interface CurrencyInfo {
     code: number;
     decimalPoints: number;
@@ -368,21 +365,6 @@ export function formatMinutesOfDay(minutes: number): string {
     const hours = Math.floor(minutes / 60);
     const mins = minutes % 60;
     return `${String(hours).padStart(2, "0")}:${String(mins).padStart(2, "0")}`;
-}
-
-/** Formats a Matter epoch-s instant as a local time, prefixed with the date when it isn't today. */
-export function formatEpochTime(matterEpochSeconds: number, relativeTo: Date = new Date()): string {
-    const date = new Date((matterEpochSeconds + MATTER_EPOCH_OFFSET_SECONDS) * 1000);
-    const time = date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
-    if (date.toDateString() === relativeTo.toDateString()) return time;
-    const tomorrow = new Date(relativeTo);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    if (date.toDateString() === tomorrow.toDateString()) return `tomorrow ${time}`;
-    const dateOptions: Intl.DateTimeFormatOptions =
-        date.getFullYear() === relativeTo.getFullYear()
-            ? { month: "2-digit", day: "2-digit" }
-            : { year: "numeric", month: "2-digit", day: "2-digit" };
-    return `${date.toLocaleDateString(undefined, dateOptions)} ${time}`;
 }
 
 export function commodityTariffInfo(attributes: Record<string, unknown>, endpoint: number): CommodityTariffInfo {

--- a/packages/dashboard/src/util/thermostat-schedule.ts
+++ b/packages/dashboard/src/util/thermostat-schedule.ts
@@ -70,7 +70,7 @@ export interface DaySegment {
     systemMode: number | null;
 }
 
-function readAttr(node: MatterNode, endpoint: number, attrId: number): unknown {
+export function readThermostatAttribute(node: MatterNode, endpoint: number, attrId: number): unknown {
     return node.attributes[`${endpoint}/${THERMOSTAT_CLUSTER_ID}/${attrId}`];
 }
 
@@ -137,7 +137,7 @@ function decodePreset(raw: unknown): ThermostatPreset | null {
     };
 }
 
-/** PresetScenarioEnum labels (Matter spec §4.3.9.3). */
+/** PresetScenarioEnum labels (Matter spec §4.3.10.17). */
 const PRESET_SCENARIO_LABELS: Record<number, string> = {
     1: "Occupied",
     2: "Unoccupied",
@@ -164,26 +164,26 @@ export function isFeatureActive(node: MatterNode, endpoint: number, code: string
 }
 
 export function readActiveScheduleHandle(node: MatterNode, endpoint: number): string | null {
-    const v = readAttr(node, endpoint, ATTR_ACTIVE_SCHEDULE_HANDLE);
+    const v = readThermostatAttribute(node, endpoint, ATTR_ACTIVE_SCHEDULE_HANDLE);
     return typeof v === "string" ? v : null;
 }
 
 export function readActivePresetHandle(node: MatterNode, endpoint: number): string | null {
-    const v = readAttr(node, endpoint, ATTR_ACTIVE_PRESET_HANDLE);
+    const v = readThermostatAttribute(node, endpoint, ATTR_ACTIVE_PRESET_HANDLE);
     return typeof v === "string" ? v : null;
 }
 
 /** Decoded Schedules, or undefined when the attribute is not in the node's attribute cache. */
 export function readSchedules(node: MatterNode, endpoint: number): ThermostatSchedule[] | undefined {
-    const raw = readAttr(node, endpoint, ATTR_SCHEDULES);
+    const raw = readThermostatAttribute(node, endpoint, ATTR_SCHEDULES);
     if (!Array.isArray(raw)) return undefined;
     return raw.map(decodeSchedule).filter((s): s is ThermostatSchedule => s !== null);
 }
 
-/** Best-effort: only meaningful when the Presets (PRES) feature is supported, but harmless to read regardless. */
-export function readPresets(node: MatterNode, endpoint: number): ThermostatPreset[] {
-    const raw = readAttr(node, endpoint, ATTR_PRESETS);
-    if (!Array.isArray(raw)) return [];
+/** Decoded Presets, or undefined when the attribute is not in the node's attribute cache. */
+export function readPresets(node: MatterNode, endpoint: number): ThermostatPreset[] | undefined {
+    const raw = readThermostatAttribute(node, endpoint, ATTR_PRESETS);
+    if (!Array.isArray(raw)) return undefined;
     return raw.map(decodePreset).filter((p): p is ThermostatPreset => p !== null);
 }
 

--- a/packages/dashboard/src/util/thermostat-schedule.ts
+++ b/packages/dashboard/src/util/thermostat-schedule.ts
@@ -12,9 +12,10 @@ import { computeActiveClusterFeatures } from "./cluster-features.js";
 /** Thermostat cluster (Matter spec §4.3). */
 export const THERMOSTAT_CLUSTER_ID = 513; // 0x0201
 
+const ATTR_ACTIVE_PRESET_HANDLE = 0x4e;
+const ATTR_ACTIVE_SCHEDULE_HANDLE = 0x4f;
 const ATTR_PRESETS = 0x50;
 const ATTR_SCHEDULES = 0x51;
-const ATTR_ACTIVE_SCHEDULE_HANDLE = 0x4f;
 const ATTR_FEATURE_MAP = 0xfffc;
 
 /** Days in display order (Mon..Sun) mapped to their ScheduleDayOfWeekBitmap bit (Sunday=0 .. Saturday=6). */
@@ -53,9 +54,11 @@ export interface ThermostatSchedule {
 
 export interface ThermostatPreset {
     handle: string;
+    scenario: number | null;
     name: string | null;
     coolingSetpoint: number | null;
     heatingSetpoint: number | null;
+    builtIn: boolean | null;
 }
 
 export interface DaySegment {
@@ -126,22 +129,47 @@ function decodePreset(raw: unknown): ThermostatPreset | null {
     if (handle === null) return null;
     return {
         handle,
+        scenario: pickNumber(obj, "1"),
         name: pickString(obj, "2"),
         coolingSetpoint: pickNumber(obj, "3"),
         heatingSetpoint: pickNumber(obj, "4"),
+        builtIn: pickBoolean(obj, "5"),
     };
 }
 
-/** Whether the Thermostat cluster's FeatureMap includes MatterScheduleConfiguration (MSCH). */
-export function isMSCHActive(node: MatterNode, endpoint: number): boolean {
+/** PresetScenarioEnum labels (Matter spec §4.3.9.3). */
+const PRESET_SCENARIO_LABELS: Record<number, string> = {
+    1: "Occupied",
+    2: "Unoccupied",
+    3: "Sleep",
+    4: "Wake",
+    5: "Vacation",
+    6: "Going to Sleep",
+    254: "User Defined",
+};
+
+/** A preset's display name: its own Name when set, else its PresetScenario label. */
+export function formatPresetLabel(preset: ThermostatPreset): string {
+    if (preset.name) return preset.name;
+    if (preset.scenario !== null) return PRESET_SCENARIO_LABELS[preset.scenario] ?? `Scenario ${preset.scenario}`;
+    return formatHandleShort(preset.handle);
+}
+
+/** Whether the Thermostat cluster's FeatureMap includes the feature with the given code (e.g. "MSCH", "PRES"). */
+export function isFeatureActive(node: MatterNode, endpoint: number, code: string): boolean {
     const knownFeatures = Object.values(clusters[THERMOSTAT_CLUSTER_ID]?.features ?? {});
     const featureMapValue = node.attributes[`${endpoint}/${THERMOSTAT_CLUSTER_ID}/${ATTR_FEATURE_MAP}`];
     if (featureMapValue === undefined) return false;
-    return computeActiveClusterFeatures(featureMapValue, knownFeatures).some(feature => feature.code === "MSCH");
+    return computeActiveClusterFeatures(featureMapValue, knownFeatures).some(feature => feature.code === code);
 }
 
 export function readActiveScheduleHandle(node: MatterNode, endpoint: number): string | null {
     const v = readAttr(node, endpoint, ATTR_ACTIVE_SCHEDULE_HANDLE);
+    return typeof v === "string" ? v : null;
+}
+
+export function readActivePresetHandle(node: MatterNode, endpoint: number): string | null {
+    const v = readAttr(node, endpoint, ATTR_ACTIVE_PRESET_HANDLE);
     return typeof v === "string" ? v : null;
 }
 

--- a/packages/dashboard/src/util/thermostat-suggestions.ts
+++ b/packages/dashboard/src/util/thermostat-suggestions.ts
@@ -10,8 +10,7 @@ import { computeActiveClusterFeatures } from "./cluster-features.js";
 import {
     formatHandleShort,
     formatPresetLabel,
-    isFeatureActive,
-    THERMOSTAT_CLUSTER_ID,
+    readThermostatAttribute,
     type ThermostatPreset,
 } from "./thermostat-schedule.js";
 
@@ -20,6 +19,16 @@ const ATTR_SUGGESTIONS = 0x54;
 const ATTR_CURRENT_SUGGESTION = 0x55;
 const ATTR_NOT_FOLLOWING_REASON = 0x56;
 
+/** AddThermostatSuggestion's ExpirationInMinutes constraint (Matter spec §4.3.12.4.3). */
+export const MIN_EXPIRATION_MINUTES = 30;
+export const MAX_EXPIRATION_MINUTES = 1440;
+
+/** Coerces user input to the ExpirationInMinutes constraint, falling back to `previous` for non-numeric input. */
+export function clampExpirationMinutes(value: number, previous: number): number {
+    if (!Number.isFinite(value)) return previous;
+    return Math.min(MAX_EXPIRATION_MINUTES, Math.max(MIN_EXPIRATION_MINUTES, Math.round(value)));
+}
+
 export interface ThermostatSuggestion {
     uniqueId: number;
     presetHandle: string;
@@ -27,7 +36,7 @@ export interface ThermostatSuggestion {
     expirationTime: number;
 }
 
-/** ThermostatSuggestionNotFollowingReasonBitmap (Matter spec §4.3.9.14). */
+/** ThermostatSuggestionNotFollowingReasonBitmap (Matter spec §4.3.10.9). */
 const NOT_FOLLOWING_REASON_BITS = [
     { bit: 0, code: "DemandResponseEvent", label: "Demand Response Event" },
     { bit: 1, code: "OngoingHold", label: "Ongoing Hold" },
@@ -38,10 +47,6 @@ const NOT_FOLLOWING_REASON_BITS = [
     { bit: 6, code: "PreCoolingOrPreHeating", label: "Pre-cooling / Pre-heating" },
     { bit: 7, code: "ConflictingSuggestions", label: "Conflicting Suggestions" },
 ];
-
-function readAttr(node: MatterNode, endpoint: number, attrId: number): unknown {
-    return node.attributes[`${endpoint}/${THERMOSTAT_CLUSTER_ID}/${attrId}`];
-}
 
 // Struct attributes reach the dashboard field-tag keyed, matching ThermostatSuggestionStruct's field order.
 function decodeSuggestion(raw: unknown): ThermostatSuggestion | null {
@@ -55,25 +60,20 @@ function decodeSuggestion(raw: unknown): ThermostatSuggestion | null {
     return { uniqueId, presetHandle, effectiveTime, expirationTime };
 }
 
-/** Whether the Thermostat cluster's FeatureMap includes Thermostat Suggestions (TSUGGEST). */
-export function isTSUGGESTActive(node: MatterNode, endpoint: number): boolean {
-    return isFeatureActive(node, endpoint, "TSUGGEST");
-}
-
 export function readMaxThermostatSuggestions(node: MatterNode, endpoint: number): number | null {
-    const v = readAttr(node, endpoint, ATTR_MAX_SUGGESTIONS);
+    const v = readThermostatAttribute(node, endpoint, ATTR_MAX_SUGGESTIONS);
     return typeof v === "number" ? v : null;
 }
 
 /** Decoded ThermostatSuggestions queue, or undefined when the attribute is not in the node's attribute cache. */
 export function readThermostatSuggestions(node: MatterNode, endpoint: number): ThermostatSuggestion[] | undefined {
-    const raw = readAttr(node, endpoint, ATTR_SUGGESTIONS);
+    const raw = readThermostatAttribute(node, endpoint, ATTR_SUGGESTIONS);
     if (!Array.isArray(raw)) return undefined;
     return raw.map(decodeSuggestion).filter((s): s is ThermostatSuggestion => s !== null);
 }
 
 export function readCurrentThermostatSuggestion(node: MatterNode, endpoint: number): ThermostatSuggestion | null {
-    return decodeSuggestion(readAttr(node, endpoint, ATTR_CURRENT_SUGGESTION));
+    return decodeSuggestion(readThermostatAttribute(node, endpoint, ATTR_CURRENT_SUGGESTION));
 }
 
 /** Reasons the device isn't following CurrentThermostatSuggestion, decoded from the reason bitmap. */
@@ -81,7 +81,7 @@ export function readThermostatSuggestionNotFollowingReasons(
     node: MatterNode,
     endpoint: number,
 ): { bit: number; code: string; label: string }[] {
-    const raw = readAttr(node, endpoint, ATTR_NOT_FOLLOWING_REASON);
+    const raw = readThermostatAttribute(node, endpoint, ATTR_NOT_FOLLOWING_REASON);
     if (typeof raw !== "number") return [];
     return computeActiveClusterFeatures(raw, NOT_FOLLOWING_REASON_BITS);
 }

--- a/packages/dashboard/src/util/thermostat-suggestions.ts
+++ b/packages/dashboard/src/util/thermostat-suggestions.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MatterNode } from "@matter-server/ws-client";
+import { asObject, pickNumber, pickString } from "./attribute-shapes.js";
+import { computeActiveClusterFeatures } from "./cluster-features.js";
+import {
+    formatHandleShort,
+    formatPresetLabel,
+    isFeatureActive,
+    THERMOSTAT_CLUSTER_ID,
+    type ThermostatPreset,
+} from "./thermostat-schedule.js";
+
+const ATTR_MAX_SUGGESTIONS = 0x53;
+const ATTR_SUGGESTIONS = 0x54;
+const ATTR_CURRENT_SUGGESTION = 0x55;
+const ATTR_NOT_FOLLOWING_REASON = 0x56;
+
+export interface ThermostatSuggestion {
+    uniqueId: number;
+    presetHandle: string;
+    effectiveTime: number;
+    expirationTime: number;
+}
+
+/** ThermostatSuggestionNotFollowingReasonBitmap (Matter spec §4.3.9.14). */
+const NOT_FOLLOWING_REASON_BITS = [
+    { bit: 0, code: "DemandResponseEvent", label: "Demand Response Event" },
+    { bit: 1, code: "OngoingHold", label: "Ongoing Hold" },
+    { bit: 2, code: "Schedule", label: "Schedule" },
+    { bit: 3, code: "Occupancy", label: "Occupancy" },
+    { bit: 4, code: "VacationMode", label: "Vacation Mode" },
+    { bit: 5, code: "TimeOfUseCostSavings", label: "Time-of-Use Cost Savings" },
+    { bit: 6, code: "PreCoolingOrPreHeating", label: "Pre-cooling / Pre-heating" },
+    { bit: 7, code: "ConflictingSuggestions", label: "Conflicting Suggestions" },
+];
+
+function readAttr(node: MatterNode, endpoint: number, attrId: number): unknown {
+    return node.attributes[`${endpoint}/${THERMOSTAT_CLUSTER_ID}/${attrId}`];
+}
+
+// Struct attributes reach the dashboard field-tag keyed, matching ThermostatSuggestionStruct's field order.
+function decodeSuggestion(raw: unknown): ThermostatSuggestion | null {
+    const obj = asObject(raw);
+    if (!obj) return null;
+    const uniqueId = pickNumber(obj, "0");
+    const presetHandle = pickString(obj, "1");
+    const effectiveTime = pickNumber(obj, "2");
+    const expirationTime = pickNumber(obj, "3");
+    if (uniqueId === null || presetHandle === null || effectiveTime === null || expirationTime === null) return null;
+    return { uniqueId, presetHandle, effectiveTime, expirationTime };
+}
+
+/** Whether the Thermostat cluster's FeatureMap includes Thermostat Suggestions (TSUGGEST). */
+export function isTSUGGESTActive(node: MatterNode, endpoint: number): boolean {
+    return isFeatureActive(node, endpoint, "TSUGGEST");
+}
+
+export function readMaxThermostatSuggestions(node: MatterNode, endpoint: number): number | null {
+    const v = readAttr(node, endpoint, ATTR_MAX_SUGGESTIONS);
+    return typeof v === "number" ? v : null;
+}
+
+/** Decoded ThermostatSuggestions queue, or undefined when the attribute is not in the node's attribute cache. */
+export function readThermostatSuggestions(node: MatterNode, endpoint: number): ThermostatSuggestion[] | undefined {
+    const raw = readAttr(node, endpoint, ATTR_SUGGESTIONS);
+    if (!Array.isArray(raw)) return undefined;
+    return raw.map(decodeSuggestion).filter((s): s is ThermostatSuggestion => s !== null);
+}
+
+export function readCurrentThermostatSuggestion(node: MatterNode, endpoint: number): ThermostatSuggestion | null {
+    return decodeSuggestion(readAttr(node, endpoint, ATTR_CURRENT_SUGGESTION));
+}
+
+/** Reasons the device isn't following CurrentThermostatSuggestion, decoded from the reason bitmap. */
+export function readThermostatSuggestionNotFollowingReasons(
+    node: MatterNode,
+    endpoint: number,
+): { bit: number; code: string; label: string }[] {
+    const raw = readAttr(node, endpoint, ATTR_NOT_FOLLOWING_REASON);
+    if (typeof raw !== "number") return [];
+    return computeActiveClusterFeatures(raw, NOT_FOLLOWING_REASON_BITS);
+}
+
+/** A suggestion's display label: its referenced preset's name/scenario, else its handle. */
+export function resolveSuggestionLabel(suggestion: ThermostatSuggestion, presets: ThermostatPreset[]): string {
+    const preset = presets.find(p => p.handle === suggestion.presetHandle);
+    return preset ? formatPresetLabel(preset) : formatHandleShort(suggestion.presetHandle);
+}

--- a/packages/dashboard/src/util/time.ts
+++ b/packages/dashboard/src/util/time.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Matter epoch-s values count seconds since 2000-01-01T00:00:00Z, not the Unix epoch. */
+const MATTER_EPOCH_OFFSET_SECONDS = 946_684_800;
+
+/** Formats a Matter epoch-s instant as a local time, prefixed with the date when it isn't today. */
+export function formatEpochTime(matterEpochSeconds: number, relativeTo: Date = new Date()): string {
+    const date = new Date((matterEpochSeconds + MATTER_EPOCH_OFFSET_SECONDS) * 1000);
+    const time = date.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+    if (date.toDateString() === relativeTo.toDateString()) return time;
+    const tomorrow = new Date(relativeTo);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    if (date.toDateString() === tomorrow.toDateString()) return `tomorrow ${time}`;
+    const dateOptions: Intl.DateTimeFormatOptions =
+        date.getFullYear() === relativeTo.getFullYear()
+            ? { month: "2-digit", day: "2-digit" }
+            : { year: "numeric", month: "2-digit", day: "2-digit" };
+    return `${date.toLocaleDateString(undefined, dateOptions)} ${time}`;
+}

--- a/packages/dashboard/test/CommodityTariffUtilTest.ts
+++ b/packages/dashboard/test/CommodityTariffUtilTest.ts
@@ -6,11 +6,11 @@
 
 import {
     commodityTariffInfo,
-    formatEpochTime,
     formatMinutesOfDay,
     formatPrice,
     type CurrencyInfo,
 } from "../src/util/commodity-tariff.js";
+import { formatEpochTime } from "../src/util/time.js";
 
 const MATTER_EPOCH_OFFSET_SECONDS = 946_684_800;
 

--- a/packages/dashboard/test/ThermostatScheduleUtilTest.ts
+++ b/packages/dashboard/test/ThermostatScheduleUtilTest.ts
@@ -13,6 +13,7 @@ import {
     firstClaimedDay,
     formatDayOfWeek,
     formatHandleShort,
+    formatPresetLabel,
     formatMinutes,
     formatSegmentTooltip,
     formatSetpoint,
@@ -110,6 +111,28 @@ describe("thermostat-schedule util", () => {
         });
         it("is false when FeatureMap is absent", () => {
             expect(isFeatureActive(node({}), 6, "MSCH")).to.equal(false);
+        });
+        it("resolves PRES and TSUGGEST against the real FeatureMap", () => {
+            const presOnly = node({ "6/513/65532": 1 << 8 });
+            expect(isFeatureActive(presOnly, 6, "PRES")).to.equal(true);
+            expect(isFeatureActive(presOnly, 6, "TSUGGEST")).to.equal(false);
+            expect(isFeatureActive(node({ "6/513/65532": 1 << 10 }), 6, "TSUGGEST")).to.equal(true);
+        });
+    });
+
+    describe("formatPresetLabel", () => {
+        it("prefers the preset's own name", () => {
+            expect(formatPresetLabel(preset(HANDLE_1, { name: "Night", scenario: 3 }))).to.equal("Night");
+        });
+        it("falls back to the PresetScenario label", () => {
+            expect(formatPresetLabel(preset(HANDLE_1, { scenario: 3 }))).to.equal("Sleep");
+            expect(formatPresetLabel(preset(HANDLE_1, { scenario: 254 }))).to.equal("User Defined");
+        });
+        it("names an unknown scenario by its numeric value", () => {
+            expect(formatPresetLabel(preset(HANDLE_1, { scenario: 42 }))).to.equal("Scenario 42");
+        });
+        it("falls back to the short handle when neither name nor scenario is reported", () => {
+            expect(formatPresetLabel(preset(HANDLE_1))).to.equal("0x01");
         });
     });
 
@@ -243,8 +266,9 @@ describe("thermostat-schedule util", () => {
                 },
             ]);
         });
-        it("returns empty when absent", () => {
-            expect(readPresets(node({}), 6)).to.deep.equal([]);
+        it("distinguishes an absent attribute from an empty list", () => {
+            expect(readPresets(node({}), 6)).to.equal(undefined);
+            expect(readPresets(node({ "6/513/80": [] }), 6)).to.deep.equal([]);
         });
     });
 

--- a/packages/dashboard/test/ThermostatScheduleUtilTest.ts
+++ b/packages/dashboard/test/ThermostatScheduleUtilTest.ts
@@ -18,6 +18,7 @@ import {
     formatSetpoint,
     isFeatureActive,
     pickSetpointForMode,
+    readActivePresetHandle,
     readActiveScheduleHandle,
     readPresets,
     readSchedules,
@@ -119,6 +120,16 @@ describe("thermostat-schedule util", () => {
         it("returns null when null/absent", () => {
             expect(readActiveScheduleHandle(node({ "6/513/79": null }), 6)).to.equal(null);
             expect(readActiveScheduleHandle(node({}), 6)).to.equal(null);
+        });
+    });
+
+    describe("readActivePresetHandle", () => {
+        it("reads the handle string", () => {
+            expect(readActivePresetHandle(node({ "6/513/78": HANDLE_1 }), 6)).to.equal(HANDLE_1);
+        });
+        it("returns null when null/absent", () => {
+            expect(readActivePresetHandle(node({ "6/513/78": null }), 6)).to.equal(null);
+            expect(readActivePresetHandle(node({}), 6)).to.equal(null);
         });
     });
 

--- a/packages/dashboard/test/ThermostatScheduleUtilTest.ts
+++ b/packages/dashboard/test/ThermostatScheduleUtilTest.ts
@@ -16,7 +16,7 @@ import {
     formatMinutes,
     formatSegmentTooltip,
     formatSetpoint,
-    isMSCHActive,
+    isFeatureActive,
     pickSetpointForMode,
     readActiveScheduleHandle,
     readPresets,
@@ -88,19 +88,27 @@ function schedule(
 }
 
 function preset(handle: string, overrides: Partial<ThermostatPreset> = {}): ThermostatPreset {
-    return { handle, name: null, coolingSetpoint: null, heatingSetpoint: null, ...overrides };
+    return {
+        handle,
+        scenario: null,
+        name: null,
+        coolingSetpoint: null,
+        heatingSetpoint: null,
+        builtIn: null,
+        ...overrides,
+    };
 }
 
 describe("thermostat-schedule util", () => {
-    describe("isMSCHActive", () => {
-        it("is true when the MSCH bit is set on the real Thermostat FeatureMap", () => {
-            expect(isMSCHActive(node({ "6/513/65532": 1 << 7 }), 6)).to.equal(true);
+    describe("isFeatureActive", () => {
+        it("is true when the given bit is set on the real Thermostat FeatureMap", () => {
+            expect(isFeatureActive(node({ "6/513/65532": 1 << 7 }), 6, "MSCH")).to.equal(true);
         });
-        it("is false when MSCH is not set", () => {
-            expect(isMSCHActive(node({ "6/513/65532": 0b1 }), 6)).to.equal(false);
+        it("is false when the given feature is not set", () => {
+            expect(isFeatureActive(node({ "6/513/65532": 0b1 }), 6, "MSCH")).to.equal(false);
         });
         it("is false when FeatureMap is absent", () => {
-            expect(isMSCHActive(node({}), 6)).to.equal(false);
+            expect(isFeatureActive(node({}), 6, "MSCH")).to.equal(false);
         });
     });
 
@@ -206,8 +214,22 @@ describe("thermostat-schedule util", () => {
                 6,
             );
             expect(presets).to.deep.equal([
-                { handle: HANDLE_1, name: "Night", coolingSetpoint: null, heatingSetpoint: 1700 },
-                { handle: HANDLE_2, name: "Morning", coolingSetpoint: 2600, heatingSetpoint: 2100 },
+                {
+                    handle: HANDLE_1,
+                    scenario: 4,
+                    name: "Night",
+                    coolingSetpoint: null,
+                    heatingSetpoint: 1700,
+                    builtIn: null,
+                },
+                {
+                    handle: HANDLE_2,
+                    scenario: 1,
+                    name: "Morning",
+                    coolingSetpoint: 2600,
+                    heatingSetpoint: 2100,
+                    builtIn: null,
+                },
             ]);
         });
         it("returns empty when absent", () => {

--- a/packages/dashboard/test/ThermostatSuggestionsUtilTest.ts
+++ b/packages/dashboard/test/ThermostatSuggestionsUtilTest.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MatterNode, type MatterNodeData } from "@matter-server/ws-client";
+import type { ThermostatPreset } from "../src/util/thermostat-schedule.js";
+import {
+    isTSUGGESTActive,
+    readCurrentThermostatSuggestion,
+    readMaxThermostatSuggestions,
+    readThermostatSuggestionNotFollowingReasons,
+    readThermostatSuggestions,
+    resolveSuggestionLabel,
+} from "../src/util/thermostat-suggestions.js";
+
+function node(attributes: Record<string, unknown>, node_id: number | bigint = 1): MatterNode {
+    const data: MatterNodeData = {
+        node_id,
+        date_commissioned: "",
+        last_interview: "",
+        interview_version: 1,
+        available: true,
+        is_bridge: false,
+        attributes,
+        attribute_subscriptions: [],
+    };
+    return new MatterNode(data);
+}
+
+// Single-byte preset handle, base64-encoded (0x01 -> "AQ==").
+const HANDLE_1 = "AQ==";
+
+function preset(handle: string, overrides: Partial<ThermostatPreset> = {}): ThermostatPreset {
+    return {
+        handle,
+        scenario: null,
+        name: null,
+        coolingSetpoint: null,
+        heatingSetpoint: null,
+        builtIn: null,
+        ...overrides,
+    };
+}
+
+describe("thermostat-suggestions util", () => {
+    describe("isTSUGGESTActive", () => {
+        it("is true when the TSUGGEST bit is set on the real Thermostat FeatureMap", () => {
+            expect(isTSUGGESTActive(node({ "6/513/65532": 1 << 10 }), 6)).to.equal(true);
+        });
+        it("is false when TSUGGEST is not set", () => {
+            expect(isTSUGGESTActive(node({ "6/513/65532": 1 << 8 }), 6)).to.equal(false);
+        });
+        it("is false when FeatureMap is absent", () => {
+            expect(isTSUGGESTActive(node({}), 6)).to.equal(false);
+        });
+    });
+
+    describe("readMaxThermostatSuggestions", () => {
+        it("reads the count", () => {
+            expect(readMaxThermostatSuggestions(node({ "6/513/83": 5 }), 6)).to.equal(5);
+        });
+        it("returns null when absent", () => {
+            expect(readMaxThermostatSuggestions(node({}), 6)).to.equal(null);
+        });
+    });
+
+    describe("readThermostatSuggestions", () => {
+        it("decodes tag-keyed suggestion structs", () => {
+            const suggestions = readThermostatSuggestions(
+                node({ "6/513/84": [{ "0": 1, "1": HANDLE_1, "2": 100, "3": 1300 }] }),
+                6,
+            );
+            expect(suggestions).to.deep.equal([
+                { uniqueId: 1, presetHandle: HANDLE_1, effectiveTime: 100, expirationTime: 1300 },
+            ]);
+        });
+        it("drops entries missing a required field", () => {
+            expect(readThermostatSuggestions(node({ "6/513/84": [{ "0": 1, "1": HANDLE_1 }] }), 6)).to.deep.equal([]);
+        });
+        it("distinguishes an absent attribute from an empty list", () => {
+            expect(readThermostatSuggestions(node({}), 6)).to.equal(undefined);
+            expect(readThermostatSuggestions(node({ "6/513/84": [] }), 6)).to.deep.equal([]);
+        });
+    });
+
+    describe("readCurrentThermostatSuggestion", () => {
+        it("decodes the current suggestion struct", () => {
+            const current = readCurrentThermostatSuggestion(
+                node({ "6/513/85": { "0": 2, "1": HANDLE_1, "2": 100, "3": 1300 } }),
+                6,
+            );
+            expect(current).to.deep.equal({
+                uniqueId: 2,
+                presetHandle: HANDLE_1,
+                effectiveTime: 100,
+                expirationTime: 1300,
+            });
+        });
+        it("returns null when absent or null", () => {
+            expect(readCurrentThermostatSuggestion(node({}), 6)).to.equal(null);
+            expect(readCurrentThermostatSuggestion(node({ "6/513/85": null }), 6)).to.equal(null);
+        });
+    });
+
+    describe("readThermostatSuggestionNotFollowingReasons", () => {
+        it("decodes the active reason bits", () => {
+            const reasons = readThermostatSuggestionNotFollowingReasons(node({ "6/513/86": (1 << 1) | (1 << 3) }), 6);
+            expect(reasons.map(r => r.code)).to.deep.equal(["OngoingHold", "Occupancy"]);
+        });
+        it("returns an empty list when absent or null", () => {
+            expect(readThermostatSuggestionNotFollowingReasons(node({}), 6)).to.deep.equal([]);
+            expect(readThermostatSuggestionNotFollowingReasons(node({ "6/513/86": null }), 6)).to.deep.equal([]);
+        });
+    });
+
+    describe("resolveSuggestionLabel", () => {
+        const suggestion = { uniqueId: 1, presetHandle: HANDLE_1, effectiveTime: 0, expirationTime: 0 };
+        it("prefers a matching preset's display label", () => {
+            const label = resolveSuggestionLabel(suggestion, [preset(HANDLE_1, { name: "Night" })]);
+            expect(label).to.equal("Night");
+        });
+        it("falls back to the handle when no preset matches", () => {
+            expect(resolveSuggestionLabel(suggestion, [])).to.equal("0x01");
+        });
+    });
+});

--- a/packages/dashboard/test/ThermostatSuggestionsUtilTest.ts
+++ b/packages/dashboard/test/ThermostatSuggestionsUtilTest.ts
@@ -7,7 +7,9 @@
 import { MatterNode, type MatterNodeData } from "@matter-server/ws-client";
 import type { ThermostatPreset } from "../src/util/thermostat-schedule.js";
 import {
-    isTSUGGESTActive,
+    clampExpirationMinutes,
+    MAX_EXPIRATION_MINUTES,
+    MIN_EXPIRATION_MINUTES,
     readCurrentThermostatSuggestion,
     readMaxThermostatSuggestions,
     readThermostatSuggestionNotFollowingReasons,
@@ -45,15 +47,20 @@ function preset(handle: string, overrides: Partial<ThermostatPreset> = {}): Ther
 }
 
 describe("thermostat-suggestions util", () => {
-    describe("isTSUGGESTActive", () => {
-        it("is true when the TSUGGEST bit is set on the real Thermostat FeatureMap", () => {
-            expect(isTSUGGESTActive(node({ "6/513/65532": 1 << 10 }), 6)).to.equal(true);
+    describe("clampExpirationMinutes", () => {
+        it("keeps an in-range value", () => {
+            expect(clampExpirationMinutes(60, 90)).to.equal(60);
         });
-        it("is false when TSUGGEST is not set", () => {
-            expect(isTSUGGESTActive(node({ "6/513/65532": 1 << 8 }), 6)).to.equal(false);
+        it("clamps to the ExpirationInMinutes constraint", () => {
+            expect(clampExpirationMinutes(5, 90)).to.equal(MIN_EXPIRATION_MINUTES);
+            expect(clampExpirationMinutes(10_000, 90)).to.equal(MAX_EXPIRATION_MINUTES);
         });
-        it("is false when FeatureMap is absent", () => {
-            expect(isTSUGGESTActive(node({}), 6)).to.equal(false);
+        it("rounds fractional input", () => {
+            expect(clampExpirationMinutes(60.6, 90)).to.equal(61);
+        });
+        it("falls back to the previous value for a cleared or non-numeric input", () => {
+            expect(clampExpirationMinutes(NaN, 90)).to.equal(90);
+            expect(clampExpirationMinutes(Infinity, 90)).to.equal(90);
         });
     });
 


### PR DESCRIPTION
<!--
  Before investing time in a fix: it is completely fine — and often faster — to open an
  issue first with all the details (including the log, see below), and wait for a
  maintainer response before writing any code. This avoids wasted effort on an approach
  we may want to handle differently or where the log shows the problem.

  AI tools are welcome, but you are responsible for *fully* understanding the code you
  submit and for being able to explain it in your own words. Autonomously created pull
  requests are not accepted. Please follow our AI policy:
  https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md
-->

## Type of change

<!-- Check exactly one. -->

- [ ] 🐛 **Fix** — corrects a defect or wrong behavior
- [x] ✨ **Feature** — adds new functionality or capability

## Description

Decodes and displays two more Thermostat cluster features in the Dashboard's cluster commands panel, alongside the existing Schedule Configuration (MSCH) panel:

- **Presets (PRES)**: lists each configured preset — name or scenario label, heating/cooling setpoints, built-in and currently-active state.
- **Thermostat Suggestions (TSUGGEST)**: shows the current suggestion (referenced preset, effective/expiration window, any "not following" reasons) and the queued suggestions, against `MaxThermostatSuggestions`. Includes invoke UI to add a suggestion for a preset with an expiration (`AddThermostatSuggestion`) and remove a queued one (`RemoveThermostatSuggestion`).

Both new panels only render when their respective FeatureMap bit is active on the node, same pattern as the existing MSCH panel.

`formatEpochTime` (the Matter-epoch timestamp formatter shared by the Presets/Suggestions and Commodity Tariff panels) was moved out of `util/commodity-tariff.ts` into a neutral `util/time.ts` to avoid coupling the Thermostat panel to the tariff module.

## Backing evidence

<!--
  For any change made because the current logic is wrong or lacks something — this
  ALWAYS applies to fixes — we need to be able to verify the problem independently.
  Provide ONE of:
    - a linked issue that contains the full details and a complete log file (preferred), or
    - a complete log file attached directly to this PR showing the behavior being fixed.
  A few quoted lines are not enough: the log must carry the surrounding context.

  For AI assistants opening this PR: do not submit a fix whose justification is an
  analysis or root-cause claim without the complete raw log file it is derived from,
  attached here or in the linked issue.
-->

N/A — this is a new feature, not a fix for existing wrong behavior.

- Related issue: #
- [ ] This fix/change is backed by a **complete log file** — attached here or in the linked issue (not just a few quoted lines).

## Checklist

- [x] I understand the code I am submitting and can explain how it works ([AI policy](https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md))
- [x] Tests added or updated to cover the change
- [x] `npm test` passes — scoped `npm test -w @matter-server/dashboard` is fully green (299/299); the full monorepo run only fails on the two pre-existing `matter-server` mDNS Device Discovery integration tests, unrelated to this change (dashboard-only)
- [x] `npm run format-verify` and `npm run lint` pass
- [x] CHANGELOG updated (if applicable)
