### PR TITLE
feat(dashboard): support expiring/temporary PIN users on Door Lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This page shows a detailed overview of the changes between versions without the 
 - Enhancement: (lboue) Added a command panel for the DoorLock cluster to Dashboard
 - Enhancement: (lboue) DoorLock cluster panel supports creating temporary/expiring PIN users (UserType=ExpiringUser) and configuring the lock's ExpiringUserTimeout
 - Enhancement: (lboue) Added Presets and Thermostat Suggestions (Thermostat cluster PRES/TSUGGEST features) panels to Dashboard
+- Fix: Door Lock PIN fields (`credentialData`, `pinCode`) are redacted from the debug logs of both the server request path and the ws-client send path, matched independently of the key's casing; ws-client exports `redactSensitiveCommandFields()` for the same purpose
 - Fix: BLE proxy connections are pinged every 15 seconds and terminated after 45 to 60 seconds of silence, so a proxy client that loses power is detected instead of staying registered indefinitely
 
 ## 1.4.0 (2026-08-07)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This page shows a detailed overview of the changes between versions without the 
 ## **WORK IN PROGRESS**
 
 - Enhancement: (lboue) Added a command panel for the DoorLock cluster to Dashboard
+- Enhancement: (lboue) DoorLock cluster panel supports creating temporary/expiring PIN users (UserType=ExpiringUser) and configuring the lock's ExpiringUserTimeout
 - Enhancement: (lboue) Added Presets and Thermostat Suggestions (Thermostat cluster PRES/TSUGGEST features) panels to Dashboard
 - Fix: BLE proxy connections are pinged every 15 seconds and terminated after 45 to 60 seconds of silence, so a proxy client that loses power is detected instead of staying registered indefinitely
 

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -762,9 +762,10 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             this._userEditorError = nameError;
             return;
         }
-        const expiring = this._newUserType === USER_TYPE_EXPIRING;
+        const canAddExpiring =
+            isFeatureActive(node, endpoint, "PIN") && isFeatureActive(node, endpoint, "USR");
+        const expiring = canAddExpiring && this._newUserType === USER_TYPE_EXPIRING;
         const pin = this._newUserPin.trim();
