### PR TITLE
Add Door Lock cluster panel with user management and WDSCH/YDSCH/HDSCH schedules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
+- Feature: (lboue) Added a command panel for the DoorLock cluster to Dashboard: lock/unlock (with optional PIN and timeout), and per-user Week Day and Year Day access schedules (WDSCH/YDSCH features), with a user picker backed by the lock's user database
 - Enhancement: (lboue) Added Presets and Thermostat Suggestions (Thermostat cluster PRES/TSUGGEST features) panels to Dashboard, including adding and removing suggestions
 
 ## 1.4.0 (2026-08-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
-- Feature: (lboue) Added a command panel for the DoorLock cluster to Dashboard: lock/unlock (with optional PIN and timeout), and per-user Week Day and Year Day access schedules (WDSCH/YDSCH features), with a user picker backed by the lock's user database
+- Feature: (lboue) Added a command panel for the DoorLock cluster to Dashboard: lock/unlock (with optional PIN and timeout), user management (add/remove), and per-user Week Day / Year Day plus lock-wide Holiday access schedules (WDSCH/YDSCH/HDSCH features), with a user picker backed by the lock's user database
 - Enhancement: (lboue) Added Presets and Thermostat Suggestions (Thermostat cluster PRES/TSUGGEST features) panels to Dashboard, including adding and removing suggestions
 
 ## 1.4.0 (2026-08-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
-- Feature: (lboue) Added a command panel for the DoorLock cluster to Dashboard: lock/unlock (with optional PIN and timeout), user management (add/remove), and per-user Week Day / Year Day plus lock-wide Holiday access schedules (WDSCH/YDSCH/HDSCH features), with a user picker backed by the lock's user database
-- Enhancement: (lboue) Added Presets and Thermostat Suggestions (Thermostat cluster PRES/TSUGGEST features) panels to Dashboard, including adding and removing suggestions
+- Enhancement: (lboue) Added a command panel for the DoorLock cluster to Dashboard
+- Enhancement: (lboue) Added Presets and Thermostat Suggestions (Thermostat cluster PRES/TSUGGEST features) panels to Dashboard
 
 ## 1.4.0 (2026-08-07)
 

--- a/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/access-control-commands.ts
@@ -30,6 +30,7 @@ import {
 } from "../../../util/access-control.js";
 import { handleAsync } from "../../../util/async-handler.js";
 import { detectBindingRelationship, type RelationshipResult } from "../../../util/binding.js";
