### PR TITLE
fix(ble-proxy): implement write_and_subscribe and tolerate the connect race in NobleBleProxyClient

### DIFF
--- a/packages/ble-proxy/src/example/NobleBleProxyClient.ts
+++ b/packages/ble-proxy/src/example/NobleBleProxyClient.ts
@@ -27,10 +27,18 @@ import {
     type ReadCharacteristicArgs,
     type SubscribeCharacteristicArgs,
     type UnsubscribeCharacteristicArgs,
+    type WriteAndSubscribeArgs,
     type WriteCharacteristicArgs,
     decodeBinaryFrame,
     encodeBinaryFrame,
 } from "../BleProxyProtocol.js";
+
+/**
+ * How long #handleConnect waits for a scan result to surface a peripheral the controller has
+ * already asked us to connect to. The controller drives connect off its own discovery bookkeeping,
+ * which can run ahead of our device_discovered event for the same advertisement.
+ */
+const CONNECT_DISCOVERY_TIMEOUT_MS = 5000;
 
 function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
     return Promise.race([promise, new Promise<never>((_, reject) => setTimeout(() => reject(new Error(message)), ms))]);
@@ -229,6 +237,9 @@ export class NobleBleProxyClient {
         this.#commandHandlers.set("subscribe_characteristic", (id, args) =>
             this.#handleSubscribeCharacteristic(id, args as unknown as SubscribeCharacteristicArgs),
         );
+        this.#commandHandlers.set("write_and_subscribe", (id, args) =>
+            this.#handleWriteAndSubscribe(id, args as unknown as WriteAndSubscribeArgs),
+        );
         this.#commandHandlers.set("unsubscribe_characteristic", (id, args) =>
             this.#handleUnsubscribeCharacteristic(id, args as unknown as UnsubscribeCharacteristicArgs),
         );
@@ -335,11 +346,28 @@ export class NobleBleProxyClient {
         this.#sendSuccess(id);
     }
 
+    /**
+     * Resolve a peripheral the controller wants to connect to, tolerating the case where its
+     * connect arrives before our own device_discovered event for the same advertisement.
+     */
+    async #awaitDiscoveredPeripheral(address: string): Promise<Peripheral | undefined> {
+        const deadline = Date.now() + CONNECT_DISCOVERY_TIMEOUT_MS;
+        while (Date.now() < deadline) {
+            await new Promise(resolve => setTimeout(resolve, 100));
+            const peripheral = this.#discoveredPeripherals.get(address);
+            if (peripheral) {
+                return peripheral;
+            }
+        }
+        return undefined;
+    }
+
     async #handleConnect(id: number, args: ConnectArgs): Promise<void> {
-        const peripheral = this.#discoveredPeripherals.get(args.address);
+        const peripheral =
+            this.#discoveredPeripherals.get(args.address) ?? (await this.#awaitDiscoveredPeripheral(args.address));
         if (!peripheral) {
             error(
-                `[CONN] No peripheral found for address "${args.address}". Known: ${[...this.#discoveredPeripherals.keys()].join(", ")}`,
+                `[CONN] No peripheral found for address "${args.address}" after ${CONNECT_DISCOVERY_TIMEOUT_MS}ms. Known: ${[...this.#discoveredPeripherals.keys()].join(", ")}`,
             );
             this.#sendError(id, "device_not_found", `No device found for address ${args.address}`);
             return;
@@ -593,6 +621,55 @@ export class NobleBleProxyClient {
         await char.subscribeAsync();
         conn.subscriptions.set(args.characteristic_uuid, char);
         log(`[GATT] subscribe ${args.characteristic_uuid} handle=${handle}`);
+        this.#sendSuccess(id);
+    }
+
+    /**
+     * Atomic write-then-subscribe used for BTP session establishment.
+     *
+     * The controller sends this instead of a separate write_characteristic and
+     * subscribe_characteristic pair because the peripheral only emits the BTP handshake
+     * response on C2 once both have happened, and it drops the endpoint after
+     * BTP_CONN_RSP_TIMEOUT. The data listener is attached before the write so an indication
+     * arriving between the write response and the subscribe response is not lost.
+     */
+    async #handleWriteAndSubscribe(id: number, args: WriteAndSubscribeArgs): Promise<void> {
+        const conn = this.#connections.get(args.connection_handle);
+        if (!conn) {
+            this.#sendError(id, "not_connected", `No connection with handle ${args.connection_handle}`);
+            return;
+        }
+
+        const writeChar = this.#findCharacteristic(conn, args.write_uuid);
+        if (!writeChar) {
+            this.#sendError(id, "characteristic_not_found", `Characteristic ${args.write_uuid} not found`);
+            return;
+        }
+
+        const subscribeChar = this.#findCharacteristic(conn, args.subscribe_uuid);
+        if (!subscribeChar) {
+            this.#sendError(id, "characteristic_not_found", `Characteristic ${args.subscribe_uuid} not found`);
+            return;
+        }
+
+        const handle = args.connection_handle;
+        subscribeChar.on("data", (data: Buffer) => {
+            log(`[GATT] notify ${args.subscribe_uuid} handle=${handle} ${data.length} bytes`);
+            this.#sendBinaryFrame(BinaryFrameOpcode.Notification, handle, new Uint8Array(data));
+        });
+
+        const data = Buffer.from(args.write_value, "base64");
+        // C1 is a write-with-response characteristic; the controller always sets this.
+        const withResponse = args.write_response ?? true;
+        log(
+            `[GATT] write_and_subscribe write ${args.write_uuid} ${data.length} bytes withResponse=${withResponse}` +
+                ` then subscribe ${args.subscribe_uuid} handle=${handle}`,
+        );
+        await writeChar.writeAsync(data, !withResponse);
+        conn.lastWriteCharacteristic = writeChar;
+
+        await subscribeChar.subscribeAsync();
+        conn.subscriptions.set(args.subscribe_uuid, subscribeChar);
         this.#sendSuccess(id);
     }
 