-        if (expiring) {
             const pinError = pinCodeLengthError(
                 pin,
                 readMinPinCodeLength(node, endpoint),

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -762,10 +762,10 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             this._userEditorError = nameError;
             return;
         }
-        const canAddExpiring =
-            isFeatureActive(node, endpoint, "PIN") && isFeatureActive(node, endpoint, "USR");
+        const canAddExpiring = isFeatureActive(node, endpoint, "PIN") && isFeatureActive(node, endpoint, "USR");
         const expiring = canAddExpiring && this._newUserType === USER_TYPE_EXPIRING;
         const pin = this._newUserPin.trim();
+        if (expiring) {
             const pinError = pinCodeLengthError(
                 pin,
                 readMinPinCodeLength(node, endpoint),

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -31,6 +31,7 @@ import "../../../components/ha-svg-icon.js";
 import { handleAsync } from "../../../util/async-handler.js";
 import {
     addUser,
+    attachPinCredential,
     buildDaySegments,
     clearHolidaySchedule,
     clearWeekDaySchedule,
@@ -40,12 +41,14 @@ import {
     DOOR_LOCK_CLUSTER_ID,
     formatDaysMask,
     formatDoorState,
+    formatExpiringTimeoutHint,
     formatScheduleStatus,
     formatLockState,
     formatLockType,
     formatOperatingMode,
     formatWallClock,
     defaultHolidayMode,
+    hasPinCredential,
     holidayModeChoices,
     formatTimeOfDay,
     formatUserLabel,
@@ -60,12 +63,17 @@ import {
     nextFreeUserIndex,
     nowAsWallClock,
     parseTimeOfDay,
+    pinCodeLengthError,
     readActuatorEnabled,
     readDoorState,
+    readExpiringUserTimeout,
     readHolidaySchedule,
     readHolidaySchedulesSupported,
     readLockState,
     readLockType,
+    readMaxPinCodeLength,
+    readMinPinCodeLength,
+    readNumberOfPinUsersSupported,
     readTotalUsersSupported,
     readUser,
     readUsers,
@@ -85,7 +93,10 @@ import {
     unlockWithTimeout,
     userNameLengthError,
     USER_NAME_MAX_LENGTH,
+    USER_STATUS_OCCUPIED_ENABLED,
+    USER_TYPE_EXPIRING,
     weekDayScheduleRangeError,
+    writeExpiringUserTimeout,
     writeHolidaySchedule,
     writeWeekDaySchedule,
     writeYearDaySchedule,
@@ -111,6 +122,12 @@ const DATE_TIME_MAX = "2136-02-07T06:28:15";
 
 /** Bounds the GetUser walk on a lock that leaves NumberOfTotalUsersSupported unreported. */
 const USER_SCAN_FALLBACK = 32;
+
+/** Bounds the free PIN credential slot search on a lock that leaves NumberOfPinUsersSupported unreported. */
+const PIN_CREDENTIAL_SCAN_FALLBACK = 32;
+
+/** UserTypeEnum.UnrestrictedUser — the default "Standard" choice in the add-user editor. */
+const USER_TYPE_STANDARD = 0;
 
 interface WeekDayEditor {
     kind: "weekDay";
@@ -160,7 +177,10 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     @state() private _editorError?: string;
     @state() private _addingUser = false;
     @state() private _newUserName = "";
+    @state() private _newUserType = USER_TYPE_STANDARD;
+    @state() private _newUserPin = "";
     @state() private _userEditorError?: string;
+    @state() private _expiringTimeoutInput = "";
     @state() private _showEmptyWeekDay = false;
     @state() private _showEmptyYearDay = false;
     @state() private _showEmptyHoliday = false;
@@ -185,6 +205,8 @@ class DoorLockClusterCommands extends BaseClusterCommands {
      */
     #busyGeneration = 0;
     #freeIndexCapacity: number | null = null;
+    /** The context `_expiringTimeoutInput` was last synced from the device for, so a user's own edits stick. */
+    #expiringTimeoutSyncedFor: string | null = null;
 
     override willUpdate(changedProperties: PropertyValues) {
         super.willUpdate(changedProperties);
@@ -216,7 +238,11 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             this._editorError = undefined;
             this._addingUser = false;
             this._newUserName = "";
+            this._newUserType = USER_TYPE_STANDARD;
+            this._newUserPin = "";
             this._userEditorError = undefined;
+            this._expiringTimeoutInput = "";
+            this.#expiringTimeoutSyncedFor = null;
             this._showEmptyWeekDay = false;
             this._showEmptyYearDay = false;
             this._showEmptyHoliday = false;
@@ -231,6 +257,16 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         if (this._users !== undefined && userCapacity !== this.#freeIndexCapacity) {
             this.#freeIndexCapacity = userCapacity;
             this._freeUserIndex = nextFreeUserIndex(this._users, userCapacity ?? USER_SCAN_FALLBACK);
+        }
+
+        // Synced once per context rather than on every render, so a value the operator is mid-edit on isn't
+        // clobbered by the attribute simply being re-read.
+        if (this.#expiringTimeoutSyncedFor !== context) {
+            const expiringTimeout = readExpiringUserTimeout(this.node, this.endpoint);
+            if (expiringTimeout !== null) {
+                this._expiringTimeoutInput = String(expiringTimeout);
+                this.#expiringTimeoutSyncedFor = context;
+            }
         }
 
         // The attribute cache fills in progressively: the feature bits can resolve before the numeric
@@ -549,6 +585,27 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         }
     }
 
+    /** Writes the lock-wide ExpiringUserTimeout attribute — how long a new Temporary PIN stays valid. */
+    async #saveExpiringTimeout() {
+        const node = this.node;
+        const endpoint = this.endpoint;
+        if (this._busy) return;
+        const minutes = Number(this._expiringTimeoutInput);
+        if (!Number.isInteger(minutes) || minutes < 1 || minutes > 0xffff) {
+            await showAlertDialog({ title: "Invalid timeout", text: "The timeout must be 1 to 65535 minutes." });
+            return;
+        }
+        const busyGeneration = this.#busyGeneration;
+        this._busy = true;
+        try {
+            await writeExpiringUserTimeout(this.client, node.node_id, endpoint, minutes);
+        } catch (error) {
+            this.#reportFailure("Set Temporary PIN expiry failed", error, node, endpoint);
+        } finally {
+            if (this.#busyGeneration === busyGeneration) this._busy = false;
+        }
+    }
+
     #saveEditor() {
         const editor = this._editor;
         if (editor === null) return;
@@ -686,6 +743,8 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     #startAddUser() {
         this._userEditorError = undefined;
         this._newUserName = "";
+        this._newUserType = USER_TYPE_STANDARD;
+        this._newUserPin = "";
         this._addingUser = true;
     }
 
@@ -703,6 +762,19 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             this._userEditorError = nameError;
             return;
         }
+        const expiring = this._newUserType === USER_TYPE_EXPIRING;
+        const pin = this._newUserPin.trim();
+        if (expiring) {
+            const pinError = pinCodeLengthError(
+                pin,
+                readMinPinCodeLength(node, endpoint),
+                readMaxPinCodeLength(node, endpoint),
+            );
+            if (pinError !== null) {
+                this._userEditorError = pinError;
+                return;
+            }
+        }
         const userIndex = this._freeUserIndex;
         if (userIndex === null) {
             this._userEditorError = "The lock's user database is full.";
@@ -712,11 +784,32 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         const busyGeneration = this.#busyGeneration;
         this._busy = true;
         try {
-            await addUser(this.client, node.node_id, endpoint, userIndex, userName);
+            await addUser(
+                this.client,
+                node.node_id,
+                endpoint,
+                userIndex,
+                userName,
+                expiring ? USER_TYPE_EXPIRING : null,
+                expiring ? USER_STATUS_OCCUPIED_ENABLED : null,
+            );
             if (!this.isSameContext(node, endpoint)) return;
-            this._addingUser = false;
+            // The user record exists at this point regardless of what happens next, so a credential
+            // failure is reported without unwinding it — the reload below must still show it.
+            let credentialError: string | undefined;
+            if (expiring) {
+                try {
+                    const capacity = readNumberOfPinUsersSupported(node, endpoint) ?? PIN_CREDENTIAL_SCAN_FALLBACK;
+                    await attachPinCredential(this.client, node.node_id, endpoint, userIndex, pin, capacity);
+                } catch (error) {
+                    if (!this.isSameContext(node, endpoint)) return;
+                    credentialError = `User created, but the PIN could not be set: ${errorText(error)}`;
+                }
+            }
+            this._addingUser = credentialError !== undefined;
             this._newUserName = "";
-            this._userEditorError = undefined;
+            this._newUserPin = "";
+            this._userEditorError = credentialError;
             this.#usersRequested = true;
             // Reload preserves the current selection, so point it at the user that was just created.
             this._selectedUserIndex = userIndex;
@@ -973,11 +1066,42 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                         : nothing
                 }
             </div>
-            ${this._addingUser ? this.#renderAddUserEditor() : nothing}
+            ${this.#renderExpiringTimeoutRow()} ${this._addingUser ? this.#renderAddUserEditor() : nothing}
+        `;
+    }
+
+    /** ExpiringUserTimeout is lock-wide, not per-user, so it is edited independently of the Add user form. */
+    #renderExpiringTimeoutRow(): TemplateResult | typeof nothing {
+        if (readExpiringUserTimeout(this.node, this.endpoint) === null) return nothing;
+        return html`
+            <div class="command-row">
+                <label for="expiringTimeout">Temporary PIN expiry (min):</label>
+                <input
+                    id="expiringTimeout"
+                    type="number"
+                    min="1"
+                    max="65535"
+                    .value=${live(this._expiringTimeoutInput)}
+                    @input=${(event: Event) => {
+                        this._expiringTimeoutInput = (event.target as HTMLInputElement).value;
+                    }}
+                />
+                <md-outlined-button ?disabled=${this._busy} @click=${handleAsync(() => this.#saveExpiringTimeout())}>
+                    <ha-svg-icon slot="icon" .path=${mdiContentSaveOutline}></ha-svg-icon>
+                    Save
+                </md-outlined-button>
+            </div>
         `;
     }
 
     #renderAddUserEditor(): TemplateResult {
+        // A Temporary PIN is created directly with a working credential (SetCredential's combined-creation
+        // use case isn't used here — see attachPinCredential — but the operator still enters the PIN up
+        // front), so the option only makes sense where the lock can store PIN credentials at all.
+        const canAddExpiring = isFeatureActive(this.node, this.endpoint, "PIN");
+        const expiring = canAddExpiring && this._newUserType === USER_TYPE_EXPIRING;
+        const minPinLength = readMinPinCodeLength(this.node, this.endpoint);
+        const maxPinLength = readMaxPinCodeLength(this.node, this.endpoint);
         return html`
             <div class="editor">
                 <div class="editor-row">
@@ -991,6 +1115,22 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                             this._newUserName = (event.target as HTMLInputElement).value;
                         }}
                     />
+                    ${
+                        canAddExpiring
+                            ? html`
+                                  <label for="newUserType">Type:</label>
+                                  <select
+                                      id="newUserType"
+                                      @change=${(event: Event) => {
+                                          this._newUserType = Number((event.target as HTMLSelectElement).value);
+                                      }}
+                                  >
+                                      <option value=${USER_TYPE_STANDARD} .selected=${!expiring}>Standard</option>
+                                      <option value=${USER_TYPE_EXPIRING} .selected=${expiring}>Temporary PIN</option>
+                                  </select>
+                              `
+                            : nothing
+                    }
                     <md-outlined-button ?disabled=${this._busy} @click=${handleAsync(() => this.#saveNewUser())}>
                         <ha-svg-icon slot="icon" .path=${mdiContentSaveOutline}></ha-svg-icon>
                         Save
@@ -999,6 +1139,32 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                         <ha-svg-icon .path=${mdiClose}></ha-svg-icon>
                     </md-outlined-icon-button>
                 </div>
+                ${
+                    expiring
+                        ? html`
+                              <div class="editor-row">
+                                  <label for="newUserPin">PIN:</label>
+                                  <input
+                                      id="newUserPin"
+                                      type="password"
+                                      autocomplete="off"
+                                      maxlength=${maxPinLength ?? nothing}
+                                      .value=${live(this._newUserPin)}
+                                      @input=${(event: Event) => {
+                                          this._newUserPin = (event.target as HTMLInputElement).value;
+                                      }}
+                                  />
+                                  ${
+                                      minPinLength !== null || maxPinLength !== null
+                                          ? html`<span class="meta">
+                                                ${minPinLength ?? 1}–${maxPinLength ?? "?"} characters
+                                            </span>`
+                                          : nothing
+                                  }
+                              </div>
+                          `
+                        : nothing
+                }
                 ${this._userEditorError !== undefined ? html`<p class="error">${this._userEditorError}</p>` : nothing}
             </div>
         `;
@@ -1009,9 +1175,15 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         if (user === undefined) return nothing;
         const status = formatUserStatus(user.userStatus);
         const type = formatUserType(user.userType);
+        const expiringHint =
+            user.userType === USER_TYPE_EXPIRING
+                ? formatExpiringTimeoutHint(readExpiringUserTimeout(this.node, this.endpoint))
+                : null;
         return html`
             ${status !== null ? html`<span class="meta">${status}</span>` : nothing}
             ${type !== null ? html`<span class="meta">${type}</span>` : nothing}
+            ${hasPinCredential(user) ? html`<span class="meta">PIN</span>` : nothing}
+            ${expiringHint !== null ? html`<span class="meta">${expiringHint}</span>` : nothing}
         `;
     }
 

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -795,27 +795,32 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             );
             if (!this.isSameContext(node, endpoint)) return;
             // The user record exists at this point regardless of what happens next, so a credential
-            // failure is reported without unwinding it — the reload below must still show it.
-            let credentialError: string | undefined;
+            // failure is reported without unwinding it — the reload below must still show it. The editor
+            // closes either way: leaving it open would let a retry recompute _freeUserIndex onto a new
+            // slot and create a duplicate user rather than retrying the credential for this one.
+            let credentialError: unknown;
             if (expiring) {
                 try {
                     const capacity = readNumberOfPinUsersSupported(node, endpoint) ?? PIN_CREDENTIAL_SCAN_FALLBACK;
                     await attachPinCredential(this.client, node.node_id, endpoint, userIndex, pin, capacity);
                 } catch (error) {
                     if (!this.isSameContext(node, endpoint)) return;
-                    credentialError = `User created, but the PIN could not be set: ${errorText(error)}`;
+                    credentialError = error;
                 }
             }
-            this._addingUser = credentialError !== undefined;
+            this._addingUser = false;
             this._newUserName = "";
             this._newUserPin = "";
-            this._userEditorError = credentialError;
+            this._userEditorError = undefined;
             this.#usersRequested = true;
             // Reload preserves the current selection, so point it at the user that was just created.
             this._selectedUserIndex = userIndex;
             this._weekDaySlots = undefined;
             this._yearDaySlots = undefined;
             await this.#loadUsers();
+            if (credentialError !== undefined) {
+                this.#reportFailure("User created, but the PIN could not be set", credentialError, node, endpoint);
+            }
         } catch (error) {
             if (!this.isSameContext(node, endpoint)) return;
             this._userEditorError = errorText(error);
@@ -1098,7 +1103,8 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         // A Temporary PIN is created directly with a working credential (SetCredential's combined-creation
         // use case isn't used here — see attachPinCredential — but the operator still enters the PIN up
         // front), so the option only makes sense where the lock can store PIN credentials at all.
-        const canAddExpiring = isFeatureActive(this.node, this.endpoint, "PIN");
+        const canAddExpiring =
+            isFeatureActive(this.node, this.endpoint, "PIN") && isFeatureActive(this.node, this.endpoint, "USR");
         const expiring = canAddExpiring && this._newUserType === USER_TYPE_EXPIRING;
         const minPinLength = readMinPinCodeLength(this.node, this.endpoint);
         const maxPinLength = readMaxPinCodeLength(this.node, this.endpoint);

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -207,6 +207,8 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     #freeIndexCapacity: number | null = null;
     /** Set once the operator edits the expiry field, so a device report cannot overwrite what they typed. */
     #expiringTimeoutDirty = false;
+    /** The value last written, still awaiting the report that confirms the lock took it. */
+    #expiringTimeoutAwaitingReport: number | null = null;
 
     override willUpdate(changedProperties: PropertyValues) {
         super.willUpdate(changedProperties);
@@ -243,6 +245,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             this._userEditorError = undefined;
             this._expiringTimeoutInput = "";
             this.#expiringTimeoutDirty = false;
+            this.#expiringTimeoutAwaitingReport = null;
             this._showEmptyWeekDay = false;
             this._showEmptyYearDay = false;
             this._showEmptyHoliday = false;
@@ -261,9 +264,15 @@ class DoorLockClusterCommands extends BaseClusterCommands {
 
         // Tracks the device until the operator types something: another client (or the lock itself) can
         // change the timeout at any time, and saving a value read once at mount would undo that.
-        if (!this.#expiringTimeoutDirty) {
-            const expiringTimeout = readExpiringUserTimeout(this.node, this.endpoint);
-            if (expiringTimeout !== null) this._expiringTimeoutInput = String(expiringTimeout);
+        const expiringTimeout = readExpiringUserTimeout(this.node, this.endpoint);
+        // A write is only settled once the cache reports it back; clearing on the write's own resolution
+        // would let this render restore the pre-write value the cache still holds.
+        if (this.#expiringTimeoutAwaitingReport !== null && expiringTimeout === this.#expiringTimeoutAwaitingReport) {
+            this.#expiringTimeoutAwaitingReport = null;
+            this.#expiringTimeoutDirty = false;
+        }
+        if (!this.#expiringTimeoutDirty && expiringTimeout !== null) {
+            this._expiringTimeoutInput = String(expiringTimeout);
         }
 
         // The attribute cache fills in progressively: the feature bits can resolve before the numeric
@@ -609,8 +618,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         this._busy = true;
         try {
             await writeExpiringUserTimeout(this.client, node.node_id, endpoint, minutes);
-            // The field matches the lock again, so let the next report track it.
-            if (this.isSameContext(node, endpoint)) this.#expiringTimeoutDirty = false;
+            if (this.isSameContext(node, endpoint)) this.#expiringTimeoutAwaitingReport = minutes;
         } catch (error) {
             this.#reportFailure("Set Temporary PIN expiry failed", error, node, endpoint);
         } finally {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -123,8 +123,8 @@ const DATE_TIME_MAX = "2136-02-07T06:28:15";
 /** Bounds the GetUser walk on a lock that leaves NumberOfTotalUsersSupported unreported. */
 const USER_SCAN_FALLBACK = 32;
 
-/** Bounds the free PIN credential slot search on a lock that leaves NumberOfPinUsersSupported unreported. */
-const PIN_CREDENTIAL_SCAN_FALLBACK = 32;
+/** ExpiringUserTimeout's upper bound: the Door Lock data model constrains it to 1–2880 minutes (spec §7.18.2.51). */
+const EXPIRING_USER_TIMEOUT_MAX_MINUTES = 2880;
 
 /** UserTypeEnum.UnrestrictedUser — the default "Standard" choice in the add-user editor. */
 const USER_TYPE_STANDARD = 0;
@@ -272,13 +272,9 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         // The attribute cache fills in progressively: the feature bits can resolve before the numeric
         // capacity attributes the load depends on. Wait for those too, or the load runs once with fallback
         // values (32 scanned users, 0 schedule slots) and #usersRequested latches true forever, so it never
-        // gets a chance to retry with the real numbers.
-        if (
-            !this.#usersRequested &&
-            this.#perUserSchedulesSupported() &&
-            isFeatureActive(this.node, this.endpoint, "USR") &&
-            this.#scheduleCapacityReady()
-        ) {
+        // gets a chance to retry with the real numbers. Users load whenever the lock has a user database at
+        // all: PIN/Temporary-PIN management needs it even on a lock with no WDSCH/YDSCH schedule feature.
+        if (!this.#usersRequested && this.#userManagementSupported() && this.#scheduleCapacityReady()) {
             this.#usersRequested = true;
             handleAsync(() => this.#loadUsers())();
         }
@@ -326,12 +322,26 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         );
     }
 
-    #perUserSchedulesSupported(): boolean {
-        return isFeatureActive(this.node, this.endpoint, "WDSCH") || isFeatureActive(this.node, this.endpoint, "YDSCH");
-    }
-
     #holidaySupported(): boolean {
         return isFeatureActive(this.node, this.endpoint, "HDSCH");
+    }
+
+    /** Whether the lock exposes a user database at all — independent of whether it also supports schedules. */
+    #userManagementSupported(): boolean {
+        return isFeatureActive(this.node, this.endpoint, "USR");
+    }
+
+    /**
+     * Whether the "Temporary PIN" user type can be offered. PIN implies USR, but neither guarantees
+     * ExpiringUser support: UserTypeEnum's Expiring value and ExpiringUserTimeout are both optional under
+     * USR, so the attribute's presence is the only reliable signal a lock actually accepts it.
+     */
+    #expiringUserSupported(): boolean {
+        return (
+            isFeatureActive(this.node, this.endpoint, "PIN") &&
+            this.#userManagementSupported() &&
+            readExpiringUserTimeout(this.node, this.endpoint) !== null
+        );
     }
 
     /** Whether a load started for `node`/`endpoint` at `generation` still owns its loader's counter. */
@@ -591,8 +601,11 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         const endpoint = this.endpoint;
         if (this._busy) return;
         const minutes = Number(this._expiringTimeoutInput);
-        if (!Number.isInteger(minutes) || minutes < 1 || minutes > 0xffff) {
-            await showAlertDialog({ title: "Invalid timeout", text: "The timeout must be 1 to 65535 minutes." });
+        if (!Number.isInteger(minutes) || minutes < 1 || minutes > EXPIRING_USER_TIMEOUT_MAX_MINUTES) {
+            await showAlertDialog({
+                title: "Invalid timeout",
+                text: `The timeout must be 1 to ${EXPIRING_USER_TIMEOUT_MAX_MINUTES} minutes.`,
+            });
             return;
         }
         const busyGeneration = this.#busyGeneration;
@@ -762,8 +775,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             this._userEditorError = nameError;
             return;
         }
-        const canAddExpiring = isFeatureActive(node, endpoint, "PIN") && isFeatureActive(node, endpoint, "USR");
-        const expiring = canAddExpiring && this._newUserType === USER_TYPE_EXPIRING;
+        const expiring = this.#expiringUserSupported() && this._newUserType === USER_TYPE_EXPIRING;
         const pin = this._newUserPin.trim();
         if (expiring) {
             const pinError = pinCodeLengthError(
@@ -773,6 +785,12 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             );
             if (pinError !== null) {
                 this._userEditorError = pinError;
+                return;
+            }
+            // Checked before SetUser runs, not guessed afterwards: SetUser would already have created the
+            // user by the time a missing capacity surfaced, leaving it with no PIN and no retry path.
+            if (readNumberOfPinUsersSupported(node, endpoint) === null) {
+                this._userEditorError = "The lock hasn't reported its PIN credential capacity yet.";
                 return;
             }
         }
@@ -802,7 +820,10 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             let credentialError: unknown;
             if (expiring) {
                 try {
-                    const capacity = readNumberOfPinUsersSupported(node, endpoint) ?? PIN_CREDENTIAL_SCAN_FALLBACK;
+                    const capacity = readNumberOfPinUsersSupported(node, endpoint);
+                    if (capacity === null) {
+                        throw new Error("The lock's PIN credential capacity is no longer available.");
+                    }
                     await attachPinCredential(this.client, node.node_id, endpoint, userIndex, pin, capacity);
                 } catch (error) {
                     if (!this.isSameContext(node, endpoint)) return;
@@ -861,7 +882,9 @@ class DoorLockClusterCommands extends BaseClusterCommands {
 
     override render() {
         if (!this.node || this.cluster !== DOOR_LOCK_CLUSTER_ID) return nothing;
-        return html`${this.#renderLockPanel()}${this.#schedulesSupported() ? this.#renderSchedulePanel() : nothing}`;
+        // A PIN+USR lock with no WDSCH/YDSCH/HDSCH feature still needs this panel for user/PIN management.
+        const showUsersPanel = this.#schedulesSupported() || this.#userManagementSupported();
+        return html`${this.#renderLockPanel()}${showUsersPanel ? this.#renderSchedulePanel() : nothing}`;
     }
 
     #renderLockPanel(): TemplateResult {
@@ -952,17 +975,20 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         const weekDayActive = isFeatureActive(this.node, this.endpoint, "WDSCH");
         const yearDayActive = isFeatureActive(this.node, this.endpoint, "YDSCH");
         const holidayActive = this.#holidaySupported();
-        const userActive = isFeatureActive(this.node, this.endpoint, "USR");
+        const userActive = this.#userManagementSupported();
         const perUserActive = weekDayActive || yearDayActive;
-        const features = [weekDayActive && "WDSCH", yearDayActive && "YDSCH", holidayActive && "HDSCH"].filter(
-            (code): code is string => code !== false,
-        );
+        const features = [
+            userActive && "USR",
+            weekDayActive && "WDSCH",
+            yearDayActive && "YDSCH",
+            holidayActive && "HDSCH",
+        ].filter((code): code is string => code !== false);
 
         return html`
             <details class="command-panel" open>
                 <summary>
                     <ha-svg-icon .path=${mdiCalendarWeek}></ha-svg-icon>
-                    Access Schedules
+                    Users &amp; Access Schedules
                     <span class="feature-map-badge">FeatureMap: ${features.join(" · ")}</span>
                 </summary>
                 <div class="command-content">
@@ -973,24 +999,24 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                             : nothing
                     }
                     ${
-                        !perUserActive
-                            ? nothing
-                            : userActive
-                              ? html`
-                                    ${this.#renderUserSelector()}
-                                    ${
-                                        this._selectedUserIndex === null
-                                            ? nothing
-                                            : html`
-                                                  ${weekDayActive ? this.#renderWeekDaySection() : nothing}
-                                                  ${yearDayActive ? this.#renderYearDaySection() : nothing}
-                                              `
-                                    }
-                                `
-                              : html`<p class="empty">
+                        userActive
+                            ? html`
+                                  ${this.#renderUserSelector()}
+                                  ${
+                                      this._selectedUserIndex === null
+                                          ? nothing
+                                          : html`
+                                                ${weekDayActive ? this.#renderWeekDaySection() : nothing}
+                                                ${yearDayActive ? this.#renderYearDaySection() : nothing}
+                                            `
+                                  }
+                              `
+                            : perUserActive
+                              ? html`<p class="empty">
                                     Schedules are assigned per user, which this lock does not expose: it reports no User
                                     (USR) feature, so its user database cannot be read.
                                 </p>`
+                              : nothing
                     }
                     ${holidayActive ? this.#renderHolidaySection() : nothing}
                 </div>
@@ -1086,7 +1112,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     id="expiringTimeout"
                     type="number"
                     min="1"
-                    max="65535"
+                    max=${EXPIRING_USER_TIMEOUT_MAX_MINUTES}
                     .value=${live(this._expiringTimeoutInput)}
                     @input=${(event: Event) => {
                         this._expiringTimeoutInput = (event.target as HTMLInputElement).value;
@@ -1104,8 +1130,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         // A Temporary PIN is created directly with a working credential (SetCredential's combined-creation
         // use case isn't used here — see attachPinCredential — but the operator still enters the PIN up
         // front), so the option only makes sense where the lock can store PIN credentials at all.
-        const canAddExpiring =
-            isFeatureActive(this.node, this.endpoint, "PIN") && isFeatureActive(this.node, this.endpoint, "USR");
+        const canAddExpiring = this.#expiringUserSupported();
         const expiring = canAddExpiring && this._newUserType === USER_TYPE_EXPIRING;
         const minPinLength = readMinPinCodeLength(this.node, this.endpoint);
         const maxPinLength = readMaxPinCodeLength(this.node, this.endpoint);
@@ -1164,7 +1189,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                                   ${
                                       minPinLength !== null || maxPinLength !== null
                                           ? html`<span class="meta">
-                                                ${minPinLength ?? 1}–${maxPinLength ?? "?"} characters
+                                                ${minPinLength ?? 1}–${maxPinLength ?? "?"} bytes
                                             </span>`
                                           : nothing
                                   }

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -205,8 +205,8 @@ class DoorLockClusterCommands extends BaseClusterCommands {
      */
     #busyGeneration = 0;
     #freeIndexCapacity: number | null = null;
-    /** The context `_expiringTimeoutInput` was last synced from the device for, so a user's own edits stick. */
-    #expiringTimeoutSyncedFor: string | null = null;
+    /** Set once the operator edits the expiry field, so a device report cannot overwrite what they typed. */
+    #expiringTimeoutDirty = false;
 
     override willUpdate(changedProperties: PropertyValues) {
         super.willUpdate(changedProperties);
@@ -242,7 +242,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             this._newUserPin = "";
             this._userEditorError = undefined;
             this._expiringTimeoutInput = "";
-            this.#expiringTimeoutSyncedFor = null;
+            this.#expiringTimeoutDirty = false;
             this._showEmptyWeekDay = false;
             this._showEmptyYearDay = false;
             this._showEmptyHoliday = false;
@@ -259,14 +259,11 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             this._freeUserIndex = nextFreeUserIndex(this._users, userCapacity ?? USER_SCAN_FALLBACK);
         }
 
-        // Synced once per context rather than on every render, so a value the operator is mid-edit on isn't
-        // clobbered by the attribute simply being re-read.
-        if (this.#expiringTimeoutSyncedFor !== context) {
+        // Tracks the device until the operator types something: another client (or the lock itself) can
+        // change the timeout at any time, and saving a value read once at mount would undo that.
+        if (!this.#expiringTimeoutDirty) {
             const expiringTimeout = readExpiringUserTimeout(this.node, this.endpoint);
-            if (expiringTimeout !== null) {
-                this._expiringTimeoutInput = String(expiringTimeout);
-                this.#expiringTimeoutSyncedFor = context;
-            }
+            if (expiringTimeout !== null) this._expiringTimeoutInput = String(expiringTimeout);
         }
 
         // The attribute cache fills in progressively: the feature bits can resolve before the numeric
@@ -612,6 +609,8 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         this._busy = true;
         try {
             await writeExpiringUserTimeout(this.client, node.node_id, endpoint, minutes);
+            // The field matches the lock again, so let the next report track it.
+            if (this.isSameContext(node, endpoint)) this.#expiringTimeoutDirty = false;
         } catch (error) {
             this.#reportFailure("Set Temporary PIN expiry failed", error, node, endpoint);
         } finally {
@@ -1123,6 +1122,7 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     .value=${live(this._expiringTimeoutInput)}
                     @input=${(event: Event) => {
                         this._expiringTimeoutInput = (event.target as HTMLInputElement).value;
+                        this.#expiringTimeoutDirty = true;
                     }}
                 />
                 <md-outlined-button ?disabled=${this._busy} @click=${handleAsync(() => this.#saveExpiringTimeout())}>

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -31,7 +31,8 @@ import "../../../components/ha-svg-icon.js";
 import { handleAsync } from "../../../util/async-handler.js";
 import {
     addUser,
-    attachPinCredential,
+    createExpiringPinUser,
+    type ExpiringPinUserFailure,
     buildDaySegments,
     clearHolidaySchedule,
     clearWeekDaySchedule,
@@ -93,7 +94,6 @@ import {
     unlockWithTimeout,
     userNameLengthError,
     USER_NAME_MAX_LENGTH,
-    USER_STATUS_OCCUPIED_ENABLED,
     USER_TYPE_EXPIRING,
     weekDayScheduleRangeError,
     writeExpiringUserTimeout,
@@ -803,36 +803,32 @@ class DoorLockClusterCommands extends BaseClusterCommands {
         const busyGeneration = this.#busyGeneration;
         this._busy = true;
         try {
-            await addUser(
-                this.client,
-                node.node_id,
-                endpoint,
-                userIndex,
-                userName,
-                expiring ? USER_TYPE_EXPIRING : null,
-                expiring ? USER_STATUS_OCCUPIED_ENABLED : null,
-            );
-            if (!this.isSameContext(node, endpoint)) return;
-            // The user record exists at this point regardless of what happens next, so a credential
-            // failure is reported without unwinding it — the reload below must still show it. The editor
-            // closes either way: leaving it open would let a retry recompute _freeUserIndex onto a new
-            // slot and create a duplicate user rather than retrying the credential for this one.
-            let credentialError: unknown;
+            let failure: ExpiringPinUserFailure | null = null;
             if (expiring) {
-                try {
-                    const capacity = readNumberOfPinUsersSupported(node, endpoint);
-                    if (capacity === null) {
-                        throw new Error("The lock's PIN credential capacity is no longer available.");
-                    }
-                    await attachPinCredential(this.client, node.node_id, endpoint, userIndex, pin, capacity);
-                } catch (error) {
-                    credentialError = error;
+                const capacity = readNumberOfPinUsersSupported(node, endpoint);
+                if (capacity === null) {
+                    this._userEditorError = "The lock's PIN credential capacity is no longer available.";
+                    return;
                 }
+                failure = await createExpiringPinUser(
+                    this.client,
+                    node.node_id,
+                    endpoint,
+                    userIndex,
+                    userName,
+                    pin,
+                    capacity,
+                );
+            } else {
+                await addUser(this.client, node.node_id, endpoint, userIndex, userName);
             }
             if (!this.isSameContext(node, endpoint)) {
-                if (credentialError !== undefined) {
-                    console.error("The PIN could not be set for the user that was just created", credentialError);
-                }
+                if (failure !== null) console.error("Creating the temporary PIN user failed", failure);
+                return;
+            }
+            if (failure?.outcome === "rolled-back") {
+                // The lock is unchanged, so the entered values stay in the editor for a retry.
+                this._userEditorError = `${failure.reason} The user was removed again; nothing was changed.`;
                 return;
             }
             this._addingUser = false;
@@ -845,8 +841,14 @@ class DoorLockClusterCommands extends BaseClusterCommands {
             this._weekDaySlots = undefined;
             this._yearDaySlots = undefined;
             await this.#loadUsers();
-            if (credentialError !== undefined) {
-                this.#reportFailure("User created, but the PIN could not be set", credentialError, node, endpoint);
+            if (failure !== null && this.isSameContext(node, endpoint)) {
+                showAlertDialog({
+                    title: "The temporary PIN could not be set",
+                    text:
+                        `${failure.reason} User ${userIndex} ("${userName}") was created on the lock but has no ` +
+                        `PIN, and removing it again also failed (${failure.rollbackReason}). It cannot open the ` +
+                        `door — delete it from the user list and try again.`,
+                }).catch(alertError => console.error("Failed to show the PIN failure dialog", alertError));
             }
         } catch (error) {
             if (!this.isSameContext(node, endpoint)) return;

--- a/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/door-lock-commands.ts
@@ -123,7 +123,7 @@ const DATE_TIME_MAX = "2136-02-07T06:28:15";
 /** Bounds the GetUser walk on a lock that leaves NumberOfTotalUsersSupported unreported. */
 const USER_SCAN_FALLBACK = 32;
 
-/** ExpiringUserTimeout's upper bound: the Door Lock data model constrains it to 1–2880 minutes (spec §7.18.2.51). */
+/** ExpiringUserTimeout's upper bound: the Door Lock data model constrains it to 1–2880 minutes. */
 const EXPIRING_USER_TIMEOUT_MAX_MINUTES = 2880;
 
 /** UserTypeEnum.UnrestrictedUser — the default "Standard" choice in the add-user editor. */
@@ -826,9 +826,14 @@ class DoorLockClusterCommands extends BaseClusterCommands {
                     }
                     await attachPinCredential(this.client, node.node_id, endpoint, userIndex, pin, capacity);
                 } catch (error) {
-                    if (!this.isSameContext(node, endpoint)) return;
                     credentialError = error;
                 }
+            }
+            if (!this.isSameContext(node, endpoint)) {
+                if (credentialError !== undefined) {
+                    console.error("The PIN could not be set for the user that was just created", credentialError);
+                }
+                return;
             }
             this._addingUser = false;
             this._newUserName = "";
@@ -1127,9 +1132,6 @@ class DoorLockClusterCommands extends BaseClusterCommands {
     }
 
     #renderAddUserEditor(): TemplateResult {
-        // A Temporary PIN is created directly with a working credential (SetCredential's combined-creation
-        // use case isn't used here — see attachPinCredential — but the operator still enters the PIN up
-        // front), so the option only makes sense where the lock can store PIN credentials at all.
         const canAddExpiring = this.#expiringUserSupported();
         const expiring = canAddExpiring && this._newUserType === USER_TYPE_EXPIRING;
         const minPinLength = readMinPinCodeLength(this.node, this.endpoint);

--- a/packages/dashboard/src/util/door-lock.ts
+++ b/packages/dashboard/src/util/door-lock.ts
@@ -6,9 +6,9 @@
 
 import type { MatterClient, MatterNode } from "@matter-server/ws-client";
 import { clusters } from "../client/models/descriptions.js";
-import { asObject, pickNumber, pickString } from "./attribute-shapes.js";
+import { asObject, pickArray, pickNumber, pickString } from "./attribute-shapes.js";
 import { computeActiveClusterFeatures } from "./cluster-features.js";
-import { getMatterStatusName } from "./matter-status.js";
+import { getMatterStatusName, requireAttributeWriteSuccess } from "./matter-status.js";
 import { MATTER_EPOCH_MAX_SECONDS, MATTER_EPOCH_OFFSET_SECONDS } from "./time.js";
 
 /** Door Lock cluster (Matter spec §5.2). */
@@ -19,11 +19,15 @@ const ATTR_LOCK_TYPE = 0x01;
 const ATTR_ACTUATOR_ENABLED = 0x02;
 const ATTR_DOOR_STATE = 0x03;
 const ATTR_NUMBER_OF_TOTAL_USERS_SUPPORTED = 0x11;
+const ATTR_NUMBER_OF_PIN_USERS_SUPPORTED = 0x12;
 const ATTR_NUMBER_OF_WEEK_DAY_SCHEDULES_SUPPORTED_PER_USER = 0x14;
 const ATTR_NUMBER_OF_YEAR_DAY_SCHEDULES_SUPPORTED_PER_USER = 0x15;
 const ATTR_NUMBER_OF_HOLIDAY_SCHEDULES_SUPPORTED = 0x16;
+const ATTR_MAX_PIN_CODE_LENGTH = 0x17;
+const ATTR_MIN_PIN_CODE_LENGTH = 0x18;
 const ATTR_SUPPORTED_OPERATING_MODES = 0x26;
 const ATTR_REQUIRE_PIN_FOR_REMOTE_OPERATION = 0x33;
+const ATTR_EXPIRING_USER_TIMEOUT = 0x35;
 const ATTR_ACCEPTED_COMMAND_LIST = 0xfff9;
 const ATTR_FEATURE_MAP = 0xfffc;
 
@@ -39,11 +43,33 @@ export const SCHEDULE_INDEX_ALL = 0xfe;
 /** UserStatusEnum.Available — a slot the lock reports as free (spec §5.2.6.17). */
 const USER_STATUS_AVAILABLE = 0;
 
-/** DataOperationTypeEnum.Add — the SetUser operation that creates a new user (spec §5.2.6.10). */
+/** DataOperationTypeEnum.Add — the SetUser/SetCredential operation that creates a new entry (spec §5.2.6.10). */
 const OPERATION_TYPE_ADD = 0;
+
+/** UserTypeEnum.ExpiringUser — access expires ExpiringUserTimeout minutes after the credential's first use. */
+export const USER_TYPE_EXPIRING = 7;
+
+/** UserStatusEnum.OccupiedEnabled — the status a newly created, active user is given (spec §5.2.6.17). */
+export const USER_STATUS_OCCUPIED_ENABLED = 1;
+
+/** CredentialTypeEnum.PIN — the only credential type this panel manages (spec §5.2.6.9). */
+const CREDENTIAL_TYPE_PIN = 1;
 
 /** SetUser's UserName constraint (spec §5.2.10.34.3), enforced here instead of round-tripping it. */
 export const USER_NAME_MAX_LENGTH = 10;
+
+/**
+ * Why the lock will reject this PIN, or null when it will accept it. `minLength`/`maxLength` are the lock's
+ * own MinPinCodeLength/MaxPinCodeLength, unknown on a lock that doesn't report them — in that case only
+ * non-emptiness is checked, same fallback as the schedule capacity attributes elsewhere in this file.
+ */
+export function pinCodeLengthError(pin: string, minLength: number | null, maxLength: number | null): string | null {
+    if (pin === "") return "Enter a PIN.";
+    const length = new TextEncoder().encode(pin).length;
+    if (minLength !== null && length < minLength) return `The PIN must be at least ${minLength} characters.`;
+    if (maxLength !== null && length > maxLength) return `The PIN must be at most ${maxLength} characters.`;
+    return null;
+}
 
 /**
  * Why the lock will reject this user name, or null when it will accept it. The constraint counts UTF-8
@@ -194,6 +220,11 @@ export interface HolidayScheduleSlot {
     schedule: HolidaySchedule | null;
 }
 
+export interface UserCredential {
+    credentialType: number;
+    credentialIndex: number;
+}
+
 export interface DoorLockUser {
     userIndex: number;
     userName: string | null;
@@ -201,6 +232,7 @@ export interface DoorLockUser {
     userType: number | null;
     nextUserIndex: number | null;
     occupied: boolean;
+    credentials: UserCredential[];
 }
 
 /** A schedule window projected onto one display day, in minutes from midnight. */
@@ -264,6 +296,42 @@ export function readYearDaySchedulesPerUser(node: MatterNode, endpoint: number):
 /** Unlike WDSCH/YDSCH, HolidaySchedules is a lock-wide table: it is not scoped to a user. */
 export function readHolidaySchedulesSupported(node: MatterNode, endpoint: number): number | null {
     return readNumberAttr(node, endpoint, ATTR_NUMBER_OF_HOLIDAY_SCHEDULES_SUPPORTED);
+}
+
+export function readNumberOfPinUsersSupported(node: MatterNode, endpoint: number): number | null {
+    return readNumberAttr(node, endpoint, ATTR_NUMBER_OF_PIN_USERS_SUPPORTED);
+}
+
+export function readMinPinCodeLength(node: MatterNode, endpoint: number): number | null {
+    return readNumberAttr(node, endpoint, ATTR_MIN_PIN_CODE_LENGTH);
+}
+
+export function readMaxPinCodeLength(node: MatterNode, endpoint: number): number | null {
+    return readNumberAttr(node, endpoint, ATTR_MAX_PIN_CODE_LENGTH);
+}
+
+/**
+ * Minutes an ExpiringUser's credential remains valid after its first use, lock-wide rather than per-user
+ * (spec §5.2.9.36). Absent on a lock that doesn't support ExpiringUser at all.
+ */
+export function readExpiringUserTimeout(node: MatterNode, endpoint: number): number | null {
+    return readNumberAttr(node, endpoint, ATTR_EXPIRING_USER_TIMEOUT);
+}
+
+export async function writeExpiringUserTimeout(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    minutes: number,
+): Promise<void> {
+    requireAttributeWriteSuccess(
+        await client.writeAttribute(
+            nodeId,
+            `${endpoint}/${DOOR_LOCK_CLUSTER_ID}/${ATTR_EXPIRING_USER_TIMEOUT}`,
+            minutes,
+        ),
+        "Writing the Expiring User Timeout attribute failed",
+    );
 }
 
 export function requiresPinForRemoteOperation(node: MatterNode, endpoint: number): boolean {
@@ -570,6 +638,17 @@ export function decodeHolidayScheduleResponse(response: unknown, holidayIndex: n
     };
 }
 
+function decodeCredentials(obj: Record<string, unknown>): UserCredential[] {
+    return pickArray(obj, "credentials").flatMap(entry => {
+        const obj = asObject(entry);
+        if (obj === null) return [];
+        const credentialType = pickNumber(obj, "credentialType");
+        const credentialIndex = pickNumber(obj, "credentialIndex");
+        if (credentialType === null || credentialIndex === null) return [];
+        return [{ credentialType, credentialIndex }];
+    });
+}
+
 export function decodeUserResponse(response: unknown): DoorLockUser | null {
     const obj = asObject(response);
     if (obj === null) return null;
@@ -584,7 +663,19 @@ export function decodeUserResponse(response: unknown): DoorLockUser | null {
         nextUserIndex: pickNumber(obj, "nextUserIndex"),
         // The spec nulls the whole record for a free slot, but locks in the field also report Available there.
         occupied: userStatus !== null && userStatus !== USER_STATUS_AVAILABLE,
+        credentials: decodeCredentials(obj),
     };
+}
+
+/** Whether a user carries a working PIN credential, as opposed to just a UserType badge. */
+export function hasPinCredential(user: DoorLockUser): boolean {
+    return user.credentials.some(credential => credential.credentialType === CREDENTIAL_TYPE_PIN);
+}
+
+/** The lock-wide ExpiringUserTimeout, phrased for display next to an ExpiringUser's badge. */
+export function formatExpiringTimeoutHint(minutes: number | null): string | null {
+    if (minutes === null) return null;
+    return `Disables ${minutes} min after first PIN use`;
 }
 
 /** Encode a PIN for the octstr PinCode field, which reaches the lock as base64. */
@@ -764,16 +855,112 @@ export async function addUser(
     endpoint: number,
     userIndex: number,
     userName: string,
+    userType: number | null = null,
+    userStatus: number | null = null,
 ): Promise<void> {
     await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "SetUser", {
         operationType: OPERATION_TYPE_ADD,
         userIndex,
         userName,
         userUniqueId: null,
-        userStatus: null,
-        userType: null,
+        userStatus,
+        userType,
         credentialRule: null,
     });
+}
+
+function decodeSetCredentialResponse(response: unknown): { status: number | null; userIndex: number | null } {
+    const obj = asObject(response);
+    return {
+        status: obj !== null ? pickNumber(obj, "status") : null,
+        userIndex: obj !== null ? pickNumber(obj, "userIndex") : null,
+    };
+}
+
+function decodeCredentialStatusResponse(response: unknown): {
+    credentialExists: boolean;
+    nextCredentialIndex: number | null;
+} {
+    const obj = asObject(response);
+    return {
+        credentialExists: obj !== null && obj["credentialExists"] === true,
+        nextCredentialIndex: obj !== null ? pickNumber(obj, "nextCredentialIndex") : null,
+    };
+}
+
+async function getCredentialStatus(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    credentialType: number,
+    credentialIndex: number,
+) {
+    const response = await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "GetCredentialStatus", {
+        credential: { credentialType, credentialIndex },
+    });
+    return decodeCredentialStatusResponse(response);
+}
+
+/**
+ * The lowest unoccupied PIN credential index in `[1, maxIndex]`, or null when every slot is taken.
+ * Mirrors nextFreeUserIndex/readUsers: GetCredentialStatus's NextCredentialIndex chains through the
+ * *occupied* slots only, so free slots are never queried directly — they are whatever is left over once
+ * the occupied ones are collected.
+ */
+async function nextFreePinCredentialIndex(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    maxIndex: number,
+): Promise<number | null> {
+    const occupied = new Set<number>();
+    // Visited is tracked separately from occupied: a lock reporting NextCredentialIndex values that never
+    // flag as existing (malformed, or genuinely free slots surfaced by mistake) must not loop forever just
+    // because `occupied` never grows.
+    const visited = new Set<number>();
+    let index: number | null = 1;
+    while (index !== null && visited.size <= maxIndex) {
+        if (visited.has(index)) break;
+        visited.add(index);
+        const status = await getCredentialStatus(client, nodeId, endpoint, CREDENTIAL_TYPE_PIN, index);
+        if (status.credentialExists) occupied.add(index);
+        index = status.nextCredentialIndex;
+    }
+    for (let candidate = 1; candidate <= maxIndex; candidate++) {
+        if (!occupied.has(candidate)) return candidate;
+    }
+    return null;
+}
+
+/**
+ * Attaches a PIN credential to an existing user (SetCredential's "add a credential to an existing user"
+ * use case — UserIndex given, UserStatus/UserType left null since the user already has both). `capacity`
+ * bounds the free-slot search, e.g. `readNumberOfPinUsersSupported(node, endpoint) ?? PIN_CREDENTIAL_SCAN_FALLBACK`.
+ */
+export async function attachPinCredential(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    userIndex: number,
+    pin: string,
+    capacity: number,
+): Promise<void> {
+    const credentialIndex = await nextFreePinCredentialIndex(client, nodeId, endpoint, capacity);
+    if (credentialIndex === null) {
+        throw new Error("The lock's PIN credential database is full.");
+    }
+    const response = await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "SetCredential", {
+        operationType: OPERATION_TYPE_ADD,
+        credential: { credentialType: CREDENTIAL_TYPE_PIN, credentialIndex },
+        credentialData: encodePinCode(pin),
+        userIndex,
+        userStatus: null,
+        userType: null,
+    });
+    const { status } = decodeSetCredentialResponse(response);
+    if (status !== 0) {
+        throw new Error(status === null ? "The lock did not report a result." : getMatterStatusName(status));
+    }
 }
 
 export async function removeUser(

--- a/packages/dashboard/src/util/door-lock.ts
+++ b/packages/dashboard/src/util/door-lock.ts
@@ -66,8 +66,8 @@ export const USER_NAME_MAX_LENGTH = 10;
 export function pinCodeLengthError(pin: string, minLength: number | null, maxLength: number | null): string | null {
     if (pin === "") return "Enter a PIN.";
     const length = new TextEncoder().encode(pin).length;
-    if (minLength !== null && length < minLength) return `The PIN must be at least ${minLength} characters.`;
-    if (maxLength !== null && length > maxLength) return `The PIN must be at most ${maxLength} characters.`;
+    if (minLength !== null && length < minLength) return `The PIN must be at least ${minLength} bytes.`;
+    if (maxLength !== null && length > maxLength) return `The PIN must be at most ${maxLength} bytes.`;
     return null;
 }
 

--- a/packages/dashboard/src/util/door-lock.ts
+++ b/packages/dashboard/src/util/door-lock.ts
@@ -992,6 +992,57 @@ export async function removeUser(
     await client.deviceCommand(nodeId, endpoint, DOOR_LOCK_CLUSTER_ID, "ClearUser", { userIndex });
 }
 
+/**
+ * Why a user is not usable after createExpiringPinUser() failed.
+ *
+ * - `rolled-back`: the user was removed again, so the lock is unchanged and a retry is safe.
+ * - `orphaned`: the user exists on the lock with no PIN and could not be removed; it cannot open the
+ *   door, so the operator has to delete it before retrying.
+ */
+export interface ExpiringPinUserFailure {
+    outcome: "rolled-back" | "orphaned";
+    /** Why the PIN could not be set. */
+    reason: string;
+    /** Why the created user could not be removed again; only set when `outcome` is `orphaned`. */
+    rollbackReason?: string;
+}
+
+/**
+ * Creates an ExpiringUser and attaches its PIN. SetUser and SetCredential are separate commands, so a
+ * PIN failure would otherwise leave a user that looks live in the list but can never open the door;
+ * the user is removed again when that happens.
+ *
+ * @returns null when the user and its PIN are both in place, otherwise what went wrong
+ * @throws when SetUser itself fails, i.e. before anything reaches the lock
+ */
+export async function createExpiringPinUser(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    userIndex: number,
+    userName: string,
+    pin: string,
+    pinCapacity: number,
+): Promise<ExpiringPinUserFailure | null> {
+    await addUser(client, nodeId, endpoint, userIndex, userName, USER_TYPE_EXPIRING, USER_STATUS_OCCUPIED_ENABLED);
+    try {
+        await attachPinCredential(client, nodeId, endpoint, userIndex, pin, pinCapacity);
+        return null;
+    } catch (credentialError) {
+        const reason = errorMessage(credentialError);
+        try {
+            await removeUser(client, nodeId, endpoint, userIndex);
+            return { outcome: "rolled-back", reason };
+        } catch (rollbackError) {
+            return { outcome: "orphaned", reason, rollbackReason: errorMessage(rollbackError) };
+        }
+    }
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
 export async function lockDoor(
     client: MatterClient,
     nodeId: number | bigint,

--- a/packages/dashboard/src/util/door-lock.ts
+++ b/packages/dashboard/src/util/door-lock.ts
@@ -675,7 +675,7 @@ export function hasPinCredential(user: DoorLockUser): boolean {
 /** The lock-wide ExpiringUserTimeout, phrased for display next to an ExpiringUser's badge. */
 export function formatExpiringTimeoutHint(minutes: number | null): string | null {
     if (minutes === null) return null;
-    return `Disables ${minutes} min after first PIN use`;
+    return `Disables ${minutes} min after first credential use`;
 }
 
 /** Encode a PIN for the octstr PinCode field, which reaches the lock as base64. */
@@ -877,6 +877,16 @@ function decodeSetCredentialResponse(response: unknown): { status: number | null
     };
 }
 
+/** DlStatus values SetCredential can return beyond the generic interaction-model status set (spec §5.2.6.20). */
+const SET_CREDENTIAL_STATUS_NAMES: Record<number, string> = {
+    2: "Duplicate",
+    3: "Occupied",
+};
+
+function formatSetCredentialStatus(status: number): string {
+    return SET_CREDENTIAL_STATUS_NAMES[status] ?? getMatterStatusName(status);
+}
+
 function decodeCredentialStatusResponse(response: unknown): {
     credentialExists: boolean;
     nextCredentialIndex: number | null;
@@ -916,11 +926,12 @@ async function nextFreePinCredentialIndex(
     const occupied = new Set<number>();
     // Visited is tracked separately from occupied: a lock reporting NextCredentialIndex values that never
     // flag as existing (malformed, or genuinely free slots surfaced by mistake) must not loop forever just
-    // because `occupied` never grows.
+    // because `occupied` never grows. The [1, maxIndex] bound below guards the same malformed-lock case for
+    // an out-of-range index, which would otherwise keep "visited" growing on values the candidate scan below
+    // never looks at.
     const visited = new Set<number>();
     let index: number | null = 1;
-    while (index !== null && visited.size <= maxIndex) {
-        if (visited.has(index)) break;
+    while (index !== null && index >= 1 && index <= maxIndex && !visited.has(index)) {
         visited.add(index);
         const status = await getCredentialStatus(client, nodeId, endpoint, CREDENTIAL_TYPE_PIN, index);
         if (status.credentialExists) occupied.add(index);
@@ -935,7 +946,8 @@ async function nextFreePinCredentialIndex(
 /**
  * Attaches a PIN credential to an existing user (SetCredential's "add a credential to an existing user"
  * use case — UserIndex given, UserStatus/UserType left null since the user already has both). `capacity`
- * bounds the free-slot search, e.g. `readNumberOfPinUsersSupported(node, endpoint) ?? PIN_CREDENTIAL_SCAN_FALLBACK`.
+ * bounds the free-slot search — pass the lock's actual `readNumberOfPinUsersSupported(node, endpoint)`
+ * rather than a guessed fallback, since a guess too high can select an index beyond the lock's real table.
  */
 export async function attachPinCredential(
     client: MatterClient,
@@ -959,7 +971,11 @@ export async function attachPinCredential(
     });
     const { status } = decodeSetCredentialResponse(response);
     if (status !== 0) {
-        throw new Error(status === null ? "The lock did not report a result." : getMatterStatusName(status));
+        throw new Error(
+            status === null
+                ? "Setting the PIN credential failed: the lock did not report a result."
+                : `Setting the PIN credential failed: ${formatSetCredentialStatus(status)} (${status})`,
+        );
     }
 }
 

--- a/packages/dashboard/src/util/door-lock.ts
+++ b/packages/dashboard/src/util/door-lock.ts
@@ -913,9 +913,9 @@ async function getCredentialStatus(
 
 /**
  * The lowest unoccupied PIN credential index in `[1, maxIndex]`, or null when every slot is taken.
- * Mirrors nextFreeUserIndex/readUsers: GetCredentialStatus's NextCredentialIndex chains through the
- * *occupied* slots only, so free slots are never queried directly — they are whatever is left over once
- * the occupied ones are collected.
+ * GetCredentialStatus's NextCredentialIndex chains through the *occupied* slots, but it is an optional
+ * response field: a lock that omits it ends the chain after the first slot, so any index the chain did
+ * not reach is probed directly rather than assumed free.
  */
 async function nextFreePinCredentialIndex(
     client: MatterClient,
@@ -938,7 +938,11 @@ async function nextFreePinCredentialIndex(
         index = status.nextCredentialIndex;
     }
     for (let candidate = 1; candidate <= maxIndex; candidate++) {
-        if (!occupied.has(candidate)) return candidate;
+        if (occupied.has(candidate)) continue;
+        if (visited.has(candidate)) return candidate;
+        const status = await getCredentialStatus(client, nodeId, endpoint, CREDENTIAL_TYPE_PIN, candidate);
+        if (!status.credentialExists) return candidate;
+        occupied.add(candidate);
     }
     return null;
 }

--- a/packages/dashboard/test/DoorLockUtilTest.ts
+++ b/packages/dashboard/test/DoorLockUtilTest.ts
@@ -6,6 +6,7 @@
 
 import { MatterNode, type MatterClient, type MatterNodeData } from "@matter-server/ws-client";
 import {
+    attachPinCredential,
     buildDaySegments,
     decodeHolidayScheduleResponse,
     decodeUserResponse,
@@ -13,6 +14,7 @@ import {
     decodeYearDayScheduleResponse,
     encodePinCode,
     formatDaysMask,
+    formatExpiringTimeoutHint,
     formatOperatingMode,
     formatScheduleStatus,
     formatTimeOfDay,
@@ -21,6 +23,7 @@ import {
     formatUserType,
     defaultHolidayMode,
     formatWallClock,
+    hasPinCredential,
     holidayModeChoices,
     fromDateTimeInputValue,
     holidayScheduleRangeError,
@@ -29,7 +32,12 @@ import {
     nextFreeUserIndex,
     nowAsWallClock,
     parseTimeOfDay,
+    pinCodeLengthError,
+    readExpiringUserTimeout,
     readHolidaySchedulesSupported,
+    readMaxPinCodeLength,
+    readMinPinCodeLength,
+    readNumberOfPinUsersSupported,
     readTotalUsersSupported,
     readUsers,
     readWeekDaySchedulesPerUser,
@@ -113,6 +121,17 @@ describe("door-lock util", () => {
             expect(requiresPinForRemoteOperation(node({ "1/257/51": true }), 1)).to.equal(true);
             expect(requiresPinForRemoteOperation(node({ "1/257/51": false }), 1)).to.equal(false);
             expect(requiresPinForRemoteOperation(node({}), 1)).to.equal(false);
+        });
+        it("reads the PIN credential capacity and length bounds", () => {
+            const lock = node({ "1/257/18": 8, "1/257/23": 8, "1/257/24": 4 });
+            expect(readNumberOfPinUsersSupported(lock, 1)).to.equal(8);
+            expect(readMaxPinCodeLength(lock, 1)).to.equal(8);
+            expect(readMinPinCodeLength(lock, 1)).to.equal(4);
+            expect(readNumberOfPinUsersSupported(node({}), 1)).to.equal(null);
+        });
+        it("reads ExpiringUserTimeout", () => {
+            expect(readExpiringUserTimeout(node({ "1/257/53": 1440 }), 1)).to.equal(1440);
+            expect(readExpiringUserTimeout(node({}), 1)).to.equal(null);
         });
     });
 
@@ -364,7 +383,26 @@ describe("door-lock util", () => {
                 userType: 2,
                 nextUserIndex: 4,
                 occupied: true,
+                credentials: [],
             });
+        });
+        it("decodes the user's credentials", () => {
+            const user = decodeUserResponse({
+                userIndex: 1,
+                userStatus: 1,
+                credentials: [{ credentialType: 1, credentialIndex: 3 }],
+            })!;
+            expect(user.credentials).to.deep.equal([{ credentialType: 1, credentialIndex: 3 }]);
+            expect(hasPinCredential(user)).to.equal(true);
+        });
+        it("reports no PIN credential when credentials are absent or of another type", () => {
+            expect(hasPinCredential(decodeUserResponse({ userIndex: 1, userStatus: 1 })!)).to.equal(false);
+            const rfidOnly = decodeUserResponse({
+                userIndex: 1,
+                userStatus: 1,
+                credentials: [{ credentialType: 2, credentialIndex: 0 }],
+            })!;
+            expect(hasPinCredential(rfidOnly)).to.equal(false);
         });
         it("treats a null and an Available status as a free slot", () => {
             expect(decodeUserResponse({ userIndex: 2, userStatus: null })?.occupied).to.equal(false);
@@ -558,6 +596,29 @@ describe("door-lock util", () => {
         });
     });
 
+    describe("pinCodeLengthError", () => {
+        it("rejects an empty PIN", () => {
+            expect(pinCodeLengthError("", null, null)).to.equal("Enter a PIN.");
+        });
+        it("accepts any non-empty PIN when the lock reports no length bounds", () => {
+            expect(pinCodeLengthError("1", null, null)).to.equal(null);
+        });
+        it("enforces known bounds", () => {
+            expect(pinCodeLengthError("123", 4, 8)).to.contain("at least 4");
+            expect(pinCodeLengthError("123456789", 4, 8)).to.contain("at most 8");
+            expect(pinCodeLengthError("1234", 4, 8)).to.equal(null);
+        });
+    });
+
+    describe("formatExpiringTimeoutHint", () => {
+        it("phrases the lock-wide timeout", () => {
+            expect(formatExpiringTimeoutHint(1440)).to.equal("Disables 1440 min after first PIN use");
+        });
+        it("is absent when the lock does not report the attribute", () => {
+            expect(formatExpiringTimeoutHint(null)).to.equal(null);
+        });
+    });
+
     describe("encodePinCode", () => {
         it("encodes the PIN as base64 for the octstr field", () => {
             expect(encodePinCode("1234")).to.equal("MTIzNA==");
@@ -611,6 +672,61 @@ describe("door-lock util", () => {
             const users = await readUsers(client, 1, 6, 2);
             expect(users.map(user => user.userIndex)).to.deep.equal([1, 2]);
             expect(calls).to.deep.equal([1, 2]);
+        });
+    });
+
+    describe("attachPinCredential", () => {
+        /** `occupiedChain` maps an occupied PIN credential index to the next occupied one (or null). */
+        function fakeCredentialClient(options: {
+            occupiedChain: Record<number, number | null>;
+            setCredentialResponse?: unknown;
+        }) {
+            const setCredentialCalls = new Array<Record<string, unknown>>();
+            const client = {
+                deviceCommand: (
+                    _nodeId: number | bigint,
+                    _endpointId: number,
+                    _clusterId: number,
+                    commandName: string,
+                    payload: Record<string, unknown> = {},
+                ) => {
+                    if (commandName === "GetCredentialStatus") {
+                        const { credentialIndex } = payload["credential"] as { credentialIndex: number };
+                        const exists = credentialIndex in options.occupiedChain;
+                        return Promise.resolve({
+                            credentialExists: exists,
+                            nextCredentialIndex: exists ? options.occupiedChain[credentialIndex] : null,
+                        });
+                    }
+                    if (commandName === "SetCredential") {
+                        setCredentialCalls.push(payload);
+                        return Promise.resolve(options.setCredentialResponse ?? { status: 0, userIndex: null });
+                    }
+                    throw new Error(`unexpected command ${commandName}`);
+                },
+            } as unknown as MatterClient;
+            return { client, setCredentialCalls };
+        }
+
+        it("attaches the PIN at the first free credential index", async () => {
+            const { client, setCredentialCalls } = fakeCredentialClient({ occupiedChain: { 1: 2, 2: null } });
+            await attachPinCredential(client, 1, 6, 3, "1234", 5);
+            expect(setCredentialCalls).to.have.length(1);
+            expect(setCredentialCalls[0]?.["credential"]).to.deep.equal({ credentialType: 1, credentialIndex: 3 });
+            expect(setCredentialCalls[0]?.["credentialData"]).to.equal(encodePinCode("1234"));
+            expect(setCredentialCalls[0]?.["userIndex"]).to.equal(3);
+            expect(setCredentialCalls[0]?.["userStatus"]).to.equal(null);
+            expect(setCredentialCalls[0]?.["userType"]).to.equal(null);
+        });
+
+        it("throws once every slot up to capacity is occupied", async () => {
+            const { client } = fakeCredentialClient({ occupiedChain: { 1: 2, 2: null } });
+            await expect(attachPinCredential(client, 1, 6, 3, "1234", 2)).to.be.rejectedWith("full");
+        });
+
+        it("throws the lock's status name when SetCredential reports failure", async () => {
+            const { client } = fakeCredentialClient({ occupiedChain: {}, setCredentialResponse: { status: 2 } });
+            await expect(attachPinCredential(client, 1, 6, 3, "1234", 5)).to.be.rejectedWith("Unknown(2)");
         });
     });
 });

--- a/packages/dashboard/test/DoorLockUtilTest.ts
+++ b/packages/dashboard/test/DoorLockUtilTest.ts
@@ -7,12 +7,15 @@
 import { MatterNode, type MatterClient, type MatterNodeData } from "@matter-server/ws-client";
 import {
     attachPinCredential,
+    createExpiringPinUser,
     buildDaySegments,
     decodeHolidayScheduleResponse,
     decodeUserResponse,
     decodeWeekDayScheduleResponse,
     decodeYearDayScheduleResponse,
     encodePinCode,
+    USER_STATUS_OCCUPIED_ENABLED,
+    USER_TYPE_EXPIRING,
     formatDaysMask,
     formatExpiringTimeoutHint,
     formatOperatingMode,
@@ -763,6 +766,92 @@ describe("door-lock util", () => {
         it("falls back to the generic status name and numeric code for other failures", async () => {
             const { client } = fakeCredentialClient({ occupiedChain: {}, setCredentialResponse: { status: 135 } });
             await expect(attachPinCredential(client, 1, 6, 3, "1234", 5)).to.be.rejectedWith("ConstraintError (135)");
+        });
+    });
+
+    describe("createExpiringPinUser", () => {
+        /** Records every command; `failCommands` makes the named commands reject. */
+        function fakeLockClient(options: { failCommands?: Record<string, string> } = {}) {
+            const commands = new Array<{ commandName: string; payload: Record<string, unknown> }>();
+            const client = {
+                deviceCommand: (
+                    _nodeId: number | bigint,
+                    _endpointId: number,
+                    _clusterId: number,
+                    commandName: string,
+                    payload: Record<string, unknown> = {},
+                ) => {
+                    commands.push({ commandName, payload });
+                    const failure = options.failCommands?.[commandName];
+                    if (failure !== undefined) return Promise.reject(new Error(failure));
+                    if (commandName === "GetCredentialStatus") {
+                        return Promise.resolve({ credentialExists: false, nextCredentialIndex: null });
+                    }
+                    return Promise.resolve({ status: 0, userIndex: null });
+                },
+            } as unknown as MatterClient;
+            return { client, commands };
+        }
+
+        it("creates the user as an ExpiringUser and attaches its PIN", async () => {
+            const { client, commands } = fakeLockClient();
+            expect(await createExpiringPinUser(client, 1, 6, 4, "Guest", "1234", 5)).to.equal(null);
+            const setUser = commands.find(c => c.commandName === "SetUser");
+            expect(setUser?.payload["userIndex"]).to.equal(4);
+            expect(setUser?.payload["userType"]).to.equal(USER_TYPE_EXPIRING);
+            expect(setUser?.payload["userStatus"]).to.equal(USER_STATUS_OCCUPIED_ENABLED);
+            expect(commands.some(c => c.commandName === "SetCredential")).to.equal(true);
+            expect(commands.some(c => c.commandName === "ClearUser")).to.equal(false);
+        });
+
+        it("removes the user again when its PIN cannot be set", async () => {
+            const { client, commands } = fakeLockClient({ failCommands: { SetCredential: "lock said no" } });
+            const failure = await createExpiringPinUser(client, 1, 6, 4, "Guest", "1234", 5);
+            expect(failure?.outcome).to.equal("rolled-back");
+            expect(failure?.reason).to.equal("lock said no");
+            expect(failure?.rollbackReason).to.equal(undefined);
+            expect(commands.filter(c => c.commandName === "ClearUser")).to.deep.equal([
+                { commandName: "ClearUser", payload: { userIndex: 4 } },
+            ]);
+        });
+
+        it("reports an orphaned user when the removal fails too", async () => {
+            const { client } = fakeLockClient({
+                failCommands: { SetCredential: "lock said no", ClearUser: "busy" },
+            });
+            const failure = await createExpiringPinUser(client, 1, 6, 4, "Guest", "1234", 5);
+            expect(failure?.outcome).to.equal("orphaned");
+            expect(failure?.reason).to.equal("lock said no");
+            expect(failure?.rollbackReason).to.equal("busy");
+        });
+
+        it("rolls back a device-side SetCredential rejection, not only a transport failure", async () => {
+            const commands = new Array<string>();
+            const client = {
+                deviceCommand: (
+                    _nodeId: number | bigint,
+                    _endpointId: number,
+                    _clusterId: number,
+                    commandName: string,
+                ) => {
+                    commands.push(commandName);
+                    if (commandName === "GetCredentialStatus") {
+                        return Promise.resolve({ credentialExists: false, nextCredentialIndex: null });
+                    }
+                    if (commandName === "SetCredential") return Promise.resolve({ status: 3, userIndex: null });
+                    return Promise.resolve({});
+                },
+            } as unknown as MatterClient;
+            const failure = await createExpiringPinUser(client, 1, 6, 4, "Guest", "1234", 5);
+            expect(failure?.outcome).to.equal("rolled-back");
+            expect(failure?.reason).to.contain("Occupied (3)");
+            expect(commands).to.contain("ClearUser");
+        });
+
+        it("propagates a SetUser failure without attempting a rollback", async () => {
+            const { client, commands } = fakeLockClient({ failCommands: { SetUser: "denied" } });
+            await expect(createExpiringPinUser(client, 1, 6, 4, "Guest", "1234", 5)).to.be.rejectedWith("denied");
+            expect(commands.map(c => c.commandName)).to.deep.equal(["SetUser"]);
         });
     });
 });

--- a/packages/dashboard/test/DoorLockUtilTest.ts
+++ b/packages/dashboard/test/DoorLockUtilTest.ts
@@ -676,10 +676,14 @@ describe("door-lock util", () => {
     });
 
     describe("attachPinCredential", () => {
-        /** `occupiedChain` maps an occupied PIN credential index to the next occupied one (or null). */
+        /**
+         * `occupiedChain` maps an occupied PIN credential index to the next occupied one (or null).
+         * `omitNextCredentialIndex` models a lock that leaves out the optional response field.
+         */
         function fakeCredentialClient(options: {
             occupiedChain: Record<number, number | null>;
             setCredentialResponse?: unknown;
+            omitNextCredentialIndex?: boolean;
         }) {
             const setCredentialCalls = new Array<Record<string, unknown>>();
             const credentialStatusIndexes = new Array<number>();
@@ -697,7 +701,12 @@ describe("door-lock util", () => {
                         const exists = credentialIndex in options.occupiedChain;
                         return Promise.resolve({
                             credentialExists: exists,
-                            nextCredentialIndex: exists ? options.occupiedChain[credentialIndex] : null,
+                            nextCredentialIndex:
+                                options.omitNextCredentialIndex === true
+                                    ? undefined
+                                    : exists
+                                      ? options.occupiedChain[credentialIndex]
+                                      : null,
                         });
                     }
                     if (commandName === "SetCredential") {
@@ -726,10 +735,21 @@ describe("door-lock util", () => {
             await expect(attachPinCredential(client, 1, 6, 3, "1234", 2)).to.be.rejectedWith("full");
         });
 
-        it("stops scanning once NextCredentialIndex reports a value outside [1, maxIndex]", async () => {
+        it("stops chaining once NextCredentialIndex reports a value outside [1, maxIndex]", async () => {
             const { client, credentialStatusIndexes } = fakeCredentialClient({ occupiedChain: { 1: 999 } });
             await attachPinCredential(client, 1, 6, 3, "1234", 5);
-            expect(credentialStatusIndexes).to.deep.equal([1]);
+            // The chain ends at 1, so 2 is probed rather than assumed free.
+            expect(credentialStatusIndexes).to.deep.equal([1, 2]);
+        });
+
+        it("probes candidates directly when the lock omits the optional NextCredentialIndex", async () => {
+            const { client, setCredentialCalls, credentialStatusIndexes } = fakeCredentialClient({
+                occupiedChain: { 1: null, 2: null },
+                omitNextCredentialIndex: true,
+            });
+            await attachPinCredential(client, 1, 6, 3, "1234", 5);
+            expect(credentialStatusIndexes).to.deep.equal([1, 2, 3]);
+            expect(setCredentialCalls[0]?.["credential"]).to.deep.equal({ credentialType: 1, credentialIndex: 3 });
         });
 
         it("maps the Door Lock-specific Duplicate/Occupied statuses instead of falling back to Unknown", async () => {

--- a/packages/dashboard/test/DoorLockUtilTest.ts
+++ b/packages/dashboard/test/DoorLockUtilTest.ts
@@ -612,7 +612,7 @@ describe("door-lock util", () => {
 
     describe("formatExpiringTimeoutHint", () => {
         it("phrases the lock-wide timeout", () => {
-            expect(formatExpiringTimeoutHint(1440)).to.equal("Disables 1440 min after first PIN use");
+            expect(formatExpiringTimeoutHint(1440)).to.equal("Disables 1440 min after first credential use");
         });
         it("is absent when the lock does not report the attribute", () => {
             expect(formatExpiringTimeoutHint(null)).to.equal(null);
@@ -682,6 +682,7 @@ describe("door-lock util", () => {
             setCredentialResponse?: unknown;
         }) {
             const setCredentialCalls = new Array<Record<string, unknown>>();
+            const credentialStatusIndexes = new Array<number>();
             const client = {
                 deviceCommand: (
                     _nodeId: number | bigint,
@@ -692,6 +693,7 @@ describe("door-lock util", () => {
                 ) => {
                     if (commandName === "GetCredentialStatus") {
                         const { credentialIndex } = payload["credential"] as { credentialIndex: number };
+                        credentialStatusIndexes.push(credentialIndex);
                         const exists = credentialIndex in options.occupiedChain;
                         return Promise.resolve({
                             credentialExists: exists,
@@ -705,7 +707,7 @@ describe("door-lock util", () => {
                     throw new Error(`unexpected command ${commandName}`);
                 },
             } as unknown as MatterClient;
-            return { client, setCredentialCalls };
+            return { client, setCredentialCalls, credentialStatusIndexes };
         }
 
         it("attaches the PIN at the first free credential index", async () => {
@@ -724,9 +726,23 @@ describe("door-lock util", () => {
             await expect(attachPinCredential(client, 1, 6, 3, "1234", 2)).to.be.rejectedWith("full");
         });
 
-        it("throws the lock's status name when SetCredential reports failure", async () => {
-            const { client } = fakeCredentialClient({ occupiedChain: {}, setCredentialResponse: { status: 2 } });
-            await expect(attachPinCredential(client, 1, 6, 3, "1234", 5)).to.be.rejectedWith("Unknown(2)");
+        it("stops scanning once NextCredentialIndex reports a value outside [1, maxIndex]", async () => {
+            const { client, credentialStatusIndexes } = fakeCredentialClient({ occupiedChain: { 1: 999 } });
+            await attachPinCredential(client, 1, 6, 3, "1234", 5);
+            expect(credentialStatusIndexes).to.deep.equal([1]);
+        });
+
+        it("maps the Door Lock-specific Duplicate/Occupied statuses instead of falling back to Unknown", async () => {
+            const duplicate = fakeCredentialClient({ occupiedChain: {}, setCredentialResponse: { status: 2 } });
+            await expect(attachPinCredential(duplicate.client, 1, 6, 3, "1234", 5)).to.be.rejectedWith("Duplicate (2)");
+
+            const occupied = fakeCredentialClient({ occupiedChain: {}, setCredentialResponse: { status: 3 } });
+            await expect(attachPinCredential(occupied.client, 1, 6, 3, "1234", 5)).to.be.rejectedWith("Occupied (3)");
+        });
+
+        it("falls back to the generic status name and numeric code for other failures", async () => {
+            const { client } = fakeCredentialClient({ occupiedChain: {}, setCredentialResponse: { status: 135 } });
+            await expect(attachPinCredential(client, 1, 6, 3, "1234", 5)).to.be.rejectedWith("ConstraintError (135)");
         });
     });
 });

--- a/packages/ws-client/src/connection.ts
+++ b/packages/ws-client/src/connection.ts
@@ -5,6 +5,7 @@
  */
 
 import { parseBigIntAwareJson, toBigIntAwareJson } from "./json-utils.js";
+import { redactSensitiveCommandFields } from "./logging-redaction.js";
 import { CommandMessage, ServerInfoMessage } from "./models/model.js";
 
 /**
@@ -100,7 +101,7 @@ export class Connection {
         if (!this.socket) {
             throw new Error("Not connected");
         }
-        console.debug("WebSocket send message", message);
+        console.debug("WebSocket send message", redactSensitiveCommandFields(message));
         this.socket.send(toBigIntAwareJson(message));
     }
 }

--- a/packages/ws-client/src/index.ts
+++ b/packages/ws-client/src/index.ts
@@ -23,6 +23,9 @@ export * from "./icd.js";
 // Export JSON utilities
 export * from "./json-utils.js";
 
+// Export debug-log redaction (shared by the client's own logging and the server's request logging)
+export * from "./logging-redaction.js";
+
 // Export models
 export * from "./models/model.js";
 export * from "./models/node.js";

--- a/packages/ws-client/src/logging-redaction.ts
+++ b/packages/ws-client/src/logging-redaction.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * `device_command` payload fields that carry a Matter PIN. The wire format encodes them as base64
+ * octstr, which is trivially reversible, so logging them verbatim writes the plaintext door PIN to
+ * the browser/server console.
+ */
+const SENSITIVE_PAYLOAD_FIELDS = ["credentialData", "pinCode"];
+
+/**
+ * Returns `message` unchanged, or a shallow copy with any {@link SENSITIVE_PAYLOAD_FIELDS} in its
+ * `args.payload` replaced by a placeholder — safe to pass to a debug logger on both the client and
+ * server side of the same wire message.
+ */
+export function redactSensitiveCommandFields<T extends { args?: unknown }>(message: T): T {
+    const args = message.args;
+    if (args === null || typeof args !== "object") return message;
+    const payload = (args as Record<string, unknown>)["payload"];
+    if (payload === null || typeof payload !== "object") return message;
+    const payloadRecord = payload as Record<string, unknown>;
+    const sensitiveKeys = SENSITIVE_PAYLOAD_FIELDS.filter(key => key in payloadRecord);
+    if (sensitiveKeys.length === 0) return message;
+    const redactedPayload = { ...payloadRecord };
+    for (const key of sensitiveKeys) redactedPayload[key] = "[redacted]";
+    return { ...message, args: { ...(args as Record<string, unknown>), payload: redactedPayload } };
+}

--- a/packages/ws-client/src/logging-redaction.ts
+++ b/packages/ws-client/src/logging-redaction.ts
@@ -9,22 +9,30 @@
  * octstr, which is trivially reversible, so logging them verbatim writes the plaintext door PIN to
  * the browser/server console.
  */
-const SENSITIVE_PAYLOAD_FIELDS = ["credentialData", "pinCode"];
+const SENSITIVE_PAYLOAD_FIELDS = ["credentialdata", "pincode"];
 
 /**
  * Returns `message` unchanged, or a shallow copy with any {@link SENSITIVE_PAYLOAD_FIELDS} in its
  * `args.payload` replaced by a placeholder — safe to pass to a debug logger on both the client and
  * server side of the same wire message.
+ *
+ * Keys are matched case-insensitively: the server camelizes every payload member before use, so a
+ * client may spell the field `PINCode` (as the Python Matter Server clients do) or `credentialData`.
  */
-export function redactSensitiveCommandFields<T extends { args?: unknown }>(message: T): T {
-    const args = message.args;
+export function redactSensitiveCommandFields(message: object): object {
+    const args = (message as Record<string, unknown>)["args"];
     if (args === null || typeof args !== "object") return message;
     const payload = (args as Record<string, unknown>)["payload"];
     if (payload === null || typeof payload !== "object") return message;
     const payloadRecord = payload as Record<string, unknown>;
-    const sensitiveKeys = SENSITIVE_PAYLOAD_FIELDS.filter(key => key in payloadRecord);
+    const sensitiveKeys = Object.keys(payloadRecord).filter(key =>
+        SENSITIVE_PAYLOAD_FIELDS.includes(key.toLowerCase()),
+    );
     if (sensitiveKeys.length === 0) return message;
     const redactedPayload = { ...payloadRecord };
     for (const key of sensitiveKeys) redactedPayload[key] = "[redacted]";
-    return { ...message, args: { ...(args as Record<string, unknown>), payload: redactedPayload } };
+    return {
+        ...(message as Record<string, unknown>),
+        args: { ...(args as Record<string, unknown>), payload: redactedPayload },
+    };
 }

--- a/packages/ws-client/test/LoggingRedactionTest.ts
+++ b/packages/ws-client/test/LoggingRedactionTest.ts
@@ -13,14 +13,14 @@ describe("redactSensitiveCommandFields", () => {
             command: "device_command",
             args: { payload: { credentialData: "MTIzNA==", credential: { credentialType: 1, credentialIndex: 3 } } },
         };
-        const redacted = redactSensitiveCommandFields(message);
+        const redacted: Record<string, any> = redactSensitiveCommandFields(message);
         expect(redacted.args.payload.credentialData).to.equal("[redacted]");
         expect(redacted.args.payload.credential).to.deep.equal({ credentialType: 1, credentialIndex: 3 });
     });
 
     it("redacts pinCode in a LockDoor/UnlockDoor payload", () => {
         const message = { message_id: "1", command: "device_command", args: { payload: { pinCode: "MTIzNA==" } } };
-        const redacted = redactSensitiveCommandFields(message);
+        const redacted: Record<string, any> = redactSensitiveCommandFields(message);
         expect(redacted.args.payload.pinCode).to.equal("[redacted]");
     });
 
@@ -28,6 +28,23 @@ describe("redactSensitiveCommandFields", () => {
         const message = { message_id: "1", command: "device_command", args: { payload: { pinCode: "MTIzNA==" } } };
         redactSensitiveCommandFields(message);
         expect(message.args.payload.pinCode).to.equal("MTIzNA==");
+    });
+
+    it("redacts the PINCode spelling the Python Matter Server clients send", () => {
+        const message = { message_id: "1", command: "device_command", args: { payload: { PINCode: "MTIzNA==" } } };
+        const redacted: Record<string, any> = redactSensitiveCommandFields(message);
+        expect(redacted.args.payload.PINCode).to.equal("[redacted]");
+    });
+
+    it("redacts CredentialData regardless of its casing", () => {
+        const message = {
+            message_id: "1",
+            command: "device_command",
+            args: { payload: { CredentialData: "MTIzNA==", userIndex: 3 } },
+        };
+        const redacted: Record<string, any> = redactSensitiveCommandFields(message);
+        expect(redacted.args.payload.CredentialData).to.equal("[redacted]");
+        expect(redacted.args.payload.userIndex).to.equal(3);
     });
 
     it("returns the same message when there is nothing sensitive to redact", () => {

--- a/packages/ws-client/test/LoggingRedactionTest.ts
+++ b/packages/ws-client/test/LoggingRedactionTest.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { redactSensitiveCommandFields } from "../src/logging-redaction.js";
+
+describe("redactSensitiveCommandFields", () => {
+    it("redacts credentialData in a device_command SetCredential payload", () => {
+        const message = {
+            message_id: "1",
+            command: "device_command",
+            args: { payload: { credentialData: "MTIzNA==", credential: { credentialType: 1, credentialIndex: 3 } } },
+        };
+        const redacted = redactSensitiveCommandFields(message);
+        expect(redacted.args.payload.credentialData).to.equal("[redacted]");
+        expect(redacted.args.payload.credential).to.deep.equal({ credentialType: 1, credentialIndex: 3 });
+    });
+
+    it("redacts pinCode in a LockDoor/UnlockDoor payload", () => {
+        const message = { message_id: "1", command: "device_command", args: { payload: { pinCode: "MTIzNA==" } } };
+        const redacted = redactSensitiveCommandFields(message);
+        expect(redacted.args.payload.pinCode).to.equal("[redacted]");
+    });
+
+    it("leaves the original message untouched", () => {
+        const message = { message_id: "1", command: "device_command", args: { payload: { pinCode: "MTIzNA==" } } };
+        redactSensitiveCommandFields(message);
+        expect(message.args.payload.pinCode).to.equal("MTIzNA==");
+    });
+
+    it("returns the same message when there is nothing sensitive to redact", () => {
+        const message = { message_id: "1", command: "get_nodes", args: undefined };
+        expect(redactSensitiveCommandFields(message)).to.equal(message);
+
+        const withPayload = { message_id: "1", command: "device_command", args: { payload: { userIndex: 3 } } };
+        expect(redactSensitiveCommandFields(withPayload)).to.equal(withPayload);
+    });
+});

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -680,15 +680,15 @@ export class WebSocketControllerHandler implements WebServerHandler {
         let messageId: string | undefined;
         let command: string | undefined;
         try {
-            // Redacted defensively: a request too malformed to redact still needs to reach the log verbatim,
-            // since it's the only record of why parsing (below) is about to fail.
             logger.debug(`[${connId}] WebSocket request`, () => {
                 try {
-                    return toBigIntAwareJson(
-                        redactSensitiveCommandFields(parseBigIntAwareJson(data) as { args?: unknown }),
-                    );
+                    const parsed = parseBigIntAwareJson(data);
+                    if (parsed === null || typeof parsed !== "object") throw new Error("not an object");
+                    return toBigIntAwareJson(redactSensitiveCommandFields(parsed));
                 } catch {
-                    return data;
+                    // A frame that cannot be parsed cannot be redacted either, and it may still carry a
+                    // credential, so only its size reaches the log.
+                    return `<unparseable request, ${data.length} bytes>`;
                 }
             });
             const request = parseBigIntAwareJson(data) as { message_id: string; command: string; args: any };

--- a/packages/ws-controller/src/server/WebSocketControllerHandler.ts
+++ b/packages/ws-controller/src/server/WebSocketControllerHandler.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { redactSensitiveCommandFields } from "@matter-server/ws-client";
 import {
     MatterError,
     Diagnostic,
@@ -679,7 +680,17 @@ export class WebSocketControllerHandler implements WebServerHandler {
         let messageId: string | undefined;
         let command: string | undefined;
         try {
-            logger.debug(`[${connId}] WebSocket request`, () => data);
+            // Redacted defensively: a request too malformed to redact still needs to reach the log verbatim,
+            // since it's the only record of why parsing (below) is about to fail.
+            logger.debug(`[${connId}] WebSocket request`, () => {
+                try {
+                    return toBigIntAwareJson(
+                        redactSensitiveCommandFields(parseBigIntAwareJson(data) as { args?: unknown }),
+                    );
+                } catch {
+                    return data;
+                }
+            });
             const request = parseBigIntAwareJson(data) as { message_id: string; command: string; args: any };
             const { args } = request;
             messageId = request.message_id;


### PR DESCRIPTION
## Type of change

<!-- Check exactly one. -->

- [ ] 🐛 **Fix** — corrects a defect or wrong behavior
- [x] ✨ **Feature** — adds new functionality or capability

## Description

Adds support for temporary/expiring PIN users to the Door Lock cluster panel, detected via the
existing `USR`/`PIN` feature bits rather than a new feature flag:

- `addUser()` now accepts `userType`/`userStatus` instead of always creating an `UnrestrictedUser`
  record.
- New `attachPinCredential()` finds a free PIN credential slot (walking `GetCredentialStatus` the
  same way `readUsers` already walks `GetUser`) and attaches a PIN to an existing user via
  `SetCredential`.
- The "Add user" editor gained a "Temporary PIN" type (shown only when the lock reports the `PIN`
  feature), which creates the user and its credential in one action.
- `ExpiringUserTimeout` is now readable and writable from a lock-wide control in the panel.
- User badges now show whether a PIN credential is set, and the expiry hint for `ExpiringUser`
  records.

Out of scope for this PR (flagged for a possible follow-up): converting an existing non-expiring
user into an expiring one after the fact, editing/removing a PIN on an existing user, and
RFID/fingerprint/face credentials.

## Backing evidence

<!--
  For any change made because the current logic is wrong or lacks something — this
  ALWAYS applies to fixes — we need to be able to verify the problem independently.
-->

- Related issue: #1025
- [ ] This fix/change is backed by a **complete log file** — N/A, this is a feature addition, not a
      fix for observed wrong behavior.

## Checklist

- [x] I understand the code I am submitting and can explain how it works ([AI policy](https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md))
- [x] Tests added or updated to cover the change
- [x] `npm test` passes (scoped `npm test -w @matter-server/dashboard`: 435/435; the full `npm test`
      only fails on the two pre-existing mDNS `IntegrationTest` "Device Discovery" cases documented
      as environment-dependent in `CLAUDE.md`, unrelated to this change)
- [x] `npm run format-verify` and `npm run lint` pass
- [x] CHANGELOG updated

---

Opened as a draft: this was scaffolded by Claude Code from issue #1025 and needs human review
before it's ready — see the AI policy link above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
