### PR TITLE
feat(dashboard): add ClosureDimension cluster command panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
+- Enhancement: (lboue) Added a command panel for the ClosureDimension cluster to Dashboard
 - Enhancement: (lboue) Added a command panel for the DoorLock cluster to Dashboard
 - Enhancement: (lboue) Added Presets and Thermostat Suggestions (Thermostat cluster PRES/TSUGGEST features) panels to Dashboard
 - Fix: BLE proxy connections are pinged every 15 seconds and terminated after 45 to 60 seconds of silence, so a proxy client that loses power is detected instead of staying registered indefinitely

--- a/packages/dashboard/src/pages/cluster-commands/clusters/closure-control-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/closure-control-commands.ts
@@ -123,11 +123,11 @@ class ClosureControlClusterCommands extends BaseClusterCommands {
                     }
 
                     <div class="states-grid">
-                        <div class="state-block">
+                        <div class="state-block state-block--current">
                             <div class="state-block-header">Current</div>
                             ${this._renderState(current, features)}
                         </div>
-                        <div class="state-block">
+                        <div class="state-block state-block--target">
                             <div class="state-block-header">Target</div>
                             ${this._renderState(target, features)}
                         </div>
@@ -379,9 +379,21 @@ class ClosureControlClusterCommands extends BaseClusterCommands {
                 padding: 12px 0;
                 margin-bottom: 12px;
             }
