### PR TITLE
feat(dashboard): add a command panel for the MediaPlayback cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
+- Enhancement: (lboue) Added a command panel for the MediaPlayback cluster to Dashboard, with transport controls (Play, Pause, Stop, Previous, Next, Rewind, Fast Forward, Start Over, Skip Forward/Backward) gated by the device's AcceptedCommandList, plus a playback state/position readout
 - Enhancement: (lboue) Added a command panel for the DoorLock cluster to Dashboard
 - Enhancement: (lboue) Added Presets and Thermostat Suggestions (Thermostat cluster PRES/TSUGGEST features) panels to Dashboard
 - Fix: BLE proxy connections are pinged every 15 seconds and terminated after 45 to 60 seconds of silence, so a proxy client that loses power is detected instead of staying registered indefinitely

--- a/packages/dashboard/src/pages/cluster-commands/clusters/media-playback-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/media-playback-commands.ts
@@ -1,0 +1,252 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import "@material/web/button/outlined-button";
+import "@material/web/iconbutton/outlined-icon-button";
+import {
+    mdiFastForward,
+    mdiPause,
+    mdiPlay,
+    mdiRestart,
+    mdiRewind,
+    mdiSkipBackward,
+    mdiSkipForward,
+    mdiSkipNext,
+    mdiSkipPrevious,
+    mdiStop,
+} from "@mdi/js";
+import { css, html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import "../../../components/ha-svg-icon.js";
+import { handleAsync } from "../../../util/async-handler.js";
+import {
+    FAST_FORWARD_COMMAND_ID,
+    formatDurationMs,
+    formatPlaybackState,
+    MEDIA_PLAYBACK_CLUSTER_ID,
+    NEXT_COMMAND_ID,
+    PAUSE_COMMAND_ID,
+    PlaybackState,
+    PLAY_COMMAND_ID,
+    PREVIOUS_COMMAND_ID,
+    readCurrentState,
+    readDurationMs,
+    readPlaybackSpeed,
+    readPositionMs,
+    REWIND_COMMAND_ID,
+    SKIP_BACKWARD_COMMAND_ID,
+    SKIP_FORWARD_COMMAND_ID,
+    START_OVER_COMMAND_ID,
+    STOP_COMMAND_ID,
+    supportsCommand,
+} from "../../../util/media-playback.js";
+import { BaseClusterCommands } from "../base-cluster-commands.js";
+import { registerClusterCommands } from "../registry.js";
+
+const DEFAULT_SKIP_MS = 10000;
+
+@customElement("media-playback-cluster-commands")
+class MediaPlaybackClusterCommands extends BaseClusterCommands {
+    @state() private _skipMs = DEFAULT_SKIP_MS;
+
+    override render() {
+        if (!this.node || this.cluster !== MEDIA_PLAYBACK_CLUSTER_ID) return nothing;
+
+        const playbackState = readCurrentState(this.node, this.endpoint);
+        const positionMs = readPositionMs(this.node, this.endpoint);
+        const durationMs = readDurationMs(this.node, this.endpoint);
+        const speed = readPlaybackSpeed(this.node, this.endpoint);
+        const online = this.node.available === true;
+        const has = (commandId: number) => supportsCommand(this.node, this.endpoint, commandId);
+
+        return html`
+            <details class="command-panel" open>
+                <summary>Media Playback Controls</summary>
+                <div class="command-content">
+                    <div class="readout">
+                        <span class="state-chip ${playbackState === PlaybackState.Playing ? "playing" : ""}"
+                            >${formatPlaybackState(playbackState)}</span
+                        >
+                        ${
+                            positionMs !== null
+                                ? html`<span
+                                      >${formatDurationMs(positionMs)}${
+                                          durationMs !== null ? html` / ${formatDurationMs(durationMs)}` : nothing
+                                      }</span
+                                  >`
+                                : nothing
+                        }
+                        ${speed !== null && speed !== 1 ? html`<span class="meta">${speed}×</span>` : nothing}
+                    </div>
+
+                    <div class="transport-row">
+                        ${
+                            has(PREVIOUS_COMMAND_ID)
+                                ? this._transportButton("Previous", mdiSkipPrevious, online, () =>
+                                      this.sendCommand("Previous"),
+                                  )
+                                : nothing
+                        }
+                        ${
+                            has(REWIND_COMMAND_ID)
+                                ? this._transportButton("Rewind", mdiRewind, online, () => this.sendCommand("Rewind"))
+                                : nothing
+                        }
+                        ${
+                            has(PLAY_COMMAND_ID)
+                                ? this._transportButton("Play", mdiPlay, online, () => this.sendCommand("Play"))
+                                : nothing
+                        }
+                        ${
+                            has(PAUSE_COMMAND_ID)
+                                ? this._transportButton("Pause", mdiPause, online, () => this.sendCommand("Pause"))
+                                : nothing
+                        }
+                        ${
+                            has(STOP_COMMAND_ID)
+                                ? this._transportButton("Stop", mdiStop, online, () => this.sendCommand("Stop"))
+                                : nothing
+                        }
+                        ${
+                            has(FAST_FORWARD_COMMAND_ID)
+                                ? this._transportButton("Fast forward", mdiFastForward, online, () =>
+                                      this.sendCommand("FastForward"),
+                                  )
+                                : nothing
+                        }
+                        ${
+                            has(NEXT_COMMAND_ID)
+                                ? this._transportButton("Next", mdiSkipNext, online, () => this.sendCommand("Next"))
+                                : nothing
+                        }
+                        ${
+                            has(START_OVER_COMMAND_ID)
+                                ? this._transportButton("Start over", mdiRestart, online, () =>
+                                      this.sendCommand("StartOver"),
+                                  )
+                                : nothing
+                        }
+                    </div>
+
+                    ${
+                        has(SKIP_BACKWARD_COMMAND_ID) || has(SKIP_FORWARD_COMMAND_ID)
+                            ? html`
+                                  <div class="command-row">
+                                      <label for="skipMs">Skip (ms):</label>
+                                      <input
+                                          id="skipMs"
+                                          type="number"
+                                          min="1"
+                                          .value=${String(this._skipMs)}
+                                          @input=${this._handleSkipMsChange}
+                                      />
+                                      ${
+                                          has(SKIP_BACKWARD_COMMAND_ID)
+                                              ? html`<md-outlined-button
+                                                    ?disabled=${!online}
+                                                    @click=${handleAsync(() => this._skipBackward())}
+                                                >
+                                                    <ha-svg-icon slot="icon" .path=${mdiSkipBackward}></ha-svg-icon>
+                                                    Skip backward
+                                                </md-outlined-button>`
+                                              : nothing
+                                      }
+                                      ${
+                                          has(SKIP_FORWARD_COMMAND_ID)
+                                              ? html`<md-outlined-button
+                                                    ?disabled=${!online}
+                                                    @click=${handleAsync(() => this._skipForward())}
+                                                >
+                                                    <ha-svg-icon slot="icon" .path=${mdiSkipForward}></ha-svg-icon>
+                                                    Skip forward
+                                                </md-outlined-button>`
+                                              : nothing
+                                      }
+                                  </div>
+                              `
+                            : nothing
+                    }
+                </div>
+            </details>
+        `;
+    }
+
+    private _transportButton(label: string, icon: string, online: boolean, onClick: () => Promise<void>) {
+        return html`
+            <md-outlined-icon-button
+                title=${label}
+                aria-label=${label}
+                ?disabled=${!online}
+                @click=${handleAsync(onClick)}
+            >
+                <ha-svg-icon .path=${icon}></ha-svg-icon>
+            </md-outlined-icon-button>
+        `;
+    }
+
+    private _handleSkipMsChange(event: Event) {
+        const value = Number((event.target as HTMLInputElement).value);
+        this._skipMs = Number.isFinite(value) && value > 0 ? Math.round(value) : DEFAULT_SKIP_MS;
+    }
+
+    private async _skipForward() {
+        await this.sendCommand("SkipForward", { deltaPositionMilliseconds: this._skipMs });
+    }
+
+    private async _skipBackward() {
+        await this.sendCommand("SkipBackward", { deltaPositionMilliseconds: this._skipMs });
+    }
+
+    static override styles = [
+        ...(Array.isArray(BaseClusterCommands.styles) ? BaseClusterCommands.styles : [BaseClusterCommands.styles]),
+        css`
+            .readout {
+                display: flex;
+                align-items: center;
+                gap: 16px;
+                flex-wrap: wrap;
+                font-family: var(--monospace-font, monospace);
+                font-size: 0.85rem;
+                padding: 4px 0 12px;
+            }
+
+            .state-chip {
+                padding: 2px 8px;
+                border-radius: 4px;
+                background: var(--md-sys-color-secondary-container);
+                color: var(--md-sys-color-on-secondary-container);
+                font-size: 0.75rem;
+            }
+
+            .state-chip.playing {
+                background: var(--md-sys-color-primary-container);
+                color: var(--md-sys-color-on-primary-container);
+            }
+
+            .meta {
+                color: var(--md-sys-color-on-surface-variant);
+            }
+
+            .transport-row {
+                display: flex;
+                align-items: center;
+                justify-content: flex-start;
+                gap: 12px;
+                padding: 4px 0 16px;
+                flex-wrap: wrap;
+            }
+        `,
+    ];
+}
+
+// Register this component for the MediaPlayback cluster
+registerClusterCommands(MEDIA_PLAYBACK_CLUSTER_ID, "media-playback-cluster-commands");
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "media-playback-cluster-commands": MediaPlaybackClusterCommands;
+    }
+}

