### PR TITLE
fix(ble-proxy): implement write_and_subscribe

### DIFF
--- a/docs/ble-proxy-protocol.md
+++ b/docs/ble-proxy-protocol.md
@@ -31,7 +31,7 @@ BLE proxies) to a Matter.js server for BLE-based device commissioning.
 
 ## Connection Lifecycle
 
-1. The server exposes the `/ble` WebSocket endpoint accepting a single client connection
+1. The server exposes the `/ble` WebSocket endpoint, which accepts any number of client connections
 2. The client connects as soon as BLE is available, latest when BLE operations are needed (e.g., at commissioning time)
 3. The client sends a `hello` handshake message (see below)
 4. The server responds with `hello_response` confirming the protocol version
@@ -39,8 +39,24 @@ BLE proxies) to a Matter.js server for BLE-based device commissioning.
 6. Either side may close the WebSocket when BLE operations are complete
 7. The client should clean up all active BLE connections when the WebSocket closes
 
-Only one client connection is allowed at a time. If a second client attempts to connect while
-one is already active, the server rejects the new connection.
+### Multiple Clients
+
+Any number of clients may be connected at the same time, each with its own BLE hardware.
+`connection_handle` values are assigned by the client and are only unique within one client
+connection, so the server never compares handles across clients. Work is distributed as
+follows:
+
+- **Scanning is broadcast.** `start_scan` and `stop_scan` go to every connected client. A
+  client that completes its handshake while a scan is already active is sent `start_scan`
+  immediately, so it joins the scan in progress.
+- **Peripherals are owned by one client.** The first client to report a peripheral in a
+  `device_discovered` event becomes its owner. Every subsequent command for that peripheral
+  — `connect`, GATT operations, binary frames — is sent only to the owner.
+- **Duplicate discoveries are expected.** Several clients may report the same peripheral;
+  the server keys peripherals by address and tracks all clients that have seen one.
+- **Ownership survives client loss.** If a peripheral's owner disconnects, ownership moves
+  to another connected client that has also reported that peripheral. If no such client
+  remains, the peripheral is dropped and must be rediscovered.
 
 ### Handshake
 
@@ -178,9 +194,15 @@ device found matching the filter criteria.
 | `already_scanning`      | A scan is already in progress   |
 
 **Notes:**
-- Only one scan can be active at a time
+- Only one scan can be active at a time per client
 - The client should start sending `device_discovered` events after responding with success
 - Scanning continues until `stop_scan` is sent or the WebSocket closes
+- The server broadcasts `start_scan` to every connected client, including clients that
+  connect while the scan is already running
+- The server may send `start_scan` while a scan is active, with different parameters. The
+  client should apply the new parameters and answer success; a repeat of the parameters
+  already running needs no action. `already_scanning` is for a client that cannot re-arm —
+  the server then keeps treating it as scanning, with the parameters of its running scan.
 
 ---
 
@@ -557,6 +579,11 @@ Sent when scanning stops unexpectedly (not initiated by a `stop_scan` command).
 |----------|--------|----------|--------------------------------------------------------------------|
 | `reason` | string | yes      | Reason for stopping (e.g. `"adapter_off"`, `"proxy_disconnected"`) |
 
+The event is per client: the server stops treating that one client as scanning and only
+reports scanning as stopped to the Matter stack once no connected client is scanning
+anymore. A client whose scan dies while others keep scanning therefore does not abort
+discovery.
+
 ---
 
 ### characteristic_notification
@@ -608,14 +635,16 @@ Binary frames do not include the characteristic UUID. The characteristic context
 by the preceding JSON command:
 
 - **`WRITE_DATA` (0x01):** Writes to the characteristic most recently targeted by a
-  `write_characteristic` JSON command for this connection handle. In practice, this is always
-  the Matter BTP characteristic C1 (`18EE2EF5-263D-4559-959F-4F9C429F9D11`). Clients MUST use
-  ATT Write Request (with response) for these writes — same constraint as the initial
-  `write_characteristic` handshake on C1.
+  `write_characteristic` or `write_and_subscribe` JSON command for this connection handle. In
+  practice, this is always the Matter BTP characteristic C1
+  (`18EE2EF5-263D-4559-959F-4F9C429F9D11`), established by the `write_and_subscribe` that
+  carries the BTP handshake request. Clients MUST use ATT Write Request (with response) for
+  these writes — same constraint as that handshake write.
 
 - **`NOTIFICATION` (0x02):** Contains data from the characteristic most recently subscribed
-  via `subscribe_characteristic` for this connection handle. In practice, this is always
-  the Matter BTP characteristic C2 (`18EE2EF5-263D-4559-959F-4F9C429F9D12`).
+  via `subscribe_characteristic` or `write_and_subscribe` for this connection handle. In
+  practice, this is always the Matter BTP characteristic C2
+  (`18EE2EF5-263D-4559-959F-4F9C429F9D12`), established by the same `write_and_subscribe`.
 
 - **`READ_RESPONSE` (0x03):** Contains the response to the most recent `read_characteristic`
   command for this connection handle. Used as an alternative to the JSON result when the