+            .state-block {
+                padding: 8px 12px;
+                border-radius: 8px;
+                background: var(--md-sys-color-surface-container-highest);
+                border-left: 3px solid var(--md-sys-color-outline-variant);
+            }
+            .state-block--target {
+                border-left-color: var(--md-sys-color-primary);
+            }
             .state-block-header {
                 font-weight: 500;
                 margin-bottom: 6px;
+            }
+            .state-block--target .state-block-header {
+                color: var(--md-sys-color-primary);
             }
             .state-fields {
                 display: flex;

--- a/packages/dashboard/src/pages/cluster-commands/clusters/closure-dimension-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/closure-dimension-commands.ts
@@ -1,0 +1,455 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import "@material/web/button/filled-button";
+import "@material/web/button/outlined-button";
+import "@material/web/select/outlined-select";
+import "@material/web/select/select-option";
+import { css, html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { handleAsync } from "../../../util/async-handler.js";
+import {
+    CLOSURE_DIMENSION_CLUSTER_ID,
+    CLOSURE_UNIT_LABELS,
+    type ClosureDimensionFeatures,
+    type DimensionState,
+    MODULATION_TYPE_LABELS,
+    OVERFLOW_LABELS,
+    ROTATION_AXIS_LABELS,
+    SPEED_LABELS,
+    STEP_DIRECTION_LABELS,
+    TRANSLATION_DIRECTION_LABELS,
+    formatPercent100ths,
+    readCurrentState,
+    readFeatures,
+    readLatchControlModes,
+    readLimitRange,
+    readModulationType,
+    readOverflow,
+    readResolution,
+    readRotationAxis,
+    readStepValue,
+    readTargetState,
+    readTranslationDirection,
+    readUnit,
+    readUnitRange,
+    setTarget,
+    step as sendStep,
+} from "../../../util/closure-dimension.js";
+import { BaseClusterCommands } from "../base-cluster-commands.js";
+import { registerClusterCommands } from "../registry.js";
+
+@customElement("closure-dimension-cluster-commands")
+class ClosureDimensionClusterCommands extends BaseClusterCommands {
+    @state() private _setTargetPosition = "";
+    @state() private _setTargetLatch = "";
+    @state() private _setTargetSpeed = "";
+    @state() private _stepDirection = "1";
+    @state() private _stepCount = 1;
+    @state() private _stepSpeed = "";
+    private _unsubscribeNodes?: () => void;
+    private _formContext?: string;
+
+    override willUpdate(changedProperties: Map<string, unknown>) {
+        super.willUpdate(changedProperties);
+        if (!this.node) return;
+        const context = `${String(this.node.node_id)}/${this.endpoint}/${this.cluster}`;
+        if (this._formContext !== undefined && this._formContext !== context) {
+            this._setTargetPosition = "";
+            this._setTargetLatch = "";
+            this._setTargetSpeed = "";
+            this._stepDirection = "1";
+            this._stepCount = 1;
+            this._stepSpeed = "";
+        }
+        this._formContext = context;
+    }
+
+    override updated(changedProperties: Map<string, unknown>) {
+        super.updated(changedProperties);
+        if (changedProperties.has("client") && this.client && !this._unsubscribeNodes) {
+            this._unsubscribeNodes = this.client.addEventListener("nodes_changed", () => {
+                this.requestUpdate();
+            });
+        }
+    }
+
+    override disconnectedCallback() {
+        super.disconnectedCallback();
+        this._unsubscribeNodes?.();
+        this._unsubscribeNodes = undefined;
+    }
+
+    override render() {
+        if (!this.node || this.cluster !== CLOSURE_DIMENSION_CLUSTER_ID) return nothing;
+        const features = readFeatures(this.node, this.endpoint);
+        const current = readCurrentState(this.node, this.endpoint);
+        const target = readTargetState(this.node, this.endpoint);
+        const latchControlModes = readLatchControlModes(this.node, this.endpoint);
+
+        return html`
+            <details class="command-panel" open>
+                <summary>Closure Dimension</summary>
+                <div class="command-content">
+                    <div class="states-grid">
+                        <div class="state-block">
+                            <div class="state-block-header">Current</div>
+                            ${this._renderState(current, features)}
+                        </div>
+                        <div class="state-block">
+                            <div class="state-block-header">Target</div>
+                            ${this._renderState(target, features)}
+                        </div>
+                    </div>
+
+                    ${this._renderStaticInfo(features)}
+
+                    <div class="set-target">
+                        <div class="set-target-header">Set target</div>
+                        <div class="set-target-controls">
+                            ${
+                                features.positioning
+                                    ? html`
+                                          <label class="field">
+                                              <span class="muted">Position (%)</span>
+                                              <input
+                                                  type="number"
+                                                  min="0"
+                                                  max="100"
+                                                  step="0.01"
+                                                  placeholder="(unchanged)"
+                                                  .value=${this._setTargetPosition}
+                                                  @input=${(e: Event) => {
+                                                      this._setTargetPosition = (e.target as HTMLInputElement).value;
+                                                  }}
+                                              />
+                                          </label>
+                                      `
+                                    : nothing
+                            }
+                            ${
+                                features.motionLatching &&
+                                (latchControlModes.remoteLatching || latchControlModes.remoteUnlatching)
+                                    ? html`
+                                          <md-outlined-select
+                                              label="Latch"
+                                              .value=${this._setTargetLatch}
+                                              @change=${(e: Event) => {
+                                                  this._setTargetLatch = (e.target as HTMLSelectElement).value;
+                                              }}
+                                          >
+                                              <md-select-option value="">
+                                                  <div slot="headline">(unchanged)</div>
+                                              </md-select-option>
+                                              ${
+                                                  latchControlModes.remoteLatching
+                                                      ? html`<md-select-option value="true">
+                                                            <div slot="headline">Latch</div>
+                                                        </md-select-option>`
+                                                      : nothing
+                                              }
+                                              ${
+                                                  latchControlModes.remoteUnlatching
+                                                      ? html`<md-select-option value="false">
+                                                            <div slot="headline">Unlatch</div>
+                                                        </md-select-option>`
+                                                      : nothing
+                                              }
+                                          </md-outlined-select>
+                                      `
+                                    : nothing
+                            }
+                            ${
+                                features.speed
+                                    ? html`
+                                          <md-outlined-select
+                                              label="Speed"
+                                              .value=${this._setTargetSpeed}
+                                              @change=${(e: Event) => {
+                                                  this._setTargetSpeed = (e.target as HTMLSelectElement).value;
+                                              }}
+                                          >
+                                              <md-select-option value="">
+                                                  <div slot="headline">(unchanged)</div>
+                                              </md-select-option>
+                                              ${Object.entries(SPEED_LABELS).map(
+                                                  ([id, label]) => html`
+                                                      <md-select-option value=${id}>
+                                                          <div slot="headline">${label}</div>
+                                                      </md-select-option>
+                                                  `,
+                                              )}
+                                          </md-outlined-select>
+                                      `
+                                    : nothing
+                            }
+                            <md-filled-button
+                                ?disabled=${
+                                    this._setTargetPosition === "" &&
+                                    this._setTargetLatch === "" &&
+                                    this._setTargetSpeed === ""
+                                }
+                                @click=${handleAsync(() => this._handleSetTarget())}
+                            >
+                                Set
+                            </md-filled-button>
+                        </div>
+                    </div>
+
+                    ${
+                        features.positioning
+                            ? html`
+                                  <div class="step">
+                                      <div class="step-header">Step</div>
+                                      <div class="step-controls">
+                                          <md-outlined-select
+                                              label="Direction"
+                                              .value=${this._stepDirection}
+                                              @change=${(e: Event) => {
+                                                  this._stepDirection = (e.target as HTMLSelectElement).value;
+                                              }}
+                                          >
+                                              ${Object.entries(STEP_DIRECTION_LABELS).map(
+                                                  ([id, label]) => html`
+                                                      <md-select-option value=${id}>
+                                                          <div slot="headline">${label}</div>
+                                                      </md-select-option>
+                                                  `,
+                                              )}
+                                          </md-outlined-select>
+                                          <label class="field">
+                                              <span class="muted">Steps</span>
+                                              <input
+                                                  type="number"
+                                                  min="1"
+                                                  .value=${String(this._stepCount)}
+                                                  @input=${(e: Event) => {
+                                                      const value = parseInt((e.target as HTMLInputElement).value, 10);
+                                                      this._stepCount = Number.isFinite(value) && value > 0 ? value : 1;
+                                                  }}
+                                              />
+                                          </label>
+                                          ${
+                                              features.speed
+                                                  ? html`
+                                                        <md-outlined-select
+                                                            label="Speed"
+                                                            .value=${this._stepSpeed}
+                                                            @change=${(e: Event) => {
+                                                                this._stepSpeed = (e.target as HTMLSelectElement).value;
+                                                            }}
+                                                        >
+                                                            <md-select-option value="">
+                                                                <div slot="headline">(unchanged)</div>
+                                                            </md-select-option>
+                                                            ${Object.entries(SPEED_LABELS).map(
+                                                                ([id, label]) => html`
+                                                                    <md-select-option value=${id}>
+                                                                        <div slot="headline">${label}</div>
+                                                                    </md-select-option>
+                                                                `,
+                                                            )}
+                                                        </md-outlined-select>
+                                                    `
+                                                  : nothing
+                                          }
+                                          <md-outlined-button @click=${handleAsync(() => this._handleStep())}>
+                                              Step
+                                          </md-outlined-button>
+                                      </div>
+                                  </div>
+                              `
+                            : nothing
+                    }
+                </div>
+            </details>
+        `;
+    }
+
+    private _renderState(state: DimensionState | null, features: ClosureDimensionFeatures) {
+        if (!state) return html`<div class="muted empty">Unknown</div>`;
+        return html`
+            <div class="state-fields">
+                ${
+                    features.positioning
+                        ? html`<div class="state-field">
+                              <span class="muted">Position:</span>
+                              <span>${formatPercent100ths(state.position)}</span>
+                          </div>`
+                        : nothing
+                }
+                ${
+                    features.motionLatching
+                        ? html`<div class="state-field">
+                              <span class="muted">Latch:</span>
+                              <span>${state.latch === null ? "Unknown" : state.latch ? "Latched" : "Unlatched"}</span>
+                          </div>`
+                        : nothing
+                }
+                ${
+                    features.speed
+                        ? html`<div class="state-field">
+                              <span class="muted">Speed:</span>
+                              <span
+                                  >${
+                                      state.speed !== null
+                                          ? (SPEED_LABELS[state.speed] ?? `#${state.speed}`)
+                                          : "Unknown"
+                                  }</span
+                              >
+                          </div>`
+                        : nothing
+                }
+            </div>
+        `;
+    }
+
+    private _renderStaticInfo(features: ClosureDimensionFeatures) {
+        const resolution = features.positioning ? readResolution(this.node, this.endpoint) : null;
+        const stepValue = features.positioning ? readStepValue(this.node, this.endpoint) : null;
+        const unit = features.unit ? readUnit(this.node, this.endpoint) : null;
+        const unitRange = features.unit ? readUnitRange(this.node, this.endpoint) : null;
+        const limitRange = features.limitation ? readLimitRange(this.node, this.endpoint) : null;
+        const translationDirection = features.translation ? readTranslationDirection(this.node, this.endpoint) : null;
+        const rotationAxis = features.rotation ? readRotationAxis(this.node, this.endpoint) : null;
+        const overflow = features.rotation ? readOverflow(this.node, this.endpoint) : null;
+        const modulationType = features.modulation ? readModulationType(this.node, this.endpoint) : null;
+
+        const rows: Array<[string, string]> = [];
+        if (resolution !== null) rows.push(["Resolution", formatPercent100ths(resolution)]);
+        if (stepValue !== null) rows.push(["Step size", formatPercent100ths(stepValue)]);
+        if (unit !== null) rows.push(["Unit", CLOSURE_UNIT_LABELS[unit] ?? `#${unit}`]);
+        if (unitRange !== null) rows.push(["Unit range", `${unitRange.min} – ${unitRange.max}`]);
+        if (limitRange !== null)
+            rows.push([
+                "Limit range",
+                `${formatPercent100ths(limitRange.min)} – ${formatPercent100ths(limitRange.max)}`,
+            ]);
+        if (translationDirection !== null)
+            rows.push([
+                "Translation",
+                TRANSLATION_DIRECTION_LABELS[translationDirection] ?? `#${translationDirection}`,
+            ]);
+        if (rotationAxis !== null)
+            rows.push(["Rotation axis", ROTATION_AXIS_LABELS[rotationAxis] ?? `#${rotationAxis}`]);
+        if (overflow !== null) rows.push(["Overflow", OVERFLOW_LABELS[overflow] ?? `#${overflow}`]);
+        if (modulationType !== null)
+            rows.push(["Modulation", MODULATION_TYPE_LABELS[modulationType] ?? `#${modulationType}`]);
+
+        if (rows.length === 0) return nothing;
+        return html`
+            <div class="static-info">
+                ${rows.map(
+                    ([label, value]) => html`
+                        <div class="static-info-row">
+                            <span class="muted">${label}:</span>
+                            <span>${value}</span>
+                        </div>
+                    `,
+                )}
+            </div>
+        `;
+    }
+
+    private async _handleSetTarget() {
+        await setTarget(this.client, this.node.node_id, this.endpoint, {
+            position: this._setTargetPosition !== "" ? Math.round(Number(this._setTargetPosition) * 100) : undefined,
+            latch: this._setTargetLatch !== "" ? this._setTargetLatch === "true" : undefined,
+            speed: this._setTargetSpeed !== "" ? Number(this._setTargetSpeed) : undefined,
+        });
+    }
+
+    private async _handleStep() {
+        await sendStep(this.client, this.node.node_id, this.endpoint, {
+            direction: Number(this._stepDirection),
+            numberOfSteps: this._stepCount,
+            speed: this._stepSpeed !== "" ? Number(this._stepSpeed) : undefined,
+        });
+    }
+
+    static override styles = [
+        ...(Array.isArray(BaseClusterCommands.styles) ? BaseClusterCommands.styles : [BaseClusterCommands.styles]),
+        css`
+            .muted {
+                color: var(--md-sys-color-on-surface-variant);
+            }
+            .states-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+                gap: 16px;
+                padding-bottom: 12px;
+            }
+            .state-block-header {
+                font-weight: 500;
+                margin-bottom: 6px;
+            }
+            .state-fields {
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+            }
+            .state-field {
+                display: flex;
+                gap: 6px;
+            }
+            .static-info {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+                gap: 4px 16px;
+                border-top: 1px solid var(--md-sys-color-outline-variant);
+                border-bottom: 1px solid var(--md-sys-color-outline-variant);
+                padding: 12px 0;
+                margin-bottom: 12px;
+            }
+            .static-info-row {
+                display: flex;
+                gap: 6px;
+            }
+            .set-target,
+            .step {
+                border-top: 1px solid var(--md-sys-color-outline-variant);
+                padding-top: 12px;
+            }
+            .step {
+                margin-top: 12px;
+            }
+            .set-target-header,
+            .step-header {
+                font-weight: 500;
+                margin-bottom: 8px;
+            }
+            .set-target-controls,
+            .step-controls {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+                flex-wrap: wrap;
+            }
+            .field {
+                display: flex;
+                flex-direction: column;
+                gap: 2px;
+                font-size: 14px;
+            }
+            .field input[type="number"] {
+                width: 100px;
+                padding: 8px;
+                border: 1px solid var(--md-sys-color-outline);
+                border-radius: 4px;
+                background: var(--md-sys-color-surface);
+                color: var(--md-sys-color-on-surface);
+            }
+        `,
+    ];
+}
+
+registerClusterCommands(CLOSURE_DIMENSION_CLUSTER_ID, "closure-dimension-cluster-commands");
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "closure-dimension-cluster-commands": ClosureDimensionClusterCommands;
+    }
+}