### PR DESCRIPTION
The Noble reference BLE proxy client cannot complete a BTP session with a real device. Two independent gaps, both hit on every commissioning attempt.

## 1. `write_and_subscribe` is unimplemented

`ProxyBleChannel` sends `BleProxyCommand.WriteAndSubscribe` to write the BTP handshake to C1 and subscribe to C2 atomically (`ProxyBleChannel.ts:198`), but `NobleBleProxyClient` registers no handler for it:

```
[←CMD] id=24 write_and_subscribe {"connection_handle":1,"write_uuid":"18ee...9d11","write_value":"ZWwEAAAA9AD/","write_response":true,"subscribe_uuid":"18ee...9d12"}
[→ERR] id=24 Unknown command: write_and_subscribe
[←CMD] id=25 disconnect {"connection_handle":1}
```

The controller then reports:

```
Unexpected error from parallel commissioning attempt: internal_error: Unknown command: write_and_subscribe
Commission failed: discovery of node with discriminator 15 failed:
  No device could be commissioned (1 of 1 started attempt(s) failed, 1 discovered)
```

From the peripheral's side nothing is ever written — a GATT connect, silence, then a disconnect ~4.5 s later:

```
I (481119) chip[DL]: BLE GAP connection established (con 0)
I (485603) chip[DL]: BLE GAP connection terminated (con 0 reason 0x213)
```

The new handler attaches the data listener **before** the write, because the C2 indication is a separate binary frame that can beat the `write_and_subscribe` response, and `binaryFrameReceived` drops frames emitted with no listener attached — the same ordering constraint `ProxyBleChannel.ts:152-154` documents on the controller side.

## 2. `connect` races the client's own discovery

With that fixed, `connect` still fails intermittently. The controller drives `connect` from its own discovery bookkeeping, which can run ahead of the client's `device_discovered` event for the same advertisement — 104 ms in this capture:

```
23:32:53.443 [←CMD] id=43 connect {"address":"f6:85:47:6b:23:ca"}
23:32:53.443 [CONN] No peripheral found for address "f6:85:47:6b:23:ca". Known:
23:32:53.547 [EVT] device_discovered addr=f6:85:47:6b:23:ca rssi=-54 serviceData=["fff6"]
```

`#handleConnect` failed immediately on an empty `#discoveredPeripherals` map. It now waits up to `CONNECT_DISCOVERY_TIMEOUT_MS` (5 s) for the scan to surface the peripheral before giving up, and the error message says how long it waited.

## Why CI doesn't catch this

`BleProxyIntegrationTest.ts:190` asserts the *controller* emits `write_and_subscribe`, but it drives a `BleProxyTestClient` double. Nothing in the suite exercises `NobleBleProxyClient`, so the reference implementation can drift from the protocol without a single test failing. Happy to add coverage here if you'd like it in the same PR — it wasn't obvious to me how you'd prefer to fake Noble.

## Verification

Against an ESP32-C6 running esp-matter v1.6 (ESP-IDF v5.5.5), commissioned over the `/ble` proxy from matter-server 0.7.1.

Before: every attempt died at the handshake, device silent throughout.

After: BTP session establishes, PASE completes, secure session comes up, 241-byte fragments flow in both directions, and commissioning proceeds to device attestation:

```
[GATT] notify 18ee2ef5263d4559959f4f9c429f9d12 handle=1 241 bytes
[←BIN] opcode=1 handle=1 payload=115 bytes
```

`npx tsc --noEmit -p packages/ble-proxy/tsconfig.json` passes.

Scope note: this is specific to the Node reference client. The Python sibling `matter-ble-proxy` (used by Home Assistant) implements `write_and_subscribe` at `client.py:318` and needs no change.