+import { errorText } from "../../../util/error-text.js";
 import { getDeviceName } from "../../../util/node-name.js";
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
@@ -111,7 +112,7 @@ class AccessControlClusterCommands extends BaseClusterCommands {
             if (this.isSameContext(node, endpoint)) {
                 await showAlertDialog({
                     title: "Delete failed",
-                    text: err instanceof Error ? err.message : String(err),
+                    text: errorText(err),
                 });
             } else {
                 console.error("Delete failed", err);
@@ -129,7 +130,7 @@ class AccessControlClusterCommands extends BaseClusterCommands {
             await downgradeToOperate(this.client, node.node_id, keys);
         } catch (err) {
             if (this.isSameContext(node, endpoint)) {
-                await showAlertDialog({ title: "Fix failed", text: err instanceof Error ? err.message : String(err) });
+                await showAlertDialog({ title: "Fix failed", text: errorText(err) });
             } else {
                 console.error("Fix failed", err);
             }

--- a/packages/dashboard/src/pages/cluster-commands/clusters/basic-information-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/basic-information-commands.ts
@@ -10,6 +10,7 @@ import { css, html, nothing, type CSSResultGroup } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { showAlertDialog } from "../../../components/dialog-box/show-dialog-box.js";
 import { handleAsync } from "../../../util/async-handler.js";
+import { errorText } from "../../../util/error-text.js";
 import { MAX_NODE_LABEL_LENGTH, NODE_LABEL_CLUSTER_ID, writeNodeLabel } from "../../../util/node-label.js";
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
@@ -112,7 +113,7 @@ export class BasicInformationClusterCommands extends BaseClusterCommands {
             }
         } catch (error) {
             if (this.isSameContext(node, endpoint)) {
-                const errorMessage = error instanceof Error ? error.message : String(error);
+                const errorMessage = errorText(error);
                 showAlertDialog({
                     title: "Failed to set node label",
                     text: errorMessage,

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -1,0 +1,1240 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import "@material/web/button/filled-button";
+import "@material/web/button/outlined-button";
+import "@material/web/iconbutton/outlined-icon-button";
+import "@material/web/progress/circular-progress";
+import type { MatterNode } from "@matter-server/ws-client";
+import {
+    mdiCalendarRange,
+    mdiCalendarWeek,
+    mdiClose,
+    mdiContentSaveOutline,
+    mdiLock,
+    mdiLockOpenVariant,
+    mdiPencilOutline,
+    mdiPlus,
+    mdiRefresh,
+    mdiTrashCanOutline,
+} from "@mdi/js";
+import { css, html, nothing, type CSSResultGroup, type TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { live } from "lit/directives/live.js";
+import { showAlertDialog, showPromptDialog } from "../../../components/dialog-box/show-dialog-box.js";
+import "../../../components/ha-svg-icon.js";
+import { handleAsync } from "../../../util/async-handler.js";
+import {
+    buildDaySegments,
+    clearWeekDaySchedule,
+    clearYearDaySchedule,
+    DAY_BITS,
+    DAY_LABELS,
+    DOOR_LOCK_CLUSTER_ID,
+    formatDaysMask,
+    formatDoorState,
+    formatLocalDateTime,
+    formatLockState,
+    formatLockType,
+    formatTimeOfDay,
+    formatUserLabel,
+    formatUserStatus,
+    formatUserType,
+    fromDateTimeInputValue,
+    isFeatureActive,
+    lockDoor,
+    maskHasDay,
+    parseTimeOfDay,
+    readActuatorEnabled,
+    readDoorState,
+    readLockState,
+    readLockType,
+    readTotalUsersSupported,
+    readUser,
+    readUsers,
+    readWeekDaySchedule,
+    readWeekDaySchedulesPerUser,
+    readYearDaySchedule,
+    readYearDaySchedulesPerUser,
+    requiresPinForRemoteOperation,
+    SCHEDULE_INDEX_ALL,
+    supportsCommand,
+    toDateTimeInputValue,
+    toggleMaskDay,
+    UNLOCK_WITH_TIMEOUT_COMMAND_ID,
+    unlockDoor,
+    unlockWithTimeout,
+    weekDayScheduleRangeError,
+    writeWeekDaySchedule,
+    writeYearDaySchedule,
+    yearDayScheduleRangeError,
+    type DoorLockUser,
+    type WeekDayScheduleSlot,
+    type YearDayScheduleSlot,
+} from "../../../util/door-lock.js";
+import { getMatterStatusName } from "../../../util/matter-status.js";
+import { BaseClusterCommands } from "../base-cluster-commands.js";
+import { registerClusterCommands } from "../registry.js";
+
+const HOUR_TICKS = [0, 6, 12, 18, 24];
+
+const DEFAULT_UNLOCK_TIMEOUT_SECONDS = 60;
+const DEFAULT_START_TIME = "08:00";
+const DEFAULT_END_TIME = "18:00";
+
+/** Bounds the GetUser walk on a lock that leaves NumberOfTotalUsersSupported unreported. */
+const USER_SCAN_FALLBACK = 32;
+
+/** DlStatus the lock returns for a schedule slot that holds nothing. */
+const STATUS_NOT_FOUND = 139;
+
+interface WeekDayEditor {
+    kind: "weekDay";
+    index: number;
+    daysMask: number;
+    start: string;
+    end: string;
+}
+
+interface YearDayEditor {
+    kind: "yearDay";
+    index: number;
+    start: string;
+    end: string;
+}
+
+type ScheduleEditor = WeekDayEditor | YearDayEditor;
+
+/**
+ * Command panel for the DoorLock cluster (ID: 0x0101 / 257).
+ * Operates the bolt and manages the WDSCH and YDSCH access schedules of a user picked from the lock's
+ * user database, which the schedule commands address by index.
+ */
+@customElement("door-lock-cluster-commands")
+class DoorLockClusterCommands extends BaseClusterCommands {
+    @state() private _users?: DoorLockUser[];
+    @state() private _selectedUserIndex: number | null = null;
+    @state() private _weekDaySlots?: WeekDayScheduleSlot[];
+    @state() private _yearDaySlots?: YearDayScheduleSlot[];
+    @state() private _loadingUsers = false;
+    @state() private _loadingSchedules = false;
+    @state() private _loadError?: string;
+    @state() private _editor: ScheduleEditor | null = null;
+    @state() private _editorError?: string;
+    @state() private _busy = false;
+    @state() private _pinCode = "";
+    @state() private _unlockTimeout = String(DEFAULT_UNLOCK_TIMEOUT_SECONDS);
+
+    #context?: string;
+    #usersRequested = false;
+    /** Bumped whenever the panel's node, endpoint or selected user changes, so stale loads drop their results. */
+    #generation = 0;
+
+    override updated(changedProperties: Map<string, unknown>) {
+        super.updated(changedProperties);
+        if (!this.client || !this.node || this.cluster !== DOOR_LOCK_CLUSTER_ID) return;
+
+        const context = `${String(this.node.node_id)}/${this.endpoint}`;
+        if (this.#context !== context) {
+            this.#context = context;
+            this.#generation++;
+            this.#usersRequested = false;
+            this._users = undefined;
+            this._selectedUserIndex = null;
+            this._weekDaySlots = undefined;
+            this._yearDaySlots = undefined;
+            this._loadingUsers = false;
+            this._loadingSchedules = false;
+            this._loadError = undefined;
+            this._editor = null;
+            this._editorError = undefined;
+            this._busy = false;
+            this._pinCode = "";
+            this._unlockTimeout = String(DEFAULT_UNLOCK_TIMEOUT_SECONDS);
+        }
+
+        // The attribute cache fills in progressively, so the feature check may only pass on a later update.
+        if (!this.#usersRequested && this.#schedulesSupported() && isFeatureActive(this.node, this.endpoint, "USR")) {
+            this.#usersRequested = true;
+            handleAsync(() => this.#loadUsers())();
+        }
+    }
+
+    #schedulesSupported(): boolean {
+        return isFeatureActive(this.node, this.endpoint, "WDSCH") || isFeatureActive(this.node, this.endpoint, "YDSCH");
+    }
+
+    #isCurrent(node: MatterNode, endpoint: number, generation: number): boolean {
+        return this.isSameContext(node, endpoint) && this.#generation === generation;
+    }
+
+    async #loadUsers() {
+        const node = this.node;
+        const endpoint = this.endpoint;
+        const generation = this.#generation;
+        this._loadingUsers = true;
+        this._loadError = undefined;
+        try {
+            const maxUsers = readTotalUsersSupported(node, endpoint) ?? USER_SCAN_FALLBACK;
+            const users = await readUsers(this.client, node.node_id, endpoint, maxUsers);
+            if (!this.#isCurrent(node, endpoint, generation)) return;
+            this._users = users;
+            const firstUser = users[0]?.userIndex ?? null;
+            this._selectedUserIndex = firstUser;
+            if (firstUser !== null) {
+                await this.#loadSchedules(node, endpoint, generation, firstUser);
+            }
+        } catch (error) {
+            if (!this.#isCurrent(node, endpoint, generation)) return;
+            this._loadError = errorText(error);
+        } finally {
+            // Generation-scoped: a newer load has already set the flag for itself, and every path that bumps
+            // the generation sets or clears it, so this cannot leave the panel wedged.
+            if (this.#generation === generation) this._loadingUsers = false;
+        }
+    }
+
+    async #loadSchedules(node: MatterNode, endpoint: number, generation: number, userIndex: number) {
+        this._loadingSchedules = true;
+        this._loadError = undefined;
+        try {
+            const weekDayCount = isFeatureActive(node, endpoint, "WDSCH")
+                ? (readWeekDaySchedulesPerUser(node, endpoint) ?? 0)
+                : 0;
+            const yearDayCount = isFeatureActive(node, endpoint, "YDSCH")
+                ? (readYearDaySchedulesPerUser(node, endpoint) ?? 0)
+                : 0;
+
+            const weekDaySlots = new Array<WeekDayScheduleSlot>();
+            for (let index = 1; index <= weekDayCount; index++) {
+                const slot = await readWeekDaySchedule(this.client, node.node_id, endpoint, index, userIndex);
+                if (!this.#isCurrent(node, endpoint, generation)) return;
+                weekDaySlots.push(slot);
+            }
+
+            const yearDaySlots = new Array<YearDayScheduleSlot>();
+            for (let index = 1; index <= yearDayCount; index++) {
+                const slot = await readYearDaySchedule(this.client, node.node_id, endpoint, index, userIndex);
+                if (!this.#isCurrent(node, endpoint, generation)) return;
+                yearDaySlots.push(slot);
+            }
+
+            this._weekDaySlots = weekDaySlots;
+            this._yearDaySlots = yearDaySlots;
+
+            // Setting a schedule may move the user to ScheduleRestrictedUser, so the badges are re-read
+            // alongside the slots they describe.
+            const user = await readUser(this.client, node.node_id, endpoint, userIndex);
+            if (!this.#isCurrent(node, endpoint, generation) || user === null) return;
+            this._users = this._users?.map(candidate => (candidate.userIndex === userIndex ? user : candidate));
+        } catch (error) {
+            if (!this.#isCurrent(node, endpoint, generation)) return;
+            this._loadError = errorText(error);
+        } finally {
+            if (this.#generation === generation) this._loadingSchedules = false;
+        }
+    }
+
+    #selectUser(userIndex: number) {
+        if (userIndex === this._selectedUserIndex) return;
+        this.#generation++;
+        this._selectedUserIndex = userIndex;
+        this._weekDaySlots = undefined;
+        this._yearDaySlots = undefined;
+        this._editor = null;
+        this._editorError = undefined;
+        this._loadError = undefined;
+        handleAsync(() => this.#loadSchedules(this.node, this.endpoint, this.#generation, userIndex))();
+    }
+
+    #reloadSchedules() {
+        const userIndex = this._selectedUserIndex;
+        if (userIndex === null) return;
+        this.#generation++;
+        handleAsync(() => this.#loadSchedules(this.node, this.endpoint, this.#generation, userIndex))();
+    }
+
+    async #runScheduleCommand(title: string, run: (node: MatterNode, endpoint: number) => Promise<void>) {
+        const node = this.node;
+        const endpoint = this.endpoint;
+        const generation = this.#generation;
+        if (this._busy) return;
+        this._busy = true;
+        try {
+            await run(node, endpoint);
+            if (!this.#isCurrent(node, endpoint, generation)) return;
+            this._editor = null;
+            this._editorError = undefined;
+            this.#reloadSchedules();
+        } catch (error) {
+            this.#reportFailure(title, error, node, endpoint);
+        } finally {
+            this._busy = false;
+        }
+    }
+
+    /** Only alerts while the panel still shows the node the command was sent to; the dialog names no device. */
+    #reportFailure(title: string, error: unknown, node: MatterNode, endpoint: number) {
+        if (!this.isSameContext(node, endpoint)) {
+            console.error(`${title} (panel moved on)`, error);
+            return;
+        }
+        showAlertDialog({ title, text: errorText(error) }).catch(alertError =>
+            console.error(`Failed to show the "${title}" dialog`, alertError),
+        );
+    }
+
+    #pinForCommand(): string | undefined {
+        const pin = this._pinCode.trim();
+        return pin === "" ? undefined : pin;
+    }
+
+    async #operateLock(action: "lock" | "unlock") {
+        const node = this.node;
+        const endpoint = this.endpoint;
+        if (this._busy) return;
+        this._busy = true;
+        try {
+            const operate = action === "lock" ? lockDoor : unlockDoor;
+            await operate(this.client, node.node_id, endpoint, this.#pinForCommand());
+        } catch (error) {
+            this.#reportFailure(action === "lock" ? "Lock failed" : "Unlock failed", error, node, endpoint);
+        } finally {
+            this._busy = false;
+        }
+    }
+
+    async #unlockWithTimeout() {
+        const node = this.node;
+        const endpoint = this.endpoint;
+        if (this._busy) return;
+        const timeout = Number(this._unlockTimeout);
+        if (!Number.isInteger(timeout) || timeout < 1 || timeout > 0xffff) {
+            await showAlertDialog({ title: "Unlock failed", text: "The timeout must be 1 to 65535 seconds." });
+            return;
+        }
+        this._busy = true;
+        try {
+            await unlockWithTimeout(this.client, node.node_id, endpoint, timeout, this.#pinForCommand());
+        } catch (error) {
+            this.#reportFailure("Unlock failed", error, node, endpoint);
+        } finally {
+            this._busy = false;
+        }
+    }
+
+    #saveEditor() {
+        const editor = this._editor;
+        const userIndex = this._selectedUserIndex;
+        if (editor === null || userIndex === null) return;
+
+        if (editor.kind === "weekDay") {
+            const start = parseTimeOfDay(editor.start);
+            const end = parseTimeOfDay(editor.end);
+            if (start === null || end === null) {
+                this._editorError = "Enter both times as HH:MM.";
+                return;
+            }
+            const schedule = {
+                weekDayIndex: editor.index,
+                daysMask: editor.daysMask,
+                startHour: start.hour,
+                startMinute: start.minute,
+                endHour: end.hour,
+                endMinute: end.minute,
+            };
+            const rangeError = weekDayScheduleRangeError(schedule);
+            if (rangeError !== null) {
+                this._editorError = rangeError;
+                return;
+            }
+            handleAsync(() =>
+                this.#runScheduleCommand("Set week day schedule failed", (node, endpoint) =>
+                    writeWeekDaySchedule(this.client, node.node_id, endpoint, userIndex, schedule),
+                ),
+            )();
+            return;
+        }
+
+        const localStartTime = fromDateTimeInputValue(editor.start);
+        const localEndTime = fromDateTimeInputValue(editor.end);
+        if (localStartTime === null || localEndTime === null) {
+            this._editorError = "Enter both a start and an end date.";
+            return;
+        }
+        const schedule = { yearDayIndex: editor.index, localStartTime, localEndTime };
+        const rangeError = yearDayScheduleRangeError(schedule);
+        if (rangeError !== null) {
+            this._editorError = rangeError;
+            return;
+        }
+        handleAsync(() =>
+            this.#runScheduleCommand("Set year day schedule failed", (node, endpoint) =>
+                writeYearDaySchedule(this.client, node.node_id, endpoint, userIndex, schedule),
+            ),
+        )();
+    }
+
+    async #clearWeekDay(weekDayIndex: number) {
+        const userIndex = this._selectedUserIndex;
+        if (userIndex === null) return;
+        if (weekDayIndex === SCHEDULE_INDEX_ALL && !(await this.#confirmClearAll("week day"))) return;
+        await this.#runScheduleCommand("Clear week day schedule failed", (node, endpoint) =>
+            clearWeekDaySchedule(this.client, node.node_id, endpoint, userIndex, weekDayIndex),
+        );
+    }
+
+    async #clearYearDay(yearDayIndex: number) {
+        const userIndex = this._selectedUserIndex;
+        if (userIndex === null) return;
+        if (yearDayIndex === SCHEDULE_INDEX_ALL && !(await this.#confirmClearAll("year day"))) return;
+        await this.#runScheduleCommand("Clear year day schedule failed", (node, endpoint) =>
+            clearYearDaySchedule(this.client, node.node_id, endpoint, userIndex, yearDayIndex),
+        );
+    }
+
+    #confirmClearAll(kind: string): Promise<boolean> {
+        const user = this._users?.find(candidate => candidate.userIndex === this._selectedUserIndex);
+        return showPromptDialog({
+            title: `Clear all ${kind} schedules`,
+            text: `Every ${kind} schedule of ${user ? formatUserLabel(user) : "this user"} will be removed from the lock.`,
+            confirmText: "Clear all",
+        });
+    }
+
+    override render() {
+        if (!this.node || this.cluster !== DOOR_LOCK_CLUSTER_ID) return nothing;
+        return html`${this.#renderLockPanel()}${this.#schedulesSupported() ? this.#renderSchedulePanel() : nothing}`;
+    }
+
+    #renderLockPanel(): TemplateResult {
+        const lockState = readLockState(this.node, this.endpoint);
+        const doorState = formatDoorState(readDoorState(this.node, this.endpoint));
+        const lockType = formatLockType(readLockType(this.node, this.endpoint));
+        const actuatorEnabled = readActuatorEnabled(this.node, this.endpoint);
+        const pinRequired = requiresPinForRemoteOperation(this.node, this.endpoint);
+        const showPin =
+            isFeatureActive(this.node, this.endpoint, "COTA") && isFeatureActive(this.node, this.endpoint, "PIN");
+        const showTimeout = supportsCommand(this.node, this.endpoint, UNLOCK_WITH_TIMEOUT_COMMAND_ID);
+
+        return html`
+            <details class="command-panel" open>
+                <summary>
+                    <ha-svg-icon .path=${lockState === 1 ? mdiLock : mdiLockOpenVariant}></ha-svg-icon>
+                    Lock Control
+                </summary>
+                <div class="command-content">
+                    <div class="status-row">
+                        <span class="state-chip ${lockState === 1 ? "locked" : lockState === null ? "" : "unlocked"}">
+                            ${formatLockState(lockState)}
+                        </span>
+                        ${doorState !== null ? html`<span class="meta">Door: ${doorState}</span>` : nothing}
+                        ${lockType !== null ? html`<span class="meta">${lockType}</span>` : nothing}
+                        ${actuatorEnabled === false ? html`<span class="meta warn">Actuator disabled</span>` : nothing}
+                    </div>
+                    <div class="command-row">
+                        ${
+                            showPin
+                                ? html`
+                                      <label for="doorLockPin">PIN${pinRequired ? " (required)" : ""}:</label>
+                                      <input
+                                          id="doorLockPin"
+                                          type="password"
+                                          autocomplete="off"
+                                          .value=${live(this._pinCode)}
+                                          @input=${(event: Event) => {
+                                              this._pinCode = (event.target as HTMLInputElement).value;
+                                          }}
+                                      />
+                                  `
+                                : nothing
+                        }
+                        <md-filled-button
+                            ?disabled=${this._busy}
+                            @click=${handleAsync(() => this.#operateLock("lock"))}
+                        >
+                            <ha-svg-icon slot="icon" .path=${mdiLock}></ha-svg-icon>
+                            Lock
+                        </md-filled-button>
+                        <md-outlined-button
+                            ?disabled=${this._busy}
+                            @click=${handleAsync(() => this.#operateLock("unlock"))}
+                        >
+                            <ha-svg-icon slot="icon" .path=${mdiLockOpenVariant}></ha-svg-icon>
+                            Unlock
+                        </md-outlined-button>
+                        ${
+                            showTimeout
+                                ? html`
+                                      <label for="doorLockTimeout">Timeout (s):</label>
+                                      <input
+                                          id="doorLockTimeout"
+                                          type="number"
+                                          min="1"
+                                          max="65535"
+                                          .value=${live(this._unlockTimeout)}
+                                          @input=${(event: Event) => {
+                                              this._unlockTimeout = (event.target as HTMLInputElement).value;
+                                          }}
+                                      />
+                                      <md-outlined-button
+                                          ?disabled=${this._busy}
+                                          @click=${handleAsync(() => this.#unlockWithTimeout())}
+                                      >
+                                          Unlock with timeout
+                                      </md-outlined-button>
+                                  `
+                                : nothing
+                        }
+                    </div>
+                </div>
+            </details>
+        `;
+    }
+
+    #renderSchedulePanel(): TemplateResult {
+        const weekDayActive = isFeatureActive(this.node, this.endpoint, "WDSCH");
+        const yearDayActive = isFeatureActive(this.node, this.endpoint, "YDSCH");
+        const userActive = isFeatureActive(this.node, this.endpoint, "USR");
+        const features = [weekDayActive ? "WDSCH" : undefined, yearDayActive ? "YDSCH" : undefined]
+            .filter(code => code !== undefined)
+            .join(" · ");
+
+        return html`
+            <details class="command-panel" open>
+                <summary>
+                    <ha-svg-icon .path=${mdiCalendarWeek}></ha-svg-icon>
+                    Access Schedules
+                    <span class="feature-map-badge">FeatureMap: ${features}</span>
+                </summary>
+                <div class="command-content">
+                    ${
+                        userActive
+                            ? html`
+                                  ${this.#renderUserSelector()}
+                                  ${
+                                      this._loadError !== undefined
+                                          ? html`<p class="error">${this._loadError}</p>`
+                                          : nothing
+                                  }
+                                  ${
+                                      this._selectedUserIndex === null
+                                          ? nothing
+                                          : html`
+                                                ${weekDayActive ? this.#renderWeekDaySection() : nothing}
+                                                ${yearDayActive ? this.#renderYearDaySection() : nothing}
+                                            `
+                                  }
+                              `
+                            : html`<p class="empty">
+                                  Schedules are assigned per user, which this lock does not expose: it reports no User
+                                  (USR) feature, so its user database cannot be read.
+                              </p>`
+                    }
+                </div>
+            </details>
+        `;
+    }
+
+    #renderUserSelector(): TemplateResult {
+        const users = this._users;
+        if (this._loadingUsers && users === undefined) {
+            return html`<div class="loading">
+                <md-circular-progress indeterminate></md-circular-progress>
+                Reading the user database…
+            </div>`;
+        }
+        if (users !== undefined && users.length === 0) {
+            return html`<p class="empty">No users are programmed on this lock.</p>`;
+        }
+        return html`
+            <div class="command-row">
+                <label for="doorLockUser">User:</label>
+                <select
+                    id="doorLockUser"
+                    ?disabled=${this._busy || this._loadingUsers || this._loadingSchedules}
+                    @change=${(event: Event) => this.#selectUser(Number((event.target as HTMLSelectElement).value))}
+                >
+                    ${(users ?? []).map(
+                        user => html`
+                            <option value=${user.userIndex} .selected=${user.userIndex === this._selectedUserIndex}>
+                                #${user.userIndex} · ${formatUserLabel(user)}
+                            </option>
+                        `,
+                    )}
+                </select>
+                ${this.#renderUserBadges()}
+                <md-outlined-button
+                    ?disabled=${this._busy || this._loadingUsers || this._loadingSchedules}
+                    @click=${() => {
+                        this.#usersRequested = true;
+                        handleAsync(() => this.#loadUsers())();
+                    }}
+                >
+                    <ha-svg-icon slot="icon" .path=${mdiRefresh}></ha-svg-icon>
+                    Reload
+                </md-outlined-button>
+            </div>
+        `;
+    }
+
+    #renderUserBadges(): TemplateResult | typeof nothing {
+        const user = this._users?.find(candidate => candidate.userIndex === this._selectedUserIndex);
+        if (user === undefined) return nothing;
+        const status = formatUserStatus(user.userStatus);
+        const type = formatUserType(user.userType);
+        return html`
+            ${status !== null ? html`<span class="meta">${status}</span>` : nothing}
+            ${type !== null ? html`<span class="meta">${type}</span>` : nothing}
+        `;
+    }
+
+    #renderWeekDaySection(): TemplateResult {
+        const slots = this._weekDaySlots;
+        const capacity = readWeekDaySchedulesPerUser(this.node, this.endpoint) ?? 0;
+        const used = slots?.filter(slot => slot.schedule !== null).length ?? 0;
+
+        return html`
+            <div class="section">
+                <div class="section-header">
+                    <span>WEEK DAY SCHEDULES · ${used}/${capacity} slots</span>
+                    ${
+                        used > 0
+                            ? html`<button
+                                  class="link-action"
+                                  ?disabled=${this._busy}
+                                  @click=${handleAsync(() => this.#clearWeekDay(SCHEDULE_INDEX_ALL))}
+                              >
+                                  Clear all
+                              </button>`
+                            : nothing
+                    }
+                </div>
+                ${
+                    slots === undefined
+                        ? this.#renderSlotsPlaceholder(capacity)
+                        : html`
+                              ${used > 0 ? this.#renderWeekTimeline(slots) : nothing}
+                              <ul class="slot-list">
+                                  ${slots.map(slot => this.#renderWeekDaySlot(slot))}
+                              </ul>
+                          `
+                }
+            </div>
+        `;
+    }
+
+    #renderWeekTimeline(slots: WeekDayScheduleSlot[]): TemplateResult {
+        return html`
+            <div class="schedule-grid">
+                <div class="grid-ticks">
+                    ${HOUR_TICKS.map(hour => html`<span>${String(hour).padStart(2, "0")}:00</span>`)}
+                </div>
+                ${DAY_LABELS.map((label, day) => {
+                    const segments = buildDaySegments(slots, day);
+                    return html`
+                        <div class="grid-row ${segments.length > 0 ? "" : "dimmed"}">
+                            <span class="day-label">${label}</span>
+                            <div class="day-timeline">
+                                ${segments.map(
+                                    segment => html`
+                                        <span
+                                            class="segment"
+                                            style=${`left:${(segment.startMin / 1440) * 100}%;width:${
+                                                ((segment.endMin - segment.startMin) / 1440) * 100
+                                            }%`}
+                                            title=${`#${segment.weekDayIndex} · ${formatTimeOfDay(
+                                                Math.floor(segment.startMin / 60),
+                                                segment.startMin % 60,
+                                            )}–${formatTimeOfDay(
+                                                Math.floor(segment.endMin / 60),
+                                                segment.endMin % 60,
+                                            )}`}
+                                        ></span>
+                                    `,
+                                )}
+                            </div>
+                        </div>
+                    `;
+                })}
+            </div>
+        `;
+    }
+
+    #renderWeekDaySlot(slot: WeekDayScheduleSlot): TemplateResult {
+        const editor = this._editor;
+        if (editor?.kind === "weekDay" && editor.index === slot.weekDayIndex) {
+            return html`<li class="slot-row editing">${this.#renderWeekDayEditor(editor)}</li>`;
+        }
+        const schedule = slot.schedule;
+        return html`
+            <li class="slot-row">
+                <span class="slot-index">#${slot.weekDayIndex}</span>
+                ${
+                    schedule === null
+                        ? html`<span class="slot-empty">${slotStatusLabel(slot.status)}</span>`
+                        : html`
+                              <span class="slot-days">${formatDaysMask(schedule.daysMask)}</span>
+                              <span class="slot-window">
+                                  ${formatTimeOfDay(schedule.startHour, schedule.startMinute)}–${formatTimeOfDay(
+                                      schedule.endHour,
+                                      schedule.endMinute,
+                                  )}
+                              </span>
+                          `
+                }
+                <span class="slot-actions">
+                    <md-outlined-icon-button
+                        title=${schedule === null ? "Set schedule" : "Edit schedule"}
+                        ?disabled=${this._busy}
+                        @click=${() => {
+                            this._editorError = undefined;
+                            this._editor = {
+                                kind: "weekDay",
+                                index: slot.weekDayIndex,
+                                daysMask: schedule?.daysMask ?? 0,
+                                start:
+                                    schedule === null
+                                        ? DEFAULT_START_TIME
+                                        : formatTimeOfDay(schedule.startHour, schedule.startMinute),
+                                end:
+                                    schedule === null
+                                        ? DEFAULT_END_TIME
+                                        : formatTimeOfDay(schedule.endHour, schedule.endMinute),
+                            };
+                        }}
+                    >
+                        <ha-svg-icon .path=${schedule === null ? mdiPlus : mdiPencilOutline}></ha-svg-icon>
+                    </md-outlined-icon-button>
+                    ${
+                        schedule === null
+                            ? nothing
+                            : html`<md-outlined-icon-button
+                                  title="Clear schedule"
+                                  ?disabled=${this._busy}
+                                  @click=${handleAsync(() => this.#clearWeekDay(slot.weekDayIndex))}
+                              >
+                                  <ha-svg-icon .path=${mdiTrashCanOutline}></ha-svg-icon>
+                              </md-outlined-icon-button>`
+                    }
+                </span>
+            </li>
+        `;
+    }
+
+    #renderWeekDayEditor(editor: WeekDayEditor): TemplateResult {
+        return html`
+            <div class="editor">
+                <div class="editor-row">
+                    <span class="slot-index">#${editor.index}</span>
+                    <div class="day-toggles">
+                        ${DAY_LABELS.map((label, day) => {
+                            const bit = DAY_BITS[day];
+                            return html`<button
+                                class="day-toggle ${maskHasDay(editor.daysMask, bit) ? "active" : ""}"
+                                @click=${() => {
+                                    this._editor = { ...editor, daysMask: toggleMaskDay(editor.daysMask, bit) };
+                                }}
+                            >
+                                ${label}
+                            </button>`;
+                        })}
+                    </div>
+                </div>
+                <div class="editor-row">
+                    <label for="weekDayStart">From:</label>
+                    <input
+                        id="weekDayStart"
+                        type="time"
+                        .value=${live(editor.start)}
+                        @input=${(event: Event) => {
+                            this._editor = { ...editor, start: (event.target as HTMLInputElement).value };
+                        }}
+                    />
+                    <label for="weekDayEnd">To:</label>
+                    <input
+                        id="weekDayEnd"
+                        type="time"
+                        .value=${live(editor.end)}
+                        @input=${(event: Event) => {
+                            this._editor = { ...editor, end: (event.target as HTMLInputElement).value };
+                        }}
+                    />
+                    ${this.#renderEditorActions()}
+                </div>
+                ${this._editorError !== undefined ? html`<p class="error">${this._editorError}</p>` : nothing}
+            </div>
+        `;
+    }
+
+    #renderYearDaySection(): TemplateResult {
+        const slots = this._yearDaySlots;
+        const capacity = readYearDaySchedulesPerUser(this.node, this.endpoint) ?? 0;
+        const used = slots?.filter(slot => slot.schedule !== null).length ?? 0;
+
+        return html`
+            <div class="section">
+                <div class="section-header">
+                    <span>YEAR DAY SCHEDULES · ${used}/${capacity} slots</span>
+                    ${
+                        used > 0
+                            ? html`<button
+                                  class="link-action"
+                                  ?disabled=${this._busy}
+                                  @click=${handleAsync(() => this.#clearYearDay(SCHEDULE_INDEX_ALL))}
+                              >
+                                  Clear all
+                              </button>`
+                            : nothing
+                    }
+                </div>
+                ${
+                    slots === undefined
+                        ? this.#renderSlotsPlaceholder(capacity)
+                        : html`
+                              <ul class="slot-list">
+                                  ${slots.map(slot => this.#renderYearDaySlot(slot))}
+                              </ul>
+                              <p class="hint">
+                                  <ha-svg-icon .path=${mdiCalendarRange}></ha-svg-icon>
+                                  Date ranges are local time at the lock, shown here in this browser's time zone.
+                              </p>
+                          `
+                }
+            </div>
+        `;
+    }
+
+    #renderYearDaySlot(slot: YearDayScheduleSlot): TemplateResult {
+        const editor = this._editor;
+        if (editor?.kind === "yearDay" && editor.index === slot.yearDayIndex) {
+            return html`<li class="slot-row editing">${this.#renderYearDayEditor(editor)}</li>`;
+        }
+        const schedule = slot.schedule;
+        return html`
+            <li class="slot-row">
+                <span class="slot-index">#${slot.yearDayIndex}</span>
+                ${
+                    schedule === null
+                        ? html`<span class="slot-empty">${slotStatusLabel(slot.status)}</span>`
+                        : html`<span class="slot-window wide">
+                              ${formatLocalDateTime(schedule.localStartTime)} →
+                              ${formatLocalDateTime(schedule.localEndTime)}
+                          </span>`
+                }
+                <span class="slot-actions">
+                    <md-outlined-icon-button
+                        title=${schedule === null ? "Set schedule" : "Edit schedule"}
+                        ?disabled=${this._busy}
+                        @click=${() => {
+                            this._editorError = undefined;
+                            const now = Math.floor(Date.now() / 1000);
+                            this._editor = {
+                                kind: "yearDay",
+                                index: slot.yearDayIndex,
+                                start: toDateTimeInputValue(schedule?.localStartTime ?? now),
+                                end: toDateTimeInputValue(schedule?.localEndTime ?? now + 86400),
+                            };
+                        }}
+                    >
+                        <ha-svg-icon .path=${schedule === null ? mdiPlus : mdiPencilOutline}></ha-svg-icon>
+                    </md-outlined-icon-button>
+                    ${
+                        schedule === null
+                            ? nothing
+                            : html`<md-outlined-icon-button
+                                  title="Clear schedule"
+                                  ?disabled=${this._busy}
+                                  @click=${handleAsync(() => this.#clearYearDay(slot.yearDayIndex))}
+                              >
+                                  <ha-svg-icon .path=${mdiTrashCanOutline}></ha-svg-icon>
+                              </md-outlined-icon-button>`
+                    }
+                </span>
+            </li>
+        `;
+    }
+
+    #renderYearDayEditor(editor: YearDayEditor): TemplateResult {
+        return html`
+            <div class="editor">
+                <div class="editor-row">
+                    <span class="slot-index">#${editor.index}</span>
+                    <label for="yearDayStart">From:</label>
+                    <input
+                        id="yearDayStart"
+                        type="datetime-local"
+                        .value=${live(editor.start)}
+                        @input=${(event: Event) => {
+                            this._editor = { ...editor, start: (event.target as HTMLInputElement).value };
+                        }}
+                    />
+                    <label for="yearDayEnd">To:</label>
+                    <input
+                        id="yearDayEnd"
+                        type="datetime-local"
+                        .value=${live(editor.end)}
+                        @input=${(event: Event) => {
+                            this._editor = { ...editor, end: (event.target as HTMLInputElement).value };
+                        }}
+                    />
+                    ${this.#renderEditorActions()}
+                </div>
+                ${this._editorError !== undefined ? html`<p class="error">${this._editorError}</p>` : nothing}
+            </div>
+        `;
+    }
+
+    #renderEditorActions(): TemplateResult {
+        return html`
+            <md-outlined-button ?disabled=${this._busy} @click=${() => this.#saveEditor()}>
+                <ha-svg-icon slot="icon" .path=${mdiContentSaveOutline}></ha-svg-icon>
+                Save
+            </md-outlined-button>
+            <md-outlined-icon-button
+                title="Cancel"
+                @click=${() => {
+                    this._editor = null;
+                    this._editorError = undefined;
+                }}
+            >
+                <ha-svg-icon .path=${mdiClose}></ha-svg-icon>
+            </md-outlined-icon-button>
+        `;
+    }
+
+    #renderSlotsPlaceholder(capacity: number): TemplateResult {
+        if (capacity === 0) return html`<p class="empty">The lock reports no schedule slot per user.</p>`;
+        return html`<div class="loading">
+            <md-circular-progress indeterminate></md-circular-progress>
+            Reading ${capacity} slots…
+        </div>`;
+    }
+
+    static override styles: CSSResultGroup = [
+        BaseClusterCommands.styles,
+        css`
+            :host {
+                display: flex;
+                flex-direction: column;
+                gap: 12px;
+            }
+
+            .feature-map-badge {
+                margin-left: auto;
+                font-size: 0.75rem;
+                font-weight: 400;
+                color: var(--md-sys-color-on-surface-variant);
+            }
+
+            .status-row {
+                display: flex;
+                align-items: center;
+                flex-wrap: wrap;
+                gap: 8px 12px;
+                margin-bottom: 12px;
+            }
+
+            .state-chip {
+                padding: 4px 12px;
+                border-radius: 8px;
+                font-weight: 500;
+                background: var(--md-sys-color-surface-container-highest);
+                color: var(--md-sys-color-on-surface);
+            }
+
+            .state-chip.locked {
+                background: var(--md-sys-color-secondary-container);
+                color: var(--md-sys-color-on-secondary-container);
+            }
+
+            .state-chip.unlocked {
+                background: color-mix(in srgb, var(--danger-color) 18%, transparent);
+                color: var(--md-sys-color-on-surface);
+            }
+
+            .meta {
+                font-size: 0.8rem;
+                color: var(--md-sys-color-on-surface-variant);
+            }
+
+            .meta.warn {
+                color: var(--danger-color);
+            }
+
+            .command-row input[type="password"],
+            .command-row input[type="time"],
+            .command-row input[type="datetime-local"] {
+                padding: 8px;
+                border: 1px solid var(--md-sys-color-outline);
+                border-radius: 4px;
+                background: var(--md-sys-color-surface);
+                color: var(--md-sys-color-on-surface);
+                font: inherit;
+            }
+
+            .command-row select {
+                padding: 8px;
+                border: 1px solid var(--md-sys-color-outline);
+                border-radius: 4px;
+                background: var(--md-sys-color-surface);
+                color: var(--md-sys-color-on-surface);
+                font: inherit;
+            }
+
+            .section {
+                margin-top: 16px;
+            }
+
+            .section-header {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+                font-weight: 500;
+                font-size: 0.8rem;
+                letter-spacing: 0.04em;
+                color: var(--md-sys-color-on-surface-variant);
+                margin-bottom: 8px;
+            }
+
+            .link-action {
+                margin-left: auto;
+                border: none;
+                background: none;
+                padding: 0;
+                font: inherit;
+                font-size: 0.75rem;
+                letter-spacing: 0.04em;
+                color: var(--danger-color);
+                cursor: pointer;
+            }
+
+            .link-action[disabled] {
+                opacity: 0.5;
+                cursor: default;
+            }
+
+            .schedule-grid {
+                margin-bottom: 12px;
+            }
+
+            .grid-ticks {
+                display: flex;
+                justify-content: space-between;
+                font-size: 0.7rem;
+                color: var(--md-sys-color-on-surface-variant);
+                padding: 0 0 4px 48px;
+            }
+
+            .grid-row {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                padding: 2px 0;
+            }
+
+            .grid-row.dimmed {
+                opacity: 0.45;
+            }
+
+            .day-label {
+                width: 40px;
+                flex-shrink: 0;
+                font-size: 0.8rem;
+                font-weight: 500;
+            }
+
+            .grid-row:not(.dimmed) .day-label {
+                font-weight: 700;
+                color: var(--md-sys-color-on-surface);
+            }
+
+            .day-timeline {
+                position: relative;
+                flex: 1;
+                height: 18px;
+                border-radius: 4px;
+                overflow: hidden;
+                background: var(--md-sys-color-surface-container-highest);
+            }
+
+            .segment {
+                position: absolute;
+                top: 0;
+                bottom: 0;
+                min-width: 2px;
+                background: var(--md-sys-color-primary);
+            }
+
+            .slot-list {
+                list-style: none;
+                margin: 0;
+                padding: 0;
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+            }
+
+            .slot-row {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+                padding: 8px 12px;
+                border-radius: 8px;
+                background: var(--md-sys-color-surface-container-highest);
+            }
+
+            .slot-row.editing {
+                background: var(--md-sys-color-surface-container-high);
+            }
+
+            .slot-index {
+                font-family: var(--monospace-font);
+                font-size: 0.8rem;
+                color: var(--md-sys-color-on-surface-variant);
+                width: 28px;
+                flex-shrink: 0;
+            }
+
+            .slot-days {
+                min-width: 104px;
+                font-weight: 500;
+            }
+
+            .slot-window {
+                font-family: var(--monospace-font);
+                color: var(--md-sys-color-on-surface-variant);
+            }
+
+            .slot-window.wide {
+                flex: 1;
+            }
+
+            .slot-empty {
+                flex: 1;
+                font-style: italic;
+                color: var(--md-sys-color-on-surface-variant);
+            }
+
+            .slot-actions {
+                display: inline-flex;
+                align-items: center;
+                gap: 4px;
+                margin-left: auto;
+                flex-shrink: 0;
+            }
+
+            .slot-actions md-outlined-icon-button {
+                --md-outlined-icon-button-container-height: 32px;
+                --md-outlined-icon-button-container-width: 32px;
+                --md-outlined-icon-button-icon-size: 16px;
+            }
+
+            .editor {
+                display: flex;
+                flex-direction: column;
+                gap: 8px;
+                width: 100%;
+            }
+
+            .editor-row {
+                display: flex;
+                align-items: center;
+                flex-wrap: wrap;
+                gap: 8px;
+            }
+
+            .editor-row label {
+                font-size: 14px;
+                color: var(--md-sys-color-on-surface-variant);
+            }
+
+            .editor-row input {
+                padding: 6px 8px;
+                border: 1px solid var(--md-sys-color-outline);
+                border-radius: 4px;
+                background: var(--md-sys-color-surface);
+                color: var(--md-sys-color-on-surface);
+                font: inherit;
+            }
+
+            .day-toggles {
+                display: inline-flex;
+                flex-wrap: wrap;
+                gap: 4px;
+            }
+
+            .day-toggle {
+                padding: 4px 10px;
+                border-radius: 8px;
+                border: 1px solid var(--md-sys-color-outline);
+                background: transparent;
+                color: var(--md-sys-color-on-surface-variant);
+                font: inherit;
+                font-size: 0.8rem;
+                cursor: pointer;
+            }
+
+            .day-toggle.active {
+                background: var(--md-sys-color-secondary-container);
+                color: var(--md-sys-color-on-secondary-container);
+                border-color: transparent;
+            }
+
+            .loading {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+                color: var(--md-sys-color-on-surface-variant);
+                font-size: 0.9rem;
+            }
+
+            .loading md-circular-progress {
+                --md-circular-progress-size: 24px;
+            }
+
+            .hint {
+                display: flex;
+                align-items: center;
+                gap: 6px;
+                margin: 8px 0 0 0;
+                font-size: 0.75rem;
+                color: var(--md-sys-color-on-surface-variant);
+            }
+
+            .hint ha-svg-icon {
+                --mdc-icon-size: 14px;
+            }
+
+            .empty {
+                color: var(--md-sys-color-on-surface-variant);
+                margin: 0;
+            }
+
+            .error {
+                color: var(--danger-color);
+                margin: 8px 0 0 0;
+                font-size: 0.85rem;
+            }
+        `,
+    ];
+}
+
+function errorText(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function slotStatusLabel(status: number): string {
+    return status === 0 || status === STATUS_NOT_FOUND ? "Empty" : getMatterStatusName(status);
+}
+
+registerClusterCommands(DOOR_LOCK_CLUSTER_ID, "door-lock-cluster-commands");
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "door-lock-cluster-commands": DoorLockClusterCommands;
+    }
+}

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -10,6 +10,8 @@ import "@material/web/iconbutton/outlined-icon-button";
 import "@material/web/progress/circular-progress";
 import type { MatterNode } from "@matter-server/ws-client";
 import {
+    mdiAccountPlusOutline,
+    mdiAccountRemoveOutline,
     mdiCalendarRange,
     mdiCalendarWeek,
     mdiClose,
@@ -28,7 +30,9 @@ import { showAlertDialog, showPromptDialog } from "../../../components/dialog-bo
 import "../../../components/ha-svg-icon.js";
 import { handleAsync } from "../../../util/async-handler.js";
 import {
+    addUser,
     buildDaySegments,
+    clearHolidaySchedule,
     clearWeekDaySchedule,
     clearYearDaySchedule,
     DAY_BITS,
@@ -39,22 +43,29 @@ import {
     formatLocalDateTime,
     formatLockState,
     formatLockType,
+    formatOperatingMode,
     formatTimeOfDay,
     formatUserLabel,
     formatUserStatus,
     formatUserType,
     fromDateTimeInputValue,
+    holidayScheduleRangeError,
     isFeatureActive,
     lockDoor,
     maskHasDay,
+    nextFreeUserIndex,
+    OPERATING_MODES,
     parseTimeOfDay,
     readActuatorEnabled,
     readDoorState,
+    readHolidaySchedule,
+    readHolidaySchedulesSupported,
     readLockState,
     readLockType,
     readTotalUsersSupported,
     readUser,
     readUsers,
+    removeUser,
     readWeekDaySchedule,
     readWeekDaySchedulesPerUser,
     readYearDaySchedule,
@@ -68,10 +79,12 @@ import {
     unlockDoor,
     unlockWithTimeout,
     weekDayScheduleRangeError,
+    writeHolidaySchedule,
     writeWeekDaySchedule,
     writeYearDaySchedule,
     yearDayScheduleRangeError,
     type DoorLockUser,
+    type HolidayScheduleSlot,
     type WeekDayScheduleSlot,
     type YearDayScheduleSlot,
 } from "../../../util/door-lock.js";
@@ -106,12 +119,20 @@ interface YearDayEditor {
     end: string;
 }
 
-type ScheduleEditor = WeekDayEditor | YearDayEditor;
+interface HolidayEditor {
+    kind: "holiday";
+    index: number;
+    start: string;
+    end: string;
+    operatingMode: number;
+}
+
+type ScheduleEditor = WeekDayEditor | YearDayEditor | HolidayEditor;
 
 /**
  * Command panel for the DoorLock cluster (ID: 0x0101 / 257).
- * Operates the bolt and manages the WDSCH and YDSCH access schedules of a user picked from the lock's
- * user database, which the schedule commands address by index.
+ * Operates the bolt, manages the WDSCH and YDSCH access schedules of a user picked from the lock's user
+ * database, and the lock-wide HDSCH holiday schedule table (not scoped to a user).
  */
 @customElement("door-lock-cluster-commands")
 class DoorLockClusterCommands extends BaseClusterCommands {
@@ -119,19 +140,33 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     @state() private _selectedUserIndex: number | null = null;
     @state() private _weekDaySlots?: WeekDayScheduleSlot[];
     @state() private _yearDaySlots?: YearDayScheduleSlot[];
+    @state() private _holidaySlots?: HolidayScheduleSlot[];
     @state() private _loadingUsers = false;
     @state() private _loadingSchedules = false;
+    @state() private _loadingHoliday = false;
     @state() private _loadError?: string;
     @state() private _editor: ScheduleEditor | null = null;
     @state() private _editorError?: string;
+    @state() private _addingUser = false;
+    @state() private _newUserName = "";
+    @state() private _userEditorError?: string;
+    @state() private _showEmptyWeekDay = false;
+    @state() private _showEmptyYearDay = false;
+    @state() private _showEmptyHoliday = false;
     @state() private _busy = false;
     @state() private _pinCode = "";
     @state() private _unlockTimeout = String(DEFAULT_UNLOCK_TIMEOUT_SECONDS);
 
     #context?: string;
     #usersRequested = false;
+    #holidayRequested = false;
     /** Bumped whenever the panel's node, endpoint or selected user changes, so stale loads drop their results. */
     #generation = 0;
+    /**
+     * Bumped only on a node/endpoint context change (unlike #generation, not on a mere user re-selection): a
+     * lock/unlock or schedule command run against the old context must not clear `_busy` for a new one.
+     */
+    #busyGeneration = 0;
 
     override updated(changedProperties: Map<string, unknown>) {
         super.updated(changedProperties);
@@ -141,30 +176,87 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         if (this.#context !== context) {
             this.#context = context;
             this.#generation++;
+            this.#busyGeneration++;
             this.#usersRequested = false;
+            this.#holidayRequested = false;
             this._users = undefined;
             this._selectedUserIndex = null;
             this._weekDaySlots = undefined;
             this._yearDaySlots = undefined;
+            this._holidaySlots = undefined;
             this._loadingUsers = false;
             this._loadingSchedules = false;
+            this._loadingHoliday = false;
             this._loadError = undefined;
             this._editor = null;
             this._editorError = undefined;
+            this._addingUser = false;
+            this._newUserName = "";
+            this._userEditorError = undefined;
+            this._showEmptyWeekDay = false;
+            this._showEmptyYearDay = false;
+            this._showEmptyHoliday = false;
             this._busy = false;
             this._pinCode = "";
             this._unlockTimeout = String(DEFAULT_UNLOCK_TIMEOUT_SECONDS);
         }
 
-        // The attribute cache fills in progressively, so the feature check may only pass on a later update.
-        if (!this.#usersRequested && this.#schedulesSupported() && isFeatureActive(this.node, this.endpoint, "USR")) {
+        // The attribute cache fills in progressively: the feature bits can resolve before the numeric
+        // capacity attributes the load depends on. Wait for those too, or the load runs once with fallback
+        // values (32 scanned users, 0 schedule slots) and #usersRequested latches true forever, so it never
+        // gets a chance to retry with the real numbers.
+        if (
+            !this.#usersRequested &&
+            this.#perUserSchedulesSupported() &&
+            isFeatureActive(this.node, this.endpoint, "USR") &&
+            this.#userCapacityReady()
+        ) {
             this.#usersRequested = true;
             handleAsync(() => this.#loadUsers())();
         }
+        // HolidaySchedules is lock-wide, not scoped to a user, so it loads independently of #loadUsers.
+        if (
+            !this.#holidayRequested &&
+            this.#holidaySupported() &&
+            readHolidaySchedulesSupported(this.node, this.endpoint) !== null
+        ) {
+            this.#holidayRequested = true;
+            handleAsync(() => this.#loadHolidaySchedules())();
+        }
+    }
+
+    /** Whether the capacity attributes #loadUsers/#loadSchedules depend on are cached yet. */
+    #userCapacityReady(): boolean {
+        if (readTotalUsersSupported(this.node, this.endpoint) === null) return false;
+        if (
+            isFeatureActive(this.node, this.endpoint, "WDSCH") &&
+            readWeekDaySchedulesPerUser(this.node, this.endpoint) === null
+        ) {
+            return false;
+        }
+        if (
+            isFeatureActive(this.node, this.endpoint, "YDSCH") &&
+            readYearDaySchedulesPerUser(this.node, this.endpoint) === null
+        ) {
+            return false;
+        }
+        return true;
     }
 
     #schedulesSupported(): boolean {
+        return (
+            isFeatureActive(this.node, this.endpoint, "WDSCH") ||
+            isFeatureActive(this.node, this.endpoint, "YDSCH") ||
+            this.#holidaySupported()
+        );
+    }
+
+    #perUserSchedulesSupported(): boolean {
         return isFeatureActive(this.node, this.endpoint, "WDSCH") || isFeatureActive(this.node, this.endpoint, "YDSCH");
+    }
+
+    #holidaySupported(): boolean {
+        return isFeatureActive(this.node, this.endpoint, "HDSCH");
     }
 
     #isCurrent(node: MatterNode, endpoint: number, generation: number): boolean {
@@ -238,6 +330,30 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         }
     }
 
+    /** HolidaySchedules is a single lock-wide table, so unlike #loadSchedules this needs no userIndex. */
+    async #loadHolidaySchedules() {
+        const node = this.node;
+        const endpoint = this.endpoint;
+        const generation = this.#generation;
+        this._loadingHoliday = true;
+        this._loadError = undefined;
+        try {
+            const capacity = readHolidaySchedulesSupported(node, endpoint) ?? 0;
+            const slots = new Array<HolidayScheduleSlot>();
+            for (let index = 1; index <= capacity; index++) {
+                const slot = await readHolidaySchedule(this.client, node.node_id, endpoint, index);
+                if (!this.#isCurrent(node, endpoint, generation)) return;
+                slots.push(slot);
+            }
+            this._holidaySlots = slots;
+        } catch (error) {
+            if (!this.#isCurrent(node, endpoint, generation)) return;
+            this._loadError = errorText(error);
+        } finally {
+            if (this.#generation === generation) this._loadingHoliday = false;
+        }
+    }
+
     #selectUser(userIndex: number) {
         if (userIndex === this._selectedUserIndex) return;
         this.#generation++;
@@ -262,6 +378,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         const endpoint = this.endpoint;
         const generation = this.#generation;
         if (this._busy) return;
+        const busyGeneration = this.#busyGeneration;
         this._busy = true;
         try {
             await run(node, endpoint);
@@ -272,7 +389,30 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         } catch (error) {
             this.#reportFailure(title, error, node, endpoint);
         } finally {
-            this._busy = false;
+            // busyGeneration-scoped, not generation-scoped: a lock/endpoint switch must clear this for the
+            // new context, but merely picking a different user on the same lock must not let a second command
+            // start while this one is still in flight.
+            if (this.#busyGeneration === busyGeneration) this._busy = false;
+        }
+    }
+
+    /** Counterpart to #runScheduleCommand for the lock-wide holiday table: no user, so no generation bump needed. */
+    async #runHolidayCommand(title: string, run: (node: MatterNode, endpoint: number) => Promise<void>) {
+        const node = this.node;
+        const endpoint = this.endpoint;
+        if (this._busy) return;
+        const busyGeneration = this.#busyGeneration;
+        this._busy = true;
+        try {
+            await run(node, endpoint);
+            if (!this.isSameContext(node, endpoint)) return;
+            this._editor = null;
+            this._editorError = undefined;
+            await this.#loadHolidaySchedules();
+        } catch (error) {
+            this.#reportFailure(title, error, node, endpoint);
+        } finally {
+            if (this.#busyGeneration === busyGeneration) this._busy = false;
         }
     }
 
@@ -292,10 +432,23 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         return pin === "" ? undefined : pin;
     }
 
+    /**
+     * Blocks a command locally when the lock reports RequirePinForRemoteOperation and the PIN field is
+     * empty, instead of round-tripping a request the lock will reject anyway.
+     */
+    async #missingRequiredPin(): Promise<boolean> {
+        if (this.#pinForCommand() !== undefined) return false;
+        if (!requiresPinForRemoteOperation(this.node, this.endpoint)) return false;
+        await showAlertDialog({ title: "PIN required", text: "This lock requires a PIN for remote operations." });
+        return true;
+    }
+
     async #operateLock(action: "lock" | "unlock") {
         const node = this.node;
         const endpoint = this.endpoint;
         if (this._busy) return;
+        if (await this.#missingRequiredPin()) return;
+        const busyGeneration = this.#busyGeneration;
         this._busy = true;
         try {
             const operate = action === "lock" ? lockDoor : unlockDoor;
@@ -303,7 +456,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         } catch (error) {
             this.#reportFailure(action === "lock" ? "Lock failed" : "Unlock failed", error, node, endpoint);
         } finally {
-            this._busy = false;
+            if (this.#busyGeneration === busyGeneration) this._busy = false;
         }
     }
 
@@ -316,20 +469,50 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             await showAlertDialog({ title: "Unlock failed", text: "The timeout must be 1 to 65535 seconds." });
             return;
         }
+        if (await this.#missingRequiredPin()) return;
+        const busyGeneration = this.#busyGeneration;
         this._busy = true;
         try {
             await unlockWithTimeout(this.client, node.node_id, endpoint, timeout, this.#pinForCommand());
         } catch (error) {
             this.#reportFailure("Unlock failed", error, node, endpoint);
         } finally {
-            this._busy = false;
+            if (this.#busyGeneration === busyGeneration) this._busy = false;
         }
     }
 
     #saveEditor() {
         const editor = this._editor;
+        if (editor === null) return;
+
+        if (editor.kind === "holiday") {
+            const localStartTime = fromDateTimeInputValue(editor.start);
+            const localEndTime = fromDateTimeInputValue(editor.end);
+            if (localStartTime === null || localEndTime === null) {
+                this._editorError = "Enter both a start and an end date.";
+                return;
+            }
+            const schedule = {
+                holidayIndex: editor.index,
+                localStartTime,
+                localEndTime,
+                operatingMode: editor.operatingMode,
+            };
+            const rangeError = holidayScheduleRangeError(schedule);
+            if (rangeError !== null) {
+                this._editorError = rangeError;
+                return;
+            }
+            handleAsync(() =>
+                this.#runHolidayCommand("Set holiday schedule failed", (node, endpoint) =>
+                    writeHolidaySchedule(this.client, node.node_id, endpoint, schedule),
+                ),
+            )();
+            return;
+        }
+
         const userIndex = this._selectedUserIndex;
-        if (editor === null || userIndex === null) return;
+        if (userIndex === null) return;
 
         if (editor.kind === "weekDay") {
             const start = parseTimeOfDay(editor.start);
@@ -381,7 +564,16 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     async #clearWeekDay(weekDayIndex: number) {
         const userIndex = this._selectedUserIndex;
         if (userIndex === null) return;
-        if (weekDayIndex === SCHEDULE_INDEX_ALL && !(await this.#confirmClearAll("week day"))) return;
+        if (weekDayIndex === SCHEDULE_INDEX_ALL) {
+            // Captured before the confirmation dialog's await: userIndex must not survive a context or
+            // selection change made while the dialog was open — confirming would then clear the wrong
+            // user's (or the wrong lock's) schedules.
+            const node = this.node;
+            const endpoint = this.endpoint;
+            const generation = this.#generation;
+            if (!(await this.#confirmClearAll("week day"))) return;
+            if (!this.#isCurrent(node, endpoint, generation)) return;
+        }
         await this.#runScheduleCommand("Clear week day schedule failed", (node, endpoint) =>
             clearWeekDaySchedule(this.client, node.node_id, endpoint, userIndex, weekDayIndex),
         );
@@ -390,7 +582,13 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     async #clearYearDay(yearDayIndex: number) {
         const userIndex = this._selectedUserIndex;
         if (userIndex === null) return;
-        if (yearDayIndex === SCHEDULE_INDEX_ALL && !(await this.#confirmClearAll("year day"))) return;
+        if (yearDayIndex === SCHEDULE_INDEX_ALL) {
+            const node = this.node;
+            const endpoint = this.endpoint;
+            const generation = this.#generation;
+            if (!(await this.#confirmClearAll("year day"))) return;
+            if (!this.#isCurrent(node, endpoint, generation)) return;
+        }
         await this.#runScheduleCommand("Clear year day schedule failed", (node, endpoint) =>
             clearYearDaySchedule(this.client, node.node_id, endpoint, userIndex, yearDayIndex),
         );
@@ -403,6 +601,100 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             text: `Every ${kind} schedule of ${user ? formatUserLabel(user) : "this user"} will be removed from the lock.`,
             confirmText: "Clear all",
         });
+    }
+
+    async #clearHoliday(holidayIndex: number) {
+        if (holidayIndex === SCHEDULE_INDEX_ALL) {
+            const node = this.node;
+            const endpoint = this.endpoint;
+            if (!(await this.#confirmClearAllHoliday())) return;
+            if (!this.isSameContext(node, endpoint)) return;
+        }
+        await this.#runHolidayCommand("Clear holiday schedule failed", (node, endpoint) =>
+            clearHolidaySchedule(this.client, node.node_id, endpoint, holidayIndex),
+        );
+    }
+
+    #confirmClearAllHoliday(): Promise<boolean> {
+        return showPromptDialog({
+            title: "Clear all holiday schedules",
+            text: "Every holiday schedule will be removed from the lock. This applies lock-wide, not to a single user.",
+            confirmText: "Clear all",
+        });
+    }
+
+    #startAddUser() {
+        this._userEditorError = undefined;
+        this._newUserName = "";
+        this._addingUser = true;
+    }
+
+    #cancelAddUser() {
+        this._addingUser = false;
+        this._userEditorError = undefined;
+    }
+
+    async #saveNewUser() {
+        const node = this.node;
+        const endpoint = this.endpoint;
+        const generation = this.#generation;
+        const userName = this._newUserName.trim();
+        if (userName === "") {
+            this._userEditorError = "Enter a name for the user.";
+            return;
+        }
+        const maxUsers = readTotalUsersSupported(node, endpoint) ?? USER_SCAN_FALLBACK;
+        const userIndex = nextFreeUserIndex(this._users ?? [], maxUsers);
+        if (userIndex === null) {
+            this._userEditorError = "The lock's user database is full.";
+            return;
+        }
+        if (this._busy) return;
+        const busyGeneration = this.#busyGeneration;
+        this._busy = true;
+        try {
+            await addUser(this.client, node.node_id, endpoint, userIndex, userName);
+            if (!this.#isCurrent(node, endpoint, generation)) return;
+            this._addingUser = false;
+            this._newUserName = "";
+            this._userEditorError = undefined;
+            this.#usersRequested = true;
+            await this.#loadUsers();
+        } catch (error) {
+            if (!this.#isCurrent(node, endpoint, generation)) return;
+            this._userEditorError = errorText(error);
+        } finally {
+            if (this.#busyGeneration === busyGeneration) this._busy = false;
+        }
+    }
+
+    async #removeSelectedUser() {
+        const userIndex = this._selectedUserIndex;
+        if (userIndex === null) return;
+        // Captured before the confirmation dialog's await: if the panel moves to a different lock while it
+        // is open, confirming must not delete a same-numbered user on the newly displayed lock.
+        const node = this.node;
+        const endpoint = this.endpoint;
+        const user = this._users?.find(candidate => candidate.userIndex === userIndex);
+        const confirmed = await showPromptDialog({
+            title: "Remove user",
+            text: `${user ? formatUserLabel(user) : "This user"} and all of its schedules will be removed from the lock.`,
+            confirmText: "Remove",
+        });
+        if (!confirmed || !this.isSameContext(node, endpoint)) return;
+        if (this._busy) return;
+        const busyGeneration = this.#busyGeneration;
+        this._busy = true;
+        try {
+            await removeUser(this.client, node.node_id, endpoint, userIndex);
+            if (!this.isSameContext(node, endpoint)) return;
+            this.#usersRequested = true;
+            await this.#loadUsers();
+        } catch (error) {
+            this.#reportFailure("Remove user failed", error, node, endpoint);
+        } finally {
+            if (this.#busyGeneration === busyGeneration) this._busy = false;
+        }
     }
 
     override render() {
@@ -498,42 +790,43 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     #renderSchedulePanel(): TemplateResult {
         const weekDayActive = isFeatureActive(this.node, this.endpoint, "WDSCH");
         const yearDayActive = isFeatureActive(this.node, this.endpoint, "YDSCH");
+        const holidayActive = this.#holidaySupported();
         const userActive = isFeatureActive(this.node, this.endpoint, "USR");
-        const features = [weekDayActive ? "WDSCH" : undefined, yearDayActive ? "YDSCH" : undefined]
-            .filter(code => code !== undefined)
-            .join(" · ");
+        const perUserActive = weekDayActive || yearDayActive;
+        const features = [weekDayActive && "WDSCH", yearDayActive && "YDSCH", holidayActive && "HDSCH"].filter(
+            (code): code is string => code !== false,
+        );
 
         return html`
             <details class="command-panel" open>
                 <summary>
                     <ha-svg-icon .path=${mdiCalendarWeek}></ha-svg-icon>
                     Access Schedules
-                    <span class="feature-map-badge">FeatureMap: ${features}</span>
+                    <span class="feature-map-badge">FeatureMap: ${features.join(" · ")}</span>
                 </summary>
                 <div class="command-content">
+                    ${this._loadError !== undefined ? html`<p class="error">${this._loadError}</p>` : nothing}
                     ${
-                        userActive
-                            ? html`
-                                  ${this.#renderUserSelector()}
-                                  ${
-                                      this._loadError !== undefined
-                                          ? html`<p class="error">${this._loadError}</p>`
-                                          : nothing
-                                  }
-                                  ${
-                                      this._selectedUserIndex === null
-                                          ? nothing
-                                          : html`
-                                                ${weekDayActive ? this.#renderWeekDaySection() : nothing}
-                                                ${yearDayActive ? this.#renderYearDaySection() : nothing}
-                                            `
-                                  }
-                              `
-                            : html`<p class="empty">
-                                  Schedules are assigned per user, which this lock does not expose: it reports no User
-                                  (USR) feature, so its user database cannot be read.
-                              </p>`
+                        !perUserActive
+                            ? nothing
+                            : userActive
+                              ? html`
+                                    ${this.#renderUserSelector()}
+                                    ${
+                                        this._selectedUserIndex === null
+                                            ? nothing
+                                            : html`
+                                                  ${weekDayActive ? this.#renderWeekDaySection() : nothing}
+                                                  ${yearDayActive ? this.#renderYearDaySection() : nothing}
+                                              `
+                                    }
+                                `
+                              : html`<p class="empty">
+                                    Schedules are assigned per user, which this lock does not expose: it reports no
+                                    User (USR) feature, so its user database cannot be read.
+                                </p>`
                     }
+                    ${holidayActive ? this.#renderHolidaySection() : nothing}
                 </div>
             </details>
         `;
@@ -547,28 +840,47 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                 Reading the user database…
             </div>`;
         }
-        if (users !== undefined && users.length === 0) {
-            return html`<p class="empty">No users are programmed on this lock.</p>`;
-        }
+
+        const busy = this._busy || this._loadingUsers || this._loadingSchedules;
+        const maxUsers = readTotalUsersSupported(this.node, this.endpoint) ?? USER_SCAN_FALLBACK;
+        const canAddUser = users !== undefined && nextFreeUserIndex(users, maxUsers) !== null;
+
         return html`
             <div class="command-row">
-                <label for="doorLockUser">User:</label>
-                <select
-                    id="doorLockUser"
-                    ?disabled=${this._busy || this._loadingUsers || this._loadingSchedules}
-                    @change=${(event: Event) => this.#selectUser(Number((event.target as HTMLSelectElement).value))}
-                >
-                    ${(users ?? []).map(
-                        user => html`
-                            <option value=${user.userIndex} .selected=${user.userIndex === this._selectedUserIndex}>
-                                #${user.userIndex} · ${formatUserLabel(user)}
-                            </option>
-                        `,
-                    )}
-                </select>
-                ${this.#renderUserBadges()}
+                ${
+                    users === undefined || users.length === 0
+                        ? html`<span class="empty">No users are programmed on this lock.</span>`
+                        : html`
+                              <label for="doorLockUser">User:</label>
+                              <select
+                                  id="doorLockUser"
+                                  ?disabled=${busy}
+                                  @change=${(event: Event) =>
+                                      this.#selectUser(Number((event.target as HTMLSelectElement).value))}
+                              >
+                                  ${users.map(
+                                      user => html`
+                                          <option
+                                              value=${user.userIndex}
+                                              .selected=${user.userIndex === this._selectedUserIndex}
+                                          >
+                                              #${user.userIndex} · ${formatUserLabel(user)}
+                                          </option>
+                                      `,
+                                  )}
+                              </select>
+                              ${this.#renderUserBadges()}
+                              <md-outlined-icon-button
+                                  title="Remove user"
+                                  ?disabled=${busy || this._selectedUserIndex === null}
+                                  @click=${handleAsync(() => this.#removeSelectedUser())}
+                              >
+                                  <ha-svg-icon .path=${mdiAccountRemoveOutline}></ha-svg-icon>
+                              </md-outlined-icon-button>
+                          `
+                }
                 <md-outlined-button
-                    ?disabled=${this._busy || this._loadingUsers || this._loadingSchedules}
+                    ?disabled=${busy}
                     @click=${() => {
                         this.#usersRequested = true;
                         handleAsync(() => this.#loadUsers())();
@@ -577,6 +889,45 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     <ha-svg-icon slot="icon" .path=${mdiRefresh}></ha-svg-icon>
                     Reload
                 </md-outlined-button>
+                ${
+                    canAddUser
+                        ? html`<md-outlined-button
+                              ?disabled=${busy || this._addingUser}
+                              @click=${() => this.#startAddUser()}
+                          >
+                              <ha-svg-icon slot="icon" .path=${mdiAccountPlusOutline}></ha-svg-icon>
+                              Add user
+                          </md-outlined-button>`
+                        : nothing
+                }
+            </div>
+            ${this._addingUser ? this.#renderAddUserEditor() : nothing}
+        `;
+    }
+
+    #renderAddUserEditor(): TemplateResult {
+        return html`
+            <div class="editor">
+                <div class="editor-row">
+                    <label for="newUserName">Name:</label>
+                    <input
+                        id="newUserName"
+                        type="text"
+                        maxlength="32"
+                        .value=${live(this._newUserName)}
+                        @input=${(event: Event) => {
+                            this._newUserName = (event.target as HTMLInputElement).value;
+                        }}
+                    />
+                    <md-outlined-button ?disabled=${this._busy} @click=${handleAsync(() => this.#saveNewUser())}>
+                        <ha-svg-icon slot="icon" .path=${mdiContentSaveOutline}></ha-svg-icon>
+                        Save
+                    </md-outlined-button>
+                    <md-outlined-icon-button title="Cancel" @click=${() => this.#cancelAddUser()}>
+                        <ha-svg-icon .path=${mdiClose}></ha-svg-icon>
+                    </md-outlined-icon-button>
+                </div>
+                ${this._userEditorError !== undefined ? html`<p class="error">${this._userEditorError}</p>` : nothing}
             </div>
         `;
     }
@@ -592,10 +943,35 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         `;
     }
 
+    /**
+     * Every occupied slot, plus (unless expanded) just the next empty one — so there is always a visible
+     * "+" to add a schedule without listing every empty slot up front.
+     */
+    #visibleSlots<T extends { schedule: unknown }>(slots: T[], expanded: boolean): T[] {
+        if (expanded) return slots;
+        let shownEmpty = false;
+        return slots.filter(slot => {
+            if (slot.schedule !== null) return true;
+            if (shownEmpty) return false;
+            shownEmpty = true;
+            return true;
+        });
+    }
+
+    /** Toggle for the slot list's collapsed empty slots; hidden when there's nothing meaningful to collapse. */
+    #renderEmptySlotsToggle(emptyTotal: number, expanded: boolean, toggle: () => void): TemplateResult | typeof nothing {
+        if (emptyTotal <= 1) return nothing;
+        const hiddenCount = expanded ? 0 : emptyTotal - 1;
+        return html`<button class="slot-list-toggle" @click=${toggle}>
+            ${expanded ? "Hide empty slots" : `Show ${hiddenCount} more empty slot${hiddenCount === 1 ? "" : "s"}`}
+        </button>`;
+    }
+
     #renderWeekDaySection(): TemplateResult {
         const slots = this._weekDaySlots;
         const capacity = readWeekDaySchedulesPerUser(this.node, this.endpoint) ?? 0;
         const used = slots?.filter(slot => slot.schedule !== null).length ?? 0;
+        const expanded = this._showEmptyWeekDay;
 
         return html`
             <div class="section">
@@ -619,8 +995,11 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                         : html`
                               ${used > 0 ? this.#renderWeekTimeline(slots) : nothing}
                               <ul class="slot-list">
-                                  ${slots.map(slot => this.#renderWeekDaySlot(slot))}
+                                  ${this.#visibleSlots(slots, expanded).map(slot => this.#renderWeekDaySlot(slot))}
                               </ul>
+                              ${this.#renderEmptySlotsToggle(slots.length - used, expanded, () => {
+                                  this._showEmptyWeekDay = !expanded;
+                              })}
                           `
                 }
             </div>
@@ -733,8 +1112,10 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     <div class="day-toggles">
                         ${DAY_LABELS.map((label, day) => {
                             const bit = DAY_BITS[day];
+                            const active = maskHasDay(editor.daysMask, bit);
                             return html`<button
-                                class="day-toggle ${maskHasDay(editor.daysMask, bit) ? "active" : ""}"
+                                class="day-toggle ${active ? "active" : ""}"
+                                aria-pressed=${active ? "true" : "false"}
                                 @click=${() => {
                                     this._editor = { ...editor, daysMask: toggleMaskDay(editor.daysMask, bit) };
                                 }}
@@ -774,6 +1155,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         const slots = this._yearDaySlots;
         const capacity = readYearDaySchedulesPerUser(this.node, this.endpoint) ?? 0;
         const used = slots?.filter(slot => slot.schedule !== null).length ?? 0;
+        const expanded = this._showEmptyYearDay;
 
         return html`
             <div class="section">
@@ -796,8 +1178,11 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                         ? this.#renderSlotsPlaceholder(capacity)
                         : html`
                               <ul class="slot-list">
-                                  ${slots.map(slot => this.#renderYearDaySlot(slot))}
+                                  ${this.#visibleSlots(slots, expanded).map(slot => this.#renderYearDaySlot(slot))}
                               </ul>
+                              ${this.#renderEmptySlotsToggle(slots.length - used, expanded, () => {
+                                  this._showEmptyYearDay = !expanded;
+                              })}
                               <p class="hint">
                                   <ha-svg-icon .path=${mdiCalendarRange}></ha-svg-icon>
                                   Date ranges are local time at the lock, shown here in this browser's time zone.
@@ -881,6 +1266,147 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                             this._editor = { ...editor, end: (event.target as HTMLInputElement).value };
                         }}
                     />
+                    ${this.#renderEditorActions()}
+                </div>
+                ${this._editorError !== undefined ? html`<p class="error">${this._editorError}</p>` : nothing}
+            </div>
+        `;
+    }
+
+    #renderHolidaySection(): TemplateResult {
+        const slots = this._holidaySlots;
+        const capacity = readHolidaySchedulesSupported(this.node, this.endpoint) ?? 0;
+        const used = slots?.filter(slot => slot.schedule !== null).length ?? 0;
+        const busy = this._busy || this._loadingHoliday;
+        const expanded = this._showEmptyHoliday;
+
+        return html`
+            <div class="section">
+                <div class="section-header">
+                    <span>HOLIDAY SCHEDULES · ${used}/${capacity} slots</span>
+                    ${
+                        used > 0
+                            ? html`<button
+                                  class="link-action"
+                                  ?disabled=${busy}
+                                  @click=${handleAsync(() => this.#clearHoliday(SCHEDULE_INDEX_ALL))}
+                              >
+                                  Clear all
+                              </button>`
+                            : nothing
+                    }
+                </div>
+                ${
+                    slots === undefined
+                        ? this.#renderSlotsPlaceholder(capacity)
+                        : html`
+                              <ul class="slot-list">
+                                  ${this.#visibleSlots(slots, expanded).map(slot => this.#renderHolidaySlot(slot, busy))}
+                              </ul>
+                              ${this.#renderEmptySlotsToggle(slots.length - used, expanded, () => {
+                                  this._showEmptyHoliday = !expanded;
+                              })}
+                              <p class="hint">
+                                  <ha-svg-icon .path=${mdiCalendarRange}></ha-svg-icon>
+                                  Applies to the whole lock, not a single user. Date ranges are local time at the
+                                  lock, shown here in this browser's time zone.
+                              </p>
+                          `
+                }
+            </div>
+        `;
+    }
+
+    #renderHolidaySlot(slot: HolidayScheduleSlot, busy: boolean): TemplateResult {
+        const editor = this._editor;
+        if (editor?.kind === "holiday" && editor.index === slot.holidayIndex) {
+            return html`<li class="slot-row editing">${this.#renderHolidayEditor(editor)}</li>`;
+        }
+        const schedule = slot.schedule;
+        return html`
+            <li class="slot-row">
+                <span class="slot-index">#${slot.holidayIndex}</span>
+                ${
+                    schedule === null
+                        ? html`<span class="slot-empty">${slotStatusLabel(slot.status)}</span>`
+                        : html`<span class="slot-window wide">
+                              ${formatLocalDateTime(schedule.localStartTime)} →
+                              ${formatLocalDateTime(schedule.localEndTime)} ·
+                              ${formatOperatingMode(schedule.operatingMode)}
+                          </span>`
+                }
+                <span class="slot-actions">
+                    <md-outlined-icon-button
+                        title=${schedule === null ? "Set schedule" : "Edit schedule"}
+                        ?disabled=${busy}
+                        @click=${() => {
+                            this._editorError = undefined;
+                            const now = Math.floor(Date.now() / 1000);
+                            this._editor = {
+                                kind: "holiday",
+                                index: slot.holidayIndex,
+                                start: toDateTimeInputValue(schedule?.localStartTime ?? now),
+                                end: toDateTimeInputValue(schedule?.localEndTime ?? now + 86400),
+                                operatingMode: schedule?.operatingMode ?? OPERATING_MODES[1],
+                            };
+                        }}
+                    >
+                        <ha-svg-icon .path=${schedule === null ? mdiPlus : mdiPencilOutline}></ha-svg-icon>
+                    </md-outlined-icon-button>
+                    ${
+                        schedule === null
+                            ? nothing
+                            : html`<md-outlined-icon-button
+                                  title="Clear schedule"
+                                  ?disabled=${busy}
+                                  @click=${handleAsync(() => this.#clearHoliday(slot.holidayIndex))}
+                              >
+                                  <ha-svg-icon .path=${mdiTrashCanOutline}></ha-svg-icon>
+                              </md-outlined-icon-button>`
+                    }
+                </span>
+            </li>
+        `;
+    }
+
+    #renderHolidayEditor(editor: HolidayEditor): TemplateResult {
+        return html`
+            <div class="editor">
+                <div class="editor-row">
+                    <span class="slot-index">#${editor.index}</span>
+                    <label for="holidayStart">From:</label>
+                    <input
+                        id="holidayStart"
+                        type="datetime-local"
+                        .value=${live(editor.start)}
+                        @input=${(event: Event) => {
+                            this._editor = { ...editor, start: (event.target as HTMLInputElement).value };
+                        }}
+                    />
+                    <label for="holidayEnd">To:</label>
+                    <input
+                        id="holidayEnd"
+                        type="datetime-local"
+                        .value=${live(editor.end)}
+                        @input=${(event: Event) => {
+                            this._editor = { ...editor, end: (event.target as HTMLInputElement).value };
+                        }}
+                    />
+                    <label for="holidayMode">Mode:</label>
+                    <select
+                        id="holidayMode"
+                        .value=${live(String(editor.operatingMode))}
+                        @change=${(event: Event) => {
+                            this._editor = {
+                                ...editor,
+                                operatingMode: Number((event.target as HTMLSelectElement).value),
+                            };
+                        }}
+                    >
+                        ${OPERATING_MODES.map(
+                            mode => html`<option value=${mode}>${formatOperatingMode(mode)}</option>`,
+                        )}
+                    </select>
                     ${this.#renderEditorActions()}
                 </div>
                 ${this._editorError !== undefined ? html`<p class="error">${this._editorError}</p>` : nothing}
@@ -1015,6 +1541,19 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             .link-action[disabled] {
                 opacity: 0.5;
                 cursor: default;
+            }
+
+            .slot-list-toggle {
+                display: block;
+                margin: 4px 0 0 0;
+                border: none;
+                background: none;
+                padding: 0;
+                font: inherit;
+                font-size: 0.75rem;
+                letter-spacing: 0.04em;
+                color: var(--md-sys-color-primary);
+                cursor: pointer;
             }
 
             .schedule-grid {
@@ -1152,7 +1691,8 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                 color: var(--md-sys-color-on-surface-variant);
             }
 
-            .editor-row input {
+            .editor-row input,
+            .editor-row select {
                 padding: 6px 8px;
                 border: 1px solid var(--md-sys-color-outline);
                 border-radius: 4px;

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -209,7 +209,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             !this.#usersRequested &&
             this.#perUserSchedulesSupported() &&
             isFeatureActive(this.node, this.endpoint, "USR") &&
-            this.#userCapacityReady()
+            this.#scheduleCapacityReady()
         ) {
             this.#usersRequested = true;
             handleAsync(() => this.#loadUsers())();
@@ -225,9 +225,16 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         }
     }
 
-    /** Whether the capacity attributes #loadUsers/#loadSchedules depend on are cached yet. */
-    #userCapacityReady(): boolean {
-        if (readTotalUsersSupported(this.node, this.endpoint) === null) return false;
+    /**
+     * Whether the schedule-capacity attributes #loadSchedules depends on are cached yet.
+     *
+     * NumberOfTotalUsersSupported is deliberately not checked here: #loadUsers already has a graceful
+     * fallback for it (USER_SCAN_FALLBACK), for a lock that never reports it at all — readUsers's walk
+     * terminates on NextUserIndex regardless, so an oversized scan bound just costs a few harmless extra
+     * round trips. WDSCH/YDSCH capacity has no such fallback: reading it as absent silently substitutes 0
+     * slots, hiding a section's content entirely, so those are worth waiting for.
+     */
+    #scheduleCapacityReady(): boolean {
         if (
             isFeatureActive(this.node, this.endpoint, "WDSCH") &&
             readWeekDaySchedulesPerUser(this.node, this.endpoint) === null
@@ -1454,8 +1461,9 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         `;
     }
 
+    /** Shared by the WeekDay/YearDay (per-user) and Holiday (lock-wide) sections, so this stays generic. */
     #renderSlotsPlaceholder(capacity: number): TemplateResult {
-        if (capacity === 0) return html`<p class="empty">The lock reports no schedule slot per user.</p>`;
+        if (capacity === 0) return html`<p class="empty">The lock reports no schedule slots.</p>`;
         return html`<div class="loading">
             <md-circular-progress indeterminate></md-circular-progress>
             Reading ${capacity} slots…

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -433,10 +433,21 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     }
 
     /**
+     * Whether the lock supports a PIN sent in a remote Lock/Unlock/UnlockWithTimeout command at all: COTA
+     * gates that (spec §5.2.4), independently of whether PinCredential is otherwise supported.
+     */
+    #pinFieldSupported(): boolean {
+        return isFeatureActive(this.node, this.endpoint, "COTA") && isFeatureActive(this.node, this.endpoint, "PIN");
+    }
+
+    /**
      * Blocks a command locally when the lock reports RequirePinForRemoteOperation and the PIN field is
-     * empty, instead of round-tripping a request the lock will reject anyway.
+     * empty, instead of round-tripping a request the lock will reject anyway. Only when a PIN can actually
+     * be entered — #pinFieldSupported() gates the field itself, so this must agree or a lock requiring a PIN
+     * without COTA would show "PIN required" with nowhere to enter one.
      */
     async #missingRequiredPin(): Promise<boolean> {
+        if (!this.#pinFieldSupported()) return false;
         if (this.#pinForCommand() !== undefined) return false;
         if (!requiresPinForRemoteOperation(this.node, this.endpoint)) return false;
         await showAlertDialog({ title: "PIN required", text: "This lock requires a PIN for remote operations." });
@@ -708,8 +719,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         const lockType = formatLockType(readLockType(this.node, this.endpoint));
         const actuatorEnabled = readActuatorEnabled(this.node, this.endpoint);
         const pinRequired = requiresPinForRemoteOperation(this.node, this.endpoint);
-        const showPin =
-            isFeatureActive(this.node, this.endpoint, "COTA") && isFeatureActive(this.node, this.endpoint, "PIN");
+        const showPin = this.#pinFieldSupported();
         const showTimeout = supportsCommand(this.node, this.endpoint, UNLOCK_WITH_TIMEOUT_COMMAND_ID);
 
         return html`
@@ -872,6 +882,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                               ${this.#renderUserBadges()}
                               <md-outlined-icon-button
                                   title="Remove user"
+                                  aria-label="Remove user"
                                   ?disabled=${busy || this._selectedUserIndex === null}
                                   @click=${handleAsync(() => this.#removeSelectedUser())}
                               >
@@ -923,7 +934,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                         <ha-svg-icon slot="icon" .path=${mdiContentSaveOutline}></ha-svg-icon>
                         Save
                     </md-outlined-button>
-                    <md-outlined-icon-button title="Cancel" @click=${() => this.#cancelAddUser()}>
+                    <md-outlined-icon-button title="Cancel" aria-label="Cancel" @click=${() => this.#cancelAddUser()}>
                         <ha-svg-icon .path=${mdiClose}></ha-svg-icon>
                     </md-outlined-icon-button>
                 </div>
@@ -1072,6 +1083,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                 <span class="slot-actions">
                     <md-outlined-icon-button
                         title=${schedule === null ? "Set schedule" : "Edit schedule"}
+                        aria-label=${schedule === null ? "Set schedule" : "Edit schedule"}
                         ?disabled=${this._busy}
                         @click=${() => {
                             this._editorError = undefined;
@@ -1097,6 +1109,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                             ? nothing
                             : html`<md-outlined-icon-button
                                   title="Clear schedule"
+                                  aria-label="Clear schedule"
                                   ?disabled=${this._busy}
                                   @click=${handleAsync(() => this.#clearWeekDay(slot.weekDayIndex))}
                               >
@@ -1217,6 +1230,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                 <span class="slot-actions">
                     <md-outlined-icon-button
                         title=${schedule === null ? "Set schedule" : "Edit schedule"}
+                        aria-label=${schedule === null ? "Set schedule" : "Edit schedule"}
                         ?disabled=${this._busy}
                         @click=${() => {
                             this._editorError = undefined;
@@ -1236,6 +1250,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                             ? nothing
                             : html`<md-outlined-icon-button
                                   title="Clear schedule"
+                                  aria-label="Clear schedule"
                                   ?disabled=${this._busy}
                                   @click=${handleAsync(() => this.#clearYearDay(slot.yearDayIndex))}
                               >
@@ -1342,6 +1357,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                 <span class="slot-actions">
                     <md-outlined-icon-button
                         title=${schedule === null ? "Set schedule" : "Edit schedule"}
+                        aria-label=${schedule === null ? "Set schedule" : "Edit schedule"}
                         ?disabled=${busy}
                         @click=${() => {
                             this._editorError = undefined;
@@ -1362,6 +1378,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                             ? nothing
                             : html`<md-outlined-icon-button
                                   title="Clear schedule"
+                                  aria-label="Clear schedule"
                                   ?disabled=${busy}
                                   @click=${handleAsync(() => this.#clearHoliday(slot.holidayIndex))}
                               >
@@ -1426,6 +1443,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             </md-outlined-button>
             <md-outlined-icon-button
                 title="Cancel"
+                aria-label="Cancel"
                 @click=${() => {
                     this._editor = null;
                     this._editorError = undefined;

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -822,8 +822,8 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                                     }
                                 `
                               : html`<p class="empty">
-                                    Schedules are assigned per user, which this lock does not expose: it reports no
-                                    User (USR) feature, so its user database cannot be read.
+                                    Schedules are assigned per user, which this lock does not expose: it reports no User
+                                    (USR) feature, so its user database cannot be read.
                                 </p>`
                     }
                     ${holidayActive ? this.#renderHolidaySection() : nothing}
@@ -959,7 +959,11 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     }
 
     /** Toggle for the slot list's collapsed empty slots; hidden when there's nothing meaningful to collapse. */
-    #renderEmptySlotsToggle(emptyTotal: number, expanded: boolean, toggle: () => void): TemplateResult | typeof nothing {
+    #renderEmptySlotsToggle(
+        emptyTotal: number,
+        expanded: boolean,
+        toggle: () => void,
+    ): TemplateResult | typeof nothing {
         if (emptyTotal <= 1) return nothing;
         const hiddenCount = expanded ? 0 : emptyTotal - 1;
         return html`<button class="slot-list-toggle" @click=${toggle}>
@@ -1308,8 +1312,8 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                               })}
                               <p class="hint">
                                   <ha-svg-icon .path=${mdiCalendarRange}></ha-svg-icon>
-                                  Applies to the whole lock, not a single user. Date ranges are local time at the
-                                  lock, shown here in this browser's time zone.
+                                  Applies to the whole lock, not a single user. Date ranges are local time at the lock,
+                                  shown here in this browser's time zone.
                               </p>
                           `
                 }

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -23,7 +23,7 @@ import {
     mdiRefresh,
     mdiTrashCanOutline,
 } from "@mdi/js";
-import { css, html, nothing, type CSSResultGroup, type TemplateResult } from "lit";
+import { css, html, nothing, type CSSResultGroup, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { live } from "lit/directives/live.js";
 import { showAlertDialog, showPromptDialog } from "../../../components/dialog-box/show-dialog-box.js";
@@ -40,21 +40,25 @@ import {
     DOOR_LOCK_CLUSTER_ID,
     formatDaysMask,
     formatDoorState,
-    formatLocalDateTime,
+    formatScheduleStatus,
     formatLockState,
     formatLockType,
     formatOperatingMode,
+    formatWallClock,
+    defaultHolidayMode,
+    holidayModeChoices,
     formatTimeOfDay,
     formatUserLabel,
     formatUserStatus,
     formatUserType,
     fromDateTimeInputValue,
     holidayScheduleRangeError,
+    isEmptyScheduleStatus,
     isFeatureActive,
     lockDoor,
     maskHasDay,
     nextFreeUserIndex,
-    OPERATING_MODES,
+    nowAsWallClock,
     parseTimeOfDay,
     readActuatorEnabled,
     readDoorState,
@@ -72,12 +76,15 @@ import {
     readYearDaySchedulesPerUser,
     requiresPinForRemoteOperation,
     SCHEDULE_INDEX_ALL,
+    supportedOperatingModes,
     supportsCommand,
     toDateTimeInputValue,
     toggleMaskDay,
     UNLOCK_WITH_TIMEOUT_COMMAND_ID,
     unlockDoor,
     unlockWithTimeout,
+    userNameLengthError,
+    USER_NAME_MAX_LENGTH,
     weekDayScheduleRangeError,
     writeHolidaySchedule,
     writeWeekDaySchedule,
@@ -88,7 +95,7 @@ import {
     type WeekDayScheduleSlot,
     type YearDayScheduleSlot,
 } from "../../../util/door-lock.js";
-import { getMatterStatusName } from "../../../util/matter-status.js";
+import { errorText } from "../../../util/error-text.js";
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
 
@@ -98,11 +105,12 @@ const DEFAULT_UNLOCK_TIMEOUT_SECONDS = 60;
 const DEFAULT_START_TIME = "08:00";
 const DEFAULT_END_TIME = "18:00";
 
+/** The window the uint32 epoch-s wire field can represent, as `<input type="datetime-local">` bounds. */
+const DATE_TIME_MIN = "2000-01-01T00:00:00";
+const DATE_TIME_MAX = "2136-02-07T06:28:15";
+
 /** Bounds the GetUser walk on a lock that leaves NumberOfTotalUsersSupported unreported. */
 const USER_SCAN_FALLBACK = 32;
-
-/** DlStatus the lock returns for a schedule slot that holds nothing. */
-const STATUS_NOT_FOUND = 139;
 
 interface WeekDayEditor {
     kind: "weekDay";
@@ -144,7 +152,10 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     @state() private _loadingUsers = false;
     @state() private _loadingSchedules = false;
     @state() private _loadingHoliday = false;
-    @state() private _loadError?: string;
+    @state() private _userLoadError?: string;
+    @state() private _scheduleLoadError?: string;
+    @state() private _holidayLoadError?: string;
+    @state() private _freeUserIndex: number | null = null;
     @state() private _editor: ScheduleEditor | null = null;
     @state() private _editorError?: string;
     @state() private _addingUser = false;
@@ -160,22 +171,31 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     #context?: string;
     #usersRequested = false;
     #holidayRequested = false;
-    /** Bumped whenever the panel's node, endpoint or selected user changes, so stale loads drop their results. */
-    #generation = 0;
     /**
-     * Bumped only on a node/endpoint context change (unlike #generation, not on a mere user re-selection): a
-     * lock/unlock or schedule command run against the old context must not clear `_busy` for a new one.
+     * One counter per loader, bumped by that loader when it starts and by a context change. A single
+     * shared counter would let an unrelated bump — picking a user, saving a schedule — strand a loader
+     * that had already returned as stale, leaving its spinner and disabled buttons up for good.
+     */
+    #usersGeneration = 0;
+    #schedulesGeneration = 0;
+    #holidayGeneration = 0;
+    /**
+     * Bumped only on a node/endpoint context change: a lock/unlock or schedule command run against the
+     * old context must not clear `_busy` for a new one.
      */
     #busyGeneration = 0;
+    #freeIndexCapacity: number | null = null;
 
-    override updated(changedProperties: Map<string, unknown>) {
-        super.updated(changedProperties);
+    override willUpdate(changedProperties: PropertyValues) {
+        super.willUpdate(changedProperties);
         if (!this.client || !this.node || this.cluster !== DOOR_LOCK_CLUSTER_ID) return;
 
         const context = `${String(this.node.node_id)}/${this.endpoint}`;
         if (this.#context !== context) {
             this.#context = context;
-            this.#generation++;
+            this.#usersGeneration++;
+            this.#schedulesGeneration++;
+            this.#holidayGeneration++;
             this.#busyGeneration++;
             this.#usersRequested = false;
             this.#holidayRequested = false;
@@ -187,7 +207,11 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             this._loadingUsers = false;
             this._loadingSchedules = false;
             this._loadingHoliday = false;
-            this._loadError = undefined;
+            this._userLoadError = undefined;
+            this._scheduleLoadError = undefined;
+            this._holidayLoadError = undefined;
+            this._freeUserIndex = null;
+            this.#freeIndexCapacity = null;
             this._editor = null;
             this._editorError = undefined;
             this._addingUser = false;
@@ -199,6 +223,14 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             this._busy = false;
             this._pinCode = "";
             this._unlockTimeout = String(DEFAULT_UNLOCK_TIMEOUT_SECONDS);
+        }
+
+        // NumberOfTotalUsersSupported can arrive after the user list has already been read against
+        // USER_SCAN_FALLBACK, which would leave "Add user" offering an index beyond the lock's capacity.
+        const userCapacity = readTotalUsersSupported(this.node, this.endpoint);
+        if (this._users !== undefined && userCapacity !== this.#freeIndexCapacity) {
+            this.#freeIndexCapacity = userCapacity;
+            this._freeUserIndex = nextFreeUserIndex(this._users, userCapacity ?? USER_SCAN_FALLBACK);
         }
 
         // The attribute cache fills in progressively: the feature bits can resolve before the numeric
@@ -266,39 +298,46 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         return isFeatureActive(this.node, this.endpoint, "HDSCH");
     }
 
-    #isCurrent(node: MatterNode, endpoint: number, generation: number): boolean {
-        return this.isSameContext(node, endpoint) && this.#generation === generation;
+    /** Whether a load started for `node`/`endpoint` at `generation` still owns its loader's counter. */
+    #isCurrent(node: MatterNode, endpoint: number, generation: number, current: number): boolean {
+        return this.isSameContext(node, endpoint) && generation === current;
     }
 
     async #loadUsers() {
         const node = this.node;
         const endpoint = this.endpoint;
-        const generation = this.#generation;
+        const generation = ++this.#usersGeneration;
+        const previousSelection = this._selectedUserIndex;
         this._loadingUsers = true;
-        this._loadError = undefined;
+        this._userLoadError = undefined;
         try {
-            const maxUsers = readTotalUsersSupported(node, endpoint) ?? USER_SCAN_FALLBACK;
+            const capacity = readTotalUsersSupported(node, endpoint);
+            const maxUsers = capacity ?? USER_SCAN_FALLBACK;
             const users = await readUsers(this.client, node.node_id, endpoint, maxUsers);
-            if (!this.#isCurrent(node, endpoint, generation)) return;
+            if (!this.#isCurrent(node, endpoint, generation, this.#usersGeneration)) return;
             this._users = users;
-            const firstUser = users[0]?.userIndex ?? null;
-            this._selectedUserIndex = firstUser;
-            if (firstUser !== null) {
-                await this.#loadSchedules(node, endpoint, generation, firstUser);
+            this.#freeIndexCapacity = capacity;
+            this._freeUserIndex = nextFreeUserIndex(users, maxUsers);
+            // A reload is not a selection change: stay on the user the operator was inspecting.
+            const selected = users.some(user => user.userIndex === previousSelection)
+                ? previousSelection
+                : (users[0]?.userIndex ?? null);
+            this._selectedUserIndex = selected;
+            if (selected !== null) {
+                await this.#loadSchedules(node, endpoint, selected);
             }
         } catch (error) {
-            if (!this.#isCurrent(node, endpoint, generation)) return;
-            this._loadError = errorText(error);
+            if (!this.#isCurrent(node, endpoint, generation, this.#usersGeneration)) return;
+            this._userLoadError = errorText(error);
         } finally {
-            // Generation-scoped: a newer load has already set the flag for itself, and every path that bumps
-            // the generation sets or clears it, so this cannot leave the panel wedged.
-            if (this.#generation === generation) this._loadingUsers = false;
+            if (this.#usersGeneration === generation) this._loadingUsers = false;
         }
     }
 
-    async #loadSchedules(node: MatterNode, endpoint: number, generation: number, userIndex: number) {
+    async #loadSchedules(node: MatterNode, endpoint: number, userIndex: number) {
+        const generation = ++this.#schedulesGeneration;
         this._loadingSchedules = true;
-        this._loadError = undefined;
+        this._scheduleLoadError = undefined;
         try {
             const weekDayCount = isFeatureActive(node, endpoint, "WDSCH")
                 ? (readWeekDaySchedulesPerUser(node, endpoint) ?? 0)
@@ -307,33 +346,36 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                 ? (readYearDaySchedulesPerUser(node, endpoint) ?? 0)
                 : 0;
 
+            // One round trip per slot, so the list is published as it fills rather than at the end.
+            this._weekDaySlots = [];
+            this._yearDaySlots = [];
+
             const weekDaySlots = new Array<WeekDayScheduleSlot>();
             for (let index = 1; index <= weekDayCount; index++) {
                 const slot = await readWeekDaySchedule(this.client, node.node_id, endpoint, index, userIndex);
-                if (!this.#isCurrent(node, endpoint, generation)) return;
+                if (!this.#isCurrent(node, endpoint, generation, this.#schedulesGeneration)) return;
                 weekDaySlots.push(slot);
+                this._weekDaySlots = [...weekDaySlots];
             }
 
             const yearDaySlots = new Array<YearDayScheduleSlot>();
             for (let index = 1; index <= yearDayCount; index++) {
                 const slot = await readYearDaySchedule(this.client, node.node_id, endpoint, index, userIndex);
-                if (!this.#isCurrent(node, endpoint, generation)) return;
+                if (!this.#isCurrent(node, endpoint, generation, this.#schedulesGeneration)) return;
                 yearDaySlots.push(slot);
+                this._yearDaySlots = [...yearDaySlots];
             }
-
-            this._weekDaySlots = weekDaySlots;
-            this._yearDaySlots = yearDaySlots;
 
             // Setting a schedule may move the user to ScheduleRestrictedUser, so the badges are re-read
             // alongside the slots they describe.
             const user = await readUser(this.client, node.node_id, endpoint, userIndex);
-            if (!this.#isCurrent(node, endpoint, generation) || user === null) return;
+            if (!this.#isCurrent(node, endpoint, generation, this.#schedulesGeneration) || user === null) return;
             this._users = this._users?.map(candidate => (candidate.userIndex === userIndex ? user : candidate));
         } catch (error) {
-            if (!this.#isCurrent(node, endpoint, generation)) return;
-            this._loadError = errorText(error);
+            if (!this.#isCurrent(node, endpoint, generation, this.#schedulesGeneration)) return;
+            this._scheduleLoadError = errorText(error);
         } finally {
-            if (this.#generation === generation) this._loadingSchedules = false;
+            if (this.#schedulesGeneration === generation) this._loadingSchedules = false;
         }
     }
 
@@ -341,69 +383,69 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     async #loadHolidaySchedules() {
         const node = this.node;
         const endpoint = this.endpoint;
-        const generation = this.#generation;
+        const generation = ++this.#holidayGeneration;
         this._loadingHoliday = true;
-        this._loadError = undefined;
+        this._holidayLoadError = undefined;
         try {
             const capacity = readHolidaySchedulesSupported(node, endpoint) ?? 0;
             const slots = new Array<HolidayScheduleSlot>();
+            this._holidaySlots = [];
             for (let index = 1; index <= capacity; index++) {
                 const slot = await readHolidaySchedule(this.client, node.node_id, endpoint, index);
-                if (!this.#isCurrent(node, endpoint, generation)) return;
+                if (!this.#isCurrent(node, endpoint, generation, this.#holidayGeneration)) return;
                 slots.push(slot);
+                this._holidaySlots = [...slots];
             }
-            this._holidaySlots = slots;
         } catch (error) {
-            if (!this.#isCurrent(node, endpoint, generation)) return;
-            this._loadError = errorText(error);
+            if (!this.#isCurrent(node, endpoint, generation, this.#holidayGeneration)) return;
+            this._holidayLoadError = errorText(error);
         } finally {
-            if (this.#generation === generation) this._loadingHoliday = false;
+            if (this.#holidayGeneration === generation) this._loadingHoliday = false;
         }
     }
 
     #selectUser(userIndex: number) {
         if (userIndex === this._selectedUserIndex) return;
-        this.#generation++;
         this._selectedUserIndex = userIndex;
         this._weekDaySlots = undefined;
         this._yearDaySlots = undefined;
+        this._showEmptyWeekDay = false;
+        this._showEmptyYearDay = false;
         this._editor = null;
         this._editorError = undefined;
-        this._loadError = undefined;
-        handleAsync(() => this.#loadSchedules(this.node, this.endpoint, this.#generation, userIndex))();
+        this._scheduleLoadError = undefined;
+        handleAsync(() => this.#loadSchedules(this.node, this.endpoint, userIndex))();
     }
 
     #reloadSchedules() {
         const userIndex = this._selectedUserIndex;
         if (userIndex === null) return;
-        this.#generation++;
-        handleAsync(() => this.#loadSchedules(this.node, this.endpoint, this.#generation, userIndex))();
+        handleAsync(() => this.#loadSchedules(this.node, this.endpoint, userIndex))();
     }
 
     async #runScheduleCommand(title: string, run: (node: MatterNode, endpoint: number) => Promise<void>) {
         const node = this.node;
         const endpoint = this.endpoint;
-        const generation = this.#generation;
+        const userIndex = this._selectedUserIndex;
         if (this._busy) return;
         const busyGeneration = this.#busyGeneration;
         this._busy = true;
         try {
             await run(node, endpoint);
-            if (!this.#isCurrent(node, endpoint, generation)) return;
+            if (!this.isSameContext(node, endpoint) || this._selectedUserIndex !== userIndex) return;
             this._editor = null;
             this._editorError = undefined;
             this.#reloadSchedules();
         } catch (error) {
             this.#reportFailure(title, error, node, endpoint);
         } finally {
-            // busyGeneration-scoped, not generation-scoped: a lock/endpoint switch must clear this for the
-            // new context, but merely picking a different user on the same lock must not let a second command
-            // start while this one is still in flight.
+            // busyGeneration-scoped, not schedule-generation-scoped: a lock/endpoint switch must clear this
+            // for the new context, but merely picking a different user on the same lock must not let a
+            // second command start while this one is still in flight.
             if (this.#busyGeneration === busyGeneration) this._busy = false;
         }
     }
 
-    /** Counterpart to #runScheduleCommand for the lock-wide holiday table: no user, so no generation bump needed. */
     async #runHolidayCommand(title: string, run: (node: MatterNode, endpoint: number) => Promise<void>) {
         const node = this.node;
         const endpoint = this.endpoint;
@@ -441,38 +483,42 @@ class DoorLockClusterCommands extends BaseClusterCommands {
 
     /**
      * Whether the lock supports a PIN sent in a remote Lock/Unlock/UnlockWithTimeout command at all: COTA
-     * gates that (spec §5.2.4), independently of whether PinCredential is otherwise supported.
+     * gates that (spec §5.2.4.7), independently of whether PinCredential is otherwise supported.
      */
     #pinFieldSupported(): boolean {
         return isFeatureActive(this.node, this.endpoint, "COTA") && isFeatureActive(this.node, this.endpoint, "PIN");
     }
 
     /**
-     * Blocks a command locally when the lock reports RequirePinForRemoteOperation and the PIN field is
-     * empty, instead of round-tripping a request the lock will reject anyway. Only when a PIN can actually
-     * be entered — #pinFieldSupported() gates the field itself, so this must agree or a lock requiring a PIN
-     * without COTA would show "PIN required" with nowhere to enter one.
+     * Why the lock will refuse this operation without ever being asked, or undefined when it can proceed.
+     * Synchronous so callers can claim `_busy` without an await in between, which would otherwise let a
+     * second click through the guard. Only reports a missing PIN where one can actually be entered —
+     * #pinFieldSupported() gates the field itself, so this must agree with it.
      */
-    async #missingRequiredPin(): Promise<boolean> {
-        if (!this.#pinFieldSupported()) return false;
-        if (this.#pinForCommand() !== undefined) return false;
-        if (!requiresPinForRemoteOperation(this.node, this.endpoint)) return false;
-        await showAlertDialog({ title: "PIN required", text: "This lock requires a PIN for remote operations." });
-        return true;
+    #missingRequiredPin(): string | undefined {
+        if (!this.#pinFieldSupported()) return undefined;
+        if (this.#pinForCommand() !== undefined) return undefined;
+        if (!requiresPinForRemoteOperation(this.node, this.endpoint)) return undefined;
+        return "This lock requires a PIN for remote operations.";
     }
 
     async #operateLock(action: "lock" | "unlock") {
         const node = this.node;
         const endpoint = this.endpoint;
+        const title = action === "lock" ? "Lock failed" : "Unlock failed";
         if (this._busy) return;
-        if (await this.#missingRequiredPin()) return;
+        const missingPin = this.#missingRequiredPin();
+        if (missingPin !== undefined) {
+            await showAlertDialog({ title: "PIN required", text: missingPin });
+            return;
+        }
         const busyGeneration = this.#busyGeneration;
         this._busy = true;
         try {
             const operate = action === "lock" ? lockDoor : unlockDoor;
             await operate(this.client, node.node_id, endpoint, this.#pinForCommand());
         } catch (error) {
-            this.#reportFailure(action === "lock" ? "Lock failed" : "Unlock failed", error, node, endpoint);
+            this.#reportFailure(title, error, node, endpoint);
         } finally {
             if (this.#busyGeneration === busyGeneration) this._busy = false;
         }
@@ -487,7 +533,11 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             await showAlertDialog({ title: "Unlock failed", text: "The timeout must be 1 to 65535 seconds." });
             return;
         }
-        if (await this.#missingRequiredPin()) return;
+        const missingPin = this.#missingRequiredPin();
+        if (missingPin !== undefined) {
+            await showAlertDialog({ title: "PIN required", text: missingPin });
+            return;
+        }
         const busyGeneration = this.#busyGeneration;
         this._busy = true;
         try {
@@ -582,16 +632,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     async #clearWeekDay(weekDayIndex: number) {
         const userIndex = this._selectedUserIndex;
         if (userIndex === null) return;
-        if (weekDayIndex === SCHEDULE_INDEX_ALL) {
-            // Captured before the confirmation dialog's await: userIndex must not survive a context or
-            // selection change made while the dialog was open — confirming would then clear the wrong
-            // user's (or the wrong lock's) schedules.
-            const node = this.node;
-            const endpoint = this.endpoint;
-            const generation = this.#generation;
-            if (!(await this.#confirmClearAll("week day"))) return;
-            if (!this.#isCurrent(node, endpoint, generation)) return;
-        }
+        if (weekDayIndex === SCHEDULE_INDEX_ALL && !(await this.#confirmClearAll("week day", userIndex))) return;
         await this.#runScheduleCommand("Clear week day schedule failed", (node, endpoint) =>
             clearWeekDaySchedule(this.client, node.node_id, endpoint, userIndex, weekDayIndex),
         );
@@ -600,25 +641,26 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     async #clearYearDay(yearDayIndex: number) {
         const userIndex = this._selectedUserIndex;
         if (userIndex === null) return;
-        if (yearDayIndex === SCHEDULE_INDEX_ALL) {
-            const node = this.node;
-            const endpoint = this.endpoint;
-            const generation = this.#generation;
-            if (!(await this.#confirmClearAll("year day"))) return;
-            if (!this.#isCurrent(node, endpoint, generation)) return;
-        }
+        if (yearDayIndex === SCHEDULE_INDEX_ALL && !(await this.#confirmClearAll("year day", userIndex))) return;
         await this.#runScheduleCommand("Clear year day schedule failed", (node, endpoint) =>
             clearYearDaySchedule(this.client, node.node_id, endpoint, userIndex, yearDayIndex),
         );
     }
 
-    #confirmClearAll(kind: string): Promise<boolean> {
-        const user = this._users?.find(candidate => candidate.userIndex === this._selectedUserIndex);
-        return showPromptDialog({
+    /**
+     * Confirms wiping `userIndex`'s whole table, and re-validates afterwards: the panel may have moved to
+     * another lock or another user while the dialog was open, and confirming must not act on that one.
+     */
+    async #confirmClearAll(kind: string, userIndex: number): Promise<boolean> {
+        const node = this.node;
+        const endpoint = this.endpoint;
+        const user = this._users?.find(candidate => candidate.userIndex === userIndex);
+        const confirmed = await showPromptDialog({
             title: `Clear all ${kind} schedules`,
             text: `Every ${kind} schedule of ${user ? formatUserLabel(user) : "this user"} will be removed from the lock.`,
             confirmText: "Clear all",
         });
+        return confirmed && this.isSameContext(node, endpoint) && this._selectedUserIndex === userIndex;
     }
 
     async #clearHoliday(holidayIndex: number) {
@@ -655,14 +697,13 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     async #saveNewUser() {
         const node = this.node;
         const endpoint = this.endpoint;
-        const generation = this.#generation;
         const userName = this._newUserName.trim();
-        if (userName === "") {
-            this._userEditorError = "Enter a name for the user.";
+        const nameError = userNameLengthError(userName);
+        if (nameError !== null) {
+            this._userEditorError = nameError;
             return;
         }
-        const maxUsers = readTotalUsersSupported(node, endpoint) ?? USER_SCAN_FALLBACK;
-        const userIndex = nextFreeUserIndex(this._users ?? [], maxUsers);
+        const userIndex = this._freeUserIndex;
         if (userIndex === null) {
             this._userEditorError = "The lock's user database is full.";
             return;
@@ -672,14 +713,18 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         this._busy = true;
         try {
             await addUser(this.client, node.node_id, endpoint, userIndex, userName);
-            if (!this.#isCurrent(node, endpoint, generation)) return;
+            if (!this.isSameContext(node, endpoint)) return;
             this._addingUser = false;
             this._newUserName = "";
             this._userEditorError = undefined;
             this.#usersRequested = true;
+            // Reload preserves the current selection, so point it at the user that was just created.
+            this._selectedUserIndex = userIndex;
+            this._weekDaySlots = undefined;
+            this._yearDaySlots = undefined;
             await this.#loadUsers();
         } catch (error) {
-            if (!this.#isCurrent(node, endpoint, generation)) return;
+            if (!this.isSameContext(node, endpoint)) return;
             this._userEditorError = errorText(error);
         } finally {
             if (this.#busyGeneration === busyGeneration) this._busy = false;
@@ -822,7 +867,12 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     <span class="feature-map-badge">FeatureMap: ${features.join(" · ")}</span>
                 </summary>
                 <div class="command-content">
-                    ${this._loadError !== undefined ? html`<p class="error">${this._loadError}</p>` : nothing}
+                    ${this._userLoadError !== undefined ? html`<p class="error">${this._userLoadError}</p>` : nothing}
+                    ${
+                        this._scheduleLoadError !== undefined
+                            ? html`<p class="error">${this._scheduleLoadError}</p>`
+                            : nothing
+                    }
                     ${
                         !perUserActive
                             ? nothing
@@ -859,8 +909,10 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         }
 
         const busy = this._busy || this._loadingUsers || this._loadingSchedules;
-        const maxUsers = readTotalUsersSupported(this.node, this.endpoint) ?? USER_SCAN_FALLBACK;
-        const canAddUser = users !== undefined && nextFreeUserIndex(users, maxUsers) !== null;
+        // Guessing an index the lock would reject is worse than not offering to add: SetUser constrains
+        // UserIndex to NumberOfTotalUsersSupported, and USER_SCAN_FALLBACK only bounds the read walk.
+        const capacityKnown = readTotalUsersSupported(this.node, this.endpoint) !== null;
+        const canAddUser = users !== undefined && capacityKnown && this._freeUserIndex !== null;
 
         return html`
             <div class="command-row">
@@ -901,6 +953,8 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     ?disabled=${busy}
                     @click=${() => {
                         this.#usersRequested = true;
+                        this._editor = null;
+                        this._editorError = undefined;
                         handleAsync(() => this.#loadUsers())();
                     }}
                 >
@@ -931,7 +985,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     <input
                         id="newUserName"
                         type="text"
-                        maxlength="32"
+                        maxlength=${USER_NAME_MAX_LENGTH}
                         .value=${live(this._newUserName)}
                         @input=${(event: Event) => {
                             this._newUserName = (event.target as HTMLInputElement).value;
@@ -963,13 +1017,14 @@ class DoorLockClusterCommands extends BaseClusterCommands {
 
     /**
      * Every occupied slot, plus (unless expanded) just the next empty one — so there is always a visible
-     * "+" to add a schedule without listing every empty slot up front.
+     * "+" to add a schedule without listing every empty slot up front. A slot the lock failed to report
+     * is never collapsed: it is not an offer to write, and hiding it would hide the failure.
      */
-    #visibleSlots<T extends { schedule: unknown }>(slots: T[], expanded: boolean): T[] {
+    #visibleSlots<T extends { schedule: unknown; status: number | null }>(slots: T[], expanded: boolean): T[] {
         if (expanded) return slots;
         let shownEmpty = false;
         return slots.filter(slot => {
-            if (slot.schedule !== null) return true;
+            if (slot.schedule !== null || !isEmptySlot(slot)) return true;
             if (shownEmpty) return false;
             shownEmpty = true;
             return true;
@@ -994,16 +1049,21 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         const capacity = readWeekDaySchedulesPerUser(this.node, this.endpoint) ?? 0;
         const used = slots?.filter(slot => slot.schedule !== null).length ?? 0;
         const expanded = this._showEmptyWeekDay;
+        const loading = this._loadingSchedules;
+        // Rows left over from the previous load stay on screen while the next one runs, and a failed walk
+        // leaves a partial list: acting on either would address an index the panel has not read.
+        const incomplete = loading || this._scheduleLoadError !== undefined;
+        const busy = this._busy || incomplete;
 
         return html`
             <div class="section">
                 <div class="section-header">
-                    <span>WEEK DAY SCHEDULES · ${used}/${capacity} slots</span>
+                    <span>WEEK DAY SCHEDULES · ${this.#slotCountLabel(slots, used, capacity, loading)}</span>
                     ${
                         used > 0
                             ? html`<button
                                   class="link-action"
-                                  ?disabled=${this._busy}
+                                  ?disabled=${busy}
                                   @click=${handleAsync(() => this.#clearWeekDay(SCHEDULE_INDEX_ALL))}
                               >
                                   Clear all
@@ -1012,14 +1072,16 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     }
                 </div>
                 ${
-                    slots === undefined
+                    slots === undefined || capacity === 0
                         ? this.#renderSlotsPlaceholder(capacity)
                         : html`
                               ${used > 0 ? this.#renderWeekTimeline(slots) : nothing}
                               <ul class="slot-list">
-                                  ${this.#visibleSlots(slots, expanded).map(slot => this.#renderWeekDaySlot(slot))}
+                                  ${this.#visibleSlots(slots, expanded).map(slot =>
+                                      this.#renderWeekDaySlot(slot, busy),
+                                  )}
                               </ul>
-                              ${this.#renderEmptySlotsToggle(slots.length - used, expanded, () => {
+                              ${this.#renderEmptySlotsToggle(countEmptySlots(slots), expanded, () => {
                                   this._showEmptyWeekDay = !expanded;
                               })}
                           `
@@ -1065,7 +1127,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         `;
     }
 
-    #renderWeekDaySlot(slot: WeekDayScheduleSlot): TemplateResult {
+    #renderWeekDaySlot(slot: WeekDayScheduleSlot, busy: boolean): TemplateResult {
         const editor = this._editor;
         if (editor?.kind === "weekDay" && editor.index === slot.weekDayIndex) {
             return html`<li class="slot-row editing">${this.#renderWeekDayEditor(editor)}</li>`;
@@ -1076,7 +1138,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                 <span class="slot-index">#${slot.weekDayIndex}</span>
                 ${
                     schedule === null
-                        ? html`<span class="slot-empty">${slotStatusLabel(slot.status)}</span>`
+                        ? html`<span class="slot-empty">${formatScheduleStatus(slot.status)}</span>`
                         : html`
                               <span class="slot-days">${formatDaysMask(schedule.daysMask)}</span>
                               <span class="slot-window">
@@ -1091,7 +1153,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     <md-outlined-icon-button
                         title=${schedule === null ? "Set schedule" : "Edit schedule"}
                         aria-label=${schedule === null ? "Set schedule" : "Edit schedule"}
-                        ?disabled=${this._busy}
+                        ?disabled=${busy}
                         @click=${() => {
                             this._editorError = undefined;
                             this._editor = {
@@ -1117,7 +1179,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                             : html`<md-outlined-icon-button
                                   title="Clear schedule"
                                   aria-label="Clear schedule"
-                                  ?disabled=${this._busy}
+                                  ?disabled=${busy}
                                   @click=${handleAsync(() => this.#clearWeekDay(slot.weekDayIndex))}
                               >
                                   <ha-svg-icon .path=${mdiTrashCanOutline}></ha-svg-icon>
@@ -1154,7 +1216,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     <input
                         id="weekDayStart"
                         type="time"
-                        .value=${live(editor.start)}
+                        .value=${editor.start}
                         @input=${(event: Event) => {
                             this._editor = { ...editor, start: (event.target as HTMLInputElement).value };
                         }}
@@ -1163,7 +1225,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     <input
                         id="weekDayEnd"
                         type="time"
-                        .value=${live(editor.end)}
+                        .value=${editor.end}
                         @input=${(event: Event) => {
                             this._editor = { ...editor, end: (event.target as HTMLInputElement).value };
                         }}
@@ -1180,16 +1242,19 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         const capacity = readYearDaySchedulesPerUser(this.node, this.endpoint) ?? 0;
         const used = slots?.filter(slot => slot.schedule !== null).length ?? 0;
         const expanded = this._showEmptyYearDay;
+        const loading = this._loadingSchedules;
+        const incomplete = loading || this._scheduleLoadError !== undefined;
+        const busy = this._busy || incomplete;
 
         return html`
             <div class="section">
                 <div class="section-header">
-                    <span>YEAR DAY SCHEDULES · ${used}/${capacity} slots</span>
+                    <span>YEAR DAY SCHEDULES · ${this.#slotCountLabel(slots, used, capacity, loading)}</span>
                     ${
                         used > 0
                             ? html`<button
                                   class="link-action"
-                                  ?disabled=${this._busy}
+                                  ?disabled=${busy}
                                   @click=${handleAsync(() => this.#clearYearDay(SCHEDULE_INDEX_ALL))}
                               >
                                   Clear all
@@ -1198,18 +1263,21 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     }
                 </div>
                 ${
-                    slots === undefined
+                    slots === undefined || capacity === 0
                         ? this.#renderSlotsPlaceholder(capacity)
                         : html`
                               <ul class="slot-list">
-                                  ${this.#visibleSlots(slots, expanded).map(slot => this.#renderYearDaySlot(slot))}
+                                  ${this.#visibleSlots(slots, expanded).map(slot =>
+                                      this.#renderYearDaySlot(slot, busy),
+                                  )}
                               </ul>
-                              ${this.#renderEmptySlotsToggle(slots.length - used, expanded, () => {
+                              ${this.#renderEmptySlotsToggle(countEmptySlots(slots), expanded, () => {
                                   this._showEmptyYearDay = !expanded;
                               })}
                               <p class="hint">
                                   <ha-svg-icon .path=${mdiCalendarRange}></ha-svg-icon>
-                                  Date ranges are local time at the lock, shown here in this browser's time zone.
+                                  Date ranges are the lock's own local time, shown here unchanged rather than converted
+                                  into this browser's time zone.
                               </p>
                           `
                 }
@@ -1217,7 +1285,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         `;
     }
 
-    #renderYearDaySlot(slot: YearDayScheduleSlot): TemplateResult {
+    #renderYearDaySlot(slot: YearDayScheduleSlot, busy: boolean): TemplateResult {
         const editor = this._editor;
         if (editor?.kind === "yearDay" && editor.index === slot.yearDayIndex) {
             return html`<li class="slot-row editing">${this.#renderYearDayEditor(editor)}</li>`;
@@ -1228,20 +1296,19 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                 <span class="slot-index">#${slot.yearDayIndex}</span>
                 ${
                     schedule === null
-                        ? html`<span class="slot-empty">${slotStatusLabel(slot.status)}</span>`
+                        ? html`<span class="slot-empty">${formatScheduleStatus(slot.status)}</span>`
                         : html`<span class="slot-window wide">
-                              ${formatLocalDateTime(schedule.localStartTime)} →
-                              ${formatLocalDateTime(schedule.localEndTime)}
+                              ${formatWallClock(schedule.localStartTime)} → ${formatWallClock(schedule.localEndTime)}
                           </span>`
                 }
                 <span class="slot-actions">
                     <md-outlined-icon-button
                         title=${schedule === null ? "Set schedule" : "Edit schedule"}
                         aria-label=${schedule === null ? "Set schedule" : "Edit schedule"}
-                        ?disabled=${this._busy}
+                        ?disabled=${busy}
                         @click=${() => {
                             this._editorError = undefined;
-                            const now = Math.floor(Date.now() / 1000);
+                            const now = nowAsWallClock();
                             this._editor = {
                                 kind: "yearDay",
                                 index: slot.yearDayIndex,
@@ -1258,7 +1325,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                             : html`<md-outlined-icon-button
                                   title="Clear schedule"
                                   aria-label="Clear schedule"
-                                  ?disabled=${this._busy}
+                                  ?disabled=${busy}
                                   @click=${handleAsync(() => this.#clearYearDay(slot.yearDayIndex))}
                               >
                                   <ha-svg-icon .path=${mdiTrashCanOutline}></ha-svg-icon>
@@ -1278,7 +1345,10 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     <input
                         id="yearDayStart"
                         type="datetime-local"
-                        .value=${live(editor.start)}
+                        step="1"
+                        min=${DATE_TIME_MIN}
+                        max=${DATE_TIME_MAX}
+                        .value=${editor.start}
                         @input=${(event: Event) => {
                             this._editor = { ...editor, start: (event.target as HTMLInputElement).value };
                         }}
@@ -1287,7 +1357,10 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     <input
                         id="yearDayEnd"
                         type="datetime-local"
-                        .value=${live(editor.end)}
+                        step="1"
+                        min=${DATE_TIME_MIN}
+                        max=${DATE_TIME_MAX}
+                        .value=${editor.end}
                         @input=${(event: Event) => {
                             this._editor = { ...editor, end: (event.target as HTMLInputElement).value };
                         }}
@@ -1303,13 +1376,15 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         const slots = this._holidaySlots;
         const capacity = readHolidaySchedulesSupported(this.node, this.endpoint) ?? 0;
         const used = slots?.filter(slot => slot.schedule !== null).length ?? 0;
-        const busy = this._busy || this._loadingHoliday;
+        const loading = this._loadingHoliday;
+        const incomplete = loading || this._holidayLoadError !== undefined;
+        const busy = this._busy || incomplete;
         const expanded = this._showEmptyHoliday;
 
         return html`
             <div class="section">
                 <div class="section-header">
-                    <span>HOLIDAY SCHEDULES · ${used}/${capacity} slots</span>
+                    <span>HOLIDAY SCHEDULES · ${this.#slotCountLabel(slots, used, capacity, loading)}</span>
                     ${
                         used > 0
                             ? html`<button
@@ -1322,20 +1397,21 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                             : nothing
                     }
                 </div>
+                ${this._holidayLoadError !== undefined ? html`<p class="error">${this._holidayLoadError}</p>` : nothing}
                 ${
-                    slots === undefined
+                    slots === undefined || capacity === 0
                         ? this.#renderSlotsPlaceholder(capacity)
                         : html`
                               <ul class="slot-list">
                                   ${this.#visibleSlots(slots, expanded).map(slot => this.#renderHolidaySlot(slot, busy))}
                               </ul>
-                              ${this.#renderEmptySlotsToggle(slots.length - used, expanded, () => {
+                              ${this.#renderEmptySlotsToggle(countEmptySlots(slots), expanded, () => {
                                   this._showEmptyHoliday = !expanded;
                               })}
                               <p class="hint">
                                   <ha-svg-icon .path=${mdiCalendarRange}></ha-svg-icon>
-                                  Applies to the whole lock, not a single user. Date ranges are local time at the lock,
-                                  shown here in this browser's time zone.
+                                  Applies to the whole lock, not a single user. Date ranges are the lock's own local
+                                  time, shown here unchanged rather than converted into this browser's time zone.
                               </p>
                           `
                 }
@@ -1354,10 +1430,9 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                 <span class="slot-index">#${slot.holidayIndex}</span>
                 ${
                     schedule === null
-                        ? html`<span class="slot-empty">${slotStatusLabel(slot.status)}</span>`
+                        ? html`<span class="slot-empty">${formatScheduleStatus(slot.status)}</span>`
                         : html`<span class="slot-window wide">
-                              ${formatLocalDateTime(schedule.localStartTime)} →
-                              ${formatLocalDateTime(schedule.localEndTime)} ·
+                              ${formatWallClock(schedule.localStartTime)} → ${formatWallClock(schedule.localEndTime)} ·
                               ${formatOperatingMode(schedule.operatingMode)}
                           </span>`
                 }
@@ -1368,13 +1443,15 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                         ?disabled=${busy}
                         @click=${() => {
                             this._editorError = undefined;
-                            const now = Math.floor(Date.now() / 1000);
+                            const now = nowAsWallClock();
                             this._editor = {
                                 kind: "holiday",
                                 index: slot.holidayIndex,
                                 start: toDateTimeInputValue(schedule?.localStartTime ?? now),
                                 end: toDateTimeInputValue(schedule?.localEndTime ?? now + 86400),
-                                operatingMode: schedule?.operatingMode ?? OPERATING_MODES[1],
+                                operatingMode:
+                                    schedule?.operatingMode ??
+                                    defaultHolidayMode(supportedOperatingModes(this.node, this.endpoint)),
                             };
                         }}
                     >
@@ -1406,7 +1483,10 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     <input
                         id="holidayStart"
                         type="datetime-local"
-                        .value=${live(editor.start)}
+                        step="1"
+                        min=${DATE_TIME_MIN}
+                        max=${DATE_TIME_MAX}
+                        .value=${editor.start}
                         @input=${(event: Event) => {
                             this._editor = { ...editor, start: (event.target as HTMLInputElement).value };
                         }}
@@ -1415,7 +1495,10 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     <input
                         id="holidayEnd"
                         type="datetime-local"
-                        .value=${live(editor.end)}
+                        step="1"
+                        min=${DATE_TIME_MIN}
+                        max=${DATE_TIME_MAX}
+                        .value=${editor.end}
                         @input=${(event: Event) => {
                             this._editor = { ...editor, end: (event.target as HTMLInputElement).value };
                         }}
@@ -1423,7 +1506,6 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     <label for="holidayMode">Mode:</label>
                     <select
                         id="holidayMode"
-                        .value=${live(String(editor.operatingMode))}
                         @change=${(event: Event) => {
                             this._editor = {
                                 ...editor,
@@ -1431,8 +1513,13 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                             };
                         }}
                     >
-                        ${OPERATING_MODES.map(
-                            mode => html`<option value=${mode}>${formatOperatingMode(mode)}</option>`,
+                        ${holidayModeChoices(
+                            supportedOperatingModes(this.node, this.endpoint),
+                            editor.operatingMode,
+                        ).map(
+                            mode => html`<option value=${mode} .selected=${mode === editor.operatingMode}>
+                                ${formatOperatingMode(mode)}
+                            </option>`,
                         )}
                     </select>
                     ${this.#renderEditorActions()}
@@ -1461,7 +1548,13 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         `;
     }
 
-    /** Shared by the WeekDay/YearDay (per-user) and Holiday (lock-wide) sections, so this stays generic. */
+    #slotCountLabel(slots: { length: number } | undefined, used: number, capacity: number, loading: boolean): string {
+        if (loading && slots !== undefined && slots.length < capacity) {
+            return `reading ${slots.length + 1} of ${capacity}…`;
+        }
+        return `${used}/${capacity} slots`;
+    }
+
     #renderSlotsPlaceholder(capacity: number): TemplateResult {
         if (capacity === 0) return html`<p class="empty">The lock reports no schedule slots.</p>`;
         return html`<div class="loading">
@@ -1793,12 +1886,12 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     ];
 }
 
-function errorText(error: unknown): string {
-    return error instanceof Error ? error.message : String(error);
+function isEmptySlot(slot: { schedule: unknown; status: number | null }): boolean {
+    return slot.schedule === null && isEmptyScheduleStatus(slot.status);
 }
 
-function slotStatusLabel(status: number): string {
-    return status === 0 || status === STATUS_NOT_FOUND ? "Empty" : getMatterStatusName(status);
+function countEmptySlots(slots: { schedule: unknown; status: number | null }[]): number {
+    return slots.filter(isEmptySlot).length;
 }
 
 registerClusterCommands(DOOR_LOCK_CLUSTER_ID, "door-lock-cluster-commands");

--- a/packages/dashboard/src/pages/cluster-commands/clusters/icd-management-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/icd-management-commands.ts
@@ -20,6 +20,7 @@ import { customElement, state } from "lit/decorators.js";
 import { showAlertDialog, showPromptDialog } from "../../../components/dialog-box/show-dialog-box.js";
 import { handleAsync } from "../../../util/async-handler.js";
 import { formatDuration } from "../../../util/duration.js";
+import { errorText } from "../../../util/error-text.js";
 import {
     decodeRegisteredClients,
     ICD_CLUSTER_ID,
@@ -489,7 +490,7 @@ export class IcdManagementClusterCommands extends BaseClusterCommands {
         try {
             await action();
         } catch (error) {
-            const message = error instanceof Error ? error.message : String(error);
+            const message = errorText(error);
             if (this.isSameContext(node, endpoint)) {
                 await showAlertDialog({ title: "ICD operation failed", text: message });
             }

--- a/packages/dashboard/src/pages/cluster-commands/index.ts
+++ b/packages/dashboard/src/pages/cluster-commands/index.ts
@@ -29,6 +29,7 @@ import "./clusters/binding-commands.js";
 import "./clusters/chime-commands.js";
 import "./clusters/closure-control-commands.js";
 import "./clusters/commodity-tariff-commands.js";
+import "./clusters/door-lock-commands.js";
 import "./clusters/icd-management-commands.js";
 import "./clusters/level-control-commands.js";
 import "./clusters/meter-identification-commands.js";

--- a/packages/dashboard/src/util/door-lock.ts
+++ b/packages/dashboard/src/util/door-lock.ts
@@ -1,0 +1,535 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MatterClient, MatterNode } from "@matter-server/ws-client";
+import { clusters } from "../client/models/descriptions.js";
+import { asObject, pickNumber, pickString } from "./attribute-shapes.js";
+import { computeActiveClusterFeatures } from "./cluster-features.js";
+
+/** Door Lock cluster (Matter spec §5.2). */
+export const DOOR_LOCK_CLUSTER_ID = 257; // 0x0101
+
+const ATTR_LOCK_STATE = 0x00;
+const ATTR_LOCK_TYPE = 0x01;
+const ATTR_ACTUATOR_ENABLED = 0x02;
+const ATTR_DOOR_STATE = 0x03;
+const ATTR_NUMBER_OF_TOTAL_USERS_SUPPORTED = 0x11;
+const ATTR_NUMBER_OF_WEEK_DAY_SCHEDULES_SUPPORTED_PER_USER = 0x14;
+const ATTR_NUMBER_OF_YEAR_DAY_SCHEDULES_SUPPORTED_PER_USER = 0x15;
+const ATTR_REQUIRE_PIN_FOR_REMOTE_OPERATION = 0x33;
+const ATTR_ACCEPTED_COMMAND_LIST = 0xfff9;
+const ATTR_FEATURE_MAP = 0xfffc;
+
+/** UnlockWithTimeout is optional even on locks that support unlocking (spec §5.2.10.4). */
+export const UNLOCK_WITH_TIMEOUT_COMMAND_ID = 0x03;
+
+/** ClearWeekDaySchedule and ClearYearDaySchedule wipe every slot of a user when addressed with this index. */
+export const SCHEDULE_INDEX_ALL = 0xfe;
+
+/** UserStatusEnum.Available — a slot the lock reports as free (spec §5.2.6.14). */
+const USER_STATUS_AVAILABLE = 0;
+
+/** Days in display order (Mon..Sun) mapped to their DaysMaskBitmap bit (Sunday=0 .. Saturday=6). */
+export const DAY_BITS = [1, 2, 3, 4, 5, 6, 0];
+export const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+const WEEKDAYS_MASK = 0b0111110;
+const WEEKEND_MASK = 0b1000001;
+const ALL_DAYS_MASK = 0b1111111;
+
+const LOCK_STATE_LABELS: Record<number, string> = {
+    0: "Not Fully Locked",
+    1: "Locked",
+    2: "Unlocked",
+    3: "Unlatched",
+};
+
+const LOCK_TYPE_LABELS: Record<number, string> = {
+    0: "Dead Bolt",
+    1: "Magnetic",
+    2: "Other",
+    3: "Mortise",
+    4: "Rim",
+    5: "Latch Bolt",
+    6: "Cylindrical Lock",
+    7: "Tubular Lock",
+    8: "Interconnected Lock",
+    9: "Dead Latch",
+    10: "Door Furniture",
+    11: "Eurocylinder",
+};
+
+const DOOR_STATE_LABELS: Record<number, string> = {
+    0: "Open",
+    1: "Closed",
+    2: "Jammed",
+    3: "Forced Open",
+    4: "Unspecified Error",
+    5: "Ajar",
+};
+
+const USER_STATUS_LABELS: Record<number, string> = {
+    0: "Available",
+    1: "Enabled",
+    3: "Disabled",
+};
+
+const USER_TYPE_LABELS: Record<number, string> = {
+    0: "Unrestricted",
+    1: "Year Day Schedule",
+    2: "Week Day Schedule",
+    3: "Programming",
+    4: "No Access",
+    5: "Forced",
+    6: "Disposable",
+    7: "Expiring",
+    8: "Schedule Restricted",
+    9: "Remote Only",
+};
+
+/** A Week Day schedule slot holding a window, as reported by GetWeekDayScheduleResponse. */
+export interface WeekDaySchedule {
+    weekDayIndex: number;
+    daysMask: number;
+    startHour: number;
+    startMinute: number;
+    endHour: number;
+    endMinute: number;
+}
+
+/** One of a user's schedule slots: `schedule` is null when the lock reported a non-success status. */
+export interface WeekDayScheduleSlot {
+    weekDayIndex: number;
+    status: number;
+    schedule: WeekDaySchedule | null;
+}
+
+/**
+ * A Year Day schedule slot holding a fixed date range. Both bounds are Unix seconds: the cluster carries
+ * them as epoch-s, which the server converts in both directions, and they mean local time at the lock.
+ */
+export interface YearDaySchedule {
+    yearDayIndex: number;
+    localStartTime: number;
+    localEndTime: number;
+}
+
+export interface YearDayScheduleSlot {
+    yearDayIndex: number;
+    status: number;
+    schedule: YearDaySchedule | null;
+}
+
+export interface DoorLockUser {
+    userIndex: number;
+    userName: string | null;
+    userStatus: number | null;
+    userType: number | null;
+    nextUserIndex: number | null;
+    occupied: boolean;
+}
+
+/** A schedule window projected onto one display day, in minutes from midnight. */
+export interface DayScheduleSegment {
+    weekDayIndex: number;
+    startMin: number;
+    endMin: number;
+}
+
+function readAttr(node: MatterNode, endpoint: number, attrId: number): unknown {
+    return node.attributes[`${endpoint}/${DOOR_LOCK_CLUSTER_ID}/${attrId}`];
+}
+
+function readNumberAttr(node: MatterNode, endpoint: number, attrId: number): number | null {
+    const value = readAttr(node, endpoint, attrId);
+    return typeof value === "number" ? value : null;
+}
+
+/** Whether the Door Lock cluster's FeatureMap includes the feature with the given code (e.g. "WDSCH", "USR"). */
+export function isFeatureActive(node: MatterNode, endpoint: number, code: string): boolean {
+    const knownFeatures = Object.values(clusters[DOOR_LOCK_CLUSTER_ID]?.features ?? {});
+    const featureMapValue = readAttr(node, endpoint, ATTR_FEATURE_MAP);
+    if (featureMapValue === undefined) return false;
+    return computeActiveClusterFeatures(featureMapValue, knownFeatures).some(feature => feature.code === code);
+}
+
+export function supportsCommand(node: MatterNode, endpoint: number, commandId: number): boolean {
+    const accepted = readAttr(node, endpoint, ATTR_ACCEPTED_COMMAND_LIST);
+    return Array.isArray(accepted) && accepted.map(value => Number(value)).includes(commandId);
+}
+
+export function readLockState(node: MatterNode, endpoint: number): number | null {
+    return readNumberAttr(node, endpoint, ATTR_LOCK_STATE);
+}
+
+export function readLockType(node: MatterNode, endpoint: number): number | null {
+    return readNumberAttr(node, endpoint, ATTR_LOCK_TYPE);
+}
+
+export function readDoorState(node: MatterNode, endpoint: number): number | null {
+    return readNumberAttr(node, endpoint, ATTR_DOOR_STATE);
+}
+
+export function readActuatorEnabled(node: MatterNode, endpoint: number): boolean | null {
+    const value = readAttr(node, endpoint, ATTR_ACTUATOR_ENABLED);
+    return typeof value === "boolean" ? value : null;
+}
+
+export function readTotalUsersSupported(node: MatterNode, endpoint: number): number | null {
+    return readNumberAttr(node, endpoint, ATTR_NUMBER_OF_TOTAL_USERS_SUPPORTED);
+}
+
+export function readWeekDaySchedulesPerUser(node: MatterNode, endpoint: number): number | null {
+    return readNumberAttr(node, endpoint, ATTR_NUMBER_OF_WEEK_DAY_SCHEDULES_SUPPORTED_PER_USER);
+}
+
+export function readYearDaySchedulesPerUser(node: MatterNode, endpoint: number): number | null {
+    return readNumberAttr(node, endpoint, ATTR_NUMBER_OF_YEAR_DAY_SCHEDULES_SUPPORTED_PER_USER);
+}
+
+export function requiresPinForRemoteOperation(node: MatterNode, endpoint: number): boolean {
+    return readAttr(node, endpoint, ATTR_REQUIRE_PIN_FOR_REMOTE_OPERATION) === true;
+}
+
+export function formatLockState(state: number | null): string {
+    if (state === null) return "Unknown";
+    return LOCK_STATE_LABELS[state] ?? `State ${state}`;
+}
+
+export function formatLockType(type: number | null): string | null {
+    if (type === null) return null;
+    return LOCK_TYPE_LABELS[type] ?? `Type ${type}`;
+}
+
+export function formatDoorState(state: number | null): string | null {
+    if (state === null) return null;
+    return DOOR_STATE_LABELS[state] ?? `State ${state}`;
+}
+
+export function formatUserStatus(status: number | null): string | null {
+    if (status === null) return null;
+    return USER_STATUS_LABELS[status] ?? `Status ${status}`;
+}
+
+export function formatUserType(type: number | null): string | null {
+    if (type === null) return null;
+    return USER_TYPE_LABELS[type] ?? `Type ${type}`;
+}
+
+/** A user's display name: its own UserName when set, else its index. */
+export function formatUserLabel(user: DoorLockUser): string {
+    return user.userName ?? `User ${user.userIndex}`;
+}
+
+export function maskHasDay(mask: number, bit: number): boolean {
+    return (mask & (1 << bit)) !== 0;
+}
+
+export function toggleMaskDay(mask: number, bit: number): number {
+    return mask ^ (1 << bit);
+}
+
+export function formatDaysMask(mask: number): string {
+    const days = mask & ALL_DAYS_MASK;
+    if (days === 0) return "No day";
+    if (days === ALL_DAYS_MASK) return "Every day";
+    if (days === WEEKDAYS_MASK) return "Mon–Fri";
+    if (days === WEEKEND_MASK) return "Sat–Sun";
+    return DAY_LABELS.filter((_, index) => maskHasDay(days, DAY_BITS[index])).join(", ");
+}
+
+export function formatTimeOfDay(hour: number, minute: number): string {
+    return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}
+
+export function parseTimeOfDay(value: string): { hour: number; minute: number } | null {
+    const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim());
+    if (!match) return null;
+    const hour = Number(match[1]);
+    const minute = Number(match[2]);
+    if (hour > 23 || minute > 59) return null;
+    return { hour, minute };
+}
+
+/**
+ * Why the schedule cannot be set as entered, or null when it is valid.
+ * A window may not span midnight: the spec constrains EndHour/EndMinute to follow the start within the day.
+ */
+export function weekDayScheduleRangeError(schedule: Omit<WeekDaySchedule, "weekDayIndex">): string | null {
+    if ((schedule.daysMask & ALL_DAYS_MASK) === 0) return "Select at least one day.";
+    const start = schedule.startHour * 60 + schedule.startMinute;
+    const end = schedule.endHour * 60 + schedule.endMinute;
+    if (end <= start) return "The end time must be later than the start time on the same day.";
+    return null;
+}
+
+/** Why the date range cannot be set as entered, or null when it is valid. */
+export function yearDayScheduleRangeError(schedule: Omit<YearDaySchedule, "yearDayIndex">): string | null {
+    if (!Number.isFinite(schedule.localStartTime) || !Number.isFinite(schedule.localEndTime)) {
+        return "Enter both a start and an end date.";
+    }
+    if (schedule.localEndTime <= schedule.localStartTime) return "The end date must be later than the start date.";
+    return null;
+}
+
+/** Formats a Unix-seconds instant as a local date and time. */
+export function formatLocalDateTime(unixSeconds: number): string {
+    return new Date(unixSeconds * 1000).toLocaleString(undefined, {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+    });
+}
+
+/** Formats a Unix-seconds instant for an `<input type="datetime-local">`, whose value is local wall time. */
+export function toDateTimeInputValue(unixSeconds: number): string {
+    const date = new Date(unixSeconds * 1000);
+    const pad = (value: number) => String(value).padStart(2, "0");
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+/** Reads an `<input type="datetime-local">` value back as Unix seconds, or null when it is empty or invalid. */
+export function fromDateTimeInputValue(value: string): number | null {
+    if (value.trim() === "") return null;
+    const parsed = new Date(value).getTime();
+    return Number.isNaN(parsed) ? null : Math.floor(parsed / 1000);
+}
+
+/** The windows covering one display day (0 = Monday .. 6 = Sunday), ordered by start time. */
+export function buildDaySegments(slots: WeekDayScheduleSlot[], displayDay: number): DayScheduleSegment[] {
+    const bit = DAY_BITS[displayDay];
+    if (bit === undefined) return [];
+    return slots
+        .flatMap(slot => {
+            const schedule = slot.schedule;
+            if (schedule === null || !maskHasDay(schedule.daysMask, bit)) return [];
+            return [
+                {
+                    weekDayIndex: schedule.weekDayIndex,
+                    startMin: schedule.startHour * 60 + schedule.startMinute,
+                    endMin: schedule.endHour * 60 + schedule.endMinute,
+                },
+            ];
+        })
+        .sort((a, b) => a.startMin - b.startMin);
+}
+
+export function decodeWeekDayScheduleResponse(response: unknown, weekDayIndex: number): WeekDayScheduleSlot {
+    const obj = asObject(response);
+    const status = (obj !== null ? pickNumber(obj, "status") : null) ?? 0;
+    if (obj === null || status !== 0) {
+        return { weekDayIndex, status, schedule: null };
+    }
+    return {
+        weekDayIndex,
+        status,
+        schedule: {
+            weekDayIndex: pickNumber(obj, "weekDayIndex") ?? weekDayIndex,
+            daysMask: pickNumber(obj, "daysMask") ?? 0,
+            startHour: pickNumber(obj, "startHour") ?? 0,
+            startMinute: pickNumber(obj, "startMinute") ?? 0,
+            endHour: pickNumber(obj, "endHour") ?? 0,
+            endMinute: pickNumber(obj, "endMinute") ?? 0,
+        },
+    };
+}
+
+export function decodeYearDayScheduleResponse(response: unknown, yearDayIndex: number): YearDayScheduleSlot {
+    const obj = asObject(response);
+    const status = (obj !== null ? pickNumber(obj, "status") : null) ?? 0;
+    const localStartTime = obj !== null ? pickNumber(obj, "localStartTime") : null;
+    const localEndTime = obj !== null ? pickNumber(obj, "localEndTime") : null;
+    if (status !== 0 || localStartTime === null || localEndTime === null) {
+        return { yearDayIndex, status, schedule: null };
+    }
+    return {
+        yearDayIndex,
+        status,
+        schedule: {
+            yearDayIndex: (obj !== null ? pickNumber(obj, "yearDayIndex") : null) ?? yearDayIndex,
+            localStartTime,
+            localEndTime,
+        },
+    };
+}
+
+export function decodeUserResponse(response: unknown): DoorLockUser | null {
+    const obj = asObject(response);
+    if (obj === null) return null;
+    const userIndex = pickNumber(obj, "userIndex");
+    if (userIndex === null) return null;
+    const userStatus = pickNumber(obj, "userStatus");
+    return {
+        userIndex,
+        userName: pickString(obj, "userName"),
+        userStatus,
+        userType: pickNumber(obj, "userType"),
+        nextUserIndex: pickNumber(obj, "nextUserIndex"),
+        // The spec nulls the whole record for a free slot, but locks in the field also report Available there.
+        occupied: userStatus !== null && userStatus !== USER_STATUS_AVAILABLE,
+    };
+}
+
+/** Encode a PIN for the octstr PinCode field, which reaches the lock as base64. */
+export function encodePinCode(pin: string): string {
+    return btoa(String.fromCharCode(...new TextEncoder().encode(pin)));
+}
+
+export async function readWeekDaySchedule(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    weekDayIndex: number,
+    userIndex: number,
+): Promise<WeekDayScheduleSlot> {
+    const response = await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "GetWeekDaySchedule", {
+        weekDayIndex,
+        userIndex,
+    });
+    return decodeWeekDayScheduleResponse(response, weekDayIndex);
+}
+
+export async function writeWeekDaySchedule(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    userIndex: number,
+    schedule: WeekDaySchedule,
+): Promise<void> {
+    await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "SetWeekDaySchedule", {
+        weekDayIndex: schedule.weekDayIndex,
+        userIndex,
+        daysMask: schedule.daysMask,
+        startHour: schedule.startHour,
+        startMinute: schedule.startMinute,
+        endHour: schedule.endHour,
+        endMinute: schedule.endMinute,
+    });
+}
+
+export async function clearWeekDaySchedule(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    userIndex: number,
+    weekDayIndex: number,
+): Promise<void> {
+    await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "ClearWeekDaySchedule", {
+        weekDayIndex,
+        userIndex,
+    });
+}
+
+export async function readYearDaySchedule(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    yearDayIndex: number,
+    userIndex: number,
+): Promise<YearDayScheduleSlot> {
+    const response = await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "GetYearDaySchedule", {
+        yearDayIndex,
+        userIndex,
+    });
+    return decodeYearDayScheduleResponse(response, yearDayIndex);
+}
+
+export async function writeYearDaySchedule(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    userIndex: number,
+    schedule: YearDaySchedule,
+): Promise<void> {
+    await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "SetYearDaySchedule", {
+        yearDayIndex: schedule.yearDayIndex,
+        userIndex,
+        localStartTime: schedule.localStartTime,
+        localEndTime: schedule.localEndTime,
+    });
+}
+
+export async function clearYearDaySchedule(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    userIndex: number,
+    yearDayIndex: number,
+): Promise<void> {
+    await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "ClearYearDaySchedule", {
+        yearDayIndex,
+        userIndex,
+    });
+}
+
+export async function readUser(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    userIndex: number,
+): Promise<DoorLockUser | null> {
+    const response = await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "GetUser", { userIndex });
+    return decodeUserResponse(response);
+}
+
+/**
+ * The lock's occupied users, walked through NextUserIndex so free slots cost no round-trip.
+ * `maxUsers` bounds the walk on a lock that never terminates the chain.
+ */
+export async function readUsers(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    maxUsers: number,
+): Promise<DoorLockUser[]> {
+    const users = new Array<DoorLockUser>();
+    const visited = new Set<number>();
+    let index: number | null = 1;
+    while (index !== null && visited.size < maxUsers) {
+        // A lock reporting a NextUserIndex it already served would otherwise loop here forever.
+        if (visited.has(index)) break;
+        visited.add(index);
+        const user = await readUser(client, nodeId, endpoint, index);
+        if (user === null) break;
+        if (user.occupied) users.push(user);
+        index = user.nextUserIndex;
+    }
+    return users;
+}
+
+export async function lockDoor(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    pinCode?: string,
+): Promise<void> {
+    const payload = pinCode ? { pinCode: encodePinCode(pinCode) } : {};
+    await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "LockDoor", payload);
+}
+
+export async function unlockDoor(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    pinCode?: string,
+): Promise<void> {
+    const payload = pinCode ? { pinCode: encodePinCode(pinCode) } : {};
+    await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "UnlockDoor", payload);
+}
+
+export async function unlockWithTimeout(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    timeoutSeconds: number,
+    pinCode?: string,
+): Promise<void> {
+    const payload: Record<string, unknown> = { timeout: timeoutSeconds };
+    if (pinCode) payload["pinCode"] = encodePinCode(pinCode);
+    await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "UnlockWithTimeout", payload);
+}

--- a/packages/dashboard/src/util/door-lock.ts
+++ b/packages/dashboard/src/util/door-lock.ts
@@ -8,6 +8,8 @@ import type { MatterClient, MatterNode } from "@matter-server/ws-client";
 import { clusters } from "../client/models/descriptions.js";
 import { asObject, pickNumber, pickString } from "./attribute-shapes.js";
 import { computeActiveClusterFeatures } from "./cluster-features.js";
+import { getMatterStatusName } from "./matter-status.js";
+import { MATTER_EPOCH_MAX_SECONDS, MATTER_EPOCH_OFFSET_SECONDS } from "./time.js";
 
 /** Door Lock cluster (Matter spec §5.2). */
 export const DOOR_LOCK_CLUSTER_ID = 257; // 0x0101
@@ -20,21 +22,40 @@ const ATTR_NUMBER_OF_TOTAL_USERS_SUPPORTED = 0x11;
 const ATTR_NUMBER_OF_WEEK_DAY_SCHEDULES_SUPPORTED_PER_USER = 0x14;
 const ATTR_NUMBER_OF_YEAR_DAY_SCHEDULES_SUPPORTED_PER_USER = 0x15;
 const ATTR_NUMBER_OF_HOLIDAY_SCHEDULES_SUPPORTED = 0x16;
+const ATTR_SUPPORTED_OPERATING_MODES = 0x26;
 const ATTR_REQUIRE_PIN_FOR_REMOTE_OPERATION = 0x33;
 const ATTR_ACCEPTED_COMMAND_LIST = 0xfff9;
 const ATTR_FEATURE_MAP = 0xfffc;
 
-/** UnlockWithTimeout is optional even on locks that support unlocking (spec §5.2.10.4). */
+/** UnlockWithTimeout is optional even on locks that support unlocking (spec §5.2.10.3). */
 export const UNLOCK_WITH_TIMEOUT_COMMAND_ID = 0x03;
 
-/** ClearWeekDaySchedule and ClearYearDaySchedule wipe every slot of a user when addressed with this index. */
+/**
+ * Wipes every slot of the addressed table: a user's week day or year day schedules, or — since the
+ * holiday table is lock-wide — every holiday schedule on the lock.
+ */
 export const SCHEDULE_INDEX_ALL = 0xfe;
 
-/** UserStatusEnum.Available — a slot the lock reports as free (spec §5.2.6.14). */
+/** UserStatusEnum.Available — a slot the lock reports as free (spec §5.2.6.17). */
 const USER_STATUS_AVAILABLE = 0;
 
-/** DataOperationTypeEnum.Add — the SetUser operation that creates a new user (spec §5.2.6.4). */
+/** DataOperationTypeEnum.Add — the SetUser operation that creates a new user (spec §5.2.6.10). */
 const OPERATION_TYPE_ADD = 0;
+
+/** SetUser's UserName constraint (spec §5.2.10.34.3), enforced here instead of round-tripping it. */
+export const USER_NAME_MAX_LENGTH = 10;
+
+/**
+ * Why the lock will reject this user name, or null when it will accept it. The constraint counts UTF-8
+ * bytes, so a name well inside the character limit can still be too long.
+ */
+export function userNameLengthError(userName: string): string | null {
+    if (userName === "") return "Enter a name for the user.";
+    if (new TextEncoder().encode(userName).length > USER_NAME_MAX_LENGTH) {
+        return `The name may be at most ${USER_NAME_MAX_LENGTH} bytes; accented and non-Latin characters take more than one.`;
+    }
+    return null;
+}
 
 /** Days in display order (Mon..Sun) mapped to their DaysMaskBitmap bit (Sunday=0 .. Saturday=6). */
 export const DAY_BITS = [1, 2, 3, 4, 5, 6, 0];
@@ -90,8 +111,13 @@ const OPERATING_MODE_LABELS: Record<number, string> = {
     4: "Passage",
 };
 
-/** All OperatingModeEnum values, in display order, for a Holiday schedule's mode picker. */
-export const OPERATING_MODES = [0, 1, 2, 3, 4];
+const OPERATING_MODES = [0, 1, 2, 3, 4];
+
+/** OperatingModeEnum.Normal, the only mode every lock must implement. */
+const OPERATING_MODE_NORMAL = 0;
+
+/** OperatingModeEnum.Vacation, what a holiday schedule is normally for. */
+const OPERATING_MODE_VACATION = 1;
 
 const USER_TYPE_LABELS: Record<number, string> = {
     0: "Unrestricted",
@@ -106,6 +132,9 @@ const USER_TYPE_LABELS: Record<number, string> = {
     9: "Remote Only",
 };
 
+/** The interaction-model status of a slot the lock holds nothing in (spec §5.2.10.6.3). */
+export const SCHEDULE_STATUS_NOT_FOUND = 0x8b;
+
 /** A Week Day schedule slot holding a window, as reported by GetWeekDayScheduleResponse. */
 export interface WeekDaySchedule {
     weekDayIndex: number;
@@ -116,16 +145,25 @@ export interface WeekDaySchedule {
     endMinute: number;
 }
 
-/** One of a user's schedule slots: `schedule` is null when the lock reported a non-success status. */
+/**
+ * One of a user's schedule slots. `schedule` is null when the lock reported a non-success status or
+ * omitted the window.
+ *
+ * `status` is null when the lock did not say what the slot holds: either no status came back, or it
+ * answered SUCCESS without the fields that must accompany it ("If this field is SUCCESS, the optional
+ * fields for this command shall be present", spec §5.2.10.6.3). Such a slot reads as unread, and is
+ * never collapsed away among the empty ones.
+ */
 export interface WeekDayScheduleSlot {
     weekDayIndex: number;
-    status: number;
+    status: number | null;
     schedule: WeekDaySchedule | null;
 }
 
 /**
- * A Year Day schedule slot holding a fixed date range. Both bounds are Unix seconds: the cluster carries
- * them as epoch-s, which the server converts in both directions, and they mean local time at the lock.
+ * A Year Day schedule slot holding a fixed date range. Both bounds are Matter epoch-s (seconds since
+ * 2000-01-01) encoding the lock's *local wall clock* rather than a UTC instant, per the spec's "Epoch
+ * Time in Seconds with local time offset" — so they are neither Unix seconds nor a viewer-relative time.
  */
 export interface YearDaySchedule {
     yearDayIndex: number;
@@ -135,7 +173,7 @@ export interface YearDaySchedule {
 
 export interface YearDayScheduleSlot {
     yearDayIndex: number;
-    status: number;
+    status: number | null;
     schedule: YearDaySchedule | null;
 }
 
@@ -152,7 +190,7 @@ export interface HolidaySchedule {
 
 export interface HolidayScheduleSlot {
     holidayIndex: number;
-    status: number;
+    status: number | null;
     schedule: HolidaySchedule | null;
 }
 
@@ -232,6 +270,18 @@ export function requiresPinForRemoteOperation(node: MatterNode, endpoint: number
     return readAttr(node, endpoint, ATTR_REQUIRE_PIN_FOR_REMOTE_OPERATION) === true;
 }
 
+/**
+ * The operating modes a Holiday schedule may switch this lock to. OperatingModesBitmap is inverted —
+ * a bit set to zero means the mode IS supported, which the spec itself calls out as "the opposite of
+ * most other semantically similar bitmaps" (spec §5.2.9.25).
+ */
+export function supportedOperatingModes(node: MatterNode, endpoint: number): number[] {
+    const bitmap = readNumberAttr(node, endpoint, ATTR_SUPPORTED_OPERATING_MODES);
+    if (bitmap === null) return [...OPERATING_MODES];
+    const supported = OPERATING_MODES.filter(mode => (bitmap & (1 << mode)) === 0);
+    return supported.length > 0 ? supported : [...OPERATING_MODES];
+}
+
 export function formatLockState(state: number | null): string {
     if (state === null) return "Unknown";
     return LOCK_STATE_LABELS[state] ?? `State ${state}`;
@@ -252,6 +302,20 @@ export function formatOperatingMode(mode: number | null): string | null {
     return OPERATING_MODE_LABELS[mode] ?? `Mode ${mode}`;
 }
 
+/**
+ * The modes a holiday mode picker offers. A mode the lock already stored is always among them even when
+ * SupportedOperatingModes no longer advertises it: an option list that cannot represent the current value
+ * leaves a `<select>` showing its first entry while a save still writes the old one.
+ */
+export function holidayModeChoices(supported: number[], current: number): number[] {
+    return supported.includes(current) ? supported : [current, ...supported];
+}
+
+export function defaultHolidayMode(supported: number[]): number {
+    if (supported.includes(OPERATING_MODE_VACATION)) return OPERATING_MODE_VACATION;
+    return supported[0] ?? OPERATING_MODE_NORMAL;
+}
+
 export function formatUserStatus(status: number | null): string | null {
     if (status === null) return null;
     return USER_STATUS_LABELS[status] ?? `Status ${status}`;
@@ -260,6 +324,17 @@ export function formatUserStatus(status: number | null): string | null {
 export function formatUserType(type: number | null): string | null {
     if (type === null) return null;
     return USER_TYPE_LABELS[type] ?? `Type ${type}`;
+}
+
+/** Whether the lock answered for this slot and reported it as holding nothing. */
+export function isEmptyScheduleStatus(status: number | null): boolean {
+    return status === 0 || status === SCHEDULE_STATUS_NOT_FOUND;
+}
+
+export function formatScheduleStatus(status: number | null): string {
+    if (status === null) return "Unreadable";
+    if (isEmptyScheduleStatus(status)) return "Empty";
+    return getMatterStatusName(status);
 }
 
 /** A user's display name: its own UserName when set, else its index. */
@@ -288,8 +363,9 @@ export function formatTimeOfDay(hour: number, minute: number): string {
     return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
 }
 
+/** Accepts the `HH:MM:SS` an `<input type="time">` emits at second precision; the cluster has no seconds. */
 export function parseTimeOfDay(value: string): { hour: number; minute: number } | null {
-    const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim());
+    const match = /^(\d{1,2}):(\d{2})(?::\d{2})?$/.exec(value.trim());
     if (!match) return null;
     const hour = Number(match[1]);
     const minute = Number(match[2]);
@@ -309,47 +385,96 @@ export function weekDayScheduleRangeError(schedule: Omit<WeekDaySchedule, "weekD
     return null;
 }
 
-/** Why the date range cannot be set as entered, or null when it is valid. */
-export function yearDayScheduleRangeError(schedule: Omit<YearDaySchedule, "yearDayIndex">): string | null {
-    if (!Number.isFinite(schedule.localStartTime) || !Number.isFinite(schedule.localEndTime)) {
+function dateRangeError(localStartTime: number, localEndTime: number): string | null {
+    if (!Number.isFinite(localStartTime) || !Number.isFinite(localEndTime)) {
         return "Enter both a start and an end date.";
     }
-    if (schedule.localEndTime <= schedule.localStartTime) return "The end date must be later than the start date.";
+    // Outside this the value no longer fits the uint32 epoch-s field the cluster carries it in.
+    for (const bound of [localStartTime, localEndTime]) {
+        if (!Number.isInteger(bound) || bound < 0 || bound > MATTER_EPOCH_MAX_SECONDS) {
+            return "Dates must fall between 2000-01-01 and 2136-02-07.";
+        }
+    }
+    if (localEndTime <= localStartTime) return "The end date must be later than the start date.";
     return null;
+}
+
+/** Why the date range cannot be set as entered, or null when it is valid. */
+export function yearDayScheduleRangeError(schedule: Omit<YearDaySchedule, "yearDayIndex">): string | null {
+    return dateRangeError(schedule.localStartTime, schedule.localEndTime);
 }
 
 /** Why the holiday schedule cannot be set as entered, or null when it is valid. */
 export function holidayScheduleRangeError(schedule: Omit<HolidaySchedule, "holidayIndex">): string | null {
-    if (!Number.isFinite(schedule.localStartTime) || !Number.isFinite(schedule.localEndTime)) {
-        return "Enter both a start and an end date.";
-    }
-    if (schedule.localEndTime <= schedule.localStartTime) return "The end date must be later than the start date.";
-    return null;
+    return dateRangeError(schedule.localStartTime, schedule.localEndTime);
 }
 
-/** Formats a Unix-seconds instant as a local date and time. */
-export function formatLocalDateTime(unixSeconds: number): string {
-    return new Date(unixSeconds * 1000).toLocaleString(undefined, {
+const pad = (value: number) => String(value).padStart(2, "0");
+
+/** The instant whose UTC components spell out the wall clock `matterEpochSeconds` encodes. */
+function wallClockOf(matterEpochSeconds: number): Date {
+    return new Date((matterEpochSeconds + MATTER_EPOCH_OFFSET_SECONDS) * 1000);
+}
+
+/** Encodes a wall clock, as the lock encodes its own: UTC components, shifted to the Matter epoch. */
+function toMatterEpoch(year: number, month: number, day: number, hour: number, minute: number, second: number) {
+    return Math.floor(Date.UTC(year, month - 1, day, hour, minute, second) / 1000) - MATTER_EPOCH_OFFSET_SECONDS;
+}
+
+/** Reads the browser's wall clock, encoded the way the lock encodes its own local time. */
+export function nowAsWallClock(): number {
+    const now = new Date();
+    return toMatterEpoch(
+        now.getFullYear(),
+        now.getMonth() + 1,
+        now.getDate(),
+        now.getHours(),
+        now.getMinutes(),
+        now.getSeconds(),
+    );
+}
+
+/** Formats the lock's wall clock for display. Deliberately not shifted into the viewer's time zone. */
+export function formatWallClock(matterEpochSeconds: number): string {
+    return wallClockOf(matterEpochSeconds).toLocaleString(undefined, {
         year: "numeric",
         month: "2-digit",
         day: "2-digit",
         hour: "2-digit",
         minute: "2-digit",
+        timeZone: "UTC",
     });
 }
 
-/** Formats a Unix-seconds instant for an `<input type="datetime-local">`, whose value is local wall time. */
-export function toDateTimeInputValue(unixSeconds: number): string {
-    const date = new Date(unixSeconds * 1000);
-    const pad = (value: number) => String(value).padStart(2, "0");
-    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+/** Formats the lock's wall clock for an `<input type="datetime-local">`, keeping seconds when it has any. */
+export function toDateTimeInputValue(matterEpochSeconds: number): string {
+    const date = wallClockOf(matterEpochSeconds);
+    const minutes = `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}T${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`;
+    const seconds = date.getUTCSeconds();
+    return seconds === 0 ? minutes : `${minutes}:${pad(seconds)}`;
 }
 
-/** Reads an `<input type="datetime-local">` value back as Unix seconds, or null when it is empty or invalid. */
+/**
+ * Reads an `<input type="datetime-local">` value back as the lock's wall clock, or null when it is
+ * empty, malformed, or names a day that does not exist.
+ */
 export function fromDateTimeInputValue(value: string): number | null {
-    if (value.trim() === "") return null;
-    const parsed = new Date(value).getTime();
-    return Number.isNaN(parsed) ? null : Math.floor(parsed / 1000);
+    const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/.exec(value.trim());
+    if (match === null) return null;
+    const [year, month, day, hour, minute] = match.slice(1, 6).map(Number);
+    const second = match[6] === undefined ? 0 : Number(match[6]);
+    if (hour > 23 || minute > 59 || second > 59) return null;
+    const matterEpochSeconds = toMatterEpoch(year, month, day, hour, minute, second);
+    const roundTrip = wallClockOf(matterEpochSeconds);
+    // Date.UTC rolls 2026-02-30 forward into March rather than rejecting it.
+    if (
+        roundTrip.getUTCFullYear() !== year ||
+        roundTrip.getUTCMonth() + 1 !== month ||
+        roundTrip.getUTCDate() !== day
+    ) {
+        return null;
+    }
+    return matterEpochSeconds;
 }
 
 /** The windows covering one display day (0 = Monday .. 6 = Sunday), ordered by start time. */
@@ -373,29 +498,40 @@ export function buildDaySegments(slots: WeekDayScheduleSlot[], displayDay: numbe
 
 export function decodeWeekDayScheduleResponse(response: unknown, weekDayIndex: number): WeekDayScheduleSlot {
     const obj = asObject(response);
-    const status = (obj !== null ? pickNumber(obj, "status") : null) ?? 0;
+    const status = obj !== null ? pickNumber(obj, "status") : null;
     if (obj === null || status !== 0) {
         return { weekDayIndex, status, schedule: null };
+    }
+    const daysMask = pickNumber(obj, "daysMask");
+    const startHour = pickNumber(obj, "startHour");
+    const startMinute = pickNumber(obj, "startMinute");
+    const endHour = pickNumber(obj, "endHour");
+    const endMinute = pickNumber(obj, "endMinute");
+    if (daysMask === null || startHour === null || startMinute === null || endHour === null || endMinute === null) {
+        return { weekDayIndex, status: null, schedule: null };
     }
     return {
         weekDayIndex,
         status,
         schedule: {
             weekDayIndex: pickNumber(obj, "weekDayIndex") ?? weekDayIndex,
-            daysMask: pickNumber(obj, "daysMask") ?? 0,
-            startHour: pickNumber(obj, "startHour") ?? 0,
-            startMinute: pickNumber(obj, "startMinute") ?? 0,
-            endHour: pickNumber(obj, "endHour") ?? 0,
-            endMinute: pickNumber(obj, "endMinute") ?? 0,
+            daysMask,
+            startHour,
+            startMinute,
+            endHour,
+            endMinute,
         },
     };
 }
 
 export function decodeYearDayScheduleResponse(response: unknown, yearDayIndex: number): YearDayScheduleSlot {
     const obj = asObject(response);
-    const status = (obj !== null ? pickNumber(obj, "status") : null) ?? 0;
+    const status = obj !== null ? pickNumber(obj, "status") : null;
     const localStartTime = obj !== null ? pickNumber(obj, "localStartTime") : null;
     const localEndTime = obj !== null ? pickNumber(obj, "localEndTime") : null;
+    if (status === 0 && (localStartTime === null || localEndTime === null)) {
+        return { yearDayIndex, status: null, schedule: null };
+    }
     if (status !== 0 || localStartTime === null || localEndTime === null) {
         return { yearDayIndex, status, schedule: null };
     }
@@ -412,10 +548,13 @@ export function decodeYearDayScheduleResponse(response: unknown, yearDayIndex: n
 
 export function decodeHolidayScheduleResponse(response: unknown, holidayIndex: number): HolidayScheduleSlot {
     const obj = asObject(response);
-    const status = (obj !== null ? pickNumber(obj, "status") : null) ?? 0;
+    const status = obj !== null ? pickNumber(obj, "status") : null;
     const localStartTime = obj !== null ? pickNumber(obj, "localStartTime") : null;
     const localEndTime = obj !== null ? pickNumber(obj, "localEndTime") : null;
     const operatingMode = obj !== null ? pickNumber(obj, "operatingMode") : null;
+    if (status === 0 && (localStartTime === null || localEndTime === null || operatingMode === null)) {
+        return { holidayIndex, status: null, schedule: null };
+    }
     if (status !== 0 || localStartTime === null || localEndTime === null || operatingMode === null) {
         return { holidayIndex, status, schedule: null };
     }

--- a/packages/dashboard/src/util/door-lock.ts
+++ b/packages/dashboard/src/util/door-lock.ts
@@ -19,6 +19,7 @@ const ATTR_DOOR_STATE = 0x03;
 const ATTR_NUMBER_OF_TOTAL_USERS_SUPPORTED = 0x11;
 const ATTR_NUMBER_OF_WEEK_DAY_SCHEDULES_SUPPORTED_PER_USER = 0x14;
 const ATTR_NUMBER_OF_YEAR_DAY_SCHEDULES_SUPPORTED_PER_USER = 0x15;
+const ATTR_NUMBER_OF_HOLIDAY_SCHEDULES_SUPPORTED = 0x16;
 const ATTR_REQUIRE_PIN_FOR_REMOTE_OPERATION = 0x33;
 const ATTR_ACCEPTED_COMMAND_LIST = 0xfff9;
 const ATTR_FEATURE_MAP = 0xfffc;
@@ -31,6 +32,9 @@ export const SCHEDULE_INDEX_ALL = 0xfe;
 
 /** UserStatusEnum.Available — a slot the lock reports as free (spec §5.2.6.14). */
 const USER_STATUS_AVAILABLE = 0;
+
+/** DataOperationTypeEnum.Add — the SetUser operation that creates a new user (spec §5.2.6.4). */
+const OPERATION_TYPE_ADD = 0;
 
 /** Days in display order (Mon..Sun) mapped to their DaysMaskBitmap bit (Sunday=0 .. Saturday=6). */
 export const DAY_BITS = [1, 2, 3, 4, 5, 6, 0];
@@ -77,6 +81,18 @@ const USER_STATUS_LABELS: Record<number, string> = {
     3: "Disabled",
 };
 
+/** OperatingModeEnum values a Holiday schedule may switch the lock to (spec §5.2.6.15). */
+const OPERATING_MODE_LABELS: Record<number, string> = {
+    0: "Normal",
+    1: "Vacation",
+    2: "Privacy",
+    3: "No Remote Lock/Unlock",
+    4: "Passage",
+};
+
+/** All OperatingModeEnum values, in display order, for a Holiday schedule's mode picker. */
+export const OPERATING_MODES = [0, 1, 2, 3, 4];
+
 const USER_TYPE_LABELS: Record<number, string> = {
     0: "Unrestricted",
     1: "Year Day Schedule",
@@ -121,6 +137,23 @@ export interface YearDayScheduleSlot {
     yearDayIndex: number;
     status: number;
     schedule: YearDaySchedule | null;
+}
+
+/**
+ * A Holiday schedule slot: unlike WDSCH/YDSCH, holidays are not scoped to a user — they apply to the whole
+ * lock — and switch it to `operatingMode` for the duration of the date range.
+ */
+export interface HolidaySchedule {
+    holidayIndex: number;
+    localStartTime: number;
+    localEndTime: number;
+    operatingMode: number;
+}
+
+export interface HolidayScheduleSlot {
+    holidayIndex: number;
+    status: number;
+    schedule: HolidaySchedule | null;
 }
 
 export interface DoorLockUser {
@@ -190,6 +223,11 @@ export function readYearDaySchedulesPerUser(node: MatterNode, endpoint: number):
     return readNumberAttr(node, endpoint, ATTR_NUMBER_OF_YEAR_DAY_SCHEDULES_SUPPORTED_PER_USER);
 }
 
+/** Unlike WDSCH/YDSCH, HolidaySchedules is a lock-wide table: it is not scoped to a user. */
+export function readHolidaySchedulesSupported(node: MatterNode, endpoint: number): number | null {
+    return readNumberAttr(node, endpoint, ATTR_NUMBER_OF_HOLIDAY_SCHEDULES_SUPPORTED);
+}
+
 export function requiresPinForRemoteOperation(node: MatterNode, endpoint: number): boolean {
     return readAttr(node, endpoint, ATTR_REQUIRE_PIN_FOR_REMOTE_OPERATION) === true;
 }
@@ -207,6 +245,11 @@ export function formatLockType(type: number | null): string | null {
 export function formatDoorState(state: number | null): string | null {
     if (state === null) return null;
     return DOOR_STATE_LABELS[state] ?? `State ${state}`;
+}
+
+export function formatOperatingMode(mode: number | null): string | null {
+    if (mode === null) return null;
+    return OPERATING_MODE_LABELS[mode] ?? `Mode ${mode}`;
 }
 
 export function formatUserStatus(status: number | null): string | null {
@@ -268,6 +311,15 @@ export function weekDayScheduleRangeError(schedule: Omit<WeekDaySchedule, "weekD
 
 /** Why the date range cannot be set as entered, or null when it is valid. */
 export function yearDayScheduleRangeError(schedule: Omit<YearDaySchedule, "yearDayIndex">): string | null {
+    if (!Number.isFinite(schedule.localStartTime) || !Number.isFinite(schedule.localEndTime)) {
+        return "Enter both a start and an end date.";
+    }
+    if (schedule.localEndTime <= schedule.localStartTime) return "The end date must be later than the start date.";
+    return null;
+}
+
+/** Why the holiday schedule cannot be set as entered, or null when it is valid. */
+export function holidayScheduleRangeError(schedule: Omit<HolidaySchedule, "holidayIndex">): string | null {
     if (!Number.isFinite(schedule.localStartTime) || !Number.isFinite(schedule.localEndTime)) {
         return "Enter both a start and an end date.";
     }
@@ -354,6 +406,27 @@ export function decodeYearDayScheduleResponse(response: unknown, yearDayIndex: n
             yearDayIndex: (obj !== null ? pickNumber(obj, "yearDayIndex") : null) ?? yearDayIndex,
             localStartTime,
             localEndTime,
+        },
+    };
+}
+
+export function decodeHolidayScheduleResponse(response: unknown, holidayIndex: number): HolidayScheduleSlot {
+    const obj = asObject(response);
+    const status = (obj !== null ? pickNumber(obj, "status") : null) ?? 0;
+    const localStartTime = obj !== null ? pickNumber(obj, "localStartTime") : null;
+    const localEndTime = obj !== null ? pickNumber(obj, "localEndTime") : null;
+    const operatingMode = obj !== null ? pickNumber(obj, "operatingMode") : null;
+    if (status !== 0 || localStartTime === null || localEndTime === null || operatingMode === null) {
+        return { holidayIndex, status, schedule: null };
+    }
+    return {
+        holidayIndex,
+        status,
+        schedule: {
+            holidayIndex: (obj !== null ? pickNumber(obj, "holidayIndex") : null) ?? holidayIndex,
+            localStartTime,
+            localEndTime,
+            operatingMode,
         },
     };
 }
@@ -467,6 +540,41 @@ export async function clearYearDaySchedule(
     });
 }
 
+export async function readHolidaySchedule(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    holidayIndex: number,
+): Promise<HolidayScheduleSlot> {
+    const response = await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "GetHolidaySchedule", {
+        holidayIndex,
+    });
+    return decodeHolidayScheduleResponse(response, holidayIndex);
+}
+
+export async function writeHolidaySchedule(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    schedule: HolidaySchedule,
+): Promise<void> {
+    await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "SetHolidaySchedule", {
+        holidayIndex: schedule.holidayIndex,
+        localStartTime: schedule.localStartTime,
+        localEndTime: schedule.localEndTime,
+        operatingMode: schedule.operatingMode,
+    });
+}
+
+export async function clearHolidaySchedule(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    holidayIndex: number,
+): Promise<void> {
+    await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "ClearHolidaySchedule", { holidayIndex });
+}
+
 export async function readUser(
     client: MatterClient,
     nodeId: number | bigint,
@@ -500,6 +608,42 @@ export async function readUsers(
         index = user.nextUserIndex;
     }
     return users;
+}
+
+/** The lowest user index in `[1, maxUsers]` not already occupied, or null when the user database is full. */
+export function nextFreeUserIndex(users: DoorLockUser[], maxUsers: number): number | null {
+    const occupied = new Set(users.map(user => user.userIndex));
+    for (let index = 1; index <= maxUsers; index++) {
+        if (!occupied.has(index)) return index;
+    }
+    return null;
+}
+
+export async function addUser(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    userIndex: number,
+    userName: string,
+): Promise<void> {
+    await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "SetUser", {
+        operationType: OPERATION_TYPE_ADD,
+        userIndex,
+        userName,
+        userUniqueId: null,
+        userStatus: null,
+        userType: null,
+        credentialRule: null,
+    });
+}
+
+export async function removeUser(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    userIndex: number,
+): Promise<void> {
+    await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "ClearUser", { userIndex });
 }
 
 export async function lockDoor(

--- a/packages/dashboard/src/util/error-text.ts
+++ b/packages/dashboard/src/util/error-text.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** The message to show a user for a thrown value, which need not be an Error. */
+export function errorText(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}

--- a/packages/dashboard/src/util/time.ts
+++ b/packages/dashboard/src/util/time.ts
@@ -5,7 +5,10 @@
  */
 
 /** Matter epoch-s values count seconds since 2000-01-01T00:00:00Z, not the Unix epoch. */
-const MATTER_EPOCH_OFFSET_SECONDS = 946_684_800;
+export const MATTER_EPOCH_OFFSET_SECONDS = 946_684_800;
+
+/** Largest value the uint32 epoch-s wire field can carry, i.e. 2136-02-07T06:28:15. */
+export const MATTER_EPOCH_MAX_SECONDS = 0xffffffff;
 
 /** Formats a Matter epoch-s instant as a local time, prefixed with the date when it isn't today. */
 export function formatEpochTime(matterEpochSeconds: number, relativeTo: Date = new Date()): string {

--- a/packages/dashboard/test/DoorLockUtilTest.ts
+++ b/packages/dashboard/test/DoorLockUtilTest.ts
@@ -1,0 +1,321 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MatterNode, type MatterNodeData } from "@matter-server/ws-client";
+import {
+    buildDaySegments,
+    decodeUserResponse,
+    decodeWeekDayScheduleResponse,
+    decodeYearDayScheduleResponse,
+    encodePinCode,
+    formatDaysMask,
+    formatTimeOfDay,
+    formatUserLabel,
+    formatUserStatus,
+    formatUserType,
+    fromDateTimeInputValue,
+    isFeatureActive,
+    maskHasDay,
+    parseTimeOfDay,
+    readTotalUsersSupported,
+    readWeekDaySchedulesPerUser,
+    readYearDaySchedulesPerUser,
+    requiresPinForRemoteOperation,
+    supportsCommand,
+    toDateTimeInputValue,
+    toggleMaskDay,
+    UNLOCK_WITH_TIMEOUT_COMMAND_ID,
+    weekDayScheduleRangeError,
+    yearDayScheduleRangeError,
+    type WeekDayScheduleSlot,
+} from "../src/util/door-lock.js";
+
+function node(attributes: Record<string, unknown>, node_id: number | bigint = 1): MatterNode {
+    const data: MatterNodeData = {
+        node_id,
+        date_commissioned: "",
+        last_interview: "",
+        interview_version: 1,
+        available: true,
+        is_bridge: false,
+        attributes,
+        attribute_subscriptions: [],
+    };
+    return new MatterNode(data);
+}
+
+// DaysMaskBitmap bits (Sunday = bit 0 .. Saturday = bit 6).
+const SUN = 1 << 0;
+const MON = 1 << 1;
+const TUE = 1 << 2;
+const WED = 1 << 3;
+const THU = 1 << 4;
+const FRI = 1 << 5;
+const SAT = 1 << 6;
+
+function weekDaySlot(weekDayIndex: number, daysMask: number, start: [number, number], end: [number, number]) {
+    return {
+        weekDayIndex,
+        status: 0,
+        schedule: {
+            weekDayIndex,
+            daysMask,
+            startHour: start[0],
+            startMinute: start[1],
+            endHour: end[0],
+            endMinute: end[1],
+        },
+    } satisfies WeekDayScheduleSlot;
+}
+
+describe("door-lock util", () => {
+    describe("isFeatureActive", () => {
+        it("resolves WDSCH and YDSCH against the real DoorLock FeatureMap", () => {
+            const weekDayOnly = node({ "1/257/65532": 1 << 4 });
+            expect(isFeatureActive(weekDayOnly, 1, "WDSCH")).to.equal(true);
+            expect(isFeatureActive(weekDayOnly, 1, "YDSCH")).to.equal(false);
+            expect(isFeatureActive(node({ "1/257/65532": 1 << 10 }), 1, "YDSCH")).to.equal(true);
+            expect(isFeatureActive(node({ "1/257/65532": 1 << 8 }), 1, "USR")).to.equal(true);
+        });
+        it("is false when FeatureMap is absent", () => {
+            expect(isFeatureActive(node({}), 1, "WDSCH")).to.equal(false);
+        });
+    });
+
+    describe("attribute readers", () => {
+        it("reads the per-user schedule capacities and the user total", () => {
+            const lock = node({ "1/257/17": 10, "1/257/20": 4, "1/257/21": 3 });
+            expect(readTotalUsersSupported(lock, 1)).to.equal(10);
+            expect(readWeekDaySchedulesPerUser(lock, 1)).to.equal(4);
+            expect(readYearDaySchedulesPerUser(lock, 1)).to.equal(3);
+        });
+        it("reports absent attributes as null", () => {
+            expect(readWeekDaySchedulesPerUser(node({}), 1)).to.equal(null);
+        });
+        it("reads RequirePinForRemoteOperation as a flag", () => {
+            expect(requiresPinForRemoteOperation(node({ "1/257/51": true }), 1)).to.equal(true);
+            expect(requiresPinForRemoteOperation(node({ "1/257/51": false }), 1)).to.equal(false);
+            expect(requiresPinForRemoteOperation(node({}), 1)).to.equal(false);
+        });
+    });
+
+    describe("supportsCommand", () => {
+        it("checks the endpoint's AcceptedCommandList", () => {
+            expect(supportsCommand(node({ "1/257/65529": [0, 1, 3] }), 1, UNLOCK_WITH_TIMEOUT_COMMAND_ID)).to.equal(
+                true,
+            );
+            expect(supportsCommand(node({ "1/257/65529": [0, 1] }), 1, UNLOCK_WITH_TIMEOUT_COMMAND_ID)).to.equal(false);
+            expect(supportsCommand(node({}), 1, UNLOCK_WITH_TIMEOUT_COMMAND_ID)).to.equal(false);
+        });
+    });
+
+    describe("formatDaysMask", () => {
+        it("names the common day sets", () => {
+            expect(formatDaysMask(MON | TUE | WED | THU | FRI)).to.equal("Mon–Fri");
+            expect(formatDaysMask(SAT | SUN)).to.equal("Sat–Sun");
+            expect(formatDaysMask(MON | TUE | WED | THU | FRI | SAT | SUN)).to.equal("Every day");
+            expect(formatDaysMask(0)).to.equal("No day");
+        });
+        it("lists other combinations in display order", () => {
+            expect(formatDaysMask(MON | WED | SUN)).to.equal("Mon, Wed, Sun");
+        });
+    });
+
+    describe("maskHasDay / toggleMaskDay", () => {
+        it("adds and removes a day", () => {
+            const withMonday = toggleMaskDay(0, 1);
+            expect(maskHasDay(withMonday, 1)).to.equal(true);
+            expect(maskHasDay(toggleMaskDay(withMonday, 1), 1)).to.equal(false);
+        });
+    });
+
+    describe("time of day", () => {
+        it("formats zero-padded", () => {
+            expect(formatTimeOfDay(8, 5)).to.equal("08:05");
+        });
+        it("parses HH:MM", () => {
+            expect(parseTimeOfDay("18:30")).to.deep.equal({ hour: 18, minute: 30 });
+            expect(parseTimeOfDay(" 7:05 ")).to.deep.equal({ hour: 7, minute: 5 });
+        });
+        it("rejects out-of-range and malformed values", () => {
+            expect(parseTimeOfDay("24:00")).to.equal(null);
+            expect(parseTimeOfDay("10:60")).to.equal(null);
+            expect(parseTimeOfDay("1030")).to.equal(null);
+            expect(parseTimeOfDay("")).to.equal(null);
+        });
+    });
+
+    describe("weekDayScheduleRangeError", () => {
+        const window = { daysMask: MON, startHour: 8, startMinute: 0, endHour: 18, endMinute: 0 };
+        it("accepts a window inside one day", () => {
+            expect(weekDayScheduleRangeError(window)).to.equal(null);
+        });
+        it("requires at least one day", () => {
+            expect(weekDayScheduleRangeError({ ...window, daysMask: 0 })).to.equal("Select at least one day.");
+        });
+        it("rejects a window that does not end after it starts", () => {
+            expect(weekDayScheduleRangeError({ ...window, endHour: 8, endMinute: 0 })).to.not.equal(null);
+            expect(weekDayScheduleRangeError({ ...window, endHour: 7 })).to.not.equal(null);
+        });
+        it("accepts an end minute later within the start hour", () => {
+            expect(weekDayScheduleRangeError({ ...window, endHour: 8, endMinute: 30 })).to.equal(null);
+        });
+    });
+
+    describe("yearDayScheduleRangeError", () => {
+        it("accepts an increasing range", () => {
+            expect(yearDayScheduleRangeError({ localStartTime: 1000, localEndTime: 2000 })).to.equal(null);
+        });
+        it("rejects an end at or before the start", () => {
+            expect(yearDayScheduleRangeError({ localStartTime: 2000, localEndTime: 2000 })).to.not.equal(null);
+        });
+        it("rejects a range that is not fully entered", () => {
+            expect(yearDayScheduleRangeError({ localStartTime: NaN, localEndTime: 2000 })).to.not.equal(null);
+        });
+    });
+
+    describe("buildDaySegments", () => {
+        const slots = [
+            weekDaySlot(1, MON | TUE | WED | THU | FRI, [8, 0], [18, 0]),
+            weekDaySlot(2, SAT | SUN, [10, 30], [12, 0]),
+            { weekDayIndex: 3, status: 139, schedule: null } satisfies WeekDayScheduleSlot,
+        ];
+        it("projects the windows covering a display day", () => {
+            expect(buildDaySegments(slots, 0)).to.deep.equal([{ weekDayIndex: 1, startMin: 480, endMin: 1080 }]);
+            expect(buildDaySegments(slots, 6)).to.deep.equal([{ weekDayIndex: 2, startMin: 630, endMin: 720 }]);
+        });
+        it("returns nothing for a day no schedule covers", () => {
+            expect(buildDaySegments([slots[1]], 0)).to.deep.equal([]);
+        });
+        it("orders overlapping windows by start time", () => {
+            const evening = weekDaySlot(2, MON, [20, 0], [22, 0]);
+            const segments = buildDaySegments([evening, slots[0]], 0);
+            expect(segments.map(segment => segment.weekDayIndex)).to.deep.equal([1, 2]);
+        });
+    });
+
+    describe("decodeWeekDayScheduleResponse", () => {
+        it("decodes a populated slot", () => {
+            const slot = decodeWeekDayScheduleResponse(
+                {
+                    weekDayIndex: 1,
+                    userIndex: 2,
+                    status: 0,
+                    daysMask: MON | FRI,
+                    startHour: 8,
+                    startMinute: 15,
+                    endHour: 17,
+                    endMinute: 45,
+                },
+                1,
+            );
+            expect(slot.status).to.equal(0);
+            expect(slot.schedule).to.deep.equal({
+                weekDayIndex: 1,
+                daysMask: MON | FRI,
+                startHour: 8,
+                startMinute: 15,
+                endHour: 17,
+                endMinute: 45,
+            });
+        });
+        it("reports an empty slot without a schedule", () => {
+            const slot = decodeWeekDayScheduleResponse({ weekDayIndex: 2, userIndex: 2, status: 139 }, 2);
+            expect(slot.status).to.equal(139);
+            expect(slot.schedule).to.equal(null);
+        });
+        it("keeps the requested index when the lock omits it", () => {
+            const slot = decodeWeekDayScheduleResponse({ status: 0, daysMask: SUN }, 3);
+            expect(slot.schedule?.weekDayIndex).to.equal(3);
+        });
+    });
+
+    describe("decodeYearDayScheduleResponse", () => {
+        it("decodes a populated slot", () => {
+            const slot = decodeYearDayScheduleResponse(
+                {
+                    yearDayIndex: 1,
+                    userIndex: 2,
+                    status: 0,
+                    localStartTime: 1_700_000_000,
+                    localEndTime: 1_700_086_400,
+                },
+                1,
+            );
+            expect(slot.schedule).to.deep.equal({
+                yearDayIndex: 1,
+                localStartTime: 1_700_000_000,
+                localEndTime: 1_700_086_400,
+            });
+        });
+        it("reports a slot whose optional times are absent as empty", () => {
+            expect(decodeYearDayScheduleResponse({ yearDayIndex: 2, status: 0 }, 2).schedule).to.equal(null);
+            expect(decodeYearDayScheduleResponse({ yearDayIndex: 2, status: 139 }, 2).schedule).to.equal(null);
+        });
+    });
+
+    describe("decodeUserResponse", () => {
+        it("decodes an occupied user", () => {
+            const user = decodeUserResponse({
+                userIndex: 1,
+                userName: "Alice",
+                userStatus: 1,
+                userType: 2,
+                nextUserIndex: 4,
+            });
+            expect(user).to.deep.equal({
+                userIndex: 1,
+                userName: "Alice",
+                userStatus: 1,
+                userType: 2,
+                nextUserIndex: 4,
+                occupied: true,
+            });
+        });
+        it("treats a null and an Available status as a free slot", () => {
+            expect(decodeUserResponse({ userIndex: 2, userStatus: null })?.occupied).to.equal(false);
+            expect(decodeUserResponse({ userIndex: 2, userStatus: 0 })?.occupied).to.equal(false);
+        });
+        it("rejects a response without a user index", () => {
+            expect(decodeUserResponse({ userStatus: 1 })).to.equal(null);
+            expect(decodeUserResponse(null)).to.equal(null);
+        });
+    });
+
+    describe("user labels", () => {
+        it("prefers the user's own name", () => {
+            const user = decodeUserResponse({ userIndex: 3, userName: "Bob", userStatus: 1 })!;
+            expect(formatUserLabel(user)).to.equal("Bob");
+        });
+        it("falls back to the index", () => {
+            const user = decodeUserResponse({ userIndex: 3, userStatus: 1 })!;
+            expect(formatUserLabel(user)).to.equal("User 3");
+        });
+        it("names the status and type enums", () => {
+            expect(formatUserStatus(1)).to.equal("Enabled");
+            expect(formatUserStatus(3)).to.equal("Disabled");
+            expect(formatUserType(8)).to.equal("Schedule Restricted");
+            expect(formatUserType(null)).to.equal(null);
+        });
+    });
+
+    describe("datetime-local values", () => {
+        it("round-trips a whole-minute instant through the input format", () => {
+            const seconds = Math.floor(Date.UTC(2026, 7, 22, 9, 30) / 1000);
+            expect(fromDateTimeInputValue(toDateTimeInputValue(seconds))).to.equal(seconds);
+        });
+        it("reads an empty or malformed value as absent", () => {
+            expect(fromDateTimeInputValue("")).to.equal(null);
+            expect(fromDateTimeInputValue("not a date")).to.equal(null);
+        });
+    });
+
+    describe("encodePinCode", () => {
+        it("encodes the PIN as base64 for the octstr field", () => {
+            expect(encodePinCode("1234")).to.equal("MTIzNA==");
+        });
+    });
+});

--- a/packages/dashboard/test/DoorLockUtilTest.ts
+++ b/packages/dashboard/test/DoorLockUtilTest.ts
@@ -14,15 +14,20 @@ import {
     encodePinCode,
     formatDaysMask,
     formatOperatingMode,
+    formatScheduleStatus,
     formatTimeOfDay,
     formatUserLabel,
     formatUserStatus,
     formatUserType,
+    defaultHolidayMode,
+    formatWallClock,
+    holidayModeChoices,
     fromDateTimeInputValue,
     holidayScheduleRangeError,
     isFeatureActive,
     maskHasDay,
     nextFreeUserIndex,
+    nowAsWallClock,
     parseTimeOfDay,
     readHolidaySchedulesSupported,
     readTotalUsersSupported,
@@ -30,10 +35,12 @@ import {
     readWeekDaySchedulesPerUser,
     readYearDaySchedulesPerUser,
     requiresPinForRemoteOperation,
+    supportedOperatingModes,
     supportsCommand,
     toDateTimeInputValue,
     toggleMaskDay,
     UNLOCK_WITH_TIMEOUT_COMMAND_ID,
+    userNameLengthError,
     weekDayScheduleRangeError,
     yearDayScheduleRangeError,
     type WeekDayScheduleSlot,
@@ -153,6 +160,9 @@ describe("door-lock util", () => {
             expect(parseTimeOfDay("1030")).to.equal(null);
             expect(parseTimeOfDay("")).to.equal(null);
         });
+        it("accepts the seconds an input at second precision emits, and drops them", () => {
+            expect(parseTimeOfDay("18:30:45")).to.deep.equal({ hour: 18, minute: 30 });
+        });
     });
 
     describe("weekDayScheduleRangeError", () => {
@@ -181,6 +191,13 @@ describe("door-lock util", () => {
         });
         it("rejects a range that is not fully entered", () => {
             expect(yearDayScheduleRangeError({ localStartTime: NaN, localEndTime: 2000 })).to.not.equal(null);
+        });
+        it("rejects a bound the uint32 epoch-s field cannot carry", () => {
+            // Asserted on the message so the earlier "enter both dates" branch cannot satisfy this.
+            expect(yearDayScheduleRangeError({ localStartTime: -1, localEndTime: 2000 })).to.contain("2136-02-07");
+            expect(yearDayScheduleRangeError({ localStartTime: 0, localEndTime: 0x1_0000_0000 })).to.contain(
+                "2136-02-07",
+            );
         });
     });
 
@@ -253,8 +270,32 @@ describe("door-lock util", () => {
             expect(slot.schedule).to.equal(null);
         });
         it("keeps the requested index when the lock omits it", () => {
-            const slot = decodeWeekDayScheduleResponse({ status: 0, daysMask: SUN }, 3);
+            const slot = decodeWeekDayScheduleResponse(
+                { status: 0, daysMask: SUN, startHour: 0, startMinute: 0, endHour: 1, endMinute: 0 },
+                3,
+            );
             expect(slot.schedule?.weekDayIndex).to.equal(3);
+        });
+        it("reports a Success response with a partial window as unreadable, not as free", () => {
+            // Half a window is not a 00:00 schedule, and rendering it as Empty offers a "+" over a slot
+            // that may well be occupied.
+            const slot = decodeWeekDayScheduleResponse({ status: 0, daysMask: SUN, startHour: 8 }, 4);
+            expect(slot.schedule).to.equal(null);
+            expect(slot.status).to.equal(null);
+        });
+        it("distinguishes a response carrying no status from a successful empty slot", () => {
+            // An empty slot is one the lock answered for; this is one it did not.
+            expect(decodeWeekDayScheduleResponse({}, 5).status).to.equal(null);
+            expect(decodeWeekDayScheduleResponse("nonsense", 5).status).to.equal(null);
+            expect(decodeYearDayScheduleResponse({}, 5).status).to.equal(null);
+            expect(decodeHolidayScheduleResponse({}, 5).status).to.equal(null);
+        });
+        it("reports a truncated Success from the year day and holiday responses as unreadable too", () => {
+            // Same spec sentence as the week day case: SUCCESS obliges the lock to send the fields.
+            expect(decodeYearDayScheduleResponse({ status: 0, localStartTime: 100 }, 6).status).to.equal(null);
+            expect(
+                decodeHolidayScheduleResponse({ status: 0, localStartTime: 100, localEndTime: 200 }, 6).status,
+            ).to.equal(null);
         });
     });
 
@@ -386,13 +427,134 @@ describe("door-lock util", () => {
     });
 
     describe("datetime-local values", () => {
-        it("round-trips a whole-minute instant through the input format", () => {
-            const seconds = Math.floor(Date.UTC(2026, 7, 22, 9, 30) / 1000);
-            expect(fromDateTimeInputValue(toDateTimeInputValue(seconds))).to.equal(seconds);
+        // 2026-08-22T09:30 on the lock's own clock. Anchored to the literal wire number rather than to a
+        // round-trip: the conversion this pins is exactly the one a self-consistent round-trip cannot see.
+        const WALL_CLOCK_2026_08_22_0930 = 840706200;
+
+        it("encodes the lock's wall clock as Matter epoch-s, not Unix seconds", () => {
+            expect(fromDateTimeInputValue("2026-08-22T09:30")).to.equal(WALL_CLOCK_2026_08_22_0930);
+            expect(toDateTimeInputValue(WALL_CLOCK_2026_08_22_0930)).to.equal("2026-08-22T09:30");
         });
-        it("reads an empty or malformed value as absent", () => {
+        describe("in a viewer time zone that is not UTC", () => {
+            // A UTC host cannot tell a local-getter bug from a correct one, so the zone is forced here.
+            let originalTimeZone: string | undefined;
+            before(() => {
+                originalTimeZone = process.env["TZ"];
+                process.env["TZ"] = "America/New_York";
+            });
+            after(() => {
+                if (originalTimeZone === undefined) delete process.env["TZ"];
+                else process.env["TZ"] = originalTimeZone;
+            });
+
+            it("shows the lock's wall clock rather than converting it to the viewer's zone", () => {
+                const asViewerLocalTime = new Date((WALL_CLOCK_2026_08_22_0930 + 946_684_800) * 1000).toLocaleString();
+                expect(formatWallClock(WALL_CLOCK_2026_08_22_0930)).to.not.equal(asViewerLocalTime);
+                expect(formatWallClock(WALL_CLOCK_2026_08_22_0930)).to.contain("09:30");
+            });
+            it("reads a value back unshifted", () => {
+                expect(toDateTimeInputValue(WALL_CLOCK_2026_08_22_0930)).to.equal("2026-08-22T09:30");
+                expect(fromDateTimeInputValue("2026-08-22T09:30")).to.equal(WALL_CLOCK_2026_08_22_0930);
+            });
+            it("reads the browser's own wall clock, not its UTC instant", () => {
+                // getUTC* here would name the New York date/time as if it were the local one. The clock is
+                // sampled on both sides so a minute rolling over mid-test cannot fail it.
+                const stamp = (at: Date) =>
+                    `${at.toLocaleDateString("en-CA")}T${at.toLocaleTimeString("en-GB").slice(0, 5)}`;
+                const before = stamp(new Date());
+                const actual = toDateTimeInputValue(nowAsWallClock()).slice(0, 16);
+                expect(actual).to.be.oneOf([before, stamp(new Date())]);
+            });
+        });
+        it("keeps seconds a lock reported rather than truncating them on the next save", () => {
+            const withSeconds = WALL_CLOCK_2026_08_22_0930 + 45;
+            expect(toDateTimeInputValue(withSeconds)).to.equal("2026-08-22T09:30:45");
+            expect(fromDateTimeInputValue("2026-08-22T09:30:45")).to.equal(withSeconds);
+        });
+        it("reads the epoch start and the field's last representable second", () => {
+            expect(fromDateTimeInputValue("2000-01-01T00:00:00")).to.equal(0);
+            expect(fromDateTimeInputValue("2136-02-07T06:28:15")).to.equal(0xffffffff);
+        });
+        it("reads an empty, malformed or impossible value as absent", () => {
             expect(fromDateTimeInputValue("")).to.equal(null);
             expect(fromDateTimeInputValue("not a date")).to.equal(null);
+            // Date.UTC would roll this into March rather than rejecting it.
+            expect(fromDateTimeInputValue("2026-02-30T09:30")).to.equal(null);
+        });
+        it("rejects an out-of-range time component the picker cannot produce but a script can", () => {
+            expect(fromDateTimeInputValue("2026-08-22T24:00")).to.equal(null);
+            expect(fromDateTimeInputValue("2026-08-22T12:99")).to.equal(null);
+            expect(fromDateTimeInputValue("2026-08-22T12:30:99")).to.equal(null);
+        });
+    });
+
+    describe("formatScheduleStatus", () => {
+        it("reads Success and NotFound as an empty slot", () => {
+            expect(formatScheduleStatus(0)).to.equal("Empty");
+            expect(formatScheduleStatus(0x8b)).to.equal("Empty");
+        });
+        it("names the interaction-model status the Status field actually carries", () => {
+            // The field is typed `status`, and the spec names INVALID_COMMAND for an out-of-range index.
+            expect(formatScheduleStatus(0x85)).to.equal("InvalidCommand");
+            expect(formatScheduleStatus(0x7e)).to.equal("UnsupportedAccess");
+        });
+        it("distinguishes a response that carried no status from a successful empty slot", () => {
+            expect(formatScheduleStatus(null)).to.equal("Unreadable");
+        });
+        it("falls back for an unknown status", () => {
+            expect(formatScheduleStatus(0x42)).to.equal("Unknown(66)");
+        });
+    });
+
+    describe("supportedOperatingModes", () => {
+        const endpointAttr = "1/257/38";
+
+        it("treats a cleared bit as supported, per the inverted bitmap", () => {
+            // Normal (bit 0) and Privacy (bit 2) clear; everything else set, i.e. unsupported.
+            expect(supportedOperatingModes(node({ [endpointAttr]: 0b11111010 }), 1)).to.deep.equal([0, 2]);
+        });
+        it("offers every mode when the lock does not report the attribute", () => {
+            expect(supportedOperatingModes(node({}), 1)).to.deep.equal([0, 1, 2, 3, 4]);
+        });
+        it("offers every mode rather than none when the lock reports all of them unsupported", () => {
+            expect(supportedOperatingModes(node({ [endpointAttr]: 0xff }), 1)).to.deep.equal([0, 1, 2, 3, 4]);
+        });
+    });
+
+    describe("holidayModeChoices", () => {
+        it("offers the supported modes unchanged when the current one is among them", () => {
+            expect(holidayModeChoices([0, 1, 3], 1)).to.deep.equal([0, 1, 3]);
+        });
+        it("keeps a stored mode the lock no longer advertises", () => {
+            // Otherwise the picker shows its first entry while a save still writes the stored mode.
+            expect(holidayModeChoices([0, 3], 1)).to.deep.equal([1, 0, 3]);
+        });
+    });
+
+    describe("defaultHolidayMode", () => {
+        it("starts a new holiday schedule on Vacation", () => {
+            expect(defaultHolidayMode([0, 1, 2, 3, 4])).to.equal(1);
+        });
+        it("falls back to the first supported mode when Vacation is not implemented", () => {
+            expect(defaultHolidayMode([0, 3])).to.equal(0);
+        });
+        it("falls back to Normal, which every lock implements, for an empty list", () => {
+            expect(defaultHolidayMode([])).to.equal(0);
+        });
+    });
+
+    describe("userNameLengthError", () => {
+        it("accepts a name inside the constraint", () => {
+            expect(userNameLengthError("Alice")).to.equal(null);
+            expect(userNameLengthError("0123456789")).to.equal(null);
+        });
+        it("rejects an empty name", () => {
+            expect(userNameLengthError("")).to.equal("Enter a name for the user.");
+        });
+        it("counts UTF-8 bytes, not characters", () => {
+            // Ten characters, but the lock measures the encoded octets and rejects this one.
+            expect(userNameLengthError("Zoë Müller")).to.contain("bytes");
+            expect(userNameLengthError("01234567890")).to.contain("bytes");
         });
     });
 
@@ -404,7 +566,7 @@ describe("door-lock util", () => {
 
     describe("readUsers", () => {
         function fakeUserClient(responses: Record<number, unknown>) {
-            const calls: number[] = [];
+            const calls = new Array<number>();
             const client = {
                 deviceCommand: (
                     _nodeId: number | bigint,

--- a/packages/dashboard/test/DoorLockUtilTest.ts
+++ b/packages/dashboard/test/DoorLockUtilTest.ts
@@ -4,23 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MatterNode, type MatterNodeData } from "@matter-server/ws-client";
+import { MatterNode, type MatterClient, type MatterNodeData } from "@matter-server/ws-client";
 import {
     buildDaySegments,
+    decodeHolidayScheduleResponse,
     decodeUserResponse,
     decodeWeekDayScheduleResponse,
     decodeYearDayScheduleResponse,
     encodePinCode,
     formatDaysMask,
+    formatOperatingMode,
     formatTimeOfDay,
     formatUserLabel,
     formatUserStatus,
     formatUserType,
     fromDateTimeInputValue,
+    holidayScheduleRangeError,
     isFeatureActive,
     maskHasDay,
+    nextFreeUserIndex,
     parseTimeOfDay,
+    readHolidaySchedulesSupported,
     readTotalUsersSupported,
+    readUsers,
     readWeekDaySchedulesPerUser,
     readYearDaySchedulesPerUser,
     requiresPinForRemoteOperation,
@@ -87,10 +93,11 @@ describe("door-lock util", () => {
 
     describe("attribute readers", () => {
         it("reads the per-user schedule capacities and the user total", () => {
-            const lock = node({ "1/257/17": 10, "1/257/20": 4, "1/257/21": 3 });
+            const lock = node({ "1/257/17": 10, "1/257/20": 4, "1/257/21": 3, "1/257/22": 2 });
             expect(readTotalUsersSupported(lock, 1)).to.equal(10);
             expect(readWeekDaySchedulesPerUser(lock, 1)).to.equal(4);
             expect(readYearDaySchedulesPerUser(lock, 1)).to.equal(3);
+            expect(readHolidaySchedulesSupported(lock, 1)).to.equal(2);
         });
         it("reports absent attributes as null", () => {
             expect(readWeekDaySchedulesPerUser(node({}), 1)).to.equal(null);
@@ -177,6 +184,24 @@ describe("door-lock util", () => {
         });
     });
 
+    describe("holidayScheduleRangeError", () => {
+        it("accepts an increasing range", () => {
+            expect(
+                holidayScheduleRangeError({ localStartTime: 1000, localEndTime: 2000, operatingMode: 1 }),
+            ).to.equal(null);
+        });
+        it("rejects an end at or before the start", () => {
+            expect(
+                holidayScheduleRangeError({ localStartTime: 2000, localEndTime: 2000, operatingMode: 1 }),
+            ).to.not.equal(null);
+        });
+        it("rejects a range that is not fully entered", () => {
+            expect(
+                holidayScheduleRangeError({ localStartTime: NaN, localEndTime: 2000, operatingMode: 1 }),
+            ).to.not.equal(null);
+        });
+    });
+
     describe("buildDaySegments", () => {
         const slots = [
             weekDaySlot(1, MON | TUE | WED | THU | FRI, [8, 0], [18, 0]),
@@ -257,6 +282,31 @@ describe("door-lock util", () => {
         });
     });
 
+    describe("decodeHolidayScheduleResponse", () => {
+        it("decodes a populated slot", () => {
+            const slot = decodeHolidayScheduleResponse(
+                {
+                    holidayIndex: 1,
+                    status: 0,
+                    localStartTime: 1_700_000_000,
+                    localEndTime: 1_700_086_400,
+                    operatingMode: 1,
+                },
+                1,
+            );
+            expect(slot.schedule).to.deep.equal({
+                holidayIndex: 1,
+                localStartTime: 1_700_000_000,
+                localEndTime: 1_700_086_400,
+                operatingMode: 1,
+            });
+        });
+        it("reports a slot whose optional fields are absent as empty", () => {
+            expect(decodeHolidayScheduleResponse({ holidayIndex: 2, status: 0 }, 2).schedule).to.equal(null);
+            expect(decodeHolidayScheduleResponse({ holidayIndex: 2, status: 139 }, 2).schedule).to.equal(null);
+        });
+    });
+
     describe("decodeUserResponse", () => {
         it("decodes an occupied user", () => {
             const user = decodeUserResponse({
@@ -285,6 +335,27 @@ describe("door-lock util", () => {
         });
     });
 
+    describe("nextFreeUserIndex", () => {
+        it("picks index 1 on an empty database", () => {
+            expect(nextFreeUserIndex([], 10)).to.equal(1);
+        });
+        it("skips occupied indices, including out of order", () => {
+            const users = [
+                decodeUserResponse({ userIndex: 2, userStatus: 1 })!,
+                decodeUserResponse({ userIndex: 1, userStatus: 1 })!,
+            ];
+            expect(nextFreeUserIndex(users, 10)).to.equal(3);
+        });
+        it("fills a gap left by a removed user before extending the range", () => {
+            const users = [1, 3, 4].map(userIndex => decodeUserResponse({ userIndex, userStatus: 1 })!);
+            expect(nextFreeUserIndex(users, 10)).to.equal(2);
+        });
+        it("returns null once every slot up to maxUsers is occupied", () => {
+            const users = [1, 2, 3].map(userIndex => decodeUserResponse({ userIndex, userStatus: 1 })!);
+            expect(nextFreeUserIndex(users, 3)).to.equal(null);
+        });
+    });
+
     describe("user labels", () => {
         it("prefers the user's own name", () => {
             const user = decodeUserResponse({ userIndex: 3, userName: "Bob", userStatus: 1 })!;
@@ -302,6 +373,18 @@ describe("door-lock util", () => {
         });
     });
 
+    describe("formatOperatingMode", () => {
+        it("names the known operating modes", () => {
+            expect(formatOperatingMode(0)).to.equal("Normal");
+            expect(formatOperatingMode(1)).to.equal("Vacation");
+            expect(formatOperatingMode(4)).to.equal("Passage");
+        });
+        it("passes null through and falls back for an unknown mode", () => {
+            expect(formatOperatingMode(null)).to.equal(null);
+            expect(formatOperatingMode(99)).to.equal("Mode 99");
+        });
+    });
+
     describe("datetime-local values", () => {
         it("round-trips a whole-minute instant through the input format", () => {
             const seconds = Math.floor(Date.UTC(2026, 7, 22, 9, 30) / 1000);
@@ -316,6 +399,56 @@ describe("door-lock util", () => {
     describe("encodePinCode", () => {
         it("encodes the PIN as base64 for the octstr field", () => {
             expect(encodePinCode("1234")).to.equal("MTIzNA==");
+        });
+    });
+
+    describe("readUsers", () => {
+        function fakeUserClient(responses: Record<number, unknown>) {
+            const calls: number[] = [];
+            const client = {
+                deviceCommand: (
+                    _nodeId: number | bigint,
+                    _endpointId: number,
+                    _clusterId: number,
+                    _commandName: string,
+                    payload: Record<string, unknown> = {},
+                ) => {
+                    const userIndex = payload["userIndex"] as number;
+                    calls.push(userIndex);
+                    return Promise.resolve(responses[userIndex]);
+                },
+            } as unknown as MatterClient;
+            return { client, calls };
+        }
+
+        it("skips a free slot and follows NextUserIndex to the occupied users", async () => {
+            const { client, calls } = fakeUserClient({
+                1: { userIndex: 1, userStatus: null, nextUserIndex: 2 },
+                2: { userIndex: 2, userName: "Bob", userStatus: 1, nextUserIndex: null },
+            });
+            const users = await readUsers(client, 1, 6, 10);
+            expect(users.map(user => user.userIndex)).to.deep.equal([2]);
+            expect(calls).to.deep.equal([1, 2]);
+        });
+
+        it("stops on a repeated index instead of looping forever", async () => {
+            const { client, calls } = fakeUserClient({
+                1: { userIndex: 1, userName: "A", userStatus: 1, nextUserIndex: 1 },
+            });
+            const users = await readUsers(client, 1, 6, 10);
+            expect(users.map(user => user.userIndex)).to.deep.equal([1]);
+            expect(calls).to.deep.equal([1]);
+        });
+
+        it("bounds the walk at maxUsers on a lock that never terminates the chain", async () => {
+            const responses: Record<number, unknown> = {};
+            for (let index = 1; index <= 5; index++) {
+                responses[index] = { userIndex: index, userName: `U${index}`, userStatus: 1, nextUserIndex: index + 1 };
+            }
+            const { client, calls } = fakeUserClient(responses);
+            const users = await readUsers(client, 1, 6, 2);
+            expect(users.map(user => user.userIndex)).to.deep.equal([1, 2]);
+            expect(calls).to.deep.equal([1, 2]);
         });
     });
 });

--- a/packages/dashboard/test/DoorLockUtilTest.ts
+++ b/packages/dashboard/test/DoorLockUtilTest.ts
@@ -186,9 +186,9 @@ describe("door-lock util", () => {
 
     describe("holidayScheduleRangeError", () => {
         it("accepts an increasing range", () => {
-            expect(
-                holidayScheduleRangeError({ localStartTime: 1000, localEndTime: 2000, operatingMode: 1 }),
-            ).to.equal(null);
+            expect(holidayScheduleRangeError({ localStartTime: 1000, localEndTime: 2000, operatingMode: 1 })).to.equal(
+                null,
+            );
         });
         it("rejects an end at or before the start", () => {
             expect(

--- a/packages/matter-server/test/fixtures/TestDoorLockDevice.ts
+++ b/packages/matter-server/test/fixtures/TestDoorLockDevice.ts
@@ -6,25 +6,36 @@
 
 /**
  * Manual test fixture: A DoorLock device with User + PIN credentials + Week Day / Year Day
- * access schedules enabled, for exercising the dashboard's Door Lock panel (PR #1004).
+ * access schedules enabled, for exercising the dashboard's Door Lock panel.
  *
  * Usage: npx tsx packages/matter-server/test/fixtures/TestDoorLockDevice.ts --storage-path=<path> --port=<port>
  */
 
 import { Environment, ServerNode } from "@matter/main";
+import { DoorLockServer } from "@matter/main/behaviors/door-lock";
 import { DoorLock } from "@matter/main/clusters/door-lock";
 import { DoorLockDevice } from "@matter/main/devices/door-lock";
 import { VendorId } from "@matter/main/types";
 
 const args = process.argv.slice(2);
+
+function numericArg(name: string, fallback: number): number {
+    const arg = args.find(candidate => candidate.startsWith(`--${name}=`));
+    if (arg === undefined) return fallback;
+    const raw = arg.slice(name.length + 3);
+    const value = Number(raw);
+    if (!/^\d+$/.test(raw) || !Number.isSafeInteger(value)) {
+        console.error(`--${name} must be a whole number, got "${raw}"`);
+        process.exit(1);
+    }
+    return value;
+}
+
 const storagePathArg = args.find(a => a.startsWith("--storage-path="));
 const storagePath = storagePathArg?.split("=")[1] ?? ".doorlock-device-storage";
-const portArg = args.find(a => a.startsWith("--port="));
-const port = portArg !== undefined ? Number.parseInt(portArg.split("=")[1], 10) : 5541;
-const discriminatorArg = args.find(a => a.startsWith("--discriminator="));
-const discriminator = discriminatorArg !== undefined ? Number.parseInt(discriminatorArg.split("=")[1], 10) : 3841;
-const passcodeArg = args.find(a => a.startsWith("--passcode="));
-const passcode = passcodeArg !== undefined ? Number.parseInt(passcodeArg.split("=")[1], 10) : 20202022;
+const port = numericArg("port", 5541);
+const discriminator = numericArg("discriminator", 3841);
+const passcode = numericArg("passcode", 20202022);
 
 const env = Environment.default;
 env.vars.set("storage.path", storagePath);
@@ -56,10 +67,18 @@ const node = await ServerNode.create({
     },
 });
 
-// The full feature set (PinCredential, User, WDSCH/YDSCH/HDSCH, ...) is baked into DoorLockServer at
-// runtime, but the device's static Type<> only widens per feature actually threaded through the cluster
-// type parameter — cast this throwaway fixture's config rather than fight that for a manual test tool.
-await node.add(DoorLockDevice, {
+const TestDoorLock = DoorLockDevice.with(
+    DoorLockServer.with(
+        "PinCredential",
+        "CredentialOverTheAirAccess",
+        "User",
+        "WeekDayAccessSchedules",
+        "YearDayAccessSchedules",
+        "HolidaySchedules",
+    ),
+);
+
+await node.add(TestDoorLock, {
     id: "doorlock",
     doorLock: {
         lockState: DoorLock.LockState.Locked,
@@ -85,7 +104,7 @@ await node.add(DoorLockDevice, {
         numberOfWeekDaySchedulesSupportedPerUser: 10,
         numberOfYearDaySchedulesSupportedPerUser: 10,
         numberOfHolidaySchedulesSupported: 5,
-    } as Record<string, unknown>,
+    },
 });
 
 console.log("Test Door Lock Device starting...");
@@ -93,18 +112,14 @@ console.log(`Storage path: ${storagePath}`);
 console.log(`Discriminator: ${discriminator}`);
 console.log(`Passcode: ${passcode}`);
 
+// Registered before run(), which only resolves once the node has already stopped.
+for (const signal of ["SIGTERM", "SIGINT"] as const) {
+    process.on(signal, () => {
+        console.log(`Received ${signal}, shutting down...`);
+        node.cancel()
+            .then(() => process.exit(0))
+            .catch(() => process.exit(1));
+    });
+}
+
 await node.run();
-
-process.on("SIGTERM", () => {
-    console.log("Received SIGTERM, shutting down...");
-    node.cancel()
-        .then(() => process.exit(0))
-        .catch(() => process.exit(1));
-});
-
-process.on("SIGINT", () => {
-    console.log("Received SIGINT, shutting down...");
-    node.cancel()
-        .then(() => process.exit(0))
-        .catch(() => process.exit(1));
-});

--- a/packages/matter-server/test/fixtures/TestDoorLockDevice.ts
+++ b/packages/matter-server/test/fixtures/TestDoorLockDevice.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Manual test fixture: A DoorLock device with User + PIN credentials + Week Day / Year Day
+ * access schedules enabled, for exercising the dashboard's Door Lock panel (PR #1004).
+ *
+ * Usage: npx tsx packages/matter-server/test/fixtures/TestDoorLockDevice.ts --storage-path=<path> --port=<port>
+ */
+
+import { Environment, ServerNode } from "@matter/main";
+import { DoorLockDevice } from "@matter/main/devices/door-lock";
+import { DoorLock } from "@matter/main/clusters/door-lock";
+import { VendorId } from "@matter/main/types";
+
+const args = process.argv.slice(2);
+const storagePathArg = args.find(a => a.startsWith("--storage-path="));
+const storagePath = storagePathArg?.split("=")[1] ?? ".doorlock-device-storage";
+const portArg = args.find(a => a.startsWith("--port="));
+const port = portArg !== undefined ? Number.parseInt(portArg.split("=")[1], 10) : 5541;
+const discriminatorArg = args.find(a => a.startsWith("--discriminator="));
+const discriminator = discriminatorArg !== undefined ? Number.parseInt(discriminatorArg.split("=")[1], 10) : 3841;
+const passcodeArg = args.find(a => a.startsWith("--passcode="));
+const passcode = passcodeArg !== undefined ? Number.parseInt(passcodeArg.split("=")[1], 10) : 20202022;
+
+const env = Environment.default;
+env.vars.set("storage.path", storagePath);
+
+const node = await ServerNode.create({
+    network: { port },
+
+    commissioning: {
+        passcode,
+        discriminator,
+    },
+
+    productDescription: {
+        name: "Test Door Lock",
+        deviceType: DoorLockDevice.deviceType,
+    },
+
+    basicInformation: {
+        vendorName: "Test Vendor",
+        vendorId: VendorId(0xfff1),
+        productName: "Test Door Lock",
+        productId: 0x8001,
+        serialNumber: "TEST-DOORLOCK-001",
+        uniqueId: "test-door-lock-unique-id",
+    },
+
+    subscriptions: {
+        persistenceEnabled: false,
+    },
+});
+
+// The full feature set (PinCredential, User, WDSCH/YDSCH/HDSCH, ...) is baked into DoorLockServer at
+// runtime, but the device's static Type<> only widens per feature actually threaded through the cluster
+// type parameter — cast this throwaway fixture's config rather than fight that for a manual test tool.
+await node.add(DoorLockDevice, {
+    id: "doorlock",
+    doorLock: {
+        lockState: DoorLock.LockState.Locked,
+        lockType: DoorLock.LockType.DeadBolt,
+        actuatorEnabled: true,
+        autoRelockTime: 0,
+        operatingMode: DoorLock.OperatingMode.Normal,
+
+        // PinCredential feature
+        numberOfPinUsersSupported: 10,
+        minPinCodeLength: 4,
+        maxPinCodeLength: 10,
+        wrongCodeEntryLimit: 5,
+        userCodeTemporaryDisableTime: 60,
+        requirePinForRemoteOperation: false,
+
+        // User feature
+        numberOfTotalUsersSupported: 10,
+        numberOfCredentialsSupportedPerUser: 5,
+        credentialRulesSupport: { single: true, dual: false, tri: false },
+
+        // WeekDayAccessSchedules / YearDayAccessSchedules / HolidaySchedules features
+        numberOfWeekDaySchedulesSupportedPerUser: 10,
+        numberOfYearDaySchedulesSupportedPerUser: 10,
+        numberOfHolidaySchedulesSupported: 5,
+    } as Record<string, unknown>,
+});
+
+console.log("Test Door Lock Device starting...");
+console.log(`Storage path: ${storagePath}`);
+console.log(`Discriminator: ${discriminator}`);
+console.log(`Passcode: ${passcode}`);
+
+await node.run();
+
+process.on("SIGTERM", () => {
+    console.log("Received SIGTERM, shutting down...");
+    node.cancel()
+        .then(() => process.exit(0))
+        .catch(() => process.exit(1));
+});
+
+process.on("SIGINT", () => {
+    console.log("Received SIGINT, shutting down...");
+    node.cancel()
+        .then(() => process.exit(0))
+        .catch(() => process.exit(1));
+});

--- a/packages/matter-server/test/fixtures/TestDoorLockDevice.ts
+++ b/packages/matter-server/test/fixtures/TestDoorLockDevice.ts
@@ -12,8 +12,8 @@
  */
 
 import { Environment, ServerNode } from "@matter/main";
-import { DoorLockDevice } from "@matter/main/devices/door-lock";
 import { DoorLock } from "@matter/main/clusters/door-lock";
+import { DoorLockDevice } from "@matter/main/devices/door-lock";
 import { VendorId } from "@matter/main/types";
 
 const args = process.argv.slice(2);


### PR DESCRIPTION
Adds a dashboard command panel for the Door Lock cluster (0x0101), which had no panel at all before this change:

- **Lock Control**: lock state/door state/type, Lock/Unlock, and UnlockWithTimeout gated on AcceptedCommandList since it's optional. A PIN required by RequirePinForRemoteOperation is validated locally instead of round-tripping a request the lock will reject.
- **Access Schedules**: a user picker fed by walking GetUser through NextUserIndex (free slots cost no round-trip), plus **Add user / Remove user** (SetUser Add / ClearUser) so the panel is usable on a lock with no users provisioned elsewhere — `nextFreeUserIndex()` reuses the gap left by a removed user.
- Per-user **Week Day (WDSCH)** and **Year Day (YDSCH)** schedule sections, and the lock-wide (not per-user) **Holiday (HDSCH)** schedule table with an OperatingMode picker (Normal/Vacation/Privacy/No Remote Lock-Unlock/Passage). Each supports add/edit/clear per slot and a "Clear all" (schedule index 0xFE) confirmed via dialog.
- Empty schedule slots collapse by default (occupied slots + the next free one), with a "Show N more empty slots" toggle, so a lock with many slots doesn't dump a wall of "Empty" rows.

All three schedule features, and User, gate independently on the FeatureMap so a lock supporting only a subset still gets a working panel.

`packages/dashboard/src/util/door-lock.ts` holds the cluster helpers (attribute readers, day-mask formatting/validation, response decoding, command wrappers); `packages/dashboard/test/DoorLockUtilTest.ts` covers the pure helpers plus `readUsers`'s NextUserIndex walk (50 cases). `packages/matter-server/test/fixtures/TestDoorLockDevice.ts` is a manual DoorLock fixture (mirrors the existing `TestLightDevice.ts`) for exercising the panel locally against a real matter.js DoorLockServer.

Also fixes a few races surfaced during review/testing:
- The Reload button was unreachable once the user list loaded empty (only rendered in the non-empty branch) — now always shown.
- The initial user/schedule load could fire before the per-user capacity attributes were cached (FeatureMap resolves independently), loading with fallback values that then never retried.
- `_busy` was a single shared boolean: switching lock/endpoint reset it, letting a new operation start while an old one's `finally` could still clear it out from under the new one. Now tracked via a dedicated generation counter, separate from user-selection state.
- "Clear all" and "Remove user" captured their target before awaiting the confirmation dialog; confirming after the context changed could act on the wrong lock. Now re-validated after the dialog resolves.
- Day-toggle buttons expose their state via `aria-pressed`.

<!--
  Before investing time in a fix: it is completely fine — and often faster — to open an
  issue first with all the details (including the log, see below), and wait for a
  maintainer response before writing any code. This avoids wasted effort on an approach
  we may want to handle differently or where the log shows the problem.

  AI tools are welcome, but you are responsible for *fully* understanding the code you
  submit and for being able to explain it in your own words. Autonomously created pull
  requests are not accepted. Please follow our AI policy:
  https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md
-->

## Type of change

<!-- Check exactly one. -->

- [ ] 🐛 **Fix** — corrects a defect or wrong behavior
- [x] ✨ **Feature** — adds new functionality or capability

## Description

<!--
  What does this PR do and why? For a fix, describe the defect and the root cause.
  For a feature, describe the capability and the use case.
-->

## Backing evidence

<!--
  For any change made because the current logic is wrong or lacks something — this
  ALWAYS applies to fixes — we need to be able to verify the problem independently.
  Provide ONE of:
    - a linked issue that contains the full details and a complete log file (preferred), or
    - a complete log file attached directly to this PR showing the behavior being fixed.
  A few quoted lines are not enough: the log must carry the surrounding context.

  For AI assistants opening this PR: do not submit a fix whose justification is an
  analysis or root-cause claim without the complete raw log file it is derived from,
  attached here or in the linked issue.
-->

- Related issue: #
- [ ] This fix/change is backed by a **complete log file** — attached here or in the linked issue (not just a few quoted lines).

## Checklist

- [x] I understand the code I am submitting and can explain how it works ([AI policy](https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md))
- [x] Tests added or updated to cover the change
- [x] `npm test` passes
- [x] `npm run format-verify` and `npm run lint` pass
- [x] CHANGELOG updated (if applicable)