--- a/packages/dashboard/src/pages/cluster-commands/clusters/closure-dimension-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/closure-dimension-commands.ts
@@ -8,6 +8,7 @@ import "@material/web/button/filled-button";
 import "@material/web/button/outlined-button";
 import "@material/web/select/outlined-select";
 import "@material/web/select/select-option";
+import "@material/web/textfield/outlined-text-field";
 import { css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { handleAsync } from "../../../util/async-handler.js";
@@ -89,17 +90,21 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
         const current = readCurrentState(this.node, this.endpoint);
         const target = readTargetState(this.node, this.endpoint);
         const latchControlModes = readLatchControlModes(this.node, this.endpoint);
+        const targetPositionValue = this._setTargetPosition !== "" ? Number(this._setTargetPosition) : null;
+        const isTargetPositionInvalid =
+            targetPositionValue !== null &&
+            (Number.isNaN(targetPositionValue) || targetPositionValue < 0 || targetPositionValue > 100);
 
         return html`
             <details class="command-panel" open>
                 <summary>Closure Dimension</summary>
                 <div class="command-content">
                     <div class="states-grid">
-                        <div class="state-block">
+                        <div class="state-block state-block--current">
                             <div class="state-block-header">Current</div>
                             ${this._renderState(current, features)}
                         </div>
-                        <div class="state-block">
+                        <div class="state-block state-block--target">
                             <div class="state-block-header">Target</div>
                             ${this._renderState(target, features)}
                         </div>
@@ -113,20 +118,18 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
                             ${
                                 features.positioning
                                     ? html`
-                                          <label class="field">
-                                              <span class="muted">Position (%)</span>
-                                              <input
-                                                  type="number"
-                                                  min="0"
-                                                  max="100"
-                                                  step="0.01"
-                                                  placeholder="(unchanged)"
-                                                  .value=${this._setTargetPosition}
-                                                  @input=${(e: Event) => {
-                                                      this._setTargetPosition = (e.target as HTMLInputElement).value;
-                                                  }}
-                                              />
-                                          </label>
+                                          <md-outlined-text-field
+                                              type="number"
+                                              label="Position (%)"
+                                              min="0"
+                                              max="100"
+                                              step="0.01"
+                                              placeholder="(unchanged)"
+                                              .value=${this._setTargetPosition}
+                                              @input=${(e: Event) => {
+                                                  this._setTargetPosition = (e.target as HTMLInputElement).value;
+                                              }}
+                                          ></md-outlined-text-field>
                                       `
                                     : nothing
                             }
@@ -188,9 +191,10 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
                             }
                             <md-filled-button
                                 ?disabled=${
-                                    this._setTargetPosition === "" &&
-                                    this._setTargetLatch === "" &&
-                                    this._setTargetSpeed === ""
+                                    isTargetPositionInvalid ||
+                                    (this._setTargetPosition === "" &&
+                                        this._setTargetLatch === "" &&
+                                        this._setTargetSpeed === "")
                                 }
                                 @click=${handleAsync(() => this._handleSetTarget())}
                             >
@@ -220,18 +224,16 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
                                                   `,
                                               )}
                                           </md-outlined-select>
-                                          <label class="field">
-                                              <span class="muted">Steps</span>
-                                              <input
-                                                  type="number"
-                                                  min="1"
-                                                  .value=${String(this._stepCount)}
-                                                  @input=${(e: Event) => {
-                                                      const value = parseInt((e.target as HTMLInputElement).value, 10);
-                                                      this._stepCount = Number.isFinite(value) && value > 0 ? value : 1;
-                                                  }}
-                                              />
-                                          </label>
+                                          <md-outlined-text-field
+                                              type="number"
+                                              label="Steps"
+                                              min="1"
+                                              .value=${String(this._stepCount)}
+                                              @input=${(e: Event) => {
+                                                  const value = parseInt((e.target as HTMLInputElement).value, 10);
+                                                  this._stepCount = Number.isFinite(value) && value > 0 ? value : 1;
+                                              }}
+                                          ></md-outlined-text-field>
                                           ${
                                               features.speed
                                                   ? html`
@@ -382,9 +384,21 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
                 gap: 16px;
                 padding-bottom: 12px;
             }
+            .state-block {
+                padding: 8px 12px;
+                border-radius: 8px;
+                background: var(--md-sys-color-surface-container-highest);
+                border-left: 3px solid var(--md-sys-color-outline-variant);
+            }
+            .state-block--target {
+                border-left-color: var(--md-sys-color-primary);
+            }
             .state-block-header {
                 font-weight: 500;
                 margin-bottom: 6px;
+            }
+            .state-block--target .state-block-header {
+                color: var(--md-sys-color-primary);
             }
             .state-fields {
                 display: flex;
@@ -396,9 +410,9 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
                 gap: 6px;
             }
             .static-info {
-                display: grid;
-                grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-                gap: 4px 16px;
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
                 border-top: 1px solid var(--md-sys-color-outline-variant);
                 border-bottom: 1px solid var(--md-sys-color-outline-variant);
                 padding: 12px 0;
@@ -428,19 +442,16 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
                 gap: 12px;
                 flex-wrap: wrap;
             }
-            .field {
-                display: flex;
-                flex-direction: column;
-                gap: 2px;
-                font-size: 14px;
+            .set-target-controls md-outlined-text-field,
+            .step-controls md-outlined-text-field {
+                width: 140px;
             }
-            .field input[type="number"] {
-                width: 100px;
-                padding: 8px;
-                border: 1px solid var(--md-sys-color-outline);
-                border-radius: 4px;
-                background: var(--md-sys-color-surface);
-                color: var(--md-sys-color-on-surface);
+            /* md-outlined-select's own shadow styles set :host{min-width:210px}, which wins over a plain
+               external width/min-width; !important is required to match the text fields' width. */
+            .set-target-controls md-outlined-select,
+            .step-controls md-outlined-select {
+                width: 140px !important;
+                min-width: 140px !important;
             }
         `,
     ];