--- a/packages/ble-proxy/src/BleProxyConnection.ts
+++ b/packages/ble-proxy/src/BleProxyConnection.ts
@@ -9,6 +9,7 @@ import { Mark } from "@matter/main/protocol";
 import { WebSocket } from "ws";
 import {
     BLE_PROXY_PROTOCOL_VERSION,
+    BleProxyCommandError,
     decodeBinaryFrame,
     encodeBinaryFrame,
     type BinaryFrame,
@@ -237,7 +238,8 @@ export class BleProxyConnection {
         if (msg.success) {
             pending.resolver(msg.result);
         } else {
-            pending.rejecter(new Error(`${msg.error}: ${msg.message}`));
+            // `error`/`message` are client-supplied: normalize so the code stays a comparable string.
+            pending.rejecter(new BleProxyCommandError(String(msg.error), String(msg.message)));
         }
     }
 

--- a/packages/ble-proxy/src/BleProxyHandler.ts
+++ b/packages/ble-proxy/src/BleProxyHandler.ts
@@ -9,11 +9,23 @@ import { Logger, Observable } from "@matter/main";
 import type { createServer } from "node:http";
 import { WebSocket, WebSocketServer } from "ws";
 import { BleProxyConnection } from "./BleProxyConnection.js";
-import { BleProxyCommand, BleProxyEvent, type DeviceDiscoveredData, type StartScanArgs } from "./BleProxyProtocol.js";
+import {
+    BleProxyCommand,
+    BleProxyCommandError,
+    BleProxyErrorCode,
+    type BleProxyErrorCodeValue,
+    BleProxyEvent,
+    type DeviceDiscoveredData,
+    type StartScanArgs,
+} from "./BleProxyProtocol.js";
 
 type HttpServer = ReturnType<typeof createServer>;
 
 const logger = Logger.get("BleProxyHandler");
+
+function isErrorCode(err: unknown, code: BleProxyErrorCodeValue): boolean {
+    return err instanceof BleProxyCommandError && err.code === code;
+}
 
 /**
  * WebSocket server handler (hub) for the `/ble` BLE proxy endpoint.
@@ -141,8 +153,7 @@ export class BleProxyHandler implements WebServerHandler {
                 this.#scanning.add(connection);
                 sends.push(
                     connection.sendCommand(BleProxyCommand.StartScan, args).catch(err => {
-                        logger.warn(`[${connection.id}] Failed to start scan:`, err);
-                        this.#markNotScanning(connection, "start scan failed");
+                        this.#onStartScanRejected(connection, err);
                     }),
                 );
             }
@@ -156,9 +167,13 @@ export class BleProxyHandler implements WebServerHandler {
         for (const connection of this.#connections) {
             if (connection.connected) {
                 sends.push(
-                    connection
-                        .sendCommand(BleProxyCommand.StopScan)
-                        .catch(err => logger.warn(`[${connection.id}] Failed to stop scan:`, err)),
+                    connection.sendCommand(BleProxyCommand.StopScan).catch(err => {
+                        if (isErrorCode(err, BleProxyErrorCode.NotScanning)) {
+                            logger.debug(`[${connection.id}] was not scanning`);
+                            return;
+                        }
+                        logger.warn(`[${connection.id}] Failed to stop scan:`, err);
+                    }),
                 );
             }
         }
@@ -171,8 +186,7 @@ export class BleProxyHandler implements WebServerHandler {
         if (this.#scanActive && this.#scanArgs) {
             this.#scanning.add(connection);
             connection.sendCommand(BleProxyCommand.StartScan, this.#scanArgs).catch(err => {
-                logger.warn(`[${connection.id}] Failed to sync scan to joining client:`, err);
-                this.#markNotScanning(connection, "start scan failed");
+                this.#onStartScanRejected(connection, err);
             });
         }
     }
@@ -183,6 +197,17 @@ export class BleProxyHandler implements WebServerHandler {
         } else if (event === BleProxyEvent.ScanStopped) {
             this.#markNotScanning(connection, (data as { reason?: string }).reason ?? "unknown");
         }
+    }
+
+    #onStartScanRejected(connection: BleProxyConnection, err: unknown): void {
+        // `already_scanning` means the client is scanning. A client that cannot re-arm keeps the
+        // parameters of its running scan, so this is only equivalent while the args do not change.
+        if (isErrorCode(err, BleProxyErrorCode.AlreadyScanning)) {
+            logger.debug(`[${connection.id}] was already scanning`);
+            return;
+        }
+        logger.warn(`[${connection.id}] Failed to start scan:`, err);
+        this.#markNotScanning(connection, "start scan failed");
     }
 
     /** Drop a connection from the scanning set; emit aggregate scanStopped once none remain. */

--- a/packages/ble-proxy/src/BleProxyProtocol.ts
+++ b/packages/ble-proxy/src/BleProxyProtocol.ts
@@ -253,6 +253,17 @@ export const BleProxyErrorCode = {
 
 export type BleProxyErrorCodeValue = (typeof BleProxyErrorCode)[keyof typeof BleProxyErrorCode];
 
+/** A command the client answered with `success: false`, carrying the protocol error code. */
+export class BleProxyCommandError extends Error {
+    constructor(
+        readonly code: string,
+        readonly detail: string,
+    ) {
+        super(`${code}: ${detail}`);
+        this.name = "BleProxyCommandError";
+    }
+}
+
 // ─── Binary Frame Opcodes ────────────────────────────────────────────────────
 
 export const BinaryFrameOpcode = {

--- a/packages/ble-proxy/src/example/NobleBleProxyClient.ts
+++ b/packages/ble-proxy/src/example/NobleBleProxyClient.ts
@@ -146,6 +146,11 @@ export class NobleBleProxyClient {
                     warn("Received invalid JSON from the server");
                     return;
                 }
+                // Valid JSON is not necessarily an object, and `"id" in null` throws.
+                if (typeof msg !== "object" || msg === null) {
+                    warn("Ignoring non-object JSON message from the server");
+                    return;
+                }
 
                 if (!handshakeComplete) {
                     if (msg.type === "hello_response") {
@@ -358,6 +363,9 @@ export class NobleBleProxyClient {
         });
 
         try {
+            // The hci-socket binding returns early from startScanning while a scan is running,
+            // keeping the previous service-uuid filter, so a filter change needs a stop first.
+            await this.#noble.stopScanningAsync();
             await this.#startScanning();
         } catch (err) {
             this.#scanRequested = false;
@@ -819,11 +827,14 @@ export class NobleBleProxyClient {
      * A no-op once `stop_scan` has been received, so the connect paths cannot resume a scan
      * the server already ended.
      */
-    #startScanning(): Promise<void> {
+    async #startScanning(): Promise<void> {
         if (!this.#scanRequested) {
-            return Promise.resolve();
+            return;
         }
-        return this.#noble!.startScanningAsync(this.#scanServiceUuids, true);
+        await this.#noble!.startScanningAsync(this.#scanServiceUuids, true);
+        if (!this.#scanRequested) {
+            await this.#noble!.stopScanningAsync();
+        }
     }
 
     // Forwarded regardless of noble's `isNotification`: on macOS that flag is derived from a

--- a/packages/ble-proxy/src/example/NobleBleProxyClient.ts
+++ b/packages/ble-proxy/src/example/NobleBleProxyClient.ts
@@ -36,6 +36,12 @@ import {
     encodeBinaryFrame,
 } from "../BleProxyProtocol.js";
 
+/**
+ * The server connects off its own discovery cache, which it replays to a new discovery callback
+ * and never clears, so it can ask for an address this process has not advertised yet.
+ */
+const CONNECT_DISCOVERY_TIMEOUT_MS = 5_000;
+
 function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
     return Promise.race([promise, new Promise<never>((_, reject) => setTimeout(() => reject(new Error(message)), ms))]);
 }
@@ -99,6 +105,7 @@ export class NobleBleProxyClient {
     #connections = new Map<number, ConnectionState>();
     #nextHandle = 1;
     #discoveredPeripherals = new Map<string, Peripheral>();
+    #discoveryWaiters = new Map<string, Set<(peripheral: Peripheral) => void>>();
     #lastDiscoverFingerprint = new Map<string, DiscoverFingerprint>();
     #scanServiceUuids: string[] = [];
     #reportDuplicates = true;
@@ -312,6 +319,14 @@ export class NobleBleProxyClient {
             const address = peripheral.address || peripheral.id;
             this.#discoveredPeripherals.set(address, peripheral);
 
+            const waiters = this.#discoveryWaiters.get(address);
+            if (waiters) {
+                this.#discoveryWaiters.delete(address);
+                for (const resolve of waiters) {
+                    resolve(peripheral);
+                }
+            }
+
             const serviceData: Record<string, string> = {};
             for (const sd of peripheral.advertisement.serviceData ?? []) {
                 serviceData[sd.uuid] = Buffer.from(sd.data).toString("base64");
@@ -387,11 +402,40 @@ export class NobleBleProxyClient {
         this.#sendSuccess(id);
     }
 
+    /** Resolves once `address` is advertised, or undefined once the wait times out. */
+    #awaitDiscovered(address: string): Promise<Peripheral | undefined> {
+        const known = this.#discoveredPeripherals.get(address);
+        if (known) {
+            return Promise.resolve(known);
+        }
+
+        log(`[CONN] "${address}" not advertised yet, waiting up to ${CONNECT_DISCOVERY_TIMEOUT_MS}ms`);
+        return new Promise<Peripheral | undefined>(resolve => {
+            const waiters = this.#discoveryWaiters.get(address) ?? new Set();
+            this.#discoveryWaiters.set(address, waiters);
+
+            const timer = setTimeout(() => {
+                waiters.delete(onDiscovered);
+                if (waiters.size === 0) {
+                    this.#discoveryWaiters.delete(address);
+                }
+                resolve(undefined);
+            }, CONNECT_DISCOVERY_TIMEOUT_MS);
+
+            const onDiscovered = (peripheral: Peripheral) => {
+                clearTimeout(timer);
+                resolve(peripheral);
+            };
+            waiters.add(onDiscovered);
+        });
+    }
+
     async #handleConnect(id: number, args: ConnectArgs): Promise<void> {
-        const peripheral = this.#discoveredPeripherals.get(args.address);
+        const peripheral = await this.#awaitDiscovered(args.address);
         if (!peripheral) {
             error(
-                `[CONN] No peripheral found for address "${args.address}". Known: ${[...this.#discoveredPeripherals.keys()].join(", ")}`,
+                `[CONN] No peripheral found for address "${args.address}" after ${CONNECT_DISCOVERY_TIMEOUT_MS}ms.` +
+                    ` Known: ${[...this.#discoveredPeripherals.keys()].join(", ")}`,
             );
             this.#sendError(id, BleProxyErrorCode.DeviceNotFound, `No device found for address ${args.address}`);
             return;

--- a/packages/ble-proxy/src/example/NobleBleProxyClient.ts
+++ b/packages/ble-proxy/src/example/NobleBleProxyClient.ts
@@ -19,14 +19,18 @@ import {
     BLE_PROXY_PROTOCOL_VERSION,
     BinaryFrameOpcode,
     type BleProxyCommandName,
+    BleProxyErrorCode,
+    type BleProxyErrorCodeValue,
     type CommandMessage,
     type ConnectArgs,
     type DeviceDiscoveredData,
     type DiscoverCharacteristicsArgs,
     type DiscoverServicesArgs,
     type ReadCharacteristicArgs,
+    type StartScanArgs,
     type SubscribeCharacteristicArgs,
     type UnsubscribeCharacteristicArgs,
+    type WriteAndSubscribeArgs,
     type WriteCharacteristicArgs,
     decodeBinaryFrame,
     encodeBinaryFrame,
@@ -61,11 +65,19 @@ type Peripheral = import("@stoprocent/noble").Peripheral;
 type Characteristic = import("@stoprocent/noble").Characteristic;
 type Service = import("@stoprocent/noble").Service;
 
+/** noble reuses the "data" event for read responses, and delivers a null payload on read failure. */
+type NotificationListener = (payload: Buffer | null) => void;
+
+interface Subscription {
+    characteristic: Characteristic;
+    onData: NotificationListener;
+}
+
 interface ConnectionState {
     peripheral: Peripheral;
     services: Map<string, Service>;
     characteristics: Map<string, Characteristic>;
-    subscriptions: Map<string, Characteristic>;
+    subscriptions: Map<string, Subscription>;
     lastWriteCharacteristic?: Characteristic;
 }
 
@@ -88,6 +100,9 @@ export class NobleBleProxyClient {
     #nextHandle = 1;
     #discoveredPeripherals = new Map<string, Peripheral>();
     #lastDiscoverFingerprint = new Map<string, DiscoverFingerprint>();
+    #scanServiceUuids: string[] = [];
+    #reportDuplicates = true;
+    #scanRequested = false;
     #commandHandlers = new Map<BleProxyCommandName, CommandHandler>();
     #closing = false;
 
@@ -95,6 +110,11 @@ export class NobleBleProxyClient {
         this.#serverUrl = serverUrl;
         this.#hciId = hciId;
         this.#registerCommandHandlers();
+    }
+
+    /** Command names this client implements. Must cover every `BleProxyCommand` value. */
+    get supportedCommands(): BleProxyCommandName[] {
+        return [...this.#commandHandlers.keys()];
     }
 
     async connect(): Promise<void> {
@@ -118,7 +138,14 @@ export class NobleBleProxyClient {
                     return;
                 }
 
-                const msg = JSON.parse(data.toString());
+                // A throw here escapes into ws's receiver and takes the process down with it.
+                let msg;
+                try {
+                    msg = JSON.parse(data.toString());
+                } catch {
+                    warn("Received invalid JSON from the server");
+                    return;
+                }
 
                 if (!handshakeComplete) {
                     if (msg.type === "hello_response") {
@@ -208,7 +235,7 @@ export class NobleBleProxyClient {
     }
 
     #registerCommandHandlers(): void {
-        this.#commandHandlers.set("start_scan", (id, _args) => this.#handleStartScan(id));
+        this.#commandHandlers.set("start_scan", (id, args) => this.#handleStartScan(id, args));
         this.#commandHandlers.set("stop_scan", id => this.#handleStopScan(id));
         this.#commandHandlers.set("connect", (id, args) => this.#handleConnect(id, args as unknown as ConnectArgs));
         this.#commandHandlers.set("disconnect", (id, args) =>
@@ -229,6 +256,9 @@ export class NobleBleProxyClient {
         this.#commandHandlers.set("subscribe_characteristic", (id, args) =>
             this.#handleSubscribeCharacteristic(id, args as unknown as SubscribeCharacteristicArgs),
         );
+        this.#commandHandlers.set("write_and_subscribe", (id, args) =>
+            this.#handleWriteAndSubscribe(id, args as unknown as WriteAndSubscribeArgs),
+        );
         this.#commandHandlers.set("unsubscribe_characteristic", (id, args) =>
             this.#handleUnsubscribeCharacteristic(id, args as unknown as UnsubscribeCharacteristicArgs),
         );
@@ -247,25 +277,28 @@ export class NobleBleProxyClient {
         const handler = this.#commandHandlers.get(msg.command);
         if (!handler) {
             error(`[→ERR] id=${msg.id} Unknown command: ${msg.command}`);
-            this.#sendError(msg.id, "internal_error", `Unknown command: ${msg.command}`);
+            this.#sendError(msg.id, BleProxyErrorCode.InternalError, `Unknown command: ${msg.command}`);
             return;
         }
         try {
             await handler(msg.id, msg.args ?? {});
         } catch (err) {
             error(`[→ERR] id=${msg.id} ${msg.command} threw: ${(err as Error).message}`);
-            this.#sendError(msg.id, "internal_error", `${(err as Error).message}`);
+            this.#sendError(msg.id, BleProxyErrorCode.InternalError, `${(err as Error).message}`);
         }
     }
 
     // ─── Command Handlers ────────────────────────────────────────────────────
 
-    async #handleStartScan(id: number): Promise<void> {
+    async #handleStartScan(id: number, args: StartScanArgs): Promise<void> {
         if (!this.#noble) {
-            this.#sendError(id, "bluetooth_unavailable", "Noble not initialized");
+            this.#sendError(id, BleProxyErrorCode.BluetoothUnavailable, "Noble not initialized");
             return;
         }
 
+        this.#scanServiceUuids = args.service_uuids ?? [];
+        this.#reportDuplicates = args.allow_duplicates ?? true;
+        this.#scanRequested = true;
         this.#lastDiscoverFingerprint.clear();
         // Remove any existing discover listeners to prevent duplicates on repeated scans
         this.#noble.removeAllListeners("discover");
@@ -301,7 +334,7 @@ export class NobleBleProxyClient {
                 prev.serviceUuids !== fingerprint.serviceUuids ||
                 prev.serviceData !== fingerprint.serviceData;
 
-            if (!changed) {
+            if (!this.#reportDuplicates && !changed) {
                 return;
             }
             this.#lastDiscoverFingerprint.set(address, fingerprint);
@@ -324,12 +357,23 @@ export class NobleBleProxyClient {
             this.#sendEvent("device_discovered", event as unknown as Record<string, unknown>);
         });
 
-        await this.#noble.startScanningAsync(["fff6"], true);
-        log("[SCAN] BLE scan started (filter: fff6)");
+        try {
+            await this.#startScanning();
+        } catch (err) {
+            this.#scanRequested = false;
+            this.#noble.removeAllListeners("discover");
+            this.#sendError(id, BleProxyErrorCode.InternalError, (err as Error).message);
+            return;
+        }
+        log(
+            `[SCAN] BLE scan started (filter: ${this.#scanServiceUuids.join(",") || "none"}` +
+                ` allowDuplicates=${this.#reportDuplicates})`,
+        );
         this.#sendSuccess(id);
     }
 
     async #handleStopScan(id: number): Promise<void> {
+        this.#scanRequested = false;
         await this.#noble?.stopScanningAsync();
         log("[SCAN] BLE scan stopped");
         this.#sendSuccess(id);
@@ -341,7 +385,7 @@ export class NobleBleProxyClient {
             error(
                 `[CONN] No peripheral found for address "${args.address}". Known: ${[...this.#discoveredPeripherals.keys()].join(", ")}`,
             );
-            this.#sendError(id, "device_not_found", `No device found for address ${args.address}`);
+            this.#sendError(id, BleProxyErrorCode.DeviceNotFound, `No device found for address ${args.address}`);
             return;
         }
 
@@ -406,7 +450,7 @@ export class NobleBleProxyClient {
 
             // Resume scanning so the server can still observe new devices and rssi updates.
             log(`[SCAN] resuming scan after connect+interview...`);
-            await this.#noble!.startScanningAsync(["fff6"], true);
+            await this.#startScanning();
 
             this.#sendSuccess(id, { connection_handle: handle, mtu });
         } catch (err) {
@@ -424,19 +468,17 @@ export class NobleBleProxyClient {
                     );
             }
             // Always try to resume scanning so subsequent connect attempts still see devices.
-            this.#noble!
-                .startScanningAsync(["fff6"], true)
-                .catch(scanErr =>
-                    warn(`[SCAN] failed to resume scanning after connect failure: ${(scanErr as Error).message}`),
-                );
-            this.#sendError(id, "internal_error", reason);
+            this.#startScanning().catch(scanErr =>
+                warn(`[SCAN] failed to resume scanning after connect failure: ${(scanErr as Error).message}`),
+            );
+            this.#sendError(id, BleProxyErrorCode.ConnectionFailed, reason);
         }
     }
 
     async #handleDisconnect(id: number, connectionHandle: number): Promise<void> {
         const conn = this.#connections.get(connectionHandle);
         if (!conn) {
-            this.#sendError(id, "not_connected", `No connection with handle ${connectionHandle}`);
+            this.#sendError(id, BleProxyErrorCode.NotConnected, `No connection with handle ${connectionHandle}`);
             return;
         }
 
@@ -450,7 +492,7 @@ export class NobleBleProxyClient {
     async #handleDiscoverServices(id: number, args: DiscoverServicesArgs): Promise<void> {
         const conn = this.#connections.get(args.connection_handle);
         if (!conn) {
-            this.#sendError(id, "not_connected", `No connection with handle ${args.connection_handle}`);
+            this.#sendError(id, BleProxyErrorCode.NotConnected, `No connection with handle ${args.connection_handle}`);
             return;
         }
 
@@ -464,11 +506,17 @@ export class NobleBleProxyClient {
 
         // Fallback: lazy discover
         log(`[GATT] handle=${args.connection_handle} discovering services (lazy)...`);
-        const services = await withTimeout(
-            conn.peripheral.discoverServicesAsync([]),
-            10_000,
-            "discoverServices timed out after 10s",
-        );
+        let services: Service[];
+        try {
+            services = await withTimeout(
+                conn.peripheral.discoverServicesAsync([]),
+                10_000,
+                "discoverServices timed out after 10s",
+            );
+        } catch (err) {
+            this.#sendError(id, BleProxyErrorCode.DiscoveryFailed, (err as Error).message);
+            return;
+        }
         for (const service of services) {
             conn.services.set(service.uuid, service);
         }
@@ -482,13 +530,13 @@ export class NobleBleProxyClient {
     async #handleDiscoverCharacteristics(id: number, args: DiscoverCharacteristicsArgs): Promise<void> {
         const conn = this.#connections.get(args.connection_handle);
         if (!conn) {
-            this.#sendError(id, "not_connected", `No connection with handle ${args.connection_handle}`);
+            this.#sendError(id, BleProxyErrorCode.NotConnected, `No connection with handle ${args.connection_handle}`);
             return;
         }
 
         const service = conn.services.get(args.service_uuid);
         if (!service) {
-            this.#sendError(id, "service_not_found", `Service ${args.service_uuid} not found`);
+            this.#sendError(id, BleProxyErrorCode.ServiceNotFound, `Service ${args.service_uuid} not found`);
             return;
         }
 
@@ -510,11 +558,17 @@ export class NobleBleProxyClient {
 
         // Fallback: lazy discover
         log(`[GATT] handle=${args.connection_handle} discovering characteristics for ${args.service_uuid} (lazy)...`);
-        const characteristics = await withTimeout(
-            service.discoverCharacteristicsAsync([]),
-            10_000,
-            `discoverCharacteristics(${args.service_uuid}) timed out after 10s`,
-        );
+        let characteristics: Characteristic[];
+        try {
+            characteristics = await withTimeout(
+                service.discoverCharacteristicsAsync([]),
+                10_000,
+                `discoverCharacteristics(${args.service_uuid}) timed out after 10s`,
+            );
+        } catch (err) {
+            this.#sendError(id, BleProxyErrorCode.DiscoveryFailed, (err as Error).message);
+            return;
+        }
         for (const char of characteristics) {
             conn.characteristics.set(char.uuid, char);
         }
@@ -534,17 +588,31 @@ export class NobleBleProxyClient {
     async #handleReadCharacteristic(id: number, args: ReadCharacteristicArgs): Promise<void> {
         const conn = this.#connections.get(args.connection_handle);
         if (!conn) {
-            this.#sendError(id, "not_connected", `No connection with handle ${args.connection_handle}`);
+            this.#sendError(id, BleProxyErrorCode.NotConnected, `No connection with handle ${args.connection_handle}`);
             return;
         }
 
         const char = this.#findCharacteristic(conn, args.characteristic_uuid);
         if (!char) {
-            this.#sendError(id, "characteristic_not_found", `Characteristic ${args.characteristic_uuid} not found`);
+            this.#sendError(
+                id,
+                BleProxyErrorCode.CharacteristicNotFound,
+                `Characteristic ${args.characteristic_uuid} not found`,
+            );
             return;
         }
 
-        const data = await char.readAsync();
+        let data: Buffer;
+        try {
+            data = await char.readAsync();
+        } catch (err) {
+            this.#sendError(
+                id,
+                BleProxyErrorCode.ReadFailed,
+                `read(${args.characteristic_uuid}): ${(err as Error).message}`,
+            );
+            return;
+        }
         log(`[GATT] read ${args.characteristic_uuid} → ${data.length} bytes`);
         this.#sendSuccess(id, { value: Buffer.from(data).toString("base64") });
     }
@@ -552,20 +620,33 @@ export class NobleBleProxyClient {
     async #handleWriteCharacteristic(id: number, args: WriteCharacteristicArgs): Promise<void> {
         const conn = this.#connections.get(args.connection_handle);
         if (!conn) {
-            this.#sendError(id, "not_connected", `No connection with handle ${args.connection_handle}`);
+            this.#sendError(id, BleProxyErrorCode.NotConnected, `No connection with handle ${args.connection_handle}`);
             return;
         }
 
         const char = this.#findCharacteristic(conn, args.characteristic_uuid);
         if (!char) {
-            this.#sendError(id, "characteristic_not_found", `Characteristic ${args.characteristic_uuid} not found`);
+            this.#sendError(
+                id,
+                BleProxyErrorCode.CharacteristicNotFound,
+                `Characteristic ${args.characteristic_uuid} not found`,
+            );
             return;
         }
 
         const data = Buffer.from(args.value, "base64");
         const withResponse = args.response ?? false;
         log(`[GATT] write ${args.characteristic_uuid} ${data.length} bytes withResponse=${withResponse}`);
-        await char.writeAsync(data, !withResponse);
+        try {
+            await char.writeAsync(data, !withResponse);
+        } catch (err) {
+            this.#sendError(
+                id,
+                BleProxyErrorCode.WriteFailed,
+                `write(${args.characteristic_uuid}): ${(err as Error).message}`,
+            );
+            return;
+        }
         conn.lastWriteCharacteristic = char;
         this.#sendSuccess(id);
     }
@@ -573,44 +654,114 @@ export class NobleBleProxyClient {
     async #handleSubscribeCharacteristic(id: number, args: SubscribeCharacteristicArgs): Promise<void> {
         const conn = this.#connections.get(args.connection_handle);
         if (!conn) {
-            this.#sendError(id, "not_connected", `No connection with handle ${args.connection_handle}`);
+            this.#sendError(id, BleProxyErrorCode.NotConnected, `No connection with handle ${args.connection_handle}`);
             return;
         }
 
         const char = this.#findCharacteristic(conn, args.characteristic_uuid);
         if (!char) {
-            this.#sendError(id, "characteristic_not_found", `Characteristic ${args.characteristic_uuid} not found`);
+            this.#sendError(
+                id,
+                BleProxyErrorCode.CharacteristicNotFound,
+                `Characteristic ${args.characteristic_uuid} not found`,
+            );
             return;
         }
 
         const handle = args.connection_handle;
-        char.on("data", (data: Buffer) => {
-            // Send notification as binary frame for efficiency
-            log(`[GATT] notify ${args.characteristic_uuid} handle=${handle} ${data.length} bytes`);
-            this.#sendBinaryFrame(BinaryFrameOpcode.Notification, handle, new Uint8Array(data));
-        });
-
-        await char.subscribeAsync();
-        conn.subscriptions.set(args.characteristic_uuid, char);
+        if (!(await this.#subscribe(id, conn, handle, args.characteristic_uuid, char))) {
+            return;
+        }
         log(`[GATT] subscribe ${args.characteristic_uuid} handle=${handle}`);
+        this.#sendSuccess(id);
+    }
+
+    /** Returns false once an error response was sent. */
+    async #subscribe(
+        id: number,
+        conn: ConnectionState,
+        handle: number,
+        uuid: string,
+        char: Characteristic,
+    ): Promise<boolean> {
+        // Attached before the CCCD enable: noble drops "data" emitted with no listener attached.
+        const onData = this.#notificationForwarder(handle, uuid);
+        char.on("data", onData);
+        try {
+            await char.subscribeAsync();
+        } catch (err) {
+            char.removeListener("data", onData);
+            this.#sendError(id, BleProxyErrorCode.SubscribeFailed, `subscribe(${uuid}): ${(err as Error).message}`);
+            return false;
+        }
+        conn.subscriptions.set(uuid, { characteristic: char, onData });
+        return true;
+    }
+
+    async #handleWriteAndSubscribe(id: number, args: WriteAndSubscribeArgs): Promise<void> {
+        const conn = this.#connections.get(args.connection_handle);
+        if (!conn) {
+            this.#sendError(id, BleProxyErrorCode.NotConnected, `No connection with handle ${args.connection_handle}`);
+            return;
+        }
+
+        const writeChar = this.#findCharacteristic(conn, args.write_uuid);
+        if (!writeChar) {
+            this.#sendError(
+                id,
+                BleProxyErrorCode.CharacteristicNotFound,
+                `Characteristic ${args.write_uuid} not found`,
+            );
+            return;
+        }
+
+        const subscribeChar = this.#findCharacteristic(conn, args.subscribe_uuid);
+        if (!subscribeChar) {
+            this.#sendError(
+                id,
+                BleProxyErrorCode.CharacteristicNotFound,
+                `Characteristic ${args.subscribe_uuid} not found`,
+            );
+            return;
+        }
+
+        const handle = args.connection_handle;
+        const value = Buffer.from(args.write_value, "base64");
+        const withResponse = args.write_response ?? false;
+        log(
+            `[GATT] write_and_subscribe handle=${handle} write=${args.write_uuid} ${value.length} bytes` +
+                ` withResponse=${withResponse} subscribe=${args.subscribe_uuid}`,
+        );
+
+        try {
+            await writeChar.writeAsync(value, !withResponse);
+        } catch (err) {
+            this.#sendError(id, BleProxyErrorCode.WriteFailed, `write(${args.write_uuid}): ${(err as Error).message}`);
+            return;
+        }
+        conn.lastWriteCharacteristic = writeChar;
+
+        if (!(await this.#subscribe(id, conn, handle, args.subscribe_uuid, subscribeChar))) {
+            return;
+        }
         this.#sendSuccess(id);
     }
 
     async #handleUnsubscribeCharacteristic(id: number, args: UnsubscribeCharacteristicArgs): Promise<void> {
         const conn = this.#connections.get(args.connection_handle);
         if (!conn) {
-            this.#sendError(id, "not_connected", `No connection with handle ${args.connection_handle}`);
+            this.#sendError(id, BleProxyErrorCode.NotConnected, `No connection with handle ${args.connection_handle}`);
             return;
         }
 
-        const char = conn.subscriptions.get(args.characteristic_uuid);
-        if (!char) {
-            this.#sendError(id, "not_subscribed", `Not subscribed to ${args.characteristic_uuid}`);
+        const subscription = conn.subscriptions.get(args.characteristic_uuid);
+        if (!subscription) {
+            this.#sendError(id, BleProxyErrorCode.NotSubscribed, `Not subscribed to ${args.characteristic_uuid}`);
             return;
         }
 
-        await char.unsubscribeAsync();
-        char.removeAllListeners("data");
+        await subscription.characteristic.unsubscribeAsync();
+        subscription.characteristic.removeListener("data", subscription.onData);
         conn.subscriptions.delete(args.characteristic_uuid);
         log(`[GATT] unsubscribe ${args.characteristic_uuid} handle=${args.connection_handle}`);
         this.#sendSuccess(id);
@@ -619,7 +770,7 @@ export class NobleBleProxyClient {
     async #handleRequestMtu(id: number, connectionHandle: number, mtu: number): Promise<void> {
         const conn = this.#connections.get(connectionHandle);
         if (!conn) {
-            this.#sendError(id, "not_connected", `No connection with handle ${connectionHandle}`);
+            this.#sendError(id, BleProxyErrorCode.NotConnected, `No connection with handle ${connectionHandle}`);
             return;
         }
         // Noble doesn't have explicit MTU request - return the peripheral's MTU
@@ -631,7 +782,14 @@ export class NobleBleProxyClient {
     // ─── Binary Frame Handling ───────────────────────────────────────────────
 
     #handleBinaryFrame(data: Buffer): void {
-        const frame = decodeBinaryFrame(new Uint8Array(data));
+        // A throw here escapes into ws's receiver and takes the process down with it.
+        let frame;
+        try {
+            frame = decodeBinaryFrame(new Uint8Array(data));
+        } catch (err) {
+            warn(`[←BIN] failed to decode binary frame: ${(err as Error).message}`);
+            return;
+        }
         log(`[←BIN] opcode=${frame.opcode} handle=${frame.connectionHandle} payload=${frame.payload.length} bytes`);
 
         if (frame.opcode === BinaryFrameOpcode.WriteData) {
@@ -650,6 +808,31 @@ export class NobleBleProxyClient {
 
     // ─── Helpers ─────────────────────────────────────────────────────────────
 
+    /**
+     * Noble is always asked for duplicates; `allow_duplicates` is honoured when reporting.
+     * A no-op once `stop_scan` has been received, so the connect paths cannot resume a scan
+     * the server already ended.
+     */
+    #startScanning(): Promise<void> {
+        if (!this.#scanRequested) {
+            return Promise.resolve();
+        }
+        return this.#noble!.startScanningAsync(this.#scanServiceUuids, true);
+    }
+
+    // Forwarded regardless of noble's `isNotification`: on macOS that flag is derived from a
+    // manager-wide pendingRead, so it reads false for a notification racing a read on any
+    // peripheral. Safe only while no subscribed characteristic is ever read.
+    #notificationForwarder(handle: number, uuid: string): NotificationListener {
+        return payload => {
+            if (payload === null) {
+                return;
+            }
+            log(`[GATT] notify ${uuid} handle=${handle} ${payload.length} bytes`);
+            this.#sendBinaryFrame(BinaryFrameOpcode.Notification, handle, new Uint8Array(payload));
+        };
+    }
+
     #findCharacteristic(conn: ConnectionState, uuid: string): Characteristic | undefined {
         // Try exact match first, then case-insensitive
         return (
@@ -663,7 +846,7 @@ export class NobleBleProxyClient {
         this.#ws?.send(JSON.stringify({ id, success: true, result: result ?? {} }));
     }
 
-    #sendError(id: number, error: string, message: string): void {
+    #sendError(id: number, error: BleProxyErrorCodeValue, message: string): void {
         this.#ws?.send(JSON.stringify({ id, success: false, error, message }));
     }
 

--- a/packages/ble-proxy/src/example/NobleBleProxyClient.ts
+++ b/packages/ble-proxy/src/example/NobleBleProxyClient.ts
@@ -676,7 +676,7 @@ export class NobleBleProxyClient {
         this.#sendSuccess(id);
     }
 
-    /** Returns false once an error response was sent. */
+    /** No-op when `uuid` is already subscribed. Returns false once an error response was sent. */
     async #subscribe(
         id: number,
         conn: ConnectionState,
@@ -684,6 +684,12 @@ export class NobleBleProxyClient {
         uuid: string,
         char: Characteristic,
     ): Promise<boolean> {
+        // noble's `_notify` resolves without re-enabling CCCD when already notifying, so a
+        // second "data" listener would double every forwarded notification.
+        if (conn.subscriptions.has(uuid)) {
+            return true;
+        }
+
         // Attached before the CCCD enable: noble drops "data" emitted with no listener attached.
         const onData = this.#notificationForwarder(handle, uuid);
         char.on("data", onData);

--- a/packages/ble-proxy/test/BleProxyTestClient.ts
+++ b/packages/ble-proxy/test/BleProxyTestClient.ts
@@ -23,6 +23,7 @@ type CommandHandler = (args: Record<string, unknown>) => Promise<Record<string, 
 export class BleProxyTestClient {
     #ws?: WebSocket;
     #commandHandlers = new Map<BleProxyCommandName, CommandHandler>();
+    #commandErrors = new Map<BleProxyCommandName, { error: string; message: string }>();
     #receivedCommands: CommandMessage[] = [];
     #commandWaiters: Array<{ command: string; resolve: (msg: CommandMessage) => void }> = [];
 
@@ -74,6 +75,11 @@ export class BleProxyTestClient {
         this.#commandHandlers.set(command, handler);
     }
 
+    /** Answer `command` the way a real client does: bare message, code in its own field. */
+    onCommandError(command: BleProxyCommandName, error: string, message: string): void {
+        this.#commandErrors.set(command, { error, message });
+    }
+
     sendEvent(event: string, data: Record<string, unknown>): void {
         this.#ws?.send(JSON.stringify({ event, data }));
     }
@@ -115,6 +121,12 @@ export class BleProxyTestClient {
     }
 
     async #dispatchCommand(msg: CommandMessage): Promise<void> {
+        const failure = this.#commandErrors.get(msg.command);
+        if (failure) {
+            this.#ws?.send(JSON.stringify({ id: msg.id, success: false, ...failure }));
+            return;
+        }
+
         const handler = this.#commandHandlers.get(msg.command);
         if (!handler) {
             // Auto-respond with success for unhandled commands

--- a/packages/ble-proxy/test/MultiClientBleProxyTest.ts
+++ b/packages/ble-proxy/test/MultiClientBleProxyTest.ts
@@ -6,7 +6,7 @@
 
 import { createServer } from "node:http";
 import { BleProxyHandler } from "../src/BleProxyHandler.js";
-import { BleProxyCommand } from "../src/BleProxyProtocol.js";
+import { BleProxyCommand, BleProxyErrorCode } from "../src/BleProxyProtocol.js";
 import { ProxyBleClient } from "../src/ProxyBleClient.js";
 import { BleProxyTestClient } from "./BleProxyTestClient.js";
 
@@ -113,6 +113,29 @@ describe("Multi-client BLE Proxy", function () {
         await new Promise<void>(resolve => setTimeout(resolve, 100));
 
         expect(stopped).to.be.true;
+    });
+
+    it("keeps a client that answers already_scanning tracked as scanning", async () => {
+        const a = await addClient();
+        await new Promise<void>(resolve => setTimeout(resolve, 50));
+
+        a.onCommandError(BleProxyCommand.StartScan, BleProxyErrorCode.AlreadyScanning, "A scan is already in progress");
+
+        let stoppedReason: string | undefined;
+        handler.scanStopped.on(reason => {
+            stoppedReason = reason;
+        });
+
+        await handler.startScan({ service_uuids: ["fff6"], allow_duplicates: false });
+        await new Promise<void>(resolve => setTimeout(resolve, 100));
+
+        expect(stoppedReason).to.be.undefined;
+
+        // Still tracked, so its own scan_stopped must still reach the Matter stack.
+        a.sendEvent("scan_stopped", { reason: "adapter_off" });
+        await new Promise<void>(resolve => setTimeout(resolve, 100));
+
+        expect(stoppedReason).to.equal("adapter_off");
     });
 
     it("assigns ownership to the first client that discovers a peripheral", async () => {

--- a/packages/ble-proxy/test/NobleBleProxyClientTest.ts
+++ b/packages/ble-proxy/test/NobleBleProxyClientTest.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BleProxyCommand } from "../src/BleProxyProtocol.js";
+import { NobleBleProxyClient } from "../src/example/NobleBleProxyClient.js";
+
+describe("NobleBleProxyClient", () => {
+    describe("protocol coverage", () => {
+        it("implements every protocol command", () => {
+            const client = new NobleBleProxyClient("ws://localhost:5580/ble");
+            const implemented = new Set(client.supportedCommands);
+            const missing = Object.values(BleProxyCommand).filter(command => !implemented.has(command));
+
+            expect(missing).to.deep.equal([]);
+        });
+    });
+});

--- a/python_ble_proxy/matter_ble_proxy/__init__.py
+++ b/python_ble_proxy/matter_ble_proxy/__init__.py
@@ -22,6 +22,8 @@ from .protocol import (
     OPCODE_READ_RESPONSE,
     OPCODE_WRITE_DATA,
     AdvertisementData,
+    BleProxyCommand,
+    BleProxyErrorCode,
 )
 
 __all__ = [
@@ -32,6 +34,8 @@ __all__ = [
     "OPCODE_WRITE_DATA",
     "AdvertisementData",
     "BleDeviceResolver",
+    "BleProxyCommand",
+    "BleProxyErrorCode",
     "BleScanSource",
     "BleakDeviceResolver",
     "BleakScanSource",

--- a/python_ble_proxy/matter_ble_proxy/client.py
+++ b/python_ble_proxy/matter_ble_proxy/client.py
@@ -35,6 +35,8 @@ from .protocol import (
     OPCODE_NOTIFICATION,
     OPCODE_WRITE_DATA,
     AdvertisementData,
+    BleProxyCommand,
+    BleProxyErrorCode,
 )
 
 if TYPE_CHECKING:
@@ -44,6 +46,8 @@ if TYPE_CHECKING:
     from bleak.backends.characteristic import BleakGATTCharacteristic
     from bleak.backends.device import BLEDevice
     from bleak.backends.service import BleakGATTServiceCollection
+
+    CommandHandler = Callable[[int, dict[str, Any]], Coroutine[Any, Any, None]]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -109,8 +113,8 @@ class ConnectionState:
         self.client = client
         self.handle = handle
         self.services: BleakGATTServiceCollection | None = None
-        self.subscriptions: dict[str, BleakGATTCharacteristic] = {}
-        self.last_write_characteristic: BleakGATTCharacteristic | None = None
+        self.subscriptions: set[str] = set()
+        self.last_write_uuid: str | None = None
         self.intentional_disconnect = False
 
 
@@ -167,10 +171,25 @@ class MatterBleProxy:
         self._connections: dict[int, ConnectionState] = {}
         self._next_handle = 1
         self._scanning = False
+        self._scan_key: tuple[frozenset[str] | None, bool] | None = None
         self._message_task: asyncio.Task[None] | None = None
         self._closed_event = asyncio.Event()
         self._loop: asyncio.AbstractEventLoop | None = None
         self._task_factory = task_factory
+        self._handlers: dict[BleProxyCommand, CommandHandler] = {
+            BleProxyCommand.START_SCAN: self._handle_start_scan,
+            BleProxyCommand.STOP_SCAN: self._handle_stop_scan,
+            BleProxyCommand.CONNECT: self._handle_connect,
+            BleProxyCommand.DISCONNECT: self._handle_disconnect,
+            BleProxyCommand.DISCOVER_SERVICES: self._handle_discover_services,
+            BleProxyCommand.DISCOVER_CHARACTERISTICS: self._handle_discover_characteristics,
+            BleProxyCommand.READ_CHARACTERISTIC: self._handle_read_characteristic,
+            BleProxyCommand.WRITE_CHARACTERISTIC: self._handle_write_characteristic,
+            BleProxyCommand.SUBSCRIBE_CHARACTERISTIC: self._handle_subscribe_characteristic,
+            BleProxyCommand.WRITE_AND_SUBSCRIBE: self._handle_write_and_subscribe,
+            BleProxyCommand.UNSUBSCRIBE_CHARACTERISTIC: self._handle_unsubscribe_characteristic,
+            BleProxyCommand.REQUEST_MTU: self._handle_request_mtu,
+        }
 
     async def connect(self) -> None:
         """Connect to the matter-server `/ble` endpoint and perform handshake."""
@@ -315,41 +334,34 @@ class MatterBleProxy:
             summary = {k: v for k, v in args.items() if k not in {"value"}}
             _LOGGER.debug("[←CMD] id=%s %s%s", cmd_id, command, f" {summary}" if summary else "")
 
-        handler = {
-            "start_scan": self._handle_start_scan,
-            "stop_scan": self._handle_stop_scan,
-            "connect": self._handle_connect,
-            "disconnect": self._handle_disconnect,
-            "discover_services": self._handle_discover_services,
-            "discover_characteristics": self._handle_discover_characteristics,
-            "read_characteristic": self._handle_read_characteristic,
-            "write_characteristic": self._handle_write_characteristic,
-            "subscribe_characteristic": self._handle_subscribe_characteristic,
-            "write_and_subscribe": self._handle_write_and_subscribe,
-            "unsubscribe_characteristic": self._handle_unsubscribe_characteristic,
-            "request_mtu": self._handle_request_mtu,
-        }.get(command)
-
-        if handler is None:
-            await self._send_error(cmd_id, "internal_error", f"Unknown command: {command}")
+        try:
+            handler = self._handlers[BleProxyCommand(command)]
+        except (KeyError, ValueError):
+            await self._send_error(cmd_id, BleProxyErrorCode.INTERNAL_ERROR, f"Unknown command: {command}")
             return
 
         try:
             await handler(cmd_id, args)
         except Exception as err:
             _LOGGER.exception("Error handling command %s", command)
-            await self._send_error(cmd_id, "internal_error", str(err))
+            await self._send_error(cmd_id, BleProxyErrorCode.INTERNAL_ERROR, str(err))
 
     # ─── Command Handlers ───────────────────────────────────────────────────
 
     async def _handle_start_scan(self, cmd_id: int, args: dict[str, Any]) -> None:
-        if self._scanning:
-            await self._send_error(cmd_id, "already_scanning", "A scan is already in progress")
-            return
-
         service_uuids: list[str] = args.get("service_uuids", [])
         service_uuid_set = {_normalize_uuid(u) for u in service_uuids} if service_uuids else None
         allow_duplicates: bool = bool(args.get("allow_duplicates", True))
+
+        # The server may re-send `start_scan` with different parameters while a scan runs.
+        # Restart the source rather than re-calling start(): a backend need not adopt a new callback.
+        scan_key = (frozenset(service_uuid_set) if service_uuid_set is not None else None, allow_duplicates)
+        if self._scanning:
+            if scan_key == self._scan_key:
+                await self._send_success(cmd_id)
+                return
+            await self._scan_source.stop()
+            self._scanning = False
 
         # When `allow_duplicates` is false, dedup by content fingerprint — Matter peripherals
         # broadcast at ~10 Hz and the server only needs state changes. When true, the server
@@ -398,11 +410,12 @@ class MatterBleProxy:
 
         await self._scan_source.start(_on_advertisement)
         self._scanning = True
+        self._scan_key = scan_key
         await self._send_success(cmd_id)
 
     async def _handle_stop_scan(self, cmd_id: int, _args: dict[str, Any]) -> None:
         if not self._scanning:
-            await self._send_error(cmd_id, "not_scanning", "No scan is currently active")
+            await self._send_error(cmd_id, BleProxyErrorCode.NOT_SCANNING, "No scan is currently active")
             return
         await self._scan_source.stop()
         self._scanning = False
@@ -416,7 +429,9 @@ class MatterBleProxy:
 
         target = await self._device_resolver.resolve(address)
         if target is None:
-            await self._send_error(cmd_id, "device_not_found", f"No BLE device found for address {address}")
+            await self._send_error(
+                cmd_id, BleProxyErrorCode.DEVICE_NOT_FOUND, f"No BLE device found for address {address}"
+            )
             return
 
         handle = self._next_handle
@@ -440,10 +455,12 @@ class MatterBleProxy:
             async with asyncio.timeout(timeout_ms / 1000):
                 await client.connect()
         except TimeoutError:
-            await self._send_error(cmd_id, "connection_failed", f"Timeout connecting to {address}")
+            await self._send_error(cmd_id, BleProxyErrorCode.CONNECTION_FAILED, f"Timeout connecting to {address}")
             return
         except Exception as err:
-            await self._send_error(cmd_id, "connection_failed", f"Failed to connect to {address}: {err}")
+            await self._send_error(
+                cmd_id, BleProxyErrorCode.CONNECTION_FAILED, f"Failed to connect to {address}: {err}"
+            )
             return
 
         conn = ConnectionState(client, handle)
@@ -456,7 +473,7 @@ class MatterBleProxy:
         handle: int = args["connection_handle"]
         conn = self._connections.pop(handle, None)
         if conn is None:
-            await self._send_error(cmd_id, "not_connected", f"No connection with handle {handle}")
+            await self._send_not_connected(cmd_id, handle)
             return
         conn.intentional_disconnect = True
         if conn.client.is_connected:
@@ -466,14 +483,14 @@ class MatterBleProxy:
     async def _handle_discover_services(self, cmd_id: int, args: dict[str, Any]) -> None:
         conn = self._get_connection(args["connection_handle"])
         if conn is None:
-            await self._send_error(cmd_id, "not_connected", f"No connection with handle {args['connection_handle']}")
+            await self._send_not_connected(cmd_id, args["connection_handle"])
             return
         # Bleak's stub claims `services` is always populated after `connect()`, but in
         # practice it can be `None` if the cache hasn't populated or the connection broke
         # before this command; cast to Optional so the None guard isn't unreachable.
         services: BleakGATTServiceCollection | None = conn.client.services
         if services is None:
-            await self._send_error(cmd_id, "discover_failed", "Service discovery has not completed")
+            await self._send_error(cmd_id, BleProxyErrorCode.DISCOVERY_FAILED, "Service discovery has not completed")
             return
         conn.services = services
         services_list = [{"uuid": service.uuid} for service in services]
@@ -482,17 +499,17 @@ class MatterBleProxy:
     async def _handle_discover_characteristics(self, cmd_id: int, args: dict[str, Any]) -> None:
         conn = self._get_connection(args["connection_handle"])
         if conn is None:
-            await self._send_error(cmd_id, "not_connected", f"No connection with handle {args['connection_handle']}")
+            await self._send_not_connected(cmd_id, args["connection_handle"])
             return
 
         service_uuid: str = args["service_uuid"]
         if conn.services is None:
-            await self._send_error(cmd_id, "service_not_found", "Services not discovered yet")
+            await self._send_error(cmd_id, BleProxyErrorCode.SERVICE_NOT_FOUND, "Services not discovered yet")
             return
 
         service = conn.services.get_service(service_uuid)
         if service is None:
-            await self._send_error(cmd_id, "service_not_found", f"Service {service_uuid} not found")
+            await self._send_error(cmd_id, BleProxyErrorCode.SERVICE_NOT_FOUND, f"Service {service_uuid} not found")
             return
 
         characteristics = [
@@ -503,20 +520,20 @@ class MatterBleProxy:
     async def _handle_read_characteristic(self, cmd_id: int, args: dict[str, Any]) -> None:
         conn = self._get_connection(args["connection_handle"])
         if conn is None:
-            await self._send_error(cmd_id, "not_connected", f"No connection with handle {args['connection_handle']}")
+            await self._send_not_connected(cmd_id, args["connection_handle"])
             return
         char_uuid: str = args["characteristic_uuid"]
         try:
             data = await conn.client.read_gatt_char(char_uuid)
         except Exception as err:
-            await self._send_error(cmd_id, "read_failed", f"read_gatt_char({char_uuid}): {err}")
+            await self._send_error(cmd_id, BleProxyErrorCode.READ_FAILED, f"read_gatt_char({char_uuid}): {err}")
             return
         await self._send_success(cmd_id, {"value": base64.b64encode(data).decode("ascii")})
 
     async def _handle_write_characteristic(self, cmd_id: int, args: dict[str, Any]) -> None:
         conn = self._get_connection(args["connection_handle"])
         if conn is None:
-            await self._send_error(cmd_id, "not_connected", f"No connection with handle {args['connection_handle']}")
+            await self._send_not_connected(cmd_id, args["connection_handle"])
             return
 
         char_uuid: str = args["characteristic_uuid"]
@@ -526,26 +543,27 @@ class MatterBleProxy:
         try:
             await conn.client.write_gatt_char(char_uuid, data, response=response)
         except Exception as err:
-            await self._send_error(cmd_id, "write_failed", f"write_gatt_char({char_uuid}): {err}")
+            await self._send_error(cmd_id, BleProxyErrorCode.WRITE_FAILED, f"write_gatt_char({char_uuid}): {err}")
             return
 
         # Remember the last-written characteristic so subsequent binary
         # WRITE_DATA frames know where to dispatch payload.
-        if conn.services is not None:
-            char_obj = conn.services.get_characteristic(char_uuid)
-            if char_obj is not None:
-                conn.last_write_characteristic = char_obj
+        conn.last_write_uuid = char_uuid
 
         await self._send_success(cmd_id)
 
     async def _handle_subscribe_characteristic(self, cmd_id: int, args: dict[str, Any]) -> None:
         conn = self._get_connection(args["connection_handle"])
         if conn is None:
-            await self._send_error(cmd_id, "not_connected", f"No connection with handle {args['connection_handle']}")
+            await self._send_not_connected(cmd_id, args["connection_handle"])
             return
 
         char_uuid: str = args["characteristic_uuid"]
         handle = conn.handle
+
+        if char_uuid in conn.subscriptions:
+            await self._send_success(cmd_id)
+            return
 
         def _on_notification(_char: BleakGATTCharacteristic, data: bytearray) -> None:
             payload = bytes(data)
@@ -559,15 +577,12 @@ class MatterBleProxy:
         try:
             await conn.client.start_notify(char_uuid, _on_notification)
         except Exception as err:
-            await self._send_error(cmd_id, "subscribe_failed", f"start_notify({char_uuid}): {err}")
+            await self._send_error(cmd_id, BleProxyErrorCode.SUBSCRIBE_FAILED, f"start_notify({char_uuid}): {err}")
             return
 
         # Track the subscription so `unsubscribe_characteristic` can detect
         # not-subscribed errors locally without leaning on Bleak's exception.
-        if conn.services is not None:
-            char_obj = conn.services.get_characteristic(char_uuid)
-            if char_obj is not None:
-                conn.subscriptions[char_uuid] = char_obj
+        conn.subscriptions.add(char_uuid)
         await self._send_success(cmd_id)
 
     async def _handle_write_and_subscribe(self, cmd_id: int, args: dict[str, Any]) -> None:
@@ -579,7 +594,7 @@ class MatterBleProxy:
         """
         conn = self._get_connection(args["connection_handle"])
         if conn is None:
-            await self._send_error(cmd_id, "not_connected", f"No connection with handle {args['connection_handle']}")
+            await self._send_not_connected(cmd_id, args["connection_handle"])
             return
 
         write_uuid: str = args["write_uuid"]
@@ -606,48 +621,46 @@ class MatterBleProxy:
         try:
             await conn.client.write_gatt_char(write_uuid, write_data, response=write_response)
         except Exception as err:
-            await self._send_error(cmd_id, "write_failed", f"write_gatt_char({write_uuid}): {err}")
+            await self._send_error(cmd_id, BleProxyErrorCode.WRITE_FAILED, f"write_gatt_char({write_uuid}): {err}")
             return
 
-        if conn.services is not None:
-            char_obj = conn.services.get_characteristic(write_uuid)
-            if char_obj is not None:
-                conn.last_write_characteristic = char_obj
+        conn.last_write_uuid = write_uuid
+
+        if subscribe_uuid in conn.subscriptions:
+            await self._send_success(cmd_id)
+            return
 
         try:
             await conn.client.start_notify(subscribe_uuid, _on_notification)
         except Exception as err:
-            await self._send_error(cmd_id, "subscribe_failed", f"start_notify({subscribe_uuid}): {err}")
+            await self._send_error(cmd_id, BleProxyErrorCode.SUBSCRIBE_FAILED, f"start_notify({subscribe_uuid}): {err}")
             return
 
-        if conn.services is not None:
-            sub_obj = conn.services.get_characteristic(subscribe_uuid)
-            if sub_obj is not None:
-                conn.subscriptions[subscribe_uuid] = sub_obj
+        conn.subscriptions.add(subscribe_uuid)
 
         await self._send_success(cmd_id)
 
     async def _handle_unsubscribe_characteristic(self, cmd_id: int, args: dict[str, Any]) -> None:
         conn = self._get_connection(args["connection_handle"])
         if conn is None:
-            await self._send_error(cmd_id, "not_connected", f"No connection with handle {args['connection_handle']}")
+            await self._send_not_connected(cmd_id, args["connection_handle"])
             return
         char_uuid: str = args["characteristic_uuid"]
         if char_uuid not in conn.subscriptions:
-            await self._send_error(cmd_id, "not_subscribed", f"Not subscribed to {char_uuid}")
+            await self._send_error(cmd_id, BleProxyErrorCode.NOT_SUBSCRIBED, f"Not subscribed to {char_uuid}")
             return
         try:
             await conn.client.stop_notify(char_uuid)
         except Exception as err:
-            await self._send_error(cmd_id, "internal_error", f"stop_notify({char_uuid}): {err}")
+            await self._send_error(cmd_id, BleProxyErrorCode.INTERNAL_ERROR, f"stop_notify({char_uuid}): {err}")
             return
-        conn.subscriptions.pop(char_uuid, None)
+        conn.subscriptions.discard(char_uuid)
         await self._send_success(cmd_id)
 
     async def _handle_request_mtu(self, cmd_id: int, args: dict[str, Any]) -> None:
         conn = self._get_connection(args["connection_handle"])
         if conn is None:
-            await self._send_error(cmd_id, "not_connected", f"No connection with handle {args['connection_handle']}")
+            await self._send_not_connected(cmd_id, args["connection_handle"])
             return
         # Bleak does not expose an explicit MTU request — return the current MTU.
         mtu = getattr(conn.client, "mtu_size", 23)
@@ -665,14 +678,21 @@ class MatterBleProxy:
 
         if opcode == OPCODE_WRITE_DATA:
             conn = self._get_connection(connection_handle)
-            if conn is None or conn.last_write_characteristic is None:
+            if conn is None:
+                _LOGGER.debug("Dropping WRITE_DATA frame for closed handle=%d", connection_handle)
+                return
+            if conn.last_write_uuid is None:
+                _LOGGER.warning(
+                    "Dropping WRITE_DATA frame for handle=%d: no write characteristic established",
+                    connection_handle,
+                )
                 return
             try:
                 # Matter BTP writes on C1 use ATT Write Request (with response).
                 # C1 typically does not advertise write-without-response, so a
                 # response=False here is silently dropped by the peripheral and
                 # the BTP session stalls.
-                await conn.client.write_gatt_char(conn.last_write_characteristic, payload, response=True)
+                await conn.client.write_gatt_char(conn.last_write_uuid, payload, response=True)
             except Exception:
                 _LOGGER.warning("Binary write error", exc_info=True)
 
@@ -685,9 +705,12 @@ class MatterBleProxy:
         if self._ws is not None and not self._ws.closed:
             await self._ws.send_json({"id": cmd_id, "success": True, "result": result or {}})
 
-    async def _send_error(self, cmd_id: int, error: str, message: str) -> None:
+    async def _send_error(self, cmd_id: int, error: BleProxyErrorCode, message: str) -> None:
         if self._ws is not None and not self._ws.closed:
-            await self._ws.send_json({"id": cmd_id, "success": False, "error": error, "message": message})
+            await self._ws.send_json({"id": cmd_id, "success": False, "error": error.value, "message": message})
+
+    async def _send_not_connected(self, cmd_id: int, handle: object) -> None:
+        await self._send_error(cmd_id, BleProxyErrorCode.NOT_CONNECTED, f"No connection with handle {handle}")
 
     async def _send_event(self, event: str, data: dict[str, Any]) -> None:
         if self._ws is not None and not self._ws.closed:

--- a/python_ble_proxy/matter_ble_proxy/protocol.py
+++ b/python_ble_proxy/matter_ble_proxy/protocol.py
@@ -7,6 +7,7 @@ specification.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 import struct
 
 # Current protocol version. Must match the matter-server's
@@ -29,6 +30,54 @@ HANDSHAKE_TIMEOUT_SECONDS = 10.0
 # does not include an explicit `timeout`. Matter BLE commissioning windows are
 # 15 minutes; this only caps a single connect attempt.
 DEFAULT_CONNECT_TIMEOUT_MS = 30_000
+
+
+class BleProxyCommand(StrEnum):
+    """Commands the server may send to a client.
+
+    Mirrors `BleProxyCommand` in `packages/ble-proxy/src/BleProxyProtocol.ts`; a client must
+    implement every member of this enum.
+    """
+
+    START_SCAN = "start_scan"
+    STOP_SCAN = "stop_scan"
+    CONNECT = "connect"
+    DISCONNECT = "disconnect"
+    DISCOVER_SERVICES = "discover_services"
+    DISCOVER_CHARACTERISTICS = "discover_characteristics"
+    READ_CHARACTERISTIC = "read_characteristic"
+    WRITE_CHARACTERISTIC = "write_characteristic"
+    SUBSCRIBE_CHARACTERISTIC = "subscribe_characteristic"
+    WRITE_AND_SUBSCRIBE = "write_and_subscribe"
+    UNSUBSCRIBE_CHARACTERISTIC = "unsubscribe_characteristic"
+    REQUEST_MTU = "request_mtu"
+
+
+class BleProxyErrorCode(StrEnum):
+    """Error codes a client may return in a command response.
+
+    Mirrors `BleProxyErrorCode` in `packages/ble-proxy/src/BleProxyProtocol.ts`; the wire
+    value of every member is its name lowercased.
+    """
+
+    BLUETOOTH_UNAVAILABLE = "bluetooth_unavailable"
+    ALREADY_SCANNING = "already_scanning"
+    NOT_SCANNING = "not_scanning"
+    DEVICE_NOT_FOUND = "device_not_found"
+    CONNECTION_FAILED = "connection_failed"
+    ALREADY_CONNECTED = "already_connected"
+    NOT_CONNECTED = "not_connected"
+    TIMEOUT = "timeout"
+    SERVICE_NOT_FOUND = "service_not_found"
+    CHARACTERISTIC_NOT_FOUND = "characteristic_not_found"
+    READ_FAILED = "read_failed"
+    WRITE_FAILED = "write_failed"
+    SUBSCRIBE_FAILED = "subscribe_failed"
+    NOT_SUBSCRIBED = "not_subscribed"
+    NOTIFY_NOT_SUPPORTED = "notify_not_supported"
+    MTU_REQUEST_FAILED = "mtu_request_failed"
+    DISCOVERY_FAILED = "discovery_failed"
+    INTERNAL_ERROR = "internal_error"
 
 
 @dataclass(slots=True)

--- a/python_ble_proxy/tests/test_client.py
+++ b/python_ble_proxy/tests/test_client.py
@@ -1,0 +1,222 @@
+"""Unit tests for the proxy client's command dispatch."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from matter_ble_proxy.client import BleDeviceResolver, BleScanSource, ConnectionState, MatterBleProxy
+from matter_ble_proxy.protocol import (
+    BINARY_FRAME_HEADER,
+    OPCODE_WRITE_DATA,
+    BleProxyCommand,
+    BleProxyErrorCode,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from matter_ble_proxy.protocol import AdvertisementData
+
+
+class _StubScanSource(BleScanSource):
+    def __init__(self) -> None:
+        self.starts = 0
+        self.stops = 0
+        self.callback: Callable[[AdvertisementData], None] | None = None
+
+    async def start(self, callback: Callable[[AdvertisementData], None]) -> None:
+        self.starts += 1
+        self.callback = callback
+
+    async def stop(self) -> None:
+        self.stops += 1
+        self.callback = None
+
+
+class _StubDeviceResolver(BleDeviceResolver):
+    async def resolve(self, address: str) -> str | None:
+        return address
+
+
+class _StubWebSocket:
+    """Captures what the client would send, standing in for the aiohttp socket."""
+
+    closed = False
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def send_json(self, payload: dict[str, Any]) -> None:
+        self.sent.append(payload)
+
+
+def _proxy() -> tuple[MatterBleProxy, _StubWebSocket]:
+    proxy, ws, _scan_source = _proxy_with_scan_source()
+    return proxy, ws
+
+
+def _proxy_with_scan_source() -> tuple[MatterBleProxy, _StubWebSocket, _StubScanSource]:
+    scan_source = _StubScanSource()
+    proxy = MatterBleProxy(
+        ws_url="ws://localhost:5580/ble",
+        scan_source=scan_source,
+        device_resolver=_StubDeviceResolver(),
+    )
+    ws = _StubWebSocket()
+    proxy._ws = ws  # type: ignore[assignment]
+    return proxy, ws, scan_source
+
+
+def test_every_protocol_command_has_a_handler():
+    proxy, _ = _proxy()
+    implemented = set(proxy._handlers)
+    assert [command for command in BleProxyCommand if command not in implemented] == []
+
+
+async def test_unknown_command_is_reported_as_an_error():
+    proxy, ws = _proxy()
+
+    await proxy._handle_command({"id": 7, "command": "teleport", "args": {}})
+
+    assert ws.sent == [
+        {
+            "id": 7,
+            "success": False,
+            "error": BleProxyErrorCode.INTERNAL_ERROR.value,
+            "message": "Unknown command: teleport",
+        }
+    ]
+
+
+class _StubBleakClient:
+    """Records the GATT calls the handlers make, standing in for BleakClient."""
+
+    is_connected = True
+
+    def __init__(self) -> None:
+        self.start_notify_uuids: list[str] = []
+        self.stop_notify_uuids: list[str] = []
+        self.writes: list[tuple[str, bytes, bool]] = []
+
+    async def start_notify(self, uuid: str, callback: object) -> None:
+        self.start_notify_uuids.append(uuid)
+
+    async def stop_notify(self, uuid: str) -> None:
+        self.stop_notify_uuids.append(uuid)
+
+    async def write_gatt_char(self, uuid: str, data: bytes, response: bool) -> None:
+        self.writes.append((uuid, data, response))
+
+
+def _connection(proxy: MatterBleProxy, handle: int) -> tuple[ConnectionState, _StubBleakClient]:
+    client = _StubBleakClient()
+    conn = ConnectionState(client, handle)  # type: ignore[arg-type]
+    proxy._connections[handle] = conn
+    return conn, client
+
+
+async def test_subscribe_to_an_already_subscribed_uuid_does_not_reenter_start_notify():
+    proxy, ws = _proxy()
+    conn, client = _connection(proxy, 1)
+    conn.subscriptions.add("fff6")
+
+    await proxy._handle_subscribe_characteristic(3, {"connection_handle": 1, "characteristic_uuid": "fff6"})
+
+    assert client.start_notify_uuids == []
+    assert ws.sent == [{"id": 3, "success": True, "result": {}}]
+
+
+async def test_write_and_subscribe_skips_a_second_cccd_enable():
+    proxy, ws = _proxy()
+    conn, client = _connection(proxy, 1)
+    conn.subscriptions.add("fff7")
+
+    await proxy._handle_write_and_subscribe(
+        4,
+        {
+            "connection_handle": 1,
+            "write_uuid": "fff6",
+            "write_value": "AQID",
+            "write_response": True,
+            "subscribe_uuid": "fff7",
+        },
+    )
+
+    assert client.writes == [("fff6", b"\x01\x02\x03", True)]
+    assert conn.last_write_uuid == "fff6"
+    assert client.start_notify_uuids == []
+    assert ws.sent == [{"id": 4, "success": True, "result": {}}]
+
+
+async def test_subscription_is_tracked_without_prior_service_discovery():
+    proxy, ws = _proxy()
+    conn, client = _connection(proxy, 1)
+    assert conn.services is None
+
+    await proxy._handle_subscribe_characteristic(1, {"connection_handle": 1, "characteristic_uuid": "fff6"})
+    await proxy._handle_subscribe_characteristic(2, {"connection_handle": 1, "characteristic_uuid": "fff6"})
+
+    assert conn.subscriptions == {"fff6"}
+    assert client.start_notify_uuids == ["fff6"]
+    assert [msg["success"] for msg in ws.sent] == [True, True]
+
+
+async def test_unsubscribe_works_without_prior_service_discovery():
+    proxy, ws = _proxy()
+    conn, client = _connection(proxy, 1)
+
+    await proxy._handle_subscribe_characteristic(1, {"connection_handle": 1, "characteristic_uuid": "fff6"})
+    await proxy._handle_unsubscribe_characteristic(2, {"connection_handle": 1, "characteristic_uuid": "fff6"})
+
+    assert client.stop_notify_uuids == ["fff6"]
+    assert conn.subscriptions == set()
+    assert [msg["success"] for msg in ws.sent] == [True, True]
+
+
+async def test_binary_write_data_targets_the_last_written_uuid_without_discovery():
+    proxy, _ws = _proxy()
+    conn, client = _connection(proxy, 1)
+
+    await proxy._handle_write_characteristic(
+        1, {"connection_handle": 1, "characteristic_uuid": "fff6", "value": "AQID"}
+    )
+    assert conn.last_write_uuid == "fff6"
+
+    await proxy._handle_binary_frame(BINARY_FRAME_HEADER.pack(OPCODE_WRITE_DATA, 1) + b"\x04\x05")
+
+    assert client.writes == [("fff6", b"\x01\x02\x03", False), ("fff6", b"\x04\x05", True)]
+
+
+async def test_repeated_start_scan_with_the_same_parameters_is_satisfied_by_the_running_scan():
+    proxy, ws, scan_source = _proxy_with_scan_source()
+    args = {"service_uuids": ["fff6"], "allow_duplicates": False}
+
+    await proxy._handle_start_scan(1, dict(args))
+    await proxy._handle_start_scan(2, dict(args))
+
+    assert (scan_source.starts, scan_source.stops) == (1, 0)
+    assert [msg["success"] for msg in ws.sent] == [True, True]
+
+
+async def test_start_scan_with_changed_parameters_rearms_the_scan():
+    proxy, ws, scan_source = _proxy_with_scan_source()
+
+    await proxy._handle_start_scan(1, {"service_uuids": ["fff6"], "allow_duplicates": False})
+    first_callback = scan_source.callback
+
+    await proxy._handle_start_scan(2, {"service_uuids": ["fff7"], "allow_duplicates": False})
+
+    assert (scan_source.starts, scan_source.stops) == (2, 1)
+    assert scan_source.callback is not first_callback
+    assert [msg["success"] for msg in ws.sent] == [True, True]
+
+
+async def test_start_scan_after_stop_scan_starts_a_fresh_scan():
+    proxy, _ws, scan_source = _proxy_with_scan_source()
+    args = {"service_uuids": ["fff6"], "allow_duplicates": False}
+
+    await proxy._handle_start_scan(1, dict(args))
+    await proxy._handle_stop_scan(2, {})
+    await proxy._handle_start_scan(3, dict(args))
+
+    assert (scan_source.starts, scan_source.stops) == (2, 1)

--- a/python_ble_proxy/tests/test_protocol.py
+++ b/python_ble_proxy/tests/test_protocol.py
@@ -10,11 +10,18 @@ from matter_ble_proxy.protocol import (
     OPCODE_READ_RESPONSE,
     OPCODE_WRITE_DATA,
     AdvertisementData,
+    BleProxyCommand,
+    BleProxyErrorCode,
 )
 
 
 def test_protocol_version_is_v1():
     assert BLE_PROXY_PROTOCOL_VERSION == 1
+
+
+def test_wire_names_are_member_names_lowercased():
+    for member in (*BleProxyCommand, *BleProxyErrorCode):
+        assert member.value == member.name.lower()
 
 
 def test_opcodes_are_distinct():

--- a/python_ble_proxy/tests/test_ts_parity.py
+++ b/python_ble_proxy/tests/test_ts_parity.py
@@ -1,0 +1,43 @@
+"""Checks the Python protocol enums against the TypeScript definitions they mirror.
+
+The enums' own tests only compare Python to Python; without this, a command or error code
+added on the TypeScript side leaves the Python client non-conformant with every test green.
+Skipped only when the package is tested standalone, without the repository around it — a
+moved or renamed TypeScript source must fail, not silently disable the check.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+import pytest
+
+from matter_ble_proxy.protocol import BleProxyCommand, BleProxyErrorCode
+
+_TS_PROTOCOL = Path(__file__).parents[2] / "packages" / "ble-proxy" / "src" / "BleProxyProtocol.ts"
+
+
+def _ts_wire_values(const_name: str) -> set[str]:
+    source = _TS_PROTOCOL.read_text()
+    match = re.search(rf"export const {const_name} = {{(.*?)}} as const;", source, re.DOTALL)
+    assert match is not None, f"{const_name} not found in {_TS_PROTOCOL}"
+    block = match.group(1)
+    values = set(re.findall(r':\s*"([a-z0-9_]+)"', block))
+    # A member whose value the pattern cannot read would drop out of both sides of the
+    # comparison and pass silently, so every declared member must be accounted for.
+    assert len(values) == len(re.findall(r"^\s*\w+:", block, re.MULTILINE))
+    return values
+
+
+pytestmark = pytest.mark.skipif(
+    not (_TS_PROTOCOL.parents[3] / "packages").is_dir(), reason="TypeScript sources not available"
+)
+
+
+def test_commands_match_typescript():
+    assert {command.value for command in BleProxyCommand} == _ts_wire_values("BleProxyCommand")
+
+
+def test_error_codes_match_typescript():
+    assert {code.value for code in BleProxyErrorCode} == _ts_wire_values("BleProxyErrorCode")


### PR DESCRIPTION
## Why

The Noble reference client registers eleven command handlers and omits `write_and_subscribe`, which the server sends for every BTP handshake. Commissioning over `--ble-proxy` with the shipped JS client always fails with `Unknown command: write_and_subscribe`; only the Python client works. Addresses #1000.

Auditing that turned up a set of related gaps in the same surface, so this PR also closes them.

## write_and_subscribe

The handler writes, awaits the Write Response, then enables the CCCD. That order matches `docs/ble-proxy-protocol.md`, the Python client, matter.js's own `NobleBleChannel`, and CHIP — where the Central subscribes in `HandleHandshakeConfirmationReceived`, after the write. The patch suggested in #1000 subscribes first; that would diverge from every existing implementation, so it is not what landed.

A protocol-coverage test asserts the handler map covers every `BleProxyCommand`, so the next command added to the protocol cannot be silently missed. The Python client gets the same guard, built from a new `BleProxyCommand` enum.

## Error-code vocabulary

Closed set on both sides now. Python gains `BleProxyCommand` and `BleProxyErrorCode` StrEnums mirroring the TypeScript constants; `_send_error` is typed to the enum so a raw string no longer type-checks, which is how the `discover_failed` / `discovery_failed` divergence survived. `#sendError` is likewise typed to `BleProxyErrorCodeValue`, and paths that fell through to `internal_error` now report `connection_failed`, `read_failed`, `write_failed`, `subscribe_failed` and `discovery_failed`, as the Python client and the doc already did.

`tests/test_ts_parity.py` compares both Python enums against `BleProxyProtocol.ts` — comparing an enum against itself proves nothing about the mirror.

## Notification handling

Notifications are forwarded regardless of noble's `isNotification`. On macOS that flag derives from a **manager-wide** `pendingRead` (`ble_manager.h:11`), cleared by the next value update of any characteristic on any peripheral, so it reads `false` for a real notification that races a read on an unrelated peripheral. matter.js's own client forwards unconditionally too.

Unsubscribing now removes its own listener instead of every `"data"` listener — `removeAllListeners("data")` also tore out the transient listener noble installs for an in-flight `readAsync`.

## Scan handling

The hub treats an `already_scanning` reply as success. It can send `start_scan` twice without an intervening `stop_scan` (the mid-scan sync to a joining client, or a retry after a command timeout), and dropping that client from the scanning set emitted a bogus aggregate `scanStopped` and left a scanning client untracked, so its later genuine `scan_stopped` never reached the Matter stack.

Because a client that cannot re-arm keeps the parameters of its running scan, the Python client now applies changed parameters instead of rejecting, and the doc states that the server may re-send `start_scan` to change them.

The reference client honours `start_scan`'s `service_uuids` and `allow_duplicates` instead of hardcoding `["fff6"]` and always deduplicating, and no longer resumes a scan after connect that `stop_scan` already ended. Noble is still always asked for duplicates: its own filter would also suppress *changed* advertisements, which deduplication must still deliver.

### Scan state has one owner

An earlier revision of this PR tracked the scan with a `#scanRequested` boolean that several fire-and-forget command handlers wrote and a queued operation read back later. Review found five defects falling out of that single shape, so the state is now owned rather than shared:

- `#desiredScan` (the scan the server asked for, or none) plus `#scanPaused` (connect holding it), changed only through `#requestScan` / `#setScanPaused`, with a generation counter.
- `#reconcileScan` drives noble to `paused ? none : desired` on one serialized chain, and returns early when a later request already owns the outcome.
- A command awaits its own reconciliation and answers with that result, so `success` means its scan actually ran — or that the server itself superseded it. The previous code answered success for a scan that never started.
- `#callNoble` is the only noble accessor and bounds every call, so a scan call that never settles can no longer stall later scans *and* `connect`. It also removes a `#noble!` / `#noble?.` disagreement between two adjacent methods.
- The discover listener is installed once and kept. `removeAllListeners("discover")` is gone: a failing `start_scan` used to tear down a concurrent one's listener, leaving the hub believing a client was scanning with nothing delivering.

Serializing is the part that matters for correctness. noble registers each scan call's completion callback with `onceExclusive`, which *removes* the previously registered one, so of two overlapping calls the earlier promise never settles and its command is answered only by the hub's 60 s `COMMAND_TIMEOUT`.

`#awaitDiscovered` now returns immediately when no scan is wanted, instead of spending its full 5 s on a `connect` that follows `stop_scan`, where nothing can resolve it.

## Crash on malformed frames

`JSON.parse` and `decodeBinaryFrame` in the client's message handler were unguarded. A throw there escapes into ws's receiver as an uncaught exception and kills the process — verified: no `error` event, no `close` event, exit code 1 — so one malformed frame ended the bridge mid-commissioning. Both now log and drop the frame, as the server side already did.

## Subscription keys

Both clients keyed subscriptions by the UUID string as the server spelled it, while each resolves characteristics case-insensitively. A characteristic named two ways therefore double-subscribed (duplicating every forwarded notification) or answered `not_subscribed` on unsubscribe. Both sides now key on a normalized form — the TypeScript client strips dashes and lowercases, the Python client reuses its existing `_normalize_uuid`. `last_write_uuid` deliberately keeps the server's spelling, since bleak resolves that specifier for the write itself.

Not reachable from this hub, which echoes back the client's own strings from `discover_characteristics`; it is a parity gap between two clients the protocol doc treats as interchangeable.

## Python state tracking

Subscription tracking and last-write bookkeeping no longer depend on `discover_services` having run. `subscriptions` becomes a `set[str]` and `last_write_characteristic` becomes `last_write_uuid`, since bleak accepts a UUID string and holding the resolved object was the only reason for the guard. Without it, `unsubscribe_characteristic` answered `not_subscribed` while notifications kept flowing, and WRITE_DATA frames were dropped.

## Docs

The protocol doc claimed `/ble` accepts a single client and rejects a second; multi-client ownership routing replaced that some time ago. It also attributed the binary WRITE_DATA and NOTIFICATION contexts to `write_characteristic` / `subscribe_characteristic`, when `write_and_subscribe` is in practice what establishes both — a third-party client written to the letter of that section would drop every BTP write.

## Reviewer notes

Two changes touch the **production** Python client that Home Assistant embeds, and deserve a closer look than the rest:

- `MatterBleProxy` re-arms on a `start_scan` with changed parameters, calling `scan_source.stop()` then `start()`. HA supplies its own `BleScanSource`, so that sequence is newly exercised.
- `ConnectionState.subscriptions` changed type and `last_write_characteristic` was renamed. `ConnectionState` is exported from the package. Checked since: nothing under `homeassistant/components/matter/` reads either attribute — `ble_proxy.py` imports only `AdvertisementData`, `BleDeviceResolver`, `BleScanSource` and `MatterBleProxy`.

## Verification

`npm run format-verify`, `npm run lint`, `npm run build`, `npm test` (exit 0; ble-proxy 45/45), and for `python_ble_proxy`: pytest 20 passed, `mypy` clean, `ruff` clean.

Each production hunk was mutation-tested — the guard reverted, the test confirmed failing, then restored. The crash fix is proved end-to-end against the built client with a fake server sending a malformed text frame and a 1-byte binary frame: guarded it logs and survives, unguarded it dies with an uncaught exception. Python mutation runs use `PYTHONDONTWRITEBYTECODE=1`; the timestamp `.pyc` cache has one-second granularity and same-second same-size edits otherwise run stale bytecode and make results meaningless.

`NobleBleProxyClient` now takes an optional stand-in for noble (`NobleApi`, a structural interface covering the six members the client drives) alongside an overridable scan-call timeout, so the scan paths are driven through the real WebSocket command path in tests rather than by calling internals. Each new guard was mutation-tested:

| Reverted | Failure |
|---|---|
| generation guard | `[{stop},{stop},{stop}]` vs `[{stop}]` |
| serialization | 3 tests, incl. `['stop+stop']` vs `[]` |
| scan-call timeout | the hang test times out waiting for a response |
| filter pass-through | `serviceUuids: ['fff6']` vs `['fff6','abcd']` |
| Python UUID normalization | `test_unsubscribe_accepts_another_spelling_of_the_subscribed_uuid` fails |

Still not covered: the notification forwarder, the frame parse guards, and `write_and_subscribe`'s own ordering. Driving those needs fake `Peripheral` / `Service` / `Characteristic` objects on top of the seam this PR adds, which is follow-up work.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