--- a/packages/dashboard/src/pages/cluster-commands/clusters/media-playback-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/media-playback-commands.ts
@@ -71,9 +71,9 @@ class MediaPlaybackClusterCommands extends BaseClusterCommands {
                             >${formatPlaybackState(playbackState)}</span
                         >
                         ${
-                            positionMs !== null
+                            positionMs !== null || durationMs !== null
                                 ? html`<span
-                                      >${formatDurationMs(positionMs)}${
+                                      >${positionMs !== null ? formatDurationMs(positionMs) : "—"}${
                                           durationMs !== null ? html` / ${formatDurationMs(durationMs)}` : nothing
                                       }</span
                                   >`
@@ -189,7 +189,7 @@ class MediaPlaybackClusterCommands extends BaseClusterCommands {
 
     private _handleSkipMsChange(event: Event) {
         const input = event.target as HTMLInputElement;
-        const roundedValue = Math.round(value);
+        const roundedValue = Math.round(Number(input.value));
         this._skipMs = Number.isSafeInteger(roundedValue) && roundedValue > 0 ? roundedValue : DEFAULT_SKIP_MS;
         input.value = String(this._skipMs);
     }
@@ -244,7 +244,6 @@ class MediaPlaybackClusterCommands extends BaseClusterCommands {
     ];
 }
 
-// Register this component for the MediaPlayback cluster
 registerClusterCommands(MEDIA_PLAYBACK_CLUSTER_ID, "media-playback-cluster-commands");
 
 declare global {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/media-playback-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/media-playback-commands.ts
@@ -189,8 +189,8 @@ class MediaPlaybackClusterCommands extends BaseClusterCommands {
 
     private _handleSkipMsChange(event: Event) {
         const input = event.target as HTMLInputElement;
-        const value = Number(input.value);
-        this._skipMs = Number.isFinite(value) && value > 0 ? Math.round(value) : DEFAULT_SKIP_MS;
+        const roundedValue = Math.round(value);
+        this._skipMs = Number.isSafeInteger(roundedValue) && roundedValue > 0 ? roundedValue : DEFAULT_SKIP_MS;
         input.value = String(this._skipMs);
     }
 

--- a/packages/dashboard/src/pages/cluster-commands/clusters/media-playback-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/media-playback-commands.ts
@@ -188,8 +188,10 @@ class MediaPlaybackClusterCommands extends BaseClusterCommands {
     }
 
     private _handleSkipMsChange(event: Event) {
-        const value = Number((event.target as HTMLInputElement).value);
+        const input = event.target as HTMLInputElement;
+        const value = Number(input.value);
         this._skipMs = Number.isFinite(value) && value > 0 ? Math.round(value) : DEFAULT_SKIP_MS;
+        input.value = String(this._skipMs);
     }
 
     private async _skipForward() {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/media-playback-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/media-playback-commands.ts
@@ -113,8 +113,9 @@ class MediaPlaybackClusterCommands extends BaseClusterCommands {
                         anyCommandAdvertised
                             ? nothing
                             : html`<div class="meta">
-                                  The device has not reported its AcceptedCommandList yet, so no transport control is
-                                  shown.
+                                  This device advertises none of the transport commands this panel offers. Its
+                                  AcceptedCommandList may not have been read yet, or it may support only commands
+                                  handled elsewhere, such as Seek or track selection.
                               </div>`
                     }
 

--- a/packages/dashboard/src/pages/cluster-commands/clusters/media-playback-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/media-playback-commands.ts
@@ -21,13 +21,16 @@ import {
 import { css, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import "../../../components/ha-svg-icon.js";
+import { showAlertDialog } from "../../../components/dialog-box/show-dialog-box.js";
 import { handleAsync } from "../../../util/async-handler.js";
 import {
     FAST_FORWARD_COMMAND_ID,
     formatDurationMs,
     formatPlaybackState,
+    invokeTransportCommand,
     MEDIA_PLAYBACK_CLUSTER_ID,
     NEXT_COMMAND_ID,
+    parseSkipMs,
     PAUSE_COMMAND_ID,
     PlaybackState,
     PLAY_COMMAND_ID,
@@ -46,11 +49,22 @@ import {
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
 
-const DEFAULT_SKIP_MS = 10000;
+const DEFAULT_SKIP_MS = "10000";
 
 @customElement("media-playback-cluster-commands")
 class MediaPlaybackClusterCommands extends BaseClusterCommands {
     @state() private _skipMs = DEFAULT_SKIP_MS;
+    private _formContext?: string;
+
+    override willUpdate(changedProperties: Map<string, unknown>) {
+        super.willUpdate(changedProperties);
+        if (!this.node) return;
+        const context = `${String(this.node.node_id)}/${this.endpoint}/${this.cluster}`;
+        if (this._formContext !== undefined && this._formContext !== context) {
+            this._skipMs = DEFAULT_SKIP_MS;
+        }
+        this._formContext = context;
+    }
 
     override render() {
         if (!this.node || this.cluster !== MEDIA_PLAYBACK_CLUSTER_ID) return nothing;
@@ -61,6 +75,19 @@ class MediaPlaybackClusterCommands extends BaseClusterCommands {
         const speed = readPlaybackSpeed(this.node, this.endpoint);
         const online = this.node.available === true;
         const has = (commandId: number) => supportsCommand(this.node, this.endpoint, commandId);
+        const skipMs = parseSkipMs(this._skipMs);
+        const anyCommandAdvertised = [
+            PREVIOUS_COMMAND_ID,
+            REWIND_COMMAND_ID,
+            PLAY_COMMAND_ID,
+            PAUSE_COMMAND_ID,
+            STOP_COMMAND_ID,
+            FAST_FORWARD_COMMAND_ID,
+            NEXT_COMMAND_ID,
+            START_OVER_COMMAND_ID,
+            SKIP_BACKWARD_COMMAND_ID,
+            SKIP_FORWARD_COMMAND_ID,
+        ].some(has);
 
         return html`
             <details class="command-panel" open>
@@ -82,50 +109,59 @@ class MediaPlaybackClusterCommands extends BaseClusterCommands {
                         ${speed !== null && speed !== 1 ? html`<span class="meta">${speed}×</span>` : nothing}
                     </div>
 
+                    ${
+                        anyCommandAdvertised
+                            ? nothing
+                            : html`<div class="meta">
+                                  The device has not reported its AcceptedCommandList yet, so no transport control is
+                                  shown.
+                              </div>`
+                    }
+
                     <div class="transport-row">
                         ${
                             has(PREVIOUS_COMMAND_ID)
                                 ? this._transportButton("Previous", mdiSkipPrevious, online, () =>
-                                      this.sendCommand("Previous"),
+                                      this._invoke("Previous"),
                                   )
                                 : nothing
                         }
                         ${
                             has(REWIND_COMMAND_ID)
-                                ? this._transportButton("Rewind", mdiRewind, online, () => this.sendCommand("Rewind"))
+                                ? this._transportButton("Rewind", mdiRewind, online, () => this._invoke("Rewind"))
                                 : nothing
                         }
                         ${
                             has(PLAY_COMMAND_ID)
-                                ? this._transportButton("Play", mdiPlay, online, () => this.sendCommand("Play"))
+                                ? this._transportButton("Play", mdiPlay, online, () => this._invoke("Play"))
                                 : nothing
                         }
                         ${
                             has(PAUSE_COMMAND_ID)
-                                ? this._transportButton("Pause", mdiPause, online, () => this.sendCommand("Pause"))
+                                ? this._transportButton("Pause", mdiPause, online, () => this._invoke("Pause"))
                                 : nothing
                         }
                         ${
                             has(STOP_COMMAND_ID)
-                                ? this._transportButton("Stop", mdiStop, online, () => this.sendCommand("Stop"))
+                                ? this._transportButton("Stop", mdiStop, online, () => this._invoke("Stop"))
                                 : nothing
                         }
                         ${
                             has(FAST_FORWARD_COMMAND_ID)
                                 ? this._transportButton("Fast forward", mdiFastForward, online, () =>
-                                      this.sendCommand("FastForward"),
+                                      this._invoke("FastForward"),
                                   )
                                 : nothing
                         }
                         ${
                             has(NEXT_COMMAND_ID)
-                                ? this._transportButton("Next", mdiSkipNext, online, () => this.sendCommand("Next"))
+                                ? this._transportButton("Next", mdiSkipNext, online, () => this._invoke("Next"))
                                 : nothing
                         }
                         ${
                             has(START_OVER_COMMAND_ID)
                                 ? this._transportButton("Start over", mdiRestart, online, () =>
-                                      this.sendCommand("StartOver"),
+                                      this._invoke("StartOver"),
                                   )
                                 : nothing
                         }
@@ -140,14 +176,19 @@ class MediaPlaybackClusterCommands extends BaseClusterCommands {
                                           id="skipMs"
                                           type="number"
                                           min="1"
-                                          .value=${String(this._skipMs)}
-                                          @input=${this._handleSkipMsChange}
+                                          .value=${this._skipMs}
+                                          @input=${(event: Event) => {
+                                              this._skipMs = (event.target as HTMLInputElement).value;
+                                          }}
                                       />
                                       ${
                                           has(SKIP_BACKWARD_COMMAND_ID)
                                               ? html`<md-outlined-button
-                                                    ?disabled=${!online}
-                                                    @click=${handleAsync(() => this._skipBackward())}
+                                                    ?disabled=${!online || skipMs === null}
+                                                    @click=${handleAsync(
+                                                        () => this._skipBackward(),
+                                                        this._failureReporter(),
+                                                    )}
                                                 >
                                                     <ha-svg-icon slot="icon" .path=${mdiSkipBackward}></ha-svg-icon>
                                                     Skip backward
@@ -157,8 +198,11 @@ class MediaPlaybackClusterCommands extends BaseClusterCommands {
                                       ${
                                           has(SKIP_FORWARD_COMMAND_ID)
                                               ? html`<md-outlined-button
-                                                    ?disabled=${!online}
-                                                    @click=${handleAsync(() => this._skipForward())}
+                                                    ?disabled=${!online || skipMs === null}
+                                                    @click=${handleAsync(
+                                                        () => this._skipForward(),
+                                                        this._failureReporter(),
+                                                    )}
                                                 >
                                                     <ha-svg-icon slot="icon" .path=${mdiSkipForward}></ha-svg-icon>
                                                     Skip forward
@@ -180,26 +224,39 @@ class MediaPlaybackClusterCommands extends BaseClusterCommands {
                 title=${label}
                 aria-label=${label}
                 ?disabled=${!online}
-                @click=${handleAsync(onClick)}
+                @click=${handleAsync(onClick, this._failureReporter())}
             >
                 <ha-svg-icon .path=${icon}></ha-svg-icon>
             </md-outlined-icon-button>
         `;
     }
 
-    private _handleSkipMsChange(event: Event) {
-        const input = event.target as HTMLInputElement;
-        const roundedValue = Math.round(Number(input.value));
-        this._skipMs = Number.isSafeInteger(roundedValue) && roundedValue > 0 ? roundedValue : DEFAULT_SKIP_MS;
-        input.value = String(this._skipMs);
+    private async _invoke(command: string, payload?: Record<string, unknown>) {
+        await invokeTransportCommand(this.client, this.node.node_id, this.endpoint, command, payload);
     }
 
     private async _skipForward() {
-        await this.sendCommand("SkipForward", { deltaPositionMilliseconds: this._skipMs });
+        const deltaPositionMilliseconds = parseSkipMs(this._skipMs);
+        if (deltaPositionMilliseconds === null) return;
+        await this._invoke("SkipForward", { deltaPositionMilliseconds });
     }
 
     private async _skipBackward() {
-        await this.sendCommand("SkipBackward", { deltaPositionMilliseconds: this._skipMs });
+        const deltaPositionMilliseconds = parseSkipMs(this._skipMs);
+        if (deltaPositionMilliseconds === null) return;
+        await this._invoke("SkipBackward", { deltaPositionMilliseconds });
+    }
+
+    /** Captures the panel's context at render time; a reused panel must not raise the old device's error. */
+    private _failureReporter() {
+        const node = this.node;
+        const endpoint = this.endpoint;
+        return (err: Error) => {
+            if (!this.isSameContext(node, endpoint)) return;
+            showAlertDialog({ title: "Media Playback command failed", text: err.message }).catch(dialogErr =>
+                console.error("Failed to show the MediaPlayback command error", dialogErr),
+            );
+        };
     }
 
     static override styles = [
@@ -244,7 +301,9 @@ class MediaPlaybackClusterCommands extends BaseClusterCommands {
     ];
 }
 
-registerClusterCommands(MEDIA_PLAYBACK_CLUSTER_ID, "media-playback-cluster-commands");
+registerClusterCommands(MEDIA_PLAYBACK_CLUSTER_ID, "media-playback-cluster-commands", {
+    renderWhenOffline: true,
+});
 
 declare global {
     interface HTMLElementTagNameMap {

--- a/packages/dashboard/src/pages/cluster-commands/index.ts
+++ b/packages/dashboard/src/pages/cluster-commands/index.ts
@@ -32,6 +32,7 @@ import "./clusters/commodity-tariff-commands.js";
 import "./clusters/door-lock-commands.js";
 import "./clusters/icd-management-commands.js";
 import "./clusters/level-control-commands.js";
+import "./clusters/media-playback-commands.js";
 import "./clusters/meter-identification-commands.js";
 import "./clusters/on-off-commands.js";
 import "./clusters/thermostat-commands.js";

--- a/packages/dashboard/src/util/media-playback.ts
+++ b/packages/dashboard/src/util/media-playback.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MatterNode } from "@matter-server/ws-client";
+import { tagField, toNumber } from "./attribute-shapes.js";
+
+export const MEDIA_PLAYBACK_CLUSTER_ID = 1286; // 0x0506
+
+const ATTR_CURRENT_STATE = 0;
+const ATTR_DURATION = 2;
+const ATTR_SAMPLED_POSITION = 3;
+const ATTR_PLAYBACK_SPEED = 4;
+const ATTR_ACCEPTED_COMMAND_LIST = 0xfff9;
+
+export const PLAY_COMMAND_ID = 0;
+export const PAUSE_COMMAND_ID = 1;
+export const STOP_COMMAND_ID = 2;
+export const START_OVER_COMMAND_ID = 3;
+export const PREVIOUS_COMMAND_ID = 4;
+export const NEXT_COMMAND_ID = 5;
+export const REWIND_COMMAND_ID = 6;
+export const FAST_FORWARD_COMMAND_ID = 7;
+export const SKIP_FORWARD_COMMAND_ID = 8;
+export const SKIP_BACKWARD_COMMAND_ID = 9;
+
+/** PlaybackStateEnum, spec §10.4.4.1. */
+export const enum PlaybackState {
+    Playing = 0,
+    Paused = 1,
+    NotPlaying = 2,
+    Buffering = 3,
+}
+
+function readAttr(node: MatterNode, endpoint: number, attrId: number): unknown {
+    return node.attributes[`${endpoint}/${MEDIA_PLAYBACK_CLUSTER_ID}/${attrId}`];
+}
+
+export function readCurrentState(node: MatterNode, endpoint: number): PlaybackState | null {
+    const value = toNumber(readAttr(node, endpoint, ATTR_CURRENT_STATE));
+    return value === undefined ? null : value;
+}
+
+export function formatPlaybackState(state: PlaybackState | null): string {
+    switch (state) {
+        case PlaybackState.Playing:
+            return "Playing";
+        case PlaybackState.Paused:
+            return "Paused";
+        case PlaybackState.NotPlaying:
+            return "Not playing";
+        case PlaybackState.Buffering:
+            return "Buffering";
+        default:
+            return "Unknown";
+    }
+}
+
+/** SampledPosition.position (field tag 1, spec §6.10.5.4.2), in milliseconds. */
+export function readPositionMs(node: MatterNode, endpoint: number): number | null {
+    return toNumber(tagField(readAttr(node, endpoint, ATTR_SAMPLED_POSITION), 1)) ?? null;
+}
+
+/** Duration, in milliseconds, or null when the device reports no duration (e.g. a live stream). */
+export function readDurationMs(node: MatterNode, endpoint: number): number | null {
+    return toNumber(readAttr(node, endpoint, ATTR_DURATION)) ?? null;
+}
+
+export function readPlaybackSpeed(node: MatterNode, endpoint: number): number | null {
+    return toNumber(readAttr(node, endpoint, ATTR_PLAYBACK_SPEED)) ?? null;
+}
+
+/** mm:ss for anything under an hour, hh:mm:ss beyond that. */
+export function formatDurationMs(ms: number): string {
+    const totalSeconds = Math.floor(ms / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return hours > 0 ? `${hours}:${pad(minutes)}:${pad(seconds)}` : `${minutes}:${pad(seconds)}`;
+}
+
+export function supportsCommand(node: MatterNode, endpoint: number, commandId: number): boolean {
+    const accepted = readAttr(node, endpoint, ATTR_ACCEPTED_COMMAND_LIST);
+    return Array.isArray(accepted) && accepted.map(value => Number(value)).includes(commandId);
+}

--- a/packages/dashboard/src/util/media-playback.ts
+++ b/packages/dashboard/src/util/media-playback.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { MatterNode } from "@matter-server/ws-client";
-import { tagField, toNumber } from "./attribute-shapes.js";
+import type { MatterClient, MatterNode } from "@matter-server/ws-client";
+import { asObject, pickNumber, tagField, toNumber } from "./attribute-shapes.js";
 
 export const MEDIA_PLAYBACK_CLUSTER_ID = 1286; // 0x0506
 
@@ -26,8 +26,8 @@ export const FAST_FORWARD_COMMAND_ID = 7;
 export const SKIP_FORWARD_COMMAND_ID = 8;
 export const SKIP_BACKWARD_COMMAND_ID = 9;
 
-/** PlaybackStateEnum, spec §10.4.4.1. */
-export const enum PlaybackState {
+/** PlaybackStateEnum. */
+export enum PlaybackState {
     Playing = 0,
     Paused = 1,
     NotPlaying = 2,
@@ -58,7 +58,7 @@ export function formatPlaybackState(state: PlaybackState | null): string {
     }
 }
 
-/** SampledPosition.position (field tag 1, spec §6.10.5.4.2), in milliseconds. */
+/** SampledPosition.Position (field tag 1), in milliseconds. */
 export function readPositionMs(node: MatterNode, endpoint: number): number | null {
     return toNumber(tagField(readAttr(node, endpoint, ATTR_SAMPLED_POSITION), 1)) ?? null;
 }
@@ -68,11 +68,17 @@ export function readDurationMs(node: MatterNode, endpoint: number): number | nul
     return toNumber(readAttr(node, endpoint, ATTR_DURATION)) ?? null;
 }
 
+/**
+ * PlaybackSpeed is a float32, so a device reporting 0.1x decodes to 0.10000000149011612; round it to
+ * the two decimals the spec's 1/16 speed steps need. A stopped player reports 0, which is not a speed.
+ */
 export function readPlaybackSpeed(node: MatterNode, endpoint: number): number | null {
-    return toNumber(readAttr(node, endpoint, ATTR_PLAYBACK_SPEED)) ?? null;
+    const speed = toNumber(readAttr(node, endpoint, ATTR_PLAYBACK_SPEED));
+    if (speed === undefined || speed === 0) return null;
+    return Math.round(speed * 100) / 100;
 }
 
-/** mm:ss for anything under an hour, hh:mm:ss beyond that. */
+/** m:ss for anything under an hour, h:mm:ss beyond that. */
 export function formatDurationMs(ms: number): string {
     const totalSeconds = Math.floor(ms / 1000);
     const hours = Math.floor(totalSeconds / 3600);
@@ -85,4 +91,42 @@ export function formatDurationMs(ms: number): string {
 export function supportsCommand(node: MatterNode, endpoint: number, commandId: number): boolean {
     const accepted = readAttr(node, endpoint, ATTR_ACCEPTED_COMMAND_LIST);
     return Array.isArray(accepted) && accepted.map(value => Number(value)).includes(commandId);
+}
+
+/** PlaybackResponse.Status. */
+const PLAYBACK_STATUS_NAMES: Record<number, string> = {
+    0: "Success",
+    1: "Invalid state for command",
+    2: "Not allowed",
+    3: "Not active",
+    4: "Speed out of range",
+    5: "Seek out of range",
+};
+
+/**
+ * Every transport command answers with PlaybackResponse, and a non-Success status is a successful
+ * invoke at the interaction layer — the caller only learns the device refused from the payload.
+ * Command responses are name-keyed (convertMatterToWebSocketNameBased), unlike attributes.
+ */
+export async function invokeTransportCommand(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    command: string,
+    payload: Record<string, unknown> = {},
+): Promise<void> {
+    const response = await client.deviceCommand(nodeId, endpoint, MEDIA_PLAYBACK_CLUSTER_ID, command, payload);
+    const status = pickNumber(asObject(response) ?? {}, "status");
+    if (status !== null && status !== 0) {
+        throw new Error(`${command} rejected: ${PLAYBACK_STATUS_NAMES[status] ?? `status ${status}`}`);
+    }
+}
+
+/** The delta the skip form would send, or null when the field holds no submittable value. */
+export function parseSkipMs(value: string): number | null {
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    const ms = Number(trimmed);
+    if (!Number.isSafeInteger(ms) || ms < 1) return null;
+    return ms;
 }

--- a/packages/dashboard/test/MediaPlaybackUtilTest.ts
+++ b/packages/dashboard/test/MediaPlaybackUtilTest.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MatterNode, type MatterNodeData } from "@matter-server/ws-client";
+import {
+    formatDurationMs,
+    formatPlaybackState,
+    NEXT_COMMAND_ID,
+    PlaybackState,
+    readCurrentState,
+    readDurationMs,
+    readPlaybackSpeed,
+    readPositionMs,
+    supportsCommand,
+} from "../src/util/media-playback.js";
+
+function node(attributes: Record<string, unknown>, node_id: number | bigint = 1): MatterNode {
+    const data: MatterNodeData = {
+        node_id,
+        date_commissioned: "",
+        last_interview: "",
+        interview_version: 1,
+        available: true,
+        is_bridge: false,
+        attributes,
+        attribute_subscriptions: [],
+    };
+    return new MatterNode(data);
+}
+
+describe("media playback util", () => {
+    describe("readCurrentState", () => {
+        it("reads the enum value", () => {
+            expect(readCurrentState(node({ "1/1286/0": 1 }), 1)).to.equal(PlaybackState.Paused);
+        });
+
+        it("returns null when the attribute is absent", () => {
+            expect(readCurrentState(node({}), 1)).to.equal(null);
+        });
+    });
+
+    describe("formatPlaybackState", () => {
+        it("names every known state", () => {
+            expect(formatPlaybackState(PlaybackState.Playing)).to.equal("Playing");
+            expect(formatPlaybackState(PlaybackState.Paused)).to.equal("Paused");
+            expect(formatPlaybackState(PlaybackState.NotPlaying)).to.equal("Not playing");
+            expect(formatPlaybackState(PlaybackState.Buffering)).to.equal("Buffering");
+        });
+
+        it("falls back to Unknown when there is no state", () => {
+            expect(formatPlaybackState(null)).to.equal("Unknown");
+        });
+    });
+
+    describe("readPositionMs", () => {
+        it("reads the struct's field-tag-1 position", () => {
+            expect(readPositionMs(node({ "1/1286/3": { "0": 1000, "1": 42_000 } }), 1)).to.equal(42_000);
+        });
+
+        it("returns null when SampledPosition is absent or null", () => {
+            expect(readPositionMs(node({}), 1)).to.equal(null);
+            expect(readPositionMs(node({ "1/1286/3": null }), 1)).to.equal(null);
+        });
+    });
+
+    describe("readDurationMs / readPlaybackSpeed", () => {
+        it("read their attributes when present", () => {
+            expect(readDurationMs(node({ "1/1286/2": 120_000 }), 1)).to.equal(120_000);
+            expect(readPlaybackSpeed(node({ "1/1286/4": 1.5 }), 1)).to.equal(1.5);
+        });
+
+        it("return null when absent", () => {
+            expect(readDurationMs(node({}), 1)).to.equal(null);
+            expect(readPlaybackSpeed(node({}), 1)).to.equal(null);
+        });
+    });
+
+    describe("formatDurationMs", () => {
+        it("formats under an hour as m:ss", () => {
+            expect(formatDurationMs(0)).to.equal("0:00");
+            expect(formatDurationMs(65_000)).to.equal("1:05");
+        });
+
+        it("formats an hour or more as h:mm:ss", () => {
+            expect(formatDurationMs(3_661_000)).to.equal("1:01:01");
+        });
+    });
+
+    describe("supportsCommand", () => {
+        it("is true when the command id is in AcceptedCommandList", () => {
+            expect(supportsCommand(node({ "1/1286/65529": [0, 1, 2, NEXT_COMMAND_ID] }), 1, NEXT_COMMAND_ID)).to.equal(
+                true,
+            );
+        });
+
+        it("is false when the command id is missing or the list is absent", () => {
+            expect(supportsCommand(node({ "1/1286/65529": [0, 1, 2] }), 1, NEXT_COMMAND_ID)).to.equal(false);
+            expect(supportsCommand(node({}), 1, NEXT_COMMAND_ID)).to.equal(false);
+        });
+    });
+});

--- a/packages/dashboard/test/MediaPlaybackUtilTest.ts
+++ b/packages/dashboard/test/MediaPlaybackUtilTest.ts
@@ -4,11 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MatterNode, type MatterNodeData } from "@matter-server/ws-client";
+import { MatterNode, type MatterClient, type MatterNodeData } from "@matter-server/ws-client";
 import {
     formatDurationMs,
     formatPlaybackState,
+    invokeTransportCommand,
     NEXT_COMMAND_ID,
+    parseSkipMs,
     PlaybackState,
     readCurrentState,
     readDurationMs,
@@ -16,6 +18,23 @@ import {
     readPositionMs,
     supportsCommand,
 } from "../src/util/media-playback.js";
+
+function fakeClient(response: unknown): { client: MatterClient; calls: Array<Record<string, unknown>> } {
+    const calls = new Array<Record<string, unknown>>();
+    const client = {
+        deviceCommand: async (
+            _nodeId: number | bigint,
+            _endpoint: number,
+            _cluster: number,
+            command: string,
+            payload: Record<string, unknown>,
+        ) => {
+            calls.push({ command, payload });
+            return response;
+        },
+    } as unknown as MatterClient;
+    return { client, calls };
+}
 
 function node(attributes: Record<string, unknown>, node_id: number | bigint = 1): MatterNode {
     const data: MatterNodeData = {
@@ -64,6 +83,14 @@ describe("media playback util", () => {
             expect(readPositionMs(node({}), 1)).to.equal(null);
             expect(readPositionMs(node({ "1/1286/3": null }), 1)).to.equal(null);
         });
+
+        it("returns null for the live-stream shape where only Position is null", () => {
+            expect(readPositionMs(node({ "1/1286/3": { "0": 1000, "1": null } }), 1)).to.equal(null);
+        });
+
+        it("reads a uint64 position that arrives as a bigint", () => {
+            expect(readPositionMs(node({ "1/1286/3": { "0": 1000, "1": 42_000n } }), 1)).to.equal(42_000);
+        });
     });
 
     describe("readDurationMs / readPlaybackSpeed", () => {
@@ -72,9 +99,19 @@ describe("media playback util", () => {
             expect(readPlaybackSpeed(node({ "1/1286/4": 1.5 }), 1)).to.equal(1.5);
         });
 
-        it("return null when absent", () => {
+        it("return null when absent or null on the wire", () => {
             expect(readDurationMs(node({}), 1)).to.equal(null);
+            expect(readDurationMs(node({ "1/1286/2": null }), 1)).to.equal(null);
             expect(readPlaybackSpeed(node({}), 1)).to.equal(null);
+        });
+
+        it("keeps a zero duration distinct from an absent one", () => {
+            expect(readDurationMs(node({ "1/1286/2": 0 }), 1)).to.equal(0);
+        });
+
+        it("rounds the float32 playback speed and drops the stopped-player zero", () => {
+            expect(readPlaybackSpeed(node({ "1/1286/4": 0.10000000149011612 }), 1)).to.equal(0.1);
+            expect(readPlaybackSpeed(node({ "1/1286/4": 0 }), 1)).to.equal(null);
         });
     });
 
@@ -85,6 +122,8 @@ describe("media playback util", () => {
         });
 
         it("formats an hour or more as h:mm:ss", () => {
+            expect(formatDurationMs(3_599_000)).to.equal("59:59");
+            expect(formatDurationMs(3_600_000)).to.equal("1:00:00");
             expect(formatDurationMs(3_661_000)).to.equal("1:01:01");
         });
     });
@@ -99,6 +138,55 @@ describe("media playback util", () => {
         it("is false when the command id is missing or the list is absent", () => {
             expect(supportsCommand(node({ "1/1286/65529": [0, 1, 2] }), 1, NEXT_COMMAND_ID)).to.equal(false);
             expect(supportsCommand(node({}), 1, NEXT_COMMAND_ID)).to.equal(false);
+        });
+    });
+
+    describe("parseSkipMs", () => {
+        it("accepts a positive safe integer", () => {
+            expect(parseSkipMs("10000")).to.equal(10_000);
+            expect(parseSkipMs(" 1 ")).to.equal(1);
+        });
+
+        it("rejects a blank, zero, negative, fractional or unsafe value", () => {
+            expect(parseSkipMs("")).to.equal(null);
+            expect(parseSkipMs("0")).to.equal(null);
+            expect(parseSkipMs("-5")).to.equal(null);
+            expect(parseSkipMs("1.5")).to.equal(null);
+            expect(parseSkipMs("1e30")).to.equal(null);
+            expect(parseSkipMs("abc")).to.equal(null);
+        });
+    });
+
+    describe("invokeTransportCommand", () => {
+        it("sends the command and resolves on a Success response", async () => {
+            const { client, calls } = fakeClient({ status: 0 });
+            await invokeTransportCommand(client, 1, 1, "Play");
+            expect(calls).to.deep.equal([{ command: "Play", payload: {} }]);
+        });
+
+        it("resolves when the device answers without a status", async () => {
+            const { client } = fakeClient({});
+            await invokeTransportCommand(client, 1, 1, "Play");
+        });
+
+        it("rejects with the decoded status name when the device refuses", async () => {
+            const { client } = fakeClient({ status: 4 });
+            let message = "";
+            await invokeTransportCommand(client, 1, 1, "Rewind").catch((err: Error) => (message = err.message));
+            expect(message).to.equal("Rewind rejected: Speed out of range");
+        });
+
+        it("reports an unknown status by number", async () => {
+            const { client } = fakeClient({ status: 42 });
+            let message = "";
+            await invokeTransportCommand(client, 1, 1, "Play").catch((err: Error) => (message = err.message));
+            expect(message).to.equal("Play rejected: status 42");
+        });
+
+        it("passes the skip payload through", async () => {
+            const { client, calls } = fakeClient({ status: 0 });
+            await invokeTransportCommand(client, 1, 1, "SkipForward", { deltaPositionMilliseconds: 5000 });
+            expect(calls).to.deep.equal([{ command: "SkipForward", payload: { deltaPositionMilliseconds: 5000 } }]);
         });
     });
 });


### PR DESCRIPTION
## Type of change

- [ ] 🐛 **Fix** — corrects a defect or wrong behavior
- [x] ✨ **Feature** — adds new functionality or capability

## Description

Adds a dedicated command panel for the MediaPlayback cluster (ID 1286 / 0x0506) to the Dashboard, replacing the generic "DEV Commands" list previously shown for that cluster.

- A playback state chip (Playing / Paused / Not playing / Buffering), decoded from `CurrentState`.
- A position/duration readout (`SampledPosition` / `Duration`), formatted as `m:ss` (or `h:mm:ss`), plus the current `PlaybackSpeed` when it differs from 1x.
- A transport control row: Previous, Rewind, Play, Pause, Stop, Fast Forward, Next, Start Over.
- Skip Forward / Skip Backward with a configurable delta (ms).

Every control is shown only if the device actually advertises the corresponding command in its `AcceptedCommandList`, matching the pattern already used for the DoorLock panel. `Seek`, `ActivateAudioTrack`, `ActivateTextTrack`, and `DeactivateTextTrack` are intentionally left out of this first pass (track selection / seek position UI is a separate, larger piece of work).

### Screenshot

<img width="480" height="283" alt="image" src="https://github.com/user-attachments/assets/67d41df0-8b74-4c2c-9348-50b18f659af6" />

## Backing evidence

Not applicable — this is a new feature, not a fix for existing wrong behavior.

- Related issue: #
- [ ] This fix/change is backed by a **complete log file** — attached here or in the linked issue (not just a few quoted lines).

## Checklist

- [x] I understand the code I am submitting and can explain how it works ([AI policy](https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md))
- [x] Tests added or updated to cover the change
- [x] `npm test` passes
- [x] `npm run format-verify` and `npm run lint` pass
- [x] CHANGELOG updated (if applicable)