--- a/packages/dashboard/src/pages/cluster-commands/clusters/closure-dimension-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/closure-dimension-commands.ts
@@ -11,12 +11,14 @@ import "@material/web/select/select-option";
 import "@material/web/textfield/outlined-text-field";
 import { css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import { showAlertDialog } from "../../../components/dialog-box/show-dialog-box.js";
 import { handleAsync } from "../../../util/async-handler.js";
 import {
     CLOSURE_DIMENSION_CLUSTER_ID,
     CLOSURE_UNIT_LABELS,
     type ClosureDimensionFeatures,
     type DimensionState,
+    MAX_NUMBER_OF_STEPS,
     MODULATION_TYPE_LABELS,
     OVERFLOW_LABELS,
     ROTATION_AXIS_LABELS,
@@ -24,6 +26,8 @@ import {
     STEP_DIRECTION_LABELS,
     TRANSLATION_DIRECTION_LABELS,
     formatPercent100ths,
+    parseNumberOfSteps,
+    parseTargetPositionPercent,
     readCurrentState,
     readFeatures,
     readLatchControlModes,
@@ -49,7 +53,7 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
     @state() private _setTargetLatch = "";
     @state() private _setTargetSpeed = "";
     @state() private _stepDirection = "1";
-    @state() private _stepCount = 1;
+    @state() private _stepCount = "1";
     @state() private _stepSpeed = "";
     private _unsubscribeNodes?: () => void;
     private _formContext?: string;
@@ -63,7 +67,7 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
             this._setTargetLatch = "";
             this._setTargetSpeed = "";
             this._stepDirection = "1";
-            this._stepCount = 1;
+            this._stepCount = "1";
             this._stepSpeed = "";
         }
         this._formContext = context;
@@ -90,10 +94,13 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
         const current = readCurrentState(this.node, this.endpoint);
         const target = readTargetState(this.node, this.endpoint);
         const latchControlModes = readLatchControlModes(this.node, this.endpoint);
-        const targetPositionValue = this._setTargetPosition !== "" ? Number(this._setTargetPosition) : null;
-        const isTargetPositionInvalid =
-            targetPositionValue !== null &&
-            (Number.isNaN(targetPositionValue) || targetPositionValue < 0 || targetPositionValue > 100);
+        const limitRange = this._limitRange();
+        const targetPosition = parseTargetPositionPercent(this._setTargetPosition, limitRange);
+        const isTargetPositionInvalid = this._setTargetPosition.trim() !== "" && targetPosition === null;
+        const stepCount = parseNumberOfSteps(this._stepCount);
+        const canLatchRemotely =
+            features.motionLatching && (latchControlModes.remoteLatching || latchControlModes.remoteUnlatching);
+        const canSetTarget = features.positioning || canLatchRemotely || features.speed;
 
         return html`
             <details class="command-panel" open>
@@ -111,98 +118,108 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
                     </div>
 
                     ${this._renderStaticInfo(features)}
-
-                    <div class="set-target">
-                        <div class="set-target-header">Set target</div>
-                        <div class="set-target-controls">
-                            ${
-                                features.positioning
-                                    ? html`
-                                          <md-outlined-text-field
-                                              type="number"
-                                              label="Position (%)"
-                                              min="0"
-                                              max="100"
-                                              step="0.01"
-                                              placeholder="(unchanged)"
-                                              .value=${this._setTargetPosition}
-                                              @input=${(e: Event) => {
-                                                  this._setTargetPosition = (e.target as HTMLInputElement).value;
-                                              }}
-                                          ></md-outlined-text-field>
-                                      `
-                                    : nothing
-                            }
-                            ${
-                                features.motionLatching &&
-                                (latchControlModes.remoteLatching || latchControlModes.remoteUnlatching)
-                                    ? html`
-                                          <md-outlined-select
-                                              label="Latch"
-                                              .value=${this._setTargetLatch}
-                                              @change=${(e: Event) => {
-                                                  this._setTargetLatch = (e.target as HTMLSelectElement).value;
-                                              }}
-                                          >
-                                              <md-select-option value="">
-                                                  <div slot="headline">(unchanged)</div>
-                                              </md-select-option>
-                                              ${
-                                                  latchControlModes.remoteLatching
-                                                      ? html`<md-select-option value="true">
-                                                            <div slot="headline">Latch</div>
-                                                        </md-select-option>`
-                                                      : nothing
-                                              }
-                                              ${
-                                                  latchControlModes.remoteUnlatching
-                                                      ? html`<md-select-option value="false">
-                                                            <div slot="headline">Unlatch</div>
-                                                        </md-select-option>`
-                                                      : nothing
-                                              }
-                                          </md-outlined-select>
-                                      `
-                                    : nothing
-                            }
-                            ${
-                                features.speed
-                                    ? html`
-                                          <md-outlined-select
-                                              label="Speed"
-                                              .value=${this._setTargetSpeed}
-                                              @change=${(e: Event) => {
-                                                  this._setTargetSpeed = (e.target as HTMLSelectElement).value;
-                                              }}
-                                          >
-                                              <md-select-option value="">
-                                                  <div slot="headline">(unchanged)</div>
-                                              </md-select-option>
-                                              ${Object.entries(SPEED_LABELS).map(
-                                                  ([id, label]) => html`
-                                                      <md-select-option value=${id}>
-                                                          <div slot="headline">${label}</div>
-                                                      </md-select-option>
-                                                  `,
-                                              )}
-                                          </md-outlined-select>
-                                      `
-                                    : nothing
-                            }
-                            <md-filled-button
-                                ?disabled=${
-                                    isTargetPositionInvalid ||
-                                    (this._setTargetPosition === "" &&
-                                        this._setTargetLatch === "" &&
-                                        this._setTargetSpeed === "")
-                                }
-                                @click=${handleAsync(() => this._handleSetTarget())}
-                            >
-                                Set
-                            </md-filled-button>
-                        </div>
-                    </div>
-
+                    ${
+                        canSetTarget
+                            ? html`<div class="set-target">
+                                  <div class="set-target-header">Set target</div>
+                                  <div class="set-target-controls">
+                                      ${
+                                          features.positioning
+                                              ? html`
+                                                    <md-outlined-text-field
+                                                        type="number"
+                                                        label="Position (%)"
+                                                        min=${(limitRange?.min ?? 0) / 100}
+                                                        max=${(limitRange?.max ?? 10000) / 100}
+                                                        step="0.01"
+                                                        placeholder="(unchanged)"
+                                                        .value=${this._setTargetPosition}
+                                                        @input=${(e: Event) => {
+                                                            this._setTargetPosition = (
+                                                                e.target as HTMLInputElement
+                                                            ).value;
+                                                        }}
+                                                    ></md-outlined-text-field>
+                                                `
+                                              : nothing
+                                      }
+                                      ${
+                                          canLatchRemotely
+                                              ? html`
+                                                    <md-outlined-select
+                                                        label="Latch"
+                                                        .value=${this._setTargetLatch}
+                                                        @change=${(e: Event) => {
+                                                            this._setTargetLatch = (
+                                                                e.target as HTMLSelectElement
+                                                            ).value;
+                                                        }}
+                                                    >
+                                                        <md-select-option value="">
+                                                            <div slot="headline">(unchanged)</div>
+                                                        </md-select-option>
+                                                        ${
+                                                            latchControlModes.remoteLatching
+                                                                ? html`<md-select-option value="true">
+                                                                      <div slot="headline">Latch</div>
+                                                                  </md-select-option>`
+                                                                : nothing
+                                                        }
+                                                        ${
+                                                            latchControlModes.remoteUnlatching
+                                                                ? html`<md-select-option value="false">
+                                                                      <div slot="headline">Unlatch</div>
+                                                                  </md-select-option>`
+                                                                : nothing
+                                                        }
+                                                    </md-outlined-select>
+                                                `
+                                              : nothing
+                                      }
+                                      ${
+                                          features.speed
+                                              ? html`
+                                                    <md-outlined-select
+                                                        label="Speed"
+                                                        .value=${this._setTargetSpeed}
+                                                        @change=${(e: Event) => {
+                                                            this._setTargetSpeed = (
+                                                                e.target as HTMLSelectElement
+                                                            ).value;
+                                                        }}
+                                                    >
+                                                        <md-select-option value="">
+                                                            <div slot="headline">(unchanged)</div>
+                                                        </md-select-option>
+                                                        ${Object.entries(SPEED_LABELS).map(
+                                                            ([id, label]) => html`
+                                                                <md-select-option value=${id}>
+                                                                    <div slot="headline">${label}</div>
+                                                                </md-select-option>
+                                                            `,
+                                                        )}
+                                                    </md-outlined-select>
+                                                `
+                                              : nothing
+                                      }
+                                      <md-filled-button
+                                          ?disabled=${
+                                              isTargetPositionInvalid ||
+                                              (this._setTargetPosition === "" &&
+                                                  this._setTargetLatch === "" &&
+                                                  this._setTargetSpeed === "")
+                                          }
+                                          @click=${handleAsync(
+                                              () => this._handleSetTarget(),
+                                              err => this._reportCommandFailure("SetTarget", err),
+                                          )}
+                                      >
+                                          Set
+                                      </md-filled-button>
+                                  </div>
+                              </div>`
+                            : nothing
+                    }
                     ${
                         features.positioning
                             ? html`
@@ -228,10 +245,11 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
                                               type="number"
                                               label="Steps"
                                               min="1"
-                                              .value=${String(this._stepCount)}
+                                              max=${MAX_NUMBER_OF_STEPS}
+                                              step="1"
+                                              .value=${this._stepCount}
                                               @input=${(e: Event) => {
-                                                  const value = parseInt((e.target as HTMLInputElement).value, 10);
-                                                  this._stepCount = Number.isFinite(value) && value > 0 ? value : 1;
+                                                  this._stepCount = (e.target as HTMLInputElement).value;
                                               }}
                                           ></md-outlined-text-field>
                                           ${
@@ -258,7 +276,13 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
                                                     `
                                                   : nothing
                                           }
-                                          <md-outlined-button @click=${handleAsync(() => this._handleStep())}>
+                                          <md-outlined-button
+                                              ?disabled=${stepCount === null}
+                                              @click=${handleAsync(
+                                                  () => this._handleStep(),
+                                                  err => this._reportCommandFailure("Step", err),
+                                              )}
+                                          >
                                               Step
                                           </md-outlined-button>
                                       </div>
@@ -356,20 +380,33 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
         `;
     }
 
+    private _limitRange() {
+        return readFeatures(this.node, this.endpoint).limitation ? readLimitRange(this.node, this.endpoint) : null;
+    }
+
     private async _handleSetTarget() {
+        const position = parseTargetPositionPercent(this._setTargetPosition, this._limitRange());
         await setTarget(this.client, this.node.node_id, this.endpoint, {
-            position: this._setTargetPosition !== "" ? Math.round(Number(this._setTargetPosition) * 100) : undefined,
+            position: position ?? undefined,
             latch: this._setTargetLatch !== "" ? this._setTargetLatch === "true" : undefined,
             speed: this._setTargetSpeed !== "" ? Number(this._setTargetSpeed) : undefined,
         });
     }
 
     private async _handleStep() {
+        const numberOfSteps = parseNumberOfSteps(this._stepCount);
+        if (numberOfSteps === null) return;
         await sendStep(this.client, this.node.node_id, this.endpoint, {
             direction: Number(this._stepDirection),
-            numberOfSteps: this._stepCount,
+            numberOfSteps,
             speed: this._stepSpeed !== "" ? Number(this._stepSpeed) : undefined,
         });
+    }
+
+    private _reportCommandFailure(command: string, err: Error) {
+        showAlertDialog({ title: `${command} failed`, text: err.message }).catch(dialogErr =>
+            console.error("Failed to show the ClosureDimension command error", dialogErr),
+        );
     }
 
     static override styles = [

--- a/packages/dashboard/src/pages/cluster-commands/clusters/closure-dimension-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/closure-dimension-commands.ts
@@ -211,7 +211,7 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
                                           }
                                           @click=${handleAsync(
                                               () => this._handleSetTarget(),
-                                              err => this._reportCommandFailure("SetTarget", err),
+                                              this._failureReporter("SetTarget"),
                                           )}
                                       >
                                           Set
@@ -280,7 +280,7 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
                                               ?disabled=${stepCount === null}
                                               @click=${handleAsync(
                                                   () => this._handleStep(),
-                                                  err => this._reportCommandFailure("Step", err),
+                                                  this._failureReporter("Step"),
                                               )}
                                           >
                                               Step
@@ -403,10 +403,19 @@ class ClosureDimensionClusterCommands extends BaseClusterCommands {
         });
     }
 
-    private _reportCommandFailure(command: string, err: Error) {
-        showAlertDialog({ title: `${command} failed`, text: err.message }).catch(dialogErr =>
-            console.error("Failed to show the ClosureDimension command error", dialogErr),
-        );
+    /** Captures the panel's context at render time; a reused panel must not raise the old device's error. */
+    private _failureReporter(command: string) {
+        const node = this.node;
+        const endpoint = this.endpoint;
+        return (err: Error) => {
+            if (!this.isSameContext(node, endpoint)) {
+                console.error(`${command} failed (panel moved on)`, err);
+                return;
+            }
+            showAlertDialog({ title: `${command} failed`, text: err.message }).catch(dialogErr =>
+                console.error("Failed to show the ClosureDimension command error", dialogErr),
+            );
+        };
     }
 
     static override styles = [

--- a/packages/dashboard/src/pages/cluster-commands/index.ts
+++ b/packages/dashboard/src/pages/cluster-commands/index.ts
@@ -28,6 +28,7 @@ import "./clusters/basic-information-commands.js";
 import "./clusters/binding-commands.js";
 import "./clusters/chime-commands.js";
 import "./clusters/closure-control-commands.js";
+import "./clusters/closure-dimension-commands.js";
 import "./clusters/commodity-tariff-commands.js";
 import "./clusters/door-lock-commands.js";
 import "./clusters/icd-management-commands.js";

--- a/packages/dashboard/src/util/closure-dimension.ts
+++ b/packages/dashboard/src/util/closure-dimension.ts
@@ -1,0 +1,276 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MatterClient, MatterNode } from "@matter-server/ws-client";
+import { asObject, pickNumber } from "./attribute-shapes.js";
+
+/** ClosureDimension cluster (Matter spec §5.5). */
+export const CLOSURE_DIMENSION_CLUSTER_ID = 261; // 0x0105
+
+const ATTR_CURRENT_STATE = 0;
+const ATTR_TARGET_STATE = 1;
+const ATTR_RESOLUTION = 2;
+const ATTR_STEP_VALUE = 3;
+const ATTR_UNIT = 4;
+const ATTR_UNIT_RANGE = 5;
+const ATTR_LIMIT_RANGE = 6;
+const ATTR_TRANSLATION_DIRECTION = 7;
+const ATTR_ROTATION_AXIS = 8;
+const ATTR_OVERFLOW = 9;
+const ATTR_MODULATION_TYPE = 10;
+const ATTR_LATCH_CONTROL_MODES = 11;
+const ATTR_FEATURE_MAP = 0xfffc;
+
+export const SPEED_LABELS: Record<number, string> = {
+    0: "Auto",
+    1: "Low",
+    2: "Medium",
+    3: "High",
+};
+
+export const CLOSURE_UNIT_LABELS: Record<number, string> = {
+    0: "Millimeter",
+    1: "Degree",
+};
+
+/** TranslationDirectionEnum (spec §5.5.6.1). */
+export const TRANSLATION_DIRECTION_LABELS: Record<number, string> = {
+    0: "Downward",
+    1: "Upward",
+    2: "Vertical mask",
+    3: "Vertical symmetry",
+    4: "Leftward",
+    5: "Rightward",
+    6: "Horizontal mask",
+    7: "Horizontal symmetry",
+    8: "Forward",
+    9: "Backward",
+    10: "Depth mask",
+    11: "Depth symmetry",
+};
+
+/** RotationAxisEnum (spec §5.5.6.2). */
+export const ROTATION_AXIS_LABELS: Record<number, string> = {
+    0: "Left",
+    1: "Centered vertical",
+    2: "Left and right",
+    3: "Right",
+    4: "Top",
+    5: "Centered horizontal",
+    6: "Top and bottom",
+    7: "Bottom",
+    8: "Left barrier",
+    9: "Left and right barriers",
+    10: "Right barrier",
+};
+
+/** OverflowEnum (spec §5.5.6.3). */
+export const OVERFLOW_LABELS: Record<number, string> = {
+    0: "No overflow",
+    1: "Inside",
+    2: "Outside",
+    3: "Top inside",
+    4: "Top outside",
+    5: "Bottom inside",
+    6: "Bottom outside",
+    7: "Left inside",
+    8: "Left outside",
+    9: "Right inside",
+    10: "Right outside",
+};
+
+/** ModulationTypeEnum (spec §5.5.6.4). */
+export const MODULATION_TYPE_LABELS: Record<number, string> = {
+    0: "Slats orientation",
+    1: "Slats openwork",
+    2: "Stripes alignment",
+    3: "Opacity",
+    4: "Ventilation",
+};
+
+/** StepDirectionEnum (spec §5.5.6.6). */
+export const STEP_DIRECTION_LABELS: Record<number, string> = {
+    0: "Decrease",
+    1: "Increase",
+};
+
+export interface ClosureDimensionFeatures {
+    positioning: boolean;
+    motionLatching: boolean;
+    unit: boolean;
+    limitation: boolean;
+    speed: boolean;
+    translation: boolean;
+    rotation: boolean;
+    modulation: boolean;
+}
+
+export interface DimensionState {
+    position: number | null;
+    latch: boolean | null;
+    speed: number | null;
+}
+
+export interface Range {
+    min: number;
+    max: number;
+}
+
+export interface LatchControlModes {
+    remoteLatching: boolean;
+    remoteUnlatching: boolean;
+}
+
+function readAttr(node: MatterNode, endpoint: number, attrId: number): unknown {
+    return node.attributes[`${endpoint}/${CLOSURE_DIMENSION_CLUSTER_ID}/${attrId}`];
+}
+
+/** ClosureDimension FeatureMap bits per Matter spec §5.5.5 (PS=0, LT=1, UT=2, LM=3, SP=4, TR=5, RO=6, MD=7). */
+export function parseClosureDimensionFeatures(featureMap: number): ClosureDimensionFeatures {
+    return {
+        positioning: (featureMap & (1 << 0)) !== 0,
+        motionLatching: (featureMap & (1 << 1)) !== 0,
+        unit: (featureMap & (1 << 2)) !== 0,
+        limitation: (featureMap & (1 << 3)) !== 0,
+        speed: (featureMap & (1 << 4)) !== 0,
+        translation: (featureMap & (1 << 5)) !== 0,
+        rotation: (featureMap & (1 << 6)) !== 0,
+        modulation: (featureMap & (1 << 7)) !== 0,
+    };
+}
+
+export function readFeatures(node: MatterNode, endpoint: number): ClosureDimensionFeatures {
+    const v = readAttr(node, endpoint, ATTR_FEATURE_MAP);
+    return parseClosureDimensionFeatures(typeof v === "number" ? v : 0);
+}
+
+function readBoolField(obj: Record<string, unknown>, name: string, tag: string): boolean | null {
+    const v = obj[name] ?? obj[tag];
+    return typeof v === "boolean" ? v : null;
+}
+
+function readDimensionState(node: MatterNode, endpoint: number, attrId: number): DimensionState | null {
+    const obj = asObject(readAttr(node, endpoint, attrId));
+    if (!obj) return null;
+    return {
+        position: pickNumber(obj, "position", "0"),
+        latch: readBoolField(obj, "latch", "1"),
+        speed: pickNumber(obj, "speed", "2"),
+    };
+}
+
+export function readCurrentState(node: MatterNode, endpoint: number): DimensionState | null {
+    return readDimensionState(node, endpoint, ATTR_CURRENT_STATE);
+}
+
+export function readTargetState(node: MatterNode, endpoint: number): DimensionState | null {
+    return readDimensionState(node, endpoint, ATTR_TARGET_STATE);
+}
+
+/** Position fields are percent100ths (0-10000 for 0.00%-100.00%); format for display. */
+export function formatPercent100ths(value: number | null): string {
+    return value === null ? "Unknown" : `${(value / 100).toFixed(2)}%`;
+}
+
+export function readResolution(node: MatterNode, endpoint: number): number | null {
+    const v = readAttr(node, endpoint, ATTR_RESOLUTION);
+    return typeof v === "number" ? v : null;
+}
+
+export function readStepValue(node: MatterNode, endpoint: number): number | null {
+    const v = readAttr(node, endpoint, ATTR_STEP_VALUE);
+    return typeof v === "number" ? v : null;
+}
+
+export function readUnit(node: MatterNode, endpoint: number): number | null {
+    const v = readAttr(node, endpoint, ATTR_UNIT);
+    return typeof v === "number" ? v : null;
+}
+
+export function readUnitRange(node: MatterNode, endpoint: number): Range | null {
+    const obj = asObject(readAttr(node, endpoint, ATTR_UNIT_RANGE));
+    if (!obj) return null;
+    const min = pickNumber(obj, "min", "0");
+    const max = pickNumber(obj, "max", "1");
+    return min === null || max === null ? null : { min, max };
+}
+
+export function readLimitRange(node: MatterNode, endpoint: number): Range | null {
+    const obj = asObject(readAttr(node, endpoint, ATTR_LIMIT_RANGE));
+    if (!obj) return null;
+    const min = pickNumber(obj, "min", "0");
+    const max = pickNumber(obj, "max", "1");
+    return min === null || max === null ? null : { min, max };
+}
+
+export function readTranslationDirection(node: MatterNode, endpoint: number): number | null {
+    const v = readAttr(node, endpoint, ATTR_TRANSLATION_DIRECTION);
+    return typeof v === "number" ? v : null;
+}
+
+export function readRotationAxis(node: MatterNode, endpoint: number): number | null {
+    const v = readAttr(node, endpoint, ATTR_ROTATION_AXIS);
+    return typeof v === "number" ? v : null;
+}
+
+export function readOverflow(node: MatterNode, endpoint: number): number | null {
+    const v = readAttr(node, endpoint, ATTR_OVERFLOW);
+    return typeof v === "number" ? v : null;
+}
+
+export function readModulationType(node: MatterNode, endpoint: number): number | null {
+    const v = readAttr(node, endpoint, ATTR_MODULATION_TYPE);
+    return typeof v === "number" ? v : null;
+}
+
+/** Whether the latch mechanism accepts remote (un)latch requests, vs. manual-only per spec §5.5.6.10. */
+export function readLatchControlModes(node: MatterNode, endpoint: number): LatchControlModes {
+    const v = readAttr(node, endpoint, ATTR_LATCH_CONTROL_MODES);
+    const bitmap = typeof v === "number" ? v : 0;
+    return {
+        remoteLatching: (bitmap & (1 << 0)) !== 0,
+        remoteUnlatching: (bitmap & (1 << 1)) !== 0,
+    };
+}
+
+export interface SetTargetParams {
+    position?: number;
+    latch?: boolean;
+    speed?: number;
+}
+
+export async function setTarget(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    params: SetTargetParams,
+): Promise<void> {
+    const payload: Record<string, unknown> = {};
+    if (params.position !== undefined) payload.position = params.position;
+    if (params.latch !== undefined) payload.latch = params.latch;
+    if (params.speed !== undefined) payload.speed = params.speed;
+    await client.deviceCommand(nodeId, endpoint, CLOSURE_DIMENSION_CLUSTER_ID, "SetTarget", payload);
+}
+
+export interface StepParams {
+    direction: number;
+    numberOfSteps: number;
+    speed?: number;
+}
+
+export async function step(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    params: StepParams,
+): Promise<void> {
+    const payload: Record<string, unknown> = {
+        direction: params.direction,
+        numberOfSteps: params.numberOfSteps,
+    };
+    if (params.speed !== undefined) payload.speed = params.speed;
+    await client.deviceCommand(nodeId, endpoint, CLOSURE_DIMENSION_CLUSTER_ID, "Step", payload);
+}

--- a/packages/dashboard/src/util/closure-dimension.ts
+++ b/packages/dashboard/src/util/closure-dimension.ts
@@ -287,7 +287,10 @@ export function parseTargetPositionPercent(value: string, limitRange: Range | nu
     if (trimmed === "") return null;
     const percent = Number(trimmed);
     if (!Number.isFinite(percent)) return null;
+    // Position is percent100ths, so a hundredth of a percent is the finest the command can carry;
+    // rounding a finer value would move the target the operator asked for.
     const position = Math.round(percent * 100);
+    if (Math.abs(percent * 100 - position) > Number.EPSILON * Math.abs(position)) return null;
     const min = limitRange?.min ?? 0;
     const max = limitRange?.max ?? 10000;
     if (position < min || position > max) return null;

--- a/packages/dashboard/src/util/closure-dimension.ts
+++ b/packages/dashboard/src/util/closure-dimension.ts
@@ -274,3 +274,31 @@ export async function step(
     if (params.speed !== undefined) payload.speed = params.speed;
     await client.deviceCommand(nodeId, endpoint, CLOSURE_DIMENSION_CLUSTER_ID, "Step", payload);
 }
+
+/** Maximum `Step.NumberOfSteps`, a uint16 with `min 1`. */
+export const MAX_NUMBER_OF_STEPS = 65535;
+
+/**
+ * The position the form would send, or null when the field holds no submittable value. `limitRange`
+ * narrows the accepted band to what the device advertises under the Limitation feature.
+ */
+export function parseTargetPositionPercent(value: string, limitRange: Range | null): number | null {
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    const percent = Number(trimmed);
+    if (!Number.isFinite(percent)) return null;
+    const position = Math.round(percent * 100);
+    const min = limitRange?.min ?? 0;
+    const max = limitRange?.max ?? 10000;
+    if (position < min || position > max) return null;
+    return position;
+}
+
+/** The step count the form would send, or null when the field holds no submittable value. */
+export function parseNumberOfSteps(value: string): number | null {
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    const steps = Number(trimmed);
+    if (!Number.isInteger(steps) || steps < 1 || steps > MAX_NUMBER_OF_STEPS) return null;
+    return steps;
+}

--- a/packages/dashboard/test/ClosureDimensionUtilTest.ts
+++ b/packages/dashboard/test/ClosureDimensionUtilTest.ts
@@ -1,0 +1,189 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MatterNode, type MatterClient, type MatterNodeData } from "@matter-server/ws-client";
+import {
+    formatPercent100ths,
+    parseClosureDimensionFeatures,
+    readCurrentState,
+    readFeatures,
+    readLatchControlModes,
+    readLimitRange,
+    readModulationType,
+    readOverflow,
+    readResolution,
+    readRotationAxis,
+    readStepValue,
+    readTargetState,
+    readTranslationDirection,
+    readUnit,
+    readUnitRange,
+    setTarget,
+    step,
+} from "../src/util/closure-dimension.js";
+
+function node(attributes: Record<string, unknown>, node_id: number | bigint = 1): MatterNode {
+    const data: MatterNodeData = {
+        node_id,
+        date_commissioned: "",
+        last_interview: "",
+        interview_version: 1,
+        available: true,
+        is_bridge: false,
+        attributes,
+        attribute_subscriptions: [],
+    };
+    return new MatterNode(data);
+}
+
+describe("closure-dimension util", () => {
+    describe("parseClosureDimensionFeatures", () => {
+        it("decodes all bits", () => {
+            expect(parseClosureDimensionFeatures(0b1111_1111)).to.deep.equal({
+                positioning: true,
+                motionLatching: true,
+                unit: true,
+                limitation: true,
+                speed: true,
+                translation: true,
+                rotation: true,
+                modulation: true,
+            });
+        });
+        it("decodes a positioning-only device", () => {
+            const features = parseClosureDimensionFeatures(0b1);
+            expect(features.positioning).to.equal(true);
+            expect(features.rotation).to.equal(false);
+        });
+    });
+
+    describe("readFeatures", () => {
+        it("reads the FeatureMap attribute for the endpoint", () => {
+            const n = node({ "6/261/65532": 0b10001 }); // Positioning | Speed
+            const features = readFeatures(n, 6);
+            expect(features.positioning).to.equal(true);
+            expect(features.speed).to.equal(true);
+            expect(features.rotation).to.equal(false);
+        });
+        it("defaults to no features when FeatureMap is absent", () => {
+            expect(readFeatures(node({}), 6).positioning).to.equal(false);
+        });
+    });
+
+    describe("readCurrentState / readTargetState", () => {
+        it("decodes named-keyed struct fields", () => {
+            const state = readCurrentState(node({ "6/261/0": { position: 5000, latch: true, speed: 2 } }), 6);
+            expect(state).to.deep.equal({ position: 5000, latch: true, speed: 2 });
+        });
+        it("decodes field-tag-keyed wire entries", () => {
+            const state = readTargetState(node({ "6/261/1": { "0": 10000, "1": false, "2": 0 } }), 6);
+            expect(state).to.deep.equal({ position: 10000, latch: false, speed: 0 });
+        });
+        it("returns null when the attribute is null/absent", () => {
+            expect(readCurrentState(node({ "6/261/0": null }), 6)).to.equal(null);
+            expect(readTargetState(node({}), 6)).to.equal(null);
+        });
+    });
+
+    describe("formatPercent100ths", () => {
+        it("formats a percent100ths value as a percentage", () => {
+            expect(formatPercent100ths(5000)).to.equal("50.00%");
+            expect(formatPercent100ths(10000)).to.equal("100.00%");
+            expect(formatPercent100ths(1)).to.equal("0.01%");
+        });
+        it("reports Unknown for null", () => {
+            expect(formatPercent100ths(null)).to.equal("Unknown");
+        });
+    });
+
+    describe("static attribute readers", () => {
+        it("readResolution / readStepValue read raw percent100ths numbers", () => {
+            expect(readResolution(node({ "6/261/2": 100 }), 6)).to.equal(100);
+            expect(readStepValue(node({ "6/261/3": 500 }), 6)).to.equal(500);
+        });
+        it("readUnit reads the enum value", () => {
+            expect(readUnit(node({ "6/261/4": 1 }), 6)).to.equal(1);
+            expect(readUnit(node({}), 6)).to.equal(null);
+        });
+        it("readUnitRange decodes min/max", () => {
+            expect(readUnitRange(node({ "6/261/5": { min: 0, max: 1000 } }), 6)).to.deep.equal({ min: 0, max: 1000 });
+            expect(readUnitRange(node({ "6/261/5": null }), 6)).to.equal(null);
+        });
+        it("readLimitRange decodes min/max", () => {
+            expect(readLimitRange(node({ "6/261/6": { "0": 0, "1": 8000 } }), 6)).to.deep.equal({ min: 0, max: 8000 });
+        });
+        it("readTranslationDirection / readRotationAxis / readOverflow / readModulationType read enum values", () => {
+            expect(readTranslationDirection(node({ "6/261/7": 1 }), 6)).to.equal(1);
+            expect(readRotationAxis(node({ "6/261/8": 3 }), 6)).to.equal(3);
+            expect(readOverflow(node({ "6/261/9": 2 }), 6)).to.equal(2);
+            expect(readModulationType(node({ "6/261/10": 4 }), 6)).to.equal(4);
+        });
+    });
+
+    describe("readLatchControlModes", () => {
+        it("decodes both bits", () => {
+            expect(readLatchControlModes(node({ "6/261/11": 0b11 }), 6)).to.deep.equal({
+                remoteLatching: true,
+                remoteUnlatching: true,
+            });
+        });
+        it("defaults to unsupported when absent", () => {
+            expect(readLatchControlModes(node({}), 6)).to.deep.equal({
+                remoteLatching: false,
+                remoteUnlatching: false,
+            });
+        });
+    });
+
+    describe("command senders", () => {
+        function fakeClient() {
+            const calls: { command: string; payload: Record<string, unknown> }[] = [];
+            const client = {
+                deviceCommand: (
+                    _nodeId: number | bigint,
+                    _endpointId: number,
+                    _clusterId: number,
+                    commandName: string,
+                    payload: Record<string, unknown> = {},
+                ) => {
+                    calls.push({ command: commandName, payload });
+                    return Promise.resolve();
+                },
+            } as unknown as MatterClient;
+            return { client, calls };
+        }
+
+        it("setTarget() only includes explicitly provided fields", async () => {
+            const { client, calls } = fakeClient();
+            await setTarget(client, 1, 6, { position: 5000 });
+            expect(calls).to.deep.equal([{ command: "SetTarget", payload: { position: 5000 } }]);
+        });
+
+        it("setTarget() includes latch even when false", async () => {
+            const { client, calls } = fakeClient();
+            await setTarget(client, 1, 6, { latch: false });
+            expect(calls).to.deep.equal([{ command: "SetTarget", payload: { latch: false } }]);
+        });
+
+        it("setTarget() sends an empty payload when nothing is set", async () => {
+            const { client, calls } = fakeClient();
+            await setTarget(client, 1, 6, {});
+            expect(calls).to.deep.equal([{ command: "SetTarget", payload: {} }]);
+        });
+
+        it("step() sends direction and numberOfSteps, omitting speed when unset", async () => {
+            const { client, calls } = fakeClient();
+            await step(client, 1, 6, { direction: 1, numberOfSteps: 3 });
+            expect(calls).to.deep.equal([{ command: "Step", payload: { direction: 1, numberOfSteps: 3 } }]);
+        });
+
+        it("step() includes speed when provided", async () => {
+            const { client, calls } = fakeClient();
+            await step(client, 1, 6, { direction: 0, numberOfSteps: 1, speed: 2 });
+            expect(calls).to.deep.equal([{ command: "Step", payload: { direction: 0, numberOfSteps: 1, speed: 2 } }]);
+        });
+    });
+});

--- a/packages/dashboard/test/ClosureDimensionUtilTest.ts
+++ b/packages/dashboard/test/ClosureDimensionUtilTest.ts
@@ -7,7 +7,10 @@
 import { MatterNode, type MatterClient, type MatterNodeData } from "@matter-server/ws-client";
 import {
     formatPercent100ths,
+    MAX_NUMBER_OF_STEPS,
     parseClosureDimensionFeatures,
+    parseNumberOfSteps,
+    parseTargetPositionPercent,
     readCurrentState,
     readFeatures,
     readLatchControlModes,
@@ -184,6 +187,49 @@ describe("closure-dimension util", () => {
             const { client, calls } = fakeClient();
             await step(client, 1, 6, { direction: 0, numberOfSteps: 1, speed: 2 });
             expect(calls).to.deep.equal([{ command: "Step", payload: { direction: 0, numberOfSteps: 1, speed: 2 } }]);
+        });
+    });
+
+    describe("form validation", () => {
+        it("parseTargetPositionPercent() scales percent to percent100ths", () => {
+            expect(parseTargetPositionPercent("50", null)).to.equal(5000);
+            expect(parseTargetPositionPercent("12.34", null)).to.equal(1234);
+            expect(parseTargetPositionPercent(" 0 ", null)).to.equal(0);
+        });
+
+        it("parseTargetPositionPercent() rejects a blank or non-numeric field", () => {
+            expect(parseTargetPositionPercent("", null)).to.equal(null);
+            expect(parseTargetPositionPercent("   ", null)).to.equal(null);
+            expect(parseTargetPositionPercent("abc", null)).to.equal(null);
+        });
+
+        it("parseTargetPositionPercent() rejects values outside 0-100% without a limit range", () => {
+            expect(parseTargetPositionPercent("-1", null)).to.equal(null);
+            expect(parseTargetPositionPercent("100.01", null)).to.equal(null);
+            expect(parseTargetPositionPercent("100", null)).to.equal(10000);
+        });
+
+        it("parseTargetPositionPercent() narrows the accepted band to the limit range", () => {
+            const limitRange = { min: 1000, max: 8000 };
+            expect(parseTargetPositionPercent("100", limitRange)).to.equal(null);
+            expect(parseTargetPositionPercent("5", limitRange)).to.equal(null);
+            expect(parseTargetPositionPercent("80", limitRange)).to.equal(8000);
+            expect(parseTargetPositionPercent("10", limitRange)).to.equal(1000);
+        });
+
+        it("parseNumberOfSteps() accepts the uint16 range only", () => {
+            expect(parseNumberOfSteps("1")).to.equal(1);
+            expect(parseNumberOfSteps(String(MAX_NUMBER_OF_STEPS))).to.equal(MAX_NUMBER_OF_STEPS);
+            expect(parseNumberOfSteps(String(MAX_NUMBER_OF_STEPS + 1))).to.equal(null);
+            expect(parseNumberOfSteps("0")).to.equal(null);
+            expect(parseNumberOfSteps("-3")).to.equal(null);
+        });
+
+        it("parseNumberOfSteps() rejects a blank, fractional or non-numeric field", () => {
+            expect(parseNumberOfSteps("")).to.equal(null);
+            expect(parseNumberOfSteps("2.5")).to.equal(null);
+            expect(parseNumberOfSteps("1e5")).to.equal(null);
+            expect(parseNumberOfSteps("abc")).to.equal(null);
         });
     });
 });

--- a/packages/dashboard/test/ClosureDimensionUtilTest.ts
+++ b/packages/dashboard/test/ClosureDimensionUtilTest.ts
@@ -197,6 +197,12 @@ describe("closure-dimension util", () => {
             expect(parseTargetPositionPercent(" 0 ", null)).to.equal(0);
         });
 
+        it("parseTargetPositionPercent() rejects a precision the command cannot carry", () => {
+            expect(parseTargetPositionPercent("12.34", null)).to.equal(1234);
+            expect(parseTargetPositionPercent("12.345", null)).to.equal(null);
+            expect(parseTargetPositionPercent("0.001", null)).to.equal(null);
+        });
+
         it("parseTargetPositionPercent() rejects a blank or non-numeric field", () => {
             expect(parseTargetPositionPercent("", null)).to.equal(null);
             expect(parseTargetPositionPercent("   ", null)).to.equal(null);


### PR DESCRIPTION
## Type of change

<!-- Check exactly one. -->

- [ ] 🐛 **Fix** — corrects a defect or wrong behavior
- [x] ✨ **Feature** — adds new functionality or capability

## Description

Adds a dashboard command panel for the ClosureDimension cluster (0x0105), mirroring the existing ClosureControl panel (which controls a closure as a whole; ClosureDimension controls one degree of freedom/axis of a composed closure, e.g. one panel or one axis of motion).

- Shows **Current**/**Target** state (position %, latch, speed), each gated on the Positioning/MotionLatching/Speed features.
- Shows feature-gated static attributes: Resolution, Step size, Unit + Unit range, Limit range, Translation direction, Rotation axis + Overflow, Modulation type.
- **Set target** form (SetTarget command): position (%), latch (only when LatchControlModes reports remote latching/unlatching support), speed — each field omitted from the payload when left "(unchanged)".
- **Step** form (Step command, Positioning feature only): direction, number of steps, optional speed.

`packages/dashboard/src/util/closure-dimension.ts` holds the cluster helpers (attribute readers, FeatureMap decoding, command wrappers); `packages/dashboard/test/ClosureDimensionUtilTest.ts` covers them (21 cases).

## Backing evidence

<!--
  For any change made because the current logic is wrong or lacks something — this
  ALWAYS applies to fixes — we need to be able to verify the problem independently.
  Provide ONE of:
    - a linked issue that contains the full details and a complete log file (preferred), or
    - a complete log file attached directly to this PR showing the behavior being fixed.
  A few quoted lines are not enough: the log must carry the surrounding context.

  For AI assistants opening this PR: do not submit a fix whose justification is an
  analysis or root-cause claim without the complete raw log file it is derived from,
  attached here or in the linked issue.
-->

- Related issue: #
- [ ] This fix/change is backed by a **complete log file** — attached here or in the linked issue (not just a few quoted lines).

N/A — this is a new feature (no existing behavior being corrected), not a fix.

## Checklist

- [x] I understand the code I am submitting and can explain how it works ([AI policy](https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md))
- [x] Tests added or updated to cover the change
- [x] `npm test` passes (dashboard package: 404/404; full monorepo `npm test` only shows the pre-existing, environment-dependent mDNS discovery integration failures noted in `AGENTS.md`, unrelated to this change)
- [x] `npm run format-verify` and `npm run lint` pass
- [x] CHANGELOG updated

