### PR TITLE
feat(dashboard): add EnergyEvse cluster decode + control panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This page shows a detailed overview of the changes between versions without the 
 ## **WORK IN PROGRESS**
 
 - Enhancement: (lboue) Added a command panel for the DoorLock cluster to Dashboard
+- Enhancement: (lboue) Added a decode and control panel for the EnergyEvse cluster to Dashboard, with a weekly charging schedule editor
 - Enhancement: (lboue) Added Presets and Thermostat Suggestions (Thermostat cluster PRES/TSUGGEST features) panels to Dashboard
 - Fix: BLE proxy connections are pinged every 15 seconds and terminated after 45 to 60 seconds of silence, so a proxy client that loses power is detected instead of staying registered indefinitely
 

--- a/packages/dashboard/scripts/generate-descriptions.ts
+++ b/packages/dashboard/scripts/generate-descriptions.ts
@@ -23,12 +23,13 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const EVENT_LIST_ATTRIBUTE_ID = 0xfffa;
 
 /**
- * Acronyms with an embedded capital preceded by a lowercase letter (e.g. the "C" in "SoC"). decamelize
- * splits on every lowercase-to-uppercase transition, so it reads that capital as its own word start and
- * lowercases it with the rest: "SoCReporting" -> "so creporting". Protecting the acronym behind a
+ * Names decamelize can't segment as a unit: an acronym with an embedded capital preceded by a lowercase
+ * letter (e.g. the "C" in "SoC"), or letters split apart by a digit (e.g. "V2X"). decamelize splits on
+ * every lowercase-to-uppercase and letter-to-digit transition, so it reads each of those as its own word
+ * start: "SoCReporting" -> "so creporting", "V2X" -> "v2 x". Protecting the acronym behind a
  * digit-suffixed placeholder sidesteps the split, since decamelize does treat digit-to-letter as a boundary.
  */
-const ACRONYMS = ["SoC"];
+const ACRONYMS = ["SoC", "V2X"];
 
 /**
  * Convert camelCase name to human-readable label with a title case.

--- a/packages/dashboard/scripts/generate-descriptions.ts
+++ b/packages/dashboard/scripts/generate-descriptions.ts
@@ -45,7 +45,12 @@ function toLabel(name: string, addSpaces = false): string {
     });
     // Title case: capitalize the first letter of each word
     const label = decamelize(protectedName, " ").replace(/\b\w/g, char => char.toUpperCase());
-    return ACRONYMS.reduce((text, acronym, index) => text.replace(`Acronym${index}`, acronym), label);
+    // Global, and tolerant of a separator decamelize might insert before the digit (e.g. "Acronym 0"):
+    // a plain string .replace() would only fix the first occurrence and only the exact "AcronymN" spelling.
+    return ACRONYMS.reduce(
+        (text, acronym, index) => text.replace(new RegExp(`Acronym\\s*${index}`, "g"), acronym),
+        label,
+    );
 }
 
 interface DeviceType {

--- a/packages/dashboard/scripts/generate-descriptions.ts
+++ b/packages/dashboard/scripts/generate-descriptions.ts
@@ -23,13 +23,28 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const EVENT_LIST_ATTRIBUTE_ID = 0xfffa;
 
 /**
+ * Acronyms with an embedded capital preceded by a lowercase letter (e.g. the "C" in "SoC"). decamelize
+ * splits on every lowercase-to-uppercase transition, so it reads that capital as its own word start and
+ * lowercases it with the rest: "SoCReporting" -> "so creporting". Protecting the acronym behind a
+ * digit-suffixed placeholder sidesteps the split, since decamelize does treat digit-to-letter as a boundary.
+ */
+const ACRONYMS = ["SoC"];
+
+/**
  * Convert camelCase name to human-readable label with a title case.
  * e.g., "OnOffLight" -> "On Off Light" when "addSpaces" is set to true, else camelize with first letter uppercase
  */
 function toLabel(name: string, addSpaces = false): string {
-    const words = addSpaces ? decamelize(name, " ") : name;
+    if (!addSpaces) {
+        return name.replace(/\b\w/g, char => char.toUpperCase());
+    }
+    let protectedName = name;
+    ACRONYMS.forEach((acronym, index) => {
+        protectedName = protectedName.split(acronym).join(`Acronym${index}`);
+    });
     // Title case: capitalize the first letter of each word
-    return words.replace(/\b\w/g, char => char.toUpperCase());
+    const label = decamelize(protectedName, " ").replace(/\b\w/g, char => char.toUpperCase());
+    return ACRONYMS.reduce((text, acronym, index) => text.replace(`Acronym${index}`, acronym), label);
 }
 
 interface DeviceType {

--- a/packages/dashboard/src/client/models/descriptions.ts
+++ b/packages/dashboard/src/client/models/descriptions.ts
@@ -8696,7 +8696,7 @@ export const clusters: Record<number, ClusterDescription> = {
             "1": {
                 "bit": 1,
                 "code": "SOC",
-                "label": "So Creporting"
+                "label": "SoC Reporting"
             },
             "2": {
                 "bit": 2,

--- a/packages/dashboard/src/client/models/descriptions.ts
+++ b/packages/dashboard/src/client/models/descriptions.ts
@@ -8711,7 +8711,7 @@ export const clusters: Record<number, ClusterDescription> = {
             "4": {
                 "bit": 4,
                 "code": "V2X",
-                "label": "V2 X"
+                "label": "V2X"
             }
         }
     },

--- a/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
@@ -4,19 +4,101 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { css, html, nothing, type CSSResultGroup } from "lit";
-import { customElement } from "lit/decorators.js";
+import "@material/web/button/filled-button";
+import "@material/web/button/outlined-button";
+import "@material/web/button/text-button";
+import { css, html, nothing, type CSSResultGroup, type PropertyValues, type TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { showAlertDialog, showPromptDialog } from "../../../components/dialog-box/show-dialog-box.js";
+import { handleAsync } from "../../../util/async-handler.js";
 import { formatDuration } from "../../../util/duration.js";
-import { ENERGY_EVSE_CLUSTER_ID, energyEvseInfo, type SessionInfo } from "../../../util/energy-evse.js";
-import { formatEpochTime } from "../../../util/time.js";
+import {
+    clearChargingTargets,
+    disableEvse,
+    ENERGY_EVSE_CLUSTER_ID,
+    enableCharging,
+    enableDischarging,
+    energyEvseInfo,
+    EVSE_WEEKDAYS,
+    getChargingTargets,
+    setChargingTargets,
+    startDiagnostics,
+    type EditableChargingSchedule,
+    type EditableChargingTarget,
+    type EvseWeekday,
+    type SessionInfo,
+} from "../../../util/energy-evse.js";
+import { errorText } from "../../../util/error-text.js";
+import { formatEpochTime, fromLocalDateTimeInputValue } from "../../../util/time.js";
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
 
+const MAX_SCHEDULES = 7;
+const MAX_TARGETS_PER_SCHEDULE = 10;
+
+function minutesToTimeInputValue(minutes: number): string {
+    const hours = Math.floor(minutes / 60) % 24;
+    const mins = minutes % 60;
+    return `${String(hours).padStart(2, "0")}:${String(mins).padStart(2, "0")}`;
+}
+
+function timeInputValueToMinutes(value: string): number | undefined {
+    const match = /^(\d{2}):(\d{2})$/.exec(value);
+    if (match === null) return undefined;
+    const hours = Number(match[1]);
+    const minutes = Number(match[2]);
+    return hours * 60 + minutes;
+}
+
 /**
- * Read-only decoding panel for the EnergyEvse cluster (ID: 0x99 / 153).
+ * Decoding and command panel for the EnergyEvse cluster (ID: 0x99 / 153).
  */
 @customElement("energy-evse-cluster-commands")
 export class EnergyEvseClusterCommands extends BaseClusterCommands {
+    @state() private _busy = false;
+    @state() private _formError?: string;
+
+    @state() private _chargeNoExpiry = true;
+    @state() private _chargeUntil = "";
+    @state() private _minChargeCurrentA = 6;
+    @state() private _maxChargeCurrentA = 16;
+
+    @state() private _dischargeNoExpiry = true;
+    @state() private _dischargeUntil = "";
+    @state() private _maxDischargeCurrentA = 16;
+
+    @state() private _schedules?: EditableChargingSchedule[];
+    @state() private _scheduleBusy = false;
+    @state() private _scheduleError?: string;
+
+    #context?: string;
+    /** Bumped only on a node/endpoint context change, so a command run against the old context can't clobber the new one's UI state. */
+    #busyGeneration = 0;
+
+    override willUpdate(changedProperties: PropertyValues) {
+        super.willUpdate(changedProperties);
+        if (!this.node || this.cluster !== ENERGY_EVSE_CLUSTER_ID) return;
+
+        const context = `${String(this.node.node_id)}/${this.endpoint}`;
+        if (this.#context === context) return;
+        this.#context = context;
+        this.#busyGeneration++;
+        this._busy = false;
+        this._formError = undefined;
+        this._chargeNoExpiry = true;
+        this._chargeUntil = "";
+        this._dischargeNoExpiry = true;
+        this._dischargeUntil = "";
+        this._schedules = undefined;
+        this._scheduleBusy = false;
+        this._scheduleError = undefined;
+
+        const info = energyEvseInfo(this.node.attributes, this.endpoint);
+        this._minChargeCurrentA = info.minimumChargeCurrentA ?? this._minChargeCurrentA;
+        this._maxChargeCurrentA = info.maximumChargeCurrentA ?? this._maxChargeCurrentA;
+        this._maxDischargeCurrentA = info.maximumDischargeCurrentA ?? this._maxDischargeCurrentA;
+    }
+
     override render() {
         if (!this.node || this.cluster !== ENERGY_EVSE_CLUSTER_ID) return nothing;
         const info = energyEvseInfo(this.node.attributes, this.endpoint);
@@ -89,101 +171,11 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                         }
                     </dl>
 
-                    ${this._renderSession(info.session, info.v2xSupported)}
-                    ${
-                        info.v2xSupported
-                            ? html`
-                                  <h4>Bidirectional charging (V2X)</h4>
-                                  <dl class="info-grid">
-                                      ${
-                                          info.dischargingEnabledUntil !== undefined
-                                              ? html`<dt>Discharging enabled until</dt>
-                                                    <dd>
-                                                        ${
-                                                            info.dischargingEnabledUntil === null
-                                                                ? "No expiry"
-                                                                : formatEpochTime(info.dischargingEnabledUntil)
-                                                        }
-                                                    </dd>`
-                                              : nothing
-                                      }
-                                      ${
-                                          info.maximumDischargeCurrentA !== undefined
-                                              ? html`<dt>Maximum discharge current</dt>
-                                                    <dd>${info.maximumDischargeCurrentA} A</dd>`
-                                              : nothing
-                                      }
-                                  </dl>
-                              `
-                            : nothing
-                    }
+                    ${this._renderChargingActions()} ${this._renderSession(info.session, info.v2xSupported)}
+                    ${info.v2xSupported ? this._renderV2x(info.dischargingEnabledUntil, info.maximumDischargeCurrentA) : nothing}
                     ${
                         info.chargingPreferencesSupported
-                            ? html`
-                                  <h4>Charging preferences</h4>
-                                  <dl class="info-grid">
-                                      ${
-                                          info.nextChargeStartTime !== undefined
-                                              ? html`<dt>Next charge start</dt>
-                                                    <dd>
-                                                        ${
-                                                            info.nextChargeStartTime === null
-                                                                ? "None scheduled"
-                                                                : formatEpochTime(info.nextChargeStartTime)
-                                                        }
-                                                    </dd>`
-                                              : nothing
-                                      }
-                                      ${
-                                          info.nextChargeTargetTime !== undefined
-                                              ? html`<dt>Next charge target</dt>
-                                                    <dd>
-                                                        ${
-                                                            info.nextChargeTargetTime === null
-                                                                ? "None scheduled"
-                                                                : formatEpochTime(info.nextChargeTargetTime)
-                                                        }
-                                                    </dd>`
-                                              : nothing
-                                      }
-                                      ${
-                                          info.nextChargeRequiredEnergyKWh !== undefined
-                                              ? html`<dt>Next charge required energy</dt>
-                                                    <dd>
-                                                        ${
-                                                            info.nextChargeRequiredEnergyKWh === null
-                                                                ? "None"
-                                                                : `${info.nextChargeRequiredEnergyKWh} kWh`
-                                                        }
-                                                    </dd>`
-                                              : nothing
-                                      }
-                                      ${
-                                          info.nextChargeTargetSoC !== undefined
-                                              ? html`<dt>Next charge target SoC</dt>
-                                                    <dd>
-                                                        ${
-                                                            info.nextChargeTargetSoC === null
-                                                                ? "None"
-                                                                : `${info.nextChargeTargetSoC}%`
-                                                        }
-                                                    </dd>`
-                                              : nothing
-                                      }
-                                      ${
-                                          info.approximateEvEfficiencyKmPerKWh !== undefined
-                                              ? html`<dt>Approximate EV efficiency</dt>
-                                                    <dd>
-                                                        ${
-                                                            info.approximateEvEfficiencyKmPerKWh === null
-                                                                ? "Unknown"
-                                                                : `${info.approximateEvEfficiencyKmPerKWh} km/kWh`
-                                                        }
-                                                    </dd>`
-                                              : nothing
-                                      }
-                                  </dl>
-                              `
+                            ? this._renderChargingPreferences(info, info.soCReportingSupported)
                             : nothing
                     }
                     ${
@@ -260,6 +252,550 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         `;
     }
 
+    private _renderChargingActions(): TemplateResult {
+        return html`
+            <h4>Charging control</h4>
+            <div class="command-row">
+                <md-outlined-button @click=${handleAsync(() => this._handleDisable())} ?disabled=${this._busy}>
+                    Disable
+                </md-outlined-button>
+                <md-outlined-button @click=${handleAsync(() => this._handleStartDiagnostics())} ?disabled=${this._busy}>
+                    Start Diagnostics
+                </md-outlined-button>
+            </div>
+            <div class="action-form">
+                <label class="checkbox-row">
+                    <input
+                        type="checkbox"
+                        .checked=${this._chargeNoExpiry}
+                        @change=${(e: Event) => (this._chargeNoExpiry = (e.target as HTMLInputElement).checked)}
+                    />
+                    No expiry
+                </label>
+                ${
+                    !this._chargeNoExpiry
+                        ? html`<input
+                              type="datetime-local"
+                              .value=${this._chargeUntil}
+                              @input=${(e: Event) => (this._chargeUntil = (e.target as HTMLInputElement).value)}
+                          />`
+                        : nothing
+                }
+                <label>
+                    Min
+                    <input
+                        type="number"
+                        min="0"
+                        step="0.1"
+                        .value=${String(this._minChargeCurrentA)}
+                        @input=${(e: Event) => (this._minChargeCurrentA = this.#parsePositiveNumber(e, this._minChargeCurrentA))}
+                    />
+                    A
+                </label>
+                <label>
+                    Max
+                    <input
+                        type="number"
+                        min="0"
+                        step="0.1"
+                        .value=${String(this._maxChargeCurrentA)}
+                        @input=${(e: Event) => (this._maxChargeCurrentA = this.#parsePositiveNumber(e, this._maxChargeCurrentA))}
+                    />
+                    A
+                </label>
+                <md-filled-button @click=${handleAsync(() => this._handleEnableCharging())} ?disabled=${this._busy}>
+                    Enable Charging
+                </md-filled-button>
+            </div>
+            ${this._formError !== undefined ? html`<p class="error">${this._formError}</p>` : nothing}
+        `;
+    }
+
+    private _renderV2x(
+        dischargingEnabledUntil: number | null | undefined,
+        maximumDischargeCurrentA: number | undefined,
+    ): TemplateResult {
+        return html`
+            <h4>Bidirectional charging (V2X)</h4>
+            <dl class="info-grid">
+                ${
+                    dischargingEnabledUntil !== undefined
+                        ? html`<dt>Discharging enabled until</dt>
+                              <dd>
+                                  ${dischargingEnabledUntil === null ? "No expiry" : formatEpochTime(dischargingEnabledUntil)}
+                              </dd>`
+                        : nothing
+                }
+                ${
+                    maximumDischargeCurrentA !== undefined
+                        ? html`<dt>Maximum discharge current</dt>
+                              <dd>${maximumDischargeCurrentA} A</dd>`
+                        : nothing
+                }
+            </dl>
+            <div class="action-form">
+                <label class="checkbox-row">
+                    <input
+                        type="checkbox"
+                        .checked=${this._dischargeNoExpiry}
+                        @change=${(e: Event) => (this._dischargeNoExpiry = (e.target as HTMLInputElement).checked)}
+                    />
+                    No expiry
+                </label>
+                ${
+                    !this._dischargeNoExpiry
+                        ? html`<input
+                              type="datetime-local"
+                              .value=${this._dischargeUntil}
+                              @input=${(e: Event) => (this._dischargeUntil = (e.target as HTMLInputElement).value)}
+                          />`
+                        : nothing
+                }
+                <label>
+                    Max
+                    <input
+                        type="number"
+                        min="0"
+                        step="0.1"
+                        .value=${String(this._maxDischargeCurrentA)}
+                        @input=${(e: Event) =>
+                            (this._maxDischargeCurrentA = this.#parsePositiveNumber(e, this._maxDischargeCurrentA))}
+                    />
+                    A
+                </label>
+                <md-filled-button @click=${handleAsync(() => this._handleEnableDischarging())} ?disabled=${this._busy}>
+                    Enable Discharging
+                </md-filled-button>
+            </div>
+        `;
+    }
+
+    private _renderChargingPreferences(
+        info: {
+            nextChargeStartTime?: number | null;
+            nextChargeTargetTime?: number | null;
+            nextChargeRequiredEnergyKWh?: number | null;
+            nextChargeTargetSoC?: number | null;
+            approximateEvEfficiencyKmPerKWh?: number | null;
+        },
+        soCSupported: boolean,
+    ): TemplateResult {
+        return html`
+            <h4>Charging preferences</h4>
+            <dl class="info-grid">
+                ${
+                    info.nextChargeStartTime !== undefined
+                        ? html`<dt>Next charge start</dt>
+                              <dd>
+                                  ${info.nextChargeStartTime === null ? "None scheduled" : formatEpochTime(info.nextChargeStartTime)}
+                              </dd>`
+                        : nothing
+                }
+                ${
+                    info.nextChargeTargetTime !== undefined
+                        ? html`<dt>Next charge target</dt>
+                              <dd>
+                                  ${
+                                      info.nextChargeTargetTime === null
+                                          ? "None scheduled"
+                                          : formatEpochTime(info.nextChargeTargetTime)
+                                  }
+                              </dd>`
+                        : nothing
+                }
+                ${
+                    info.nextChargeRequiredEnergyKWh !== undefined
+                        ? html`<dt>Next charge required energy</dt>
+                              <dd>
+                                  ${info.nextChargeRequiredEnergyKWh === null ? "None" : `${info.nextChargeRequiredEnergyKWh} kWh`}
+                              </dd>`
+                        : nothing
+                }
+                ${
+                    info.nextChargeTargetSoC !== undefined
+                        ? html`<dt>Next charge target SoC</dt>
+                              <dd>${info.nextChargeTargetSoC === null ? "None" : `${info.nextChargeTargetSoC}%`}</dd>`
+                        : nothing
+                }
+                ${
+                    info.approximateEvEfficiencyKmPerKWh !== undefined
+                        ? html`<dt>Approximate EV efficiency</dt>
+                              <dd>
+                                  ${
+                                      info.approximateEvEfficiencyKmPerKWh === null
+                                          ? "Unknown"
+                                          : `${info.approximateEvEfficiencyKmPerKWh} km/kWh`
+                                  }
+                              </dd>`
+                        : nothing
+                }
+            </dl>
+            <details class="schedule-editor">
+                <summary>Weekly charging schedule</summary>
+                <div class="command-row">
+                    <md-outlined-button
+                        @click=${handleAsync(() => this._handleLoadSchedule())}
+                        ?disabled=${this._scheduleBusy}
+                    >
+                        Load current
+                    </md-outlined-button>
+                    <md-outlined-button
+                        @click=${handleAsync(() => this._handleClearSchedule())}
+                        ?disabled=${this._scheduleBusy}
+                    >
+                        Clear all
+                    </md-outlined-button>
+                </div>
+                ${
+                    this._schedules === undefined
+                        ? html`<p class="hint">
+                              Load the schedule currently stored on the EVSE, or build a new one below.
+                          </p>`
+                        : nothing
+                }
+                ${(this._schedules ?? []).map((schedule, index) => this._renderScheduleEditor(schedule, index, soCSupported))}
+                <div class="command-row">
+                    <md-text-button
+                        @click=${() => this._handleAddSchedule()}
+                        ?disabled=${(this._schedules ?? []).length >= MAX_SCHEDULES}
+                    >
+                        Add schedule
+                    </md-text-button>
+                    <md-filled-button
+                        @click=${handleAsync(() => this._handleSaveSchedule())}
+                        ?disabled=${this._scheduleBusy || !this._schedules || this._schedules.length === 0}
+                    >
+                        Save schedule
+                    </md-filled-button>
+                </div>
+                ${this._scheduleError !== undefined ? html`<p class="error">${this._scheduleError}</p>` : nothing}
+            </details>
+        `;
+    }
+
+    private _renderScheduleEditor(
+        schedule: EditableChargingSchedule,
+        scheduleIndex: number,
+        soCSupported: boolean,
+    ): TemplateResult {
+        return html`
+            <div class="schedule-card">
+                <div class="schedule-days">
+                    ${EVSE_WEEKDAYS.map(
+                        ({ key, label }) => html`
+                            <button
+                                type="button"
+                                class="day-chip ${schedule.days[key] ? "selected" : ""}"
+                                @click=${() => this._handleToggleDay(scheduleIndex, key)}
+                            >
+                                ${label}
+                            </button>
+                        `,
+                    )}
+                    <md-text-button @click=${() => this._handleRemoveSchedule(scheduleIndex)}>Remove</md-text-button>
+                </div>
+                ${schedule.targets.map((target, targetIndex) =>
+                    this._renderTargetEditor(scheduleIndex, targetIndex, target, soCSupported),
+                )}
+                <md-text-button
+                    @click=${() => this._handleAddTarget(scheduleIndex)}
+                    ?disabled=${schedule.targets.length >= MAX_TARGETS_PER_SCHEDULE}
+                >
+                    Add target
+                </md-text-button>
+            </div>
+        `;
+    }
+
+    private _renderTargetEditor(
+        scheduleIndex: number,
+        targetIndex: number,
+        target: EditableChargingTarget,
+        soCSupported: boolean,
+    ): TemplateResult {
+        return html`
+            <div class="target-row">
+                <input
+                    type="time"
+                    .value=${minutesToTimeInputValue(target.timeMinutes)}
+                    @change=${(e: Event) => this._handleTargetTimeChange(scheduleIndex, targetIndex, e)}
+                />
+                ${
+                    soCSupported
+                        ? html`<label>
+                              <input
+                                  type="number"
+                                  min="0"
+                                  max="100"
+                                  .value=${target.targetSoC !== undefined ? String(target.targetSoC) : ""}
+                                  @input=${(e: Event) => this._handleTargetSoCChange(scheduleIndex, targetIndex, e)}
+                              />
+                              % SoC
+                          </label>`
+                        : html`<label>
+                              <input
+                                  type="number"
+                                  min="0"
+                                  step="0.1"
+                                  .value=${target.addedEnergyKWh !== undefined ? String(target.addedEnergyKWh) : ""}
+                                  @input=${(e: Event) => this._handleTargetEnergyChange(scheduleIndex, targetIndex, e)}
+                              />
+                              kWh
+                          </label>`
+                }
+                <md-text-button @click=${() => this._handleRemoveTarget(scheduleIndex, targetIndex)}
+                    >Remove</md-text-button
+                >
+            </div>
+        `;
+    }
+
+    #parsePositiveNumber(e: Event, previous: number): number {
+        const value = Number((e.target as HTMLInputElement).value);
+        return Number.isFinite(value) && value >= 0 ? value : previous;
+    }
+
+    private async _handleDisable() {
+        if (this._busy) return;
+        const node = this.node;
+        const endpoint = this.endpoint;
+        const busyGeneration = this.#busyGeneration;
+        this._busy = true;
+        try {
+            await disableEvse(this.client, node.node_id, endpoint);
+        } catch (error) {
+            this.#reportFailure("Disable failed", error);
+        } finally {
+            if (this.#busyGeneration === busyGeneration) this._busy = false;
+        }
+    }
+
+    private async _handleStartDiagnostics() {
+        if (this._busy) return;
+        const node = this.node;
+        const endpoint = this.endpoint;
+        const busyGeneration = this.#busyGeneration;
+        this._busy = true;
+        try {
+            await startDiagnostics(this.client, node.node_id, endpoint);
+        } catch (error) {
+            this.#reportFailure("Start diagnostics failed", error);
+        } finally {
+            if (this.#busyGeneration === busyGeneration) this._busy = false;
+        }
+    }
+
+    private async _handleEnableCharging() {
+        if (this._busy) return;
+        this._formError = undefined;
+        let chargingEnabledUntil: number | null = null;
+        if (!this._chargeNoExpiry) {
+            const parsed = fromLocalDateTimeInputValue(this._chargeUntil);
+            if (parsed === undefined) {
+                this._formError = "Enter a charging end time, or choose no expiry.";
+                return;
+            }
+            chargingEnabledUntil = parsed;
+        }
+        if (this._minChargeCurrentA > this._maxChargeCurrentA) {
+            this._formError = "The minimum current cannot exceed the maximum current.";
+            return;
+        }
+        const node = this.node;
+        const endpoint = this.endpoint;
+        const busyGeneration = this.#busyGeneration;
+        this._busy = true;
+        try {
+            await enableCharging(this.client, node.node_id, endpoint, {
+                chargingEnabledUntil,
+                minimumChargeCurrentA: this._minChargeCurrentA,
+                maximumChargeCurrentA: this._maxChargeCurrentA,
+            });
+        } catch (error) {
+            this.#reportFailure("Enable charging failed", error);
+        } finally {
+            if (this.#busyGeneration === busyGeneration) this._busy = false;
+        }
+    }
+
+    private async _handleEnableDischarging() {
+        if (this._busy) return;
+        this._formError = undefined;
+        let dischargingEnabledUntil: number | null = null;
+        if (!this._dischargeNoExpiry) {
+            const parsed = fromLocalDateTimeInputValue(this._dischargeUntil);
+            if (parsed === undefined) {
+                this._formError = "Enter a discharging end time, or choose no expiry.";
+                return;
+            }
+            dischargingEnabledUntil = parsed;
+        }
+        const node = this.node;
+        const endpoint = this.endpoint;
+        const busyGeneration = this.#busyGeneration;
+        this._busy = true;
+        try {
+            await enableDischarging(this.client, node.node_id, endpoint, {
+                dischargingEnabledUntil,
+                maximumDischargeCurrentA: this._maxDischargeCurrentA,
+            });
+        } catch (error) {
+            this.#reportFailure("Enable discharging failed", error);
+        } finally {
+            if (this.#busyGeneration === busyGeneration) this._busy = false;
+        }
+    }
+
+    #reportFailure(title: string, error: unknown) {
+        showAlertDialog({ title, text: errorText(error) }).catch(alertError =>
+            console.error("Failed to show alert dialog:", alertError),
+        );
+    }
+
+    private async _handleLoadSchedule() {
+        if (this._scheduleBusy) return;
+        const node = this.node;
+        const endpoint = this.endpoint;
+        const busyGeneration = this.#busyGeneration;
+        this._scheduleBusy = true;
+        this._scheduleError = undefined;
+        try {
+            const schedules = await getChargingTargets(this.client, node.node_id, endpoint);
+            if (this.#busyGeneration !== busyGeneration) return;
+            this._schedules = schedules;
+        } catch (error) {
+            if (this.#busyGeneration !== busyGeneration) return;
+            this._scheduleError = errorText(error);
+        } finally {
+            if (this.#busyGeneration === busyGeneration) this._scheduleBusy = false;
+        }
+    }
+
+    private async _handleSaveSchedule() {
+        const schedules = this._schedules;
+        if (!schedules || schedules.length === 0 || this._scheduleBusy) return;
+        if (schedules.some(schedule => Object.values(schedule.days).every(selected => selected !== true))) {
+            this._scheduleError = "Select at least one day for every schedule.";
+            return;
+        }
+        if (schedules.some(schedule => schedule.targets.length === 0)) {
+            this._scheduleError = "Add at least one target time to every schedule.";
+            return;
+        }
+        const node = this.node;
+        const endpoint = this.endpoint;
+        const busyGeneration = this.#busyGeneration;
+        this._scheduleBusy = true;
+        this._scheduleError = undefined;
+        try {
+            await setChargingTargets(this.client, node.node_id, endpoint, schedules);
+        } catch (error) {
+            if (this.#busyGeneration !== busyGeneration) return;
+            this._scheduleError = errorText(error);
+        } finally {
+            if (this.#busyGeneration === busyGeneration) this._scheduleBusy = false;
+        }
+    }
+
+    private async _handleClearSchedule() {
+        const node = this.node;
+        const endpoint = this.endpoint;
+        const confirmed = await showPromptDialog({
+            title: "Clear charging schedule",
+            text: "Every stored charging target will be removed from the EVSE.",
+            confirmText: "Clear",
+        });
+        if (!confirmed || !this.isSameContext(node, endpoint) || this._scheduleBusy) return;
+        const busyGeneration = this.#busyGeneration;
+        this._scheduleBusy = true;
+        this._scheduleError = undefined;
+        try {
+            await clearChargingTargets(this.client, node.node_id, endpoint);
+            if (this.#busyGeneration !== busyGeneration) return;
+            this._schedules = [];
+        } catch (error) {
+            if (this.#busyGeneration !== busyGeneration) return;
+            this._scheduleError = errorText(error);
+        } finally {
+            if (this.#busyGeneration === busyGeneration) this._scheduleBusy = false;
+        }
+    }
+
+    private _handleAddSchedule() {
+        const schedules = this._schedules ?? [];
+        if (schedules.length >= MAX_SCHEDULES) return;
+        this._schedules = [...schedules, { days: {}, targets: [{ timeMinutes: 360 }] }];
+    }
+
+    private _handleRemoveSchedule(scheduleIndex: number) {
+        if (!this._schedules) return;
+        this._schedules = this._schedules.filter((_, index) => index !== scheduleIndex);
+    }
+
+    private _handleToggleDay(scheduleIndex: number, day: EvseWeekday) {
+        this.#updateSchedule(scheduleIndex, schedule => ({
+            ...schedule,
+            days: { ...schedule.days, [day]: schedule.days[day] !== true },
+        }));
+    }
+
+    private _handleAddTarget(scheduleIndex: number) {
+        this.#updateSchedule(scheduleIndex, schedule =>
+            schedule.targets.length >= MAX_TARGETS_PER_SCHEDULE
+                ? schedule
+                : { ...schedule, targets: [...schedule.targets, { timeMinutes: 360 }] },
+        );
+    }
+
+    private _handleRemoveTarget(scheduleIndex: number, targetIndex: number) {
+        this.#updateSchedule(scheduleIndex, schedule => ({
+            ...schedule,
+            targets: schedule.targets.filter((_, index) => index !== targetIndex),
+        }));
+    }
+
+    private _handleTargetTimeChange(scheduleIndex: number, targetIndex: number, e: Event) {
+        const minutes = timeInputValueToMinutes((e.target as HTMLInputElement).value);
+        if (minutes === undefined) return;
+        this.#updateTarget(scheduleIndex, targetIndex, target => ({ ...target, timeMinutes: minutes }));
+    }
+
+    private _handleTargetSoCChange(scheduleIndex: number, targetIndex: number, e: Event) {
+        const value = Number((e.target as HTMLInputElement).value);
+        const targetSoC = Number.isFinite(value) ? Math.min(100, Math.max(0, value)) : undefined;
+        this.#updateTarget(scheduleIndex, targetIndex, target => ({
+            timeMinutes: target.timeMinutes,
+            targetSoC,
+        }));
+    }
+
+    private _handleTargetEnergyChange(scheduleIndex: number, targetIndex: number, e: Event) {
+        const value = Number((e.target as HTMLInputElement).value);
+        const addedEnergyKWh = Number.isFinite(value) && value >= 0 ? value : undefined;
+        this.#updateTarget(scheduleIndex, targetIndex, target => ({
+            timeMinutes: target.timeMinutes,
+            addedEnergyKWh,
+        }));
+    }
+
+    #updateSchedule(scheduleIndex: number, updater: (schedule: EditableChargingSchedule) => EditableChargingSchedule) {
+        if (!this._schedules) return;
+        this._schedules = this._schedules.map((schedule, index) =>
+            index === scheduleIndex ? updater(schedule) : schedule,
+        );
+    }
+
+    #updateTarget(
+        scheduleIndex: number,
+        targetIndex: number,
+        updater: (target: EditableChargingTarget) => EditableChargingTarget,
+    ) {
+        this.#updateSchedule(scheduleIndex, schedule => ({
+            ...schedule,
+            targets: schedule.targets.map((target, index) => (index === targetIndex ? updater(target) : target)),
+        }));
+    }
+
     static override styles: CSSResultGroup = [
         BaseClusterCommands.styles,
         css`
@@ -286,6 +822,100 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
             }
             .info-grid dd.fault {
                 color: var(--danger-color, #d32f2f);
+            }
+            .action-form {
+                display: flex;
+                align-items: center;
+                flex-wrap: wrap;
+                gap: 10px;
+                margin-top: 10px;
+                font-size: 13px;
+            }
+            .action-form label {
+                display: flex;
+                align-items: center;
+                gap: 4px;
+                color: var(--text-color, rgba(0, 0, 0, 0.6));
+            }
+            .action-form input[type="number"] {
+                width: 64px;
+                padding: 6px;
+                border: 1px solid var(--md-sys-color-outline);
+                border-radius: 4px;
+                background: var(--md-sys-color-surface);
+                color: var(--md-sys-color-on-surface);
+            }
+            .action-form input[type="datetime-local"] {
+                padding: 6px;
+                border: 1px solid var(--md-sys-color-outline);
+                border-radius: 4px;
+                background: var(--md-sys-color-surface);
+                color: var(--md-sys-color-on-surface);
+            }
+            .checkbox-row {
+                display: flex;
+                align-items: center;
+                gap: 6px;
+            }
+            .schedule-editor {
+                margin-top: 12px;
+            }
+            .schedule-editor summary {
+                cursor: pointer;
+                color: var(--md-sys-color-primary);
+                font-size: 13px;
+            }
+            .schedule-card {
+                margin-top: 10px;
+                padding: 10px;
+                border-radius: 8px;
+                background: var(--md-sys-color-surface-container-high);
+            }
+            .schedule-days {
+                display: flex;
+                align-items: center;
+                flex-wrap: wrap;
+                gap: 6px;
+                margin-bottom: 8px;
+            }
+            .day-chip {
+                border: 1px solid var(--md-sys-color-outline);
+                border-radius: 16px;
+                background: transparent;
+                color: var(--md-sys-color-on-surface);
+                padding: 4px 10px;
+                font-size: 12px;
+                cursor: pointer;
+            }
+            .day-chip.selected {
+                background: var(--md-sys-color-primary);
+                border-color: var(--md-sys-color-primary);
+                color: var(--md-sys-color-on-primary);
+            }
+            .target-row {
+                display: flex;
+                align-items: center;
+                gap: 10px;
+                margin: 6px 0;
+                font-size: 13px;
+            }
+            .target-row input[type="time"],
+            .target-row input[type="number"] {
+                padding: 6px;
+                border: 1px solid var(--md-sys-color-outline);
+                border-radius: 4px;
+                background: var(--md-sys-color-surface);
+                color: var(--md-sys-color-on-surface);
+                width: 90px;
+            }
+            .hint {
+                color: var(--text-color, rgba(0, 0, 0, 0.6));
+                font-size: 13px;
+            }
+            .error {
+                color: var(--danger-color);
+                margin: 8px 0 0 0;
+                font-size: 0.85rem;
             }
         `,
     ];

--- a/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
@@ -512,6 +512,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                             <button
                                 type="button"
                                 class="day-chip ${schedule.days[key] ? "selected" : ""}"
+                                aria-pressed=${schedule.days[key] ? "true" : "false"}
                                 @click=${() => this._handleToggleDay(scheduleIndex, key)}
                             >
                                 ${label}

--- a/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
@@ -1,0 +1,300 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { css, html, nothing, type CSSResultGroup } from "lit";
+import { customElement } from "lit/decorators.js";
+import { formatDuration } from "../../../util/duration.js";
+import { ENERGY_EVSE_CLUSTER_ID, energyEvseInfo, type SessionInfo } from "../../../util/energy-evse.js";
+import { formatEpochTime } from "../../../util/time.js";
+import { BaseClusterCommands } from "../base-cluster-commands.js";
+import { registerClusterCommands } from "../registry.js";
+
+/**
+ * Read-only decoding panel for the EnergyEvse cluster (ID: 0x99 / 153).
+ */
+@customElement("energy-evse-cluster-commands")
+export class EnergyEvseClusterCommands extends BaseClusterCommands {
+    override render() {
+        if (!this.node || this.cluster !== ENERGY_EVSE_CLUSTER_ID) return nothing;
+        const info = energyEvseInfo(this.node.attributes, this.endpoint);
+        if (!info.supported) return nothing;
+
+        return html`
+            <details class="command-panel" open>
+                <summary>Energy EVSE</summary>
+                <div class="command-content">
+                    <dl class="info-grid">
+                        ${
+                            info.state
+                                ? html`<dt>State</dt>
+                                      <dd>${info.state}</dd>`
+                                : nothing
+                        }
+                        ${
+                            info.supplyState
+                                ? html`<dt>Supply state</dt>
+                                      <dd>${info.supplyState}</dd>`
+                                : nothing
+                        }
+                        ${
+                            info.faultState
+                                ? html`<dt>Fault state</dt>
+                                      <dd class=${info.faultActive ? "fault" : ""}>${info.faultState}</dd>`
+                                : nothing
+                        }
+                        ${
+                            info.chargingEnabledUntil !== undefined
+                                ? html`<dt>Charging enabled until</dt>
+                                      <dd>
+                                          ${
+                                              info.chargingEnabledUntil === null
+                                                  ? "No expiry"
+                                                  : formatEpochTime(info.chargingEnabledUntil)
+                                          }
+                                      </dd>`
+                                : nothing
+                        }
+                        ${
+                            info.circuitCapacityA !== undefined
+                                ? html`<dt>Circuit capacity</dt>
+                                      <dd>${info.circuitCapacityA} A</dd>`
+                                : nothing
+                        }
+                        ${
+                            info.minimumChargeCurrentA !== undefined
+                                ? html`<dt>Minimum charge current</dt>
+                                      <dd>${info.minimumChargeCurrentA} A</dd>`
+                                : nothing
+                        }
+                        ${
+                            info.maximumChargeCurrentA !== undefined
+                                ? html`<dt>Maximum charge current</dt>
+                                      <dd>${info.maximumChargeCurrentA} A</dd>`
+                                : nothing
+                        }
+                        ${
+                            info.userMaximumChargeCurrentA !== undefined
+                                ? html`<dt>User maximum charge current</dt>
+                                      <dd>${info.userMaximumChargeCurrentA} A</dd>`
+                                : nothing
+                        }
+                        ${
+                            info.randomizationDelayWindowS !== undefined
+                                ? html`<dt>Randomization delay window</dt>
+                                      <dd>${formatDuration(info.randomizationDelayWindowS)}</dd>`
+                                : nothing
+                        }
+                    </dl>
+
+                    ${this._renderSession(info.session, info.v2xSupported)}
+                    ${
+                        info.v2xSupported
+                            ? html`
+                                  <h4>Bidirectional charging (V2X)</h4>
+                                  <dl class="info-grid">
+                                      ${
+                                          info.dischargingEnabledUntil !== undefined
+                                              ? html`<dt>Discharging enabled until</dt>
+                                                    <dd>
+                                                        ${
+                                                            info.dischargingEnabledUntil === null
+                                                                ? "No expiry"
+                                                                : formatEpochTime(info.dischargingEnabledUntil)
+                                                        }
+                                                    </dd>`
+                                              : nothing
+                                      }
+                                      ${
+                                          info.maximumDischargeCurrentA !== undefined
+                                              ? html`<dt>Maximum discharge current</dt>
+                                                    <dd>${info.maximumDischargeCurrentA} A</dd>`
+                                              : nothing
+                                      }
+                                  </dl>
+                              `
+                            : nothing
+                    }
+                    ${
+                        info.chargingPreferencesSupported
+                            ? html`
+                                  <h4>Charging preferences</h4>
+                                  <dl class="info-grid">
+                                      ${
+                                          info.nextChargeStartTime !== undefined
+                                              ? html`<dt>Next charge start</dt>
+                                                    <dd>
+                                                        ${
+                                                            info.nextChargeStartTime === null
+                                                                ? "None scheduled"
+                                                                : formatEpochTime(info.nextChargeStartTime)
+                                                        }
+                                                    </dd>`
+                                              : nothing
+                                      }
+                                      ${
+                                          info.nextChargeTargetTime !== undefined
+                                              ? html`<dt>Next charge target</dt>
+                                                    <dd>
+                                                        ${
+                                                            info.nextChargeTargetTime === null
+                                                                ? "None scheduled"
+                                                                : formatEpochTime(info.nextChargeTargetTime)
+                                                        }
+                                                    </dd>`
+                                              : nothing
+                                      }
+                                      ${
+                                          info.nextChargeRequiredEnergyKWh !== undefined
+                                              ? html`<dt>Next charge required energy</dt>
+                                                    <dd>
+                                                        ${
+                                                            info.nextChargeRequiredEnergyKWh === null
+                                                                ? "None"
+                                                                : `${info.nextChargeRequiredEnergyKWh} kWh`
+                                                        }
+                                                    </dd>`
+                                              : nothing
+                                      }
+                                      ${
+                                          info.nextChargeTargetSoC !== undefined
+                                              ? html`<dt>Next charge target SoC</dt>
+                                                    <dd>
+                                                        ${
+                                                            info.nextChargeTargetSoC === null
+                                                                ? "None"
+                                                                : `${info.nextChargeTargetSoC}%`
+                                                        }
+                                                    </dd>`
+                                              : nothing
+                                      }
+                                      ${
+                                          info.approximateEvEfficiencyKmPerKWh !== undefined
+                                              ? html`<dt>Approximate EV efficiency</dt>
+                                                    <dd>
+                                                        ${
+                                                            info.approximateEvEfficiencyKmPerKWh === null
+                                                                ? "Unknown"
+                                                                : `${info.approximateEvEfficiencyKmPerKWh} km/kWh`
+                                                        }
+                                                    </dd>`
+                                              : nothing
+                                      }
+                                  </dl>
+                              `
+                            : nothing
+                    }
+                    ${
+                        info.soCReportingSupported
+                            ? html`
+                                  <h4>Vehicle state of charge</h4>
+                                  <dl class="info-grid">
+                                      ${
+                                          info.stateOfCharge !== undefined
+                                              ? html`<dt>State of charge</dt>
+                                                    <dd>
+                                                        ${info.stateOfCharge === null ? "Unknown" : `${info.stateOfCharge}%`}
+                                                    </dd>`
+                                              : nothing
+                                      }
+                                      ${
+                                          info.batteryCapacityKWh !== undefined
+                                              ? html`<dt>Battery capacity</dt>
+                                                    <dd>
+                                                        ${
+                                                            info.batteryCapacityKWh === null
+                                                                ? "Unknown"
+                                                                : `${info.batteryCapacityKWh} kWh`
+                                                        }
+                                                    </dd>`
+                                              : nothing
+                                      }
+                                  </dl>
+                              `
+                            : nothing
+                    }
+                    ${
+                        info.plugAndChargeSupported && info.vehicleId !== undefined
+                            ? html`
+                                  <h4>Plug and Charge</h4>
+                                  <dl class="info-grid">
+                                      <dt>Vehicle ID</dt>
+                                      <dd>${info.vehicleId ?? "Unknown"}</dd>
+                                  </dl>
+                              `
+                            : nothing
+                    }
+                </div>
+            </details>
+        `;
+    }
+
+    private _renderSession(session: SessionInfo | undefined, v2xSupported: boolean) {
+        if (!session) return nothing;
+        return html`
+            <h4>Session</h4>
+            <dl class="info-grid">
+                <dt>Session ID</dt>
+                <dd>${session.id}</dd>
+                ${
+                    session.durationS !== undefined
+                        ? html`<dt>Duration</dt>
+                              <dd>${formatDuration(session.durationS)}</dd>`
+                        : nothing
+                }
+                ${
+                    session.energyChargedKWh !== undefined
+                        ? html`<dt>Energy charged</dt>
+                              <dd>${session.energyChargedKWh} kWh</dd>`
+                        : nothing
+                }
+                ${
+                    v2xSupported && session.energyDischargedKWh !== undefined
+                        ? html`<dt>Energy discharged</dt>
+                              <dd>${session.energyDischargedKWh} kWh</dd>`
+                        : nothing
+                }
+            </dl>
+        `;
+    }
+
+    static override styles: CSSResultGroup = [
+        BaseClusterCommands.styles,
+        css`
+            h4 {
+                margin: 16px 0 6px 0;
+                font-size: 13px;
+                color: var(--md-sys-color-on-surface-variant);
+            }
+            .info-grid {
+                display: grid;
+                grid-template-columns: auto 1fr;
+                gap: 6px 16px;
+                margin: 0;
+            }
+            .info-grid dt {
+                color: var(--text-color, rgba(0, 0, 0, 0.6));
+                font-size: 13px;
+            }
+            .info-grid dd {
+                margin: 0;
+                font-weight: 500;
+            }
+            .info-grid dd.fault {
+                color: var(--danger-color, #d32f2f);
+            }
+        `,
+    ];
+}
+
+registerClusterCommands(ENERGY_EVSE_CLUSTER_ID, "energy-evse-cluster-commands", {
+    renderWhenOffline: true,
+});
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "energy-evse-cluster-commands": EnergyEvseClusterCommands;
+    }
+}

--- a/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
@@ -36,6 +36,10 @@ import { registerClusterCommands } from "../registry.js";
 const MAX_SCHEDULES = 7;
 const MAX_TARGETS_PER_SCHEDULE = 10;
 
+/** Matter only reports a status code (e.g. "Failure(1)"), not the device's reason, so name the likely cause. */
+const DIAGNOSTICS_OR_ALREADY_ENABLED_HINT =
+    "If the EVSE is in self-diagnostics mode, or already enabled for charging/discharging, click Disable first and try again.";
+
 function minutesToTimeInputValue(minutes: number): string {
     const hours = Math.floor(minutes / 60) % 24;
     const mins = minutes % 60;
@@ -171,8 +175,17 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                         }
                     </dl>
 
-                    ${this._renderChargingActions()} ${this._renderSession(info.session, info.v2xSupported)}
-                    ${info.v2xSupported ? this._renderV2x(info.dischargingEnabledUntil, info.maximumDischargeCurrentA) : nothing}
+                    ${this._renderChargingActions(info.diagnosticsActive, info.canStartDiagnostics)}
+                    ${this._renderSession(info.session, info.v2xSupported)}
+                    ${
+                        info.v2xSupported
+                            ? this._renderV2x(
+                                  info.dischargingEnabledUntil,
+                                  info.maximumDischargeCurrentA,
+                                  info.diagnosticsActive,
+                              )
+                            : nothing
+                    }
                     ${
                         info.chargingPreferencesSupported
                             ? this._renderChargingPreferences(info, info.soCReportingSupported)
@@ -252,14 +265,18 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         `;
     }
 
-    private _renderChargingActions(): TemplateResult {
+    private _renderChargingActions(diagnosticsActive: boolean, canStartDiagnostics: boolean): TemplateResult {
         return html`
             <h4>Charging control</h4>
             <div class="command-row">
                 <md-outlined-button @click=${handleAsync(() => this._handleDisable())} ?disabled=${this._busy}>
                     Disable
                 </md-outlined-button>
-                <md-outlined-button @click=${handleAsync(() => this._handleStartDiagnostics())} ?disabled=${this._busy}>
+                <md-outlined-button
+                    @click=${handleAsync(() => this._handleStartDiagnostics())}
+                    ?disabled=${this._busy || !canStartDiagnostics}
+                    title=${canStartDiagnostics ? nothing : "Only available while charging is disabled"}
+                >
                     Start Diagnostics
                 </md-outlined-button>
             </div>
@@ -303,7 +320,11 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                     />
                     A
                 </label>
-                <md-filled-button @click=${handleAsync(() => this._handleEnableCharging())} ?disabled=${this._busy}>
+                <md-filled-button
+                    @click=${handleAsync(() => this._handleEnableCharging())}
+                    ?disabled=${this._busy || diagnosticsActive}
+                    title=${diagnosticsActive ? "Not available while self-diagnostics are active — click Disable first" : nothing}
+                >
                     Enable Charging
                 </md-filled-button>
             </div>
@@ -314,6 +335,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
     private _renderV2x(
         dischargingEnabledUntil: number | null | undefined,
         maximumDischargeCurrentA: number | undefined,
+        diagnosticsActive: boolean,
     ): TemplateResult {
         return html`
             <h4>Bidirectional charging (V2X)</h4>
@@ -363,7 +385,11 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                     />
                     A
                 </label>
-                <md-filled-button @click=${handleAsync(() => this._handleEnableDischarging())} ?disabled=${this._busy}>
+                <md-filled-button
+                    @click=${handleAsync(() => this._handleEnableDischarging())}
+                    ?disabled=${this._busy || diagnosticsActive}
+                    title=${diagnosticsActive ? "Not available while self-diagnostics are active — click Disable first" : nothing}
+                >
                     Enable Discharging
                 </md-filled-button>
             </div>
@@ -579,7 +605,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         try {
             await startDiagnostics(this.client, node.node_id, endpoint);
         } catch (error) {
-            this.#reportFailure("Start diagnostics failed", error);
+            this.#reportFailure("Start diagnostics failed", error, DIAGNOSTICS_OR_ALREADY_ENABLED_HINT);
         } finally {
             if (this.#busyGeneration === busyGeneration) this._busy = false;
         }
@@ -612,7 +638,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 maximumChargeCurrentA: this._maxChargeCurrentA,
             });
         } catch (error) {
-            this.#reportFailure("Enable charging failed", error);
+            this.#reportFailure("Enable charging failed", error, DIAGNOSTICS_OR_ALREADY_ENABLED_HINT);
         } finally {
             if (this.#busyGeneration === busyGeneration) this._busy = false;
         }
@@ -640,16 +666,22 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 maximumDischargeCurrentA: this._maxDischargeCurrentA,
             });
         } catch (error) {
-            this.#reportFailure("Enable discharging failed", error);
+            this.#reportFailure("Enable discharging failed", error, DIAGNOSTICS_OR_ALREADY_ENABLED_HINT);
         } finally {
             if (this.#busyGeneration === busyGeneration) this._busy = false;
         }
     }
 
-    #reportFailure(title: string, error: unknown) {
-        showAlertDialog({ title, text: errorText(error) }).catch(alertError =>
-            console.error("Failed to show alert dialog:", alertError),
-        );
+    /**
+     * `hint` adds a line of general guidance below the raw failure: Matter only sends the controller a
+     * status code (e.g. "Failure(1)"), never the descriptive reason the device logged locally.
+     */
+    #reportFailure(title: string, error: unknown, hint?: string) {
+        const text = hint
+            ? html`<p>${errorText(error)}</p>
+                  <p>${hint}</p>`
+            : errorText(error);
+        showAlertDialog({ title, text }).catch(alertError => console.error("Failed to show alert dialog:", alertError));
     }
 
     private async _handleLoadSchedule() {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
@@ -270,7 +270,9 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
             }
             .info-grid {
                 display: grid;
-                grid-template-columns: auto 1fr;
+                /* Fixed, not auto: several separate <dl>s share this panel, and each auto-sized
+                   column would size to its own widest label, misaligning the value column across sections. */
+                grid-template-columns: 190px 1fr;
                 gap: 6px 16px;
                 margin: 0;
             }

--- a/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
@@ -28,8 +28,14 @@ import {
     type EvseWeekday,
     type SessionInfo,
 } from "../../../util/energy-evse.js";
+import type { EnergyEvseInfo } from "../../../util/energy-evse.js";
 import { errorText } from "../../../util/error-text.js";
-import { formatEpochTime, fromLocalDateTimeInputValue } from "../../../util/time.js";
+import {
+    formatEpochTime,
+    fromLocalDateTimeInputValue,
+    MATTER_EPOCH_MAX_INPUT_VALUE,
+    MATTER_EPOCH_MIN_INPUT_VALUE,
+} from "../../../util/time.js";
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
 
@@ -107,6 +113,9 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         if (!this.node || this.cluster !== ENERGY_EVSE_CLUSTER_ID) return nothing;
         const info = energyEvseInfo(this.node.attributes, this.endpoint);
         if (!info.supported) return nothing;
+        // The panel stays mounted while the node is unreachable so its cached decoding survives, but
+        // nothing it could send would reach the device.
+        const offline = this.node.available !== true;
 
         return html`
             <details class="command-panel" open>
@@ -175,7 +184,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                         }
                     </dl>
 
-                    ${this._renderChargingActions(info.diagnosticsActive, info.canStartDiagnostics)}
+                    ${this._renderChargingActions(info, offline)}
                     ${this._renderSession(info.session, info.v2xSupported)}
                     ${
                         info.v2xSupported
@@ -183,12 +192,13 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                                   info.dischargingEnabledUntil,
                                   info.maximumDischargeCurrentA,
                                   info.diagnosticsActive,
+                                  offline,
                               )
                             : nothing
                     }
                     ${
                         info.chargingPreferencesSupported
-                            ? this._renderChargingPreferences(info, info.soCReportingSupported)
+                            ? this._renderChargingPreferences(info, info.soCReportingSupported, offline)
                             : nothing
                     }
                     ${
@@ -265,20 +275,29 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         `;
     }
 
-    private _renderChargingActions(diagnosticsActive: boolean, canStartDiagnostics: boolean): TemplateResult {
+    private _renderChargingActions(info: EnergyEvseInfo, offline: boolean): TemplateResult {
+        const diagnosticsActive = info.diagnosticsActive;
+        const canStartDiagnostics = info.canStartDiagnostics;
         return html`
             <h4>Charging control</h4>
             <div class="command-row">
-                <md-outlined-button @click=${handleAsync(() => this._handleDisable())} ?disabled=${this._busy}>
+                <md-outlined-button
+                    @click=${handleAsync(() => this._handleDisable())}
+                    ?disabled=${this._busy || offline}
+                >
                     Disable
                 </md-outlined-button>
-                <md-outlined-button
-                    @click=${handleAsync(() => this._handleStartDiagnostics())}
-                    ?disabled=${this._busy || !canStartDiagnostics}
-                    title=${canStartDiagnostics ? nothing : "Only available while charging is disabled"}
-                >
-                    Start Diagnostics
-                </md-outlined-button>
+                ${
+                    info.startDiagnosticsSupported
+                        ? html`<md-outlined-button
+                              @click=${handleAsync(() => this._handleStartDiagnostics())}
+                              ?disabled=${this._busy || offline || !canStartDiagnostics}
+                              title=${canStartDiagnostics ? nothing : "Only available while charging is disabled"}
+                          >
+                              Start Diagnostics
+                          </md-outlined-button>`
+                        : nothing
+                }
             </div>
             <div class="action-form">
                 <label class="checkbox-row">
@@ -291,11 +310,16 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 </label>
                 ${
                     !this._chargeNoExpiry
-                        ? html`<input
-                              type="datetime-local"
-                              .value=${this._chargeUntil}
-                              @input=${(e: Event) => (this._chargeUntil = (e.target as HTMLInputElement).value)}
-                          />`
+                        ? html`<label>
+                              Charge until
+                              <input
+                                  type="datetime-local"
+                                  min=${MATTER_EPOCH_MIN_INPUT_VALUE}
+                                  max=${MATTER_EPOCH_MAX_INPUT_VALUE}
+                                  .value=${this._chargeUntil}
+                                  @input=${(e: Event) => (this._chargeUntil = (e.target as HTMLInputElement).value)}
+                              />
+                          </label>`
                         : nothing
                 }
                 <label>
@@ -322,7 +346,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 </label>
                 <md-filled-button
                     @click=${handleAsync(() => this._handleEnableCharging())}
-                    ?disabled=${this._busy || diagnosticsActive}
+                    ?disabled=${this._busy || offline || diagnosticsActive}
                     title=${diagnosticsActive ? "Not available while self-diagnostics are active — click Disable first" : nothing}
                 >
                     Enable Charging
@@ -336,6 +360,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         dischargingEnabledUntil: number | null | undefined,
         maximumDischargeCurrentA: number | undefined,
         diagnosticsActive: boolean,
+        offline: boolean,
     ): TemplateResult {
         return html`
             <h4>Bidirectional charging (V2X)</h4>
@@ -366,11 +391,16 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 </label>
                 ${
                     !this._dischargeNoExpiry
-                        ? html`<input
-                              type="datetime-local"
-                              .value=${this._dischargeUntil}
-                              @input=${(e: Event) => (this._dischargeUntil = (e.target as HTMLInputElement).value)}
-                          />`
+                        ? html`<label>
+                              Discharge until
+                              <input
+                                  type="datetime-local"
+                                  min=${MATTER_EPOCH_MIN_INPUT_VALUE}
+                                  max=${MATTER_EPOCH_MAX_INPUT_VALUE}
+                                  .value=${this._dischargeUntil}
+                                  @input=${(e: Event) => (this._dischargeUntil = (e.target as HTMLInputElement).value)}
+                              />
+                          </label>`
                         : nothing
                 }
                 <label>
@@ -387,7 +417,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 </label>
                 <md-filled-button
                     @click=${handleAsync(() => this._handleEnableDischarging())}
-                    ?disabled=${this._busy || diagnosticsActive}
+                    ?disabled=${this._busy || offline || diagnosticsActive}
                     title=${diagnosticsActive ? "Not available while self-diagnostics are active — click Disable first" : nothing}
                 >
                     Enable Discharging
@@ -405,6 +435,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
             approximateEvEfficiencyKmPerKWh?: number | null;
         },
         soCSupported: boolean,
+        offline: boolean,
     ): TemplateResult {
         return html`
             <h4>Charging preferences</h4>
@@ -461,13 +492,13 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 <div class="command-row">
                     <md-outlined-button
                         @click=${handleAsync(() => this._handleLoadSchedule())}
-                        ?disabled=${this._scheduleBusy}
+                        ?disabled=${this._scheduleBusy || offline}
                     >
                         Load current
                     </md-outlined-button>
                     <md-outlined-button
                         @click=${handleAsync(() => this._handleClearSchedule())}
-                        ?disabled=${this._scheduleBusy}
+                        ?disabled=${this._scheduleBusy || offline}
                     >
                         Clear all
                     </md-outlined-button>
@@ -489,7 +520,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                     </md-text-button>
                     <md-filled-button
                         @click=${handleAsync(() => this._handleSaveSchedule())}
-                        ?disabled=${this._scheduleBusy || !this._schedules || this._schedules.length === 0}
+                        ?disabled=${this._scheduleBusy || offline || !this._schedules || this._schedules.length === 0}
                     >
                         Save schedule
                     </md-filled-button>
@@ -542,11 +573,14 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
     ): TemplateResult {
         return html`
             <div class="target-row">
-                <input
-                    type="time"
-                    .value=${minutesToTimeInputValue(target.timeMinutes)}
-                    @change=${(e: Event) => this._handleTargetTimeChange(scheduleIndex, targetIndex, e)}
-                />
+                <label>
+                    Charged by
+                    <input
+                        type="time"
+                        .value=${minutesToTimeInputValue(target.timeMinutes)}
+                        @change=${(e: Event) => this._handleTargetTimeChange(scheduleIndex, targetIndex, e)}
+                    />
+                </label>
                 ${
                     soCSupported
                         ? html`<label>
@@ -559,17 +593,18 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                               />
                               % SoC
                           </label>`
-                        : html`<label>
-                              <input
-                                  type="number"
-                                  min="0"
-                                  step="0.1"
-                                  .value=${target.addedEnergyKWh !== undefined ? String(target.addedEnergyKWh) : ""}
-                                  @input=${(e: Event) => this._handleTargetEnergyChange(scheduleIndex, targetIndex, e)}
-                              />
-                              kWh
-                          </label>`
+                        : nothing
                 }
+                <label>
+                    <input
+                        type="number"
+                        min="0"
+                        step="0.1"
+                        .value=${target.addedEnergyKWh !== undefined ? String(target.addedEnergyKWh) : ""}
+                        @input=${(e: Event) => this._handleTargetEnergyChange(scheduleIndex, targetIndex, e)}
+                    />
+                    kWh
+                </label>
                 <md-text-button @click=${() => this._handleRemoveTarget(scheduleIndex, targetIndex)}
                     >Remove</md-text-button
                 >
@@ -577,9 +612,17 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         `;
     }
 
+    /** An emptied field is "not entered", which `Number("")` would otherwise read as 0. */
+    #optionalNumber(e: Event): number | undefined {
+        const raw = (e.target as HTMLInputElement).value.trim();
+        if (raw === "") return undefined;
+        const value = Number(raw);
+        return Number.isFinite(value) ? value : undefined;
+    }
+
     #parsePositiveNumber(e: Event, previous: number): number {
-        const value = Number((e.target as HTMLInputElement).value);
-        return Number.isFinite(value) && value >= 0 ? value : previous;
+        const value = this.#optionalNumber(e);
+        return value !== undefined && value >= 0 ? value : previous;
     }
 
     private async _handleDisable() {
@@ -591,7 +634,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         try {
             await disableEvse(this.client, node.node_id, endpoint);
         } catch (error) {
-            this.#reportFailure("Disable failed", error);
+            this.#reportFailure("Disable failed", error, undefined, busyGeneration);
         } finally {
             if (this.#busyGeneration === busyGeneration) this._busy = false;
         }
@@ -606,7 +649,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         try {
             await startDiagnostics(this.client, node.node_id, endpoint);
         } catch (error) {
-            this.#reportFailure("Start diagnostics failed", error, DIAGNOSTICS_OR_ALREADY_ENABLED_HINT);
+            this.#reportFailure("Start diagnostics failed", error, DIAGNOSTICS_OR_ALREADY_ENABLED_HINT, busyGeneration);
         } finally {
             if (this.#busyGeneration === busyGeneration) this._busy = false;
         }
@@ -639,7 +682,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 maximumChargeCurrentA: this._maxChargeCurrentA,
             });
         } catch (error) {
-            this.#reportFailure("Enable charging failed", error, DIAGNOSTICS_OR_ALREADY_ENABLED_HINT);
+            this.#reportFailure("Enable charging failed", error, DIAGNOSTICS_OR_ALREADY_ENABLED_HINT, busyGeneration);
         } finally {
             if (this.#busyGeneration === busyGeneration) this._busy = false;
         }
@@ -667,7 +710,12 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 maximumDischargeCurrentA: this._maxDischargeCurrentA,
             });
         } catch (error) {
-            this.#reportFailure("Enable discharging failed", error, DIAGNOSTICS_OR_ALREADY_ENABLED_HINT);
+            this.#reportFailure(
+                "Enable discharging failed",
+                error,
+                DIAGNOSTICS_OR_ALREADY_ENABLED_HINT,
+                busyGeneration,
+            );
         } finally {
             if (this.#busyGeneration === busyGeneration) this._busy = false;
         }
@@ -677,7 +725,11 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
      * `hint` adds a line of general guidance below the raw failure: Matter only sends the controller a
      * status code (e.g. "Failure(1)"), never the descriptive reason the device logged locally.
      */
-    #reportFailure(title: string, error: unknown, hint?: string) {
+    #reportFailure(title: string, error: unknown, hint?: string, busyGeneration?: number) {
+        if (busyGeneration !== undefined && this.#busyGeneration !== busyGeneration) {
+            console.error(`${title} (panel already moved on):`, error);
+            return;
+        }
         const text = hint
             ? html`<p>${errorText(error)}</p>
                   <p>${hint}</p>`
@@ -713,6 +765,27 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         }
         if (schedules.some(schedule => schedule.targets.length === 0)) {
             this._scheduleError = "Add at least one target time to every schedule.";
+            return;
+        }
+        // ChargingTargetSchedules: a weekday may appear in only one schedule.
+        const claimedDays = new Set<string>();
+        for (const schedule of schedules) {
+            for (const [day, selected] of Object.entries(schedule.days)) {
+                if (selected !== true) continue;
+                if (claimedDays.has(day)) {
+                    this._scheduleError = "Each day may be used by only one schedule.";
+                    return;
+                }
+                claimedDays.add(day);
+            }
+        }
+        // ChargingTargetStruct's O.a+ group: a target must carry a SoC or an added-energy goal.
+        if (
+            schedules.some(schedule =>
+                schedule.targets.some(target => target.targetSoC === undefined && target.addedEnergyKWh === undefined),
+            )
+        ) {
+            this._scheduleError = "Give every target a SoC or an added-energy goal.";
             return;
         }
         const node = this.node;
@@ -794,19 +867,21 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
     }
 
     private _handleTargetSoCChange(scheduleIndex: number, targetIndex: number, e: Event) {
-        const value = Number((e.target as HTMLInputElement).value);
-        const targetSoC = Number.isFinite(value) ? Math.min(100, Math.max(0, value)) : undefined;
+        const value = this.#optionalNumber(e);
+        const targetSoC = value === undefined ? undefined : Math.min(100, Math.max(0, value));
         this.#updateTarget(scheduleIndex, targetIndex, target => ({
             timeMinutes: target.timeMinutes,
             targetSoC,
+            addedEnergyKWh: targetSoC === undefined ? target.addedEnergyKWh : undefined,
         }));
     }
 
     private _handleTargetEnergyChange(scheduleIndex: number, targetIndex: number, e: Event) {
-        const value = Number((e.target as HTMLInputElement).value);
-        const addedEnergyKWh = Number.isFinite(value) && value >= 0 ? value : undefined;
+        const value = this.#optionalNumber(e);
+        const addedEnergyKWh = value === undefined || value < 0 ? undefined : value;
         this.#updateTarget(scheduleIndex, targetIndex, target => ({
             timeMinutes: target.timeMinutes,
+            targetSoC: addedEnergyKWh === undefined ? target.targetSoC : undefined,
             addedEnergyKWh,
         }));
     }
@@ -902,7 +977,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 margin-top: 10px;
                 padding: 10px;
                 border-radius: 8px;
-                background: var(--md-sys-color-surface-container-high);
+                background: var(--md-sys-color-surface-container-highest);
             }
             .schedule-days {
                 display: flex;

--- a/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
@@ -191,12 +191,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                     ${this._renderSession(info.session, info.v2xSupported)}
                     ${
                         info.v2xSupported
-                            ? this._renderV2x(
-                                  info.dischargingEnabledUntil,
-                                  info.maximumDischargeCurrentA,
-                                  info.diagnosticsActive,
-                                  offline,
-                              )
+                            ? this._renderV2x(info.dischargingEnabledUntil, info.maximumDischargeCurrentA, offline)
                             : nothing
                     }
                     ${
@@ -279,7 +274,6 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
     }
 
     private _renderChargingActions(info: EnergyEvseInfo, offline: boolean): TemplateResult {
-        const diagnosticsActive = info.diagnosticsActive;
         const canStartDiagnostics = info.canStartDiagnostics;
         return html`
             <h4>Charging control</h4>
@@ -349,8 +343,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 </label>
                 <md-filled-button
                     @click=${handleAsync(() => this._handleEnableCharging())}
-                    ?disabled=${this._busy || offline || diagnosticsActive}
-                    title=${diagnosticsActive ? "Not available while self-diagnostics are active — click Disable first" : nothing}
+                    ?disabled=${this._busy || offline}
                 >
                     Enable Charging
                 </md-filled-button>
@@ -362,7 +355,6 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
     private _renderV2x(
         dischargingEnabledUntil: number | null | undefined,
         maximumDischargeCurrentA: number | undefined,
-        diagnosticsActive: boolean,
         offline: boolean,
     ): TemplateResult {
         return html`
@@ -420,8 +412,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 </label>
                 <md-filled-button
                     @click=${handleAsync(() => this._handleEnableDischarging())}
-                    ?disabled=${this._busy || offline || diagnosticsActive}
-                    title=${diagnosticsActive ? "Not available while self-diagnostics are active — click Disable first" : nothing}
+                    ?disabled=${this._busy || offline}
                 >
                     Enable Discharging
                 </md-filled-button>

--- a/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
@@ -39,6 +39,8 @@ import {
 import { BaseClusterCommands } from "../base-cluster-commands.js";
 import { registerClusterCommands } from "../registry.js";
 
+const DEFAULT_MIN_CHARGE_CURRENT_A = 6;
+const DEFAULT_MAX_CURRENT_A = 16;
 const MAX_SCHEDULES = 7;
 const MAX_TARGETS_PER_SCHEDULE = 10;
 
@@ -70,12 +72,12 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
 
     @state() private _chargeNoExpiry = true;
     @state() private _chargeUntil = "";
-    @state() private _minChargeCurrentA = 6;
-    @state() private _maxChargeCurrentA = 16;
+    @state() private _minChargeCurrentA = DEFAULT_MIN_CHARGE_CURRENT_A;
+    @state() private _maxChargeCurrentA = DEFAULT_MAX_CURRENT_A;
 
     @state() private _dischargeNoExpiry = true;
     @state() private _dischargeUntil = "";
-    @state() private _maxDischargeCurrentA = 16;
+    @state() private _maxDischargeCurrentA = DEFAULT_MAX_CURRENT_A;
 
     @state() private _schedules?: EditableChargingSchedule[];
     @state() private _scheduleBusy = false;
@@ -104,9 +106,10 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         this._scheduleError = undefined;
 
         const info = energyEvseInfo(this.node.attributes, this.endpoint);
-        this._minChargeCurrentA = info.minimumChargeCurrentA ?? this._minChargeCurrentA;
-        this._maxChargeCurrentA = info.maximumChargeCurrentA ?? this._maxChargeCurrentA;
-        this._maxDischargeCurrentA = info.maximumDischargeCurrentA ?? this._maxDischargeCurrentA;
+        // Falling back to the current field values would prefill the new EVSE with the old one's limits.
+        this._minChargeCurrentA = info.minimumChargeCurrentA ?? DEFAULT_MIN_CHARGE_CURRENT_A;
+        this._maxChargeCurrentA = info.maximumChargeCurrentA ?? DEFAULT_MAX_CURRENT_A;
+        this._maxDischargeCurrentA = info.maximumDischargeCurrentA ?? DEFAULT_MAX_CURRENT_A;
     }
 
     override render() {

--- a/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
@@ -506,11 +506,13 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                           </p>`
                         : nothing
                 }
-                ${(this._schedules ?? []).map((schedule, index) => this._renderScheduleEditor(schedule, index, soCSupported))}
+                ${(this._schedules ?? []).map((schedule, index) =>
+                    this._renderScheduleEditor(schedule, index, soCSupported, this._scheduleBusy),
+                )}
                 <div class="command-row">
                     <md-text-button
                         @click=${() => this._handleAddSchedule()}
-                        ?disabled=${(this._schedules ?? []).length >= MAX_CHARGING_SCHEDULES}
+                        ?disabled=${this._scheduleBusy || (this._schedules ?? []).length >= MAX_CHARGING_SCHEDULES}
                     >
                         Add schedule
                     </md-text-button>
@@ -530,6 +532,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         schedule: EditableChargingSchedule,
         scheduleIndex: number,
         soCSupported: boolean,
+        disabled: boolean,
     ): TemplateResult {
         return html`
             <div class="schedule-card">
@@ -540,20 +543,23 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                                 type="button"
                                 class="day-chip ${schedule.days[key] ? "selected" : ""}"
                                 aria-pressed=${schedule.days[key] ? "true" : "false"}
+                                ?disabled=${disabled}
                                 @click=${() => this._handleToggleDay(scheduleIndex, key)}
                             >
                                 ${label}
                             </button>
                         `,
                     )}
-                    <md-text-button @click=${() => this._handleRemoveSchedule(scheduleIndex)}>Remove</md-text-button>
+                    <md-text-button ?disabled=${disabled} @click=${() => this._handleRemoveSchedule(scheduleIndex)}>
+                        Remove
+                    </md-text-button>
                 </div>
                 ${schedule.targets.map((target, targetIndex) =>
-                    this._renderTargetEditor(scheduleIndex, targetIndex, target, soCSupported),
+                    this._renderTargetEditor(scheduleIndex, targetIndex, target, soCSupported, disabled),
                 )}
                 <md-text-button
                     @click=${() => this._handleAddTarget(scheduleIndex)}
-                    ?disabled=${schedule.targets.length >= MAX_CHARGING_TARGETS_PER_SCHEDULE}
+                    ?disabled=${disabled || schedule.targets.length >= MAX_CHARGING_TARGETS_PER_SCHEDULE}
                 >
                     Add target
                 </md-text-button>
@@ -566,6 +572,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         targetIndex: number,
         target: EditableChargingTarget,
         soCSupported: boolean,
+        disabled: boolean,
     ): TemplateResult {
         return html`
             <div class="target-row">
@@ -574,6 +581,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                     <input
                         type="time"
                         .value=${minutesToTimeInputValue(target.timeMinutes)}
+                        ?disabled=${disabled}
                         @change=${(e: Event) => this._handleTargetTimeChange(scheduleIndex, targetIndex, e)}
                     />
                 </label>
@@ -585,6 +593,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                                   min="0"
                                   max="100"
                                   .value=${target.targetSoC !== undefined ? String(target.targetSoC) : ""}
+                                  ?disabled=${disabled}
                                   @input=${(e: Event) => this._handleTargetSoCChange(scheduleIndex, targetIndex, e)}
                               />
                               % SoC
@@ -597,13 +606,17 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                         min="0"
                         step="0.1"
                         .value=${target.addedEnergyKWh !== undefined ? String(target.addedEnergyKWh) : ""}
+                        ?disabled=${disabled}
                         @input=${(e: Event) => this._handleTargetEnergyChange(scheduleIndex, targetIndex, e)}
                     />
                     kWh
                 </label>
-                <md-text-button @click=${() => this._handleRemoveTarget(scheduleIndex, targetIndex)}
-                    >Remove</md-text-button
+                <md-text-button
+                    ?disabled=${disabled}
+                    @click=${() => this._handleRemoveTarget(scheduleIndex, targetIndex)}
                 >
+                    Remove
+                </md-text-button>
             </div>
         `;
     }
@@ -983,6 +996,10 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 border-color: var(--md-sys-color-primary);
                 color: var(--md-sys-color-on-primary);
             }
+            .day-chip:disabled {
+                opacity: 0.5;
+                cursor: not-allowed;
+            }
             .target-row {
                 display: flex;
                 align-items: center;
@@ -998,6 +1015,9 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 background: var(--md-sys-color-surface);
                 color: var(--md-sys-color-on-surface);
                 width: 90px;
+            }
+            .target-row input:disabled {
+                opacity: 0.5;
             }
             .hint {
                 color: var(--text-color, rgba(0, 0, 0, 0.6));

--- a/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
@@ -590,7 +590,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                     Charged by
                     <input
                         type="time"
-                        .value=${minutesToTimeInputValue(target.timeMinutes)}
+                        .value=${target.timeMinutes !== undefined ? minutesToTimeInputValue(target.timeMinutes) : ""}
                         ?disabled=${disabled}
                         @change=${(e: Event) => this._handleTargetTimeChange(scheduleIndex, targetIndex, e)}
                     />
@@ -866,8 +866,8 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
     }
 
     private _handleTargetTimeChange(scheduleIndex: number, targetIndex: number, e: Event) {
+        // Keeping the previous time on a cleared field would leave a blank control that still saves.
         const minutes = timeInputValueToMinutes((e.target as HTMLInputElement).value);
-        if (minutes === undefined) return;
         this.#updateTarget(scheduleIndex, targetIndex, target => ({ ...target, timeMinutes: minutes }));
     }
 

--- a/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
@@ -48,8 +48,8 @@ const DEFAULT_MIN_CHARGE_CURRENT_A = 6;
 const DEFAULT_MAX_CURRENT_A = 16;
 
 /** Matter only reports a status code (e.g. "Failure(1)"), not the device's reason, so name the likely cause. */
-const DIAGNOSTICS_OR_ALREADY_ENABLED_HINT =
-    "If the EVSE is in self-diagnostics mode, or already enabled for charging/discharging, click Disable first and try again.";
+const COMMAND_REFUSED_HINT =
+    "The EVSE refuses these commands while it reports a fault or is running self-diagnostics. A fault has to clear and diagnostics finish on the device itself; neither can be ended from here.";
 
 function minutesToTimeInputValue(minutes: number): string {
     const hours = Math.floor(minutes / 60) % 24;
@@ -197,7 +197,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                             ? this._renderV2x(
                                   info.dischargingEnabledUntil,
                                   info.maximumDischargeCurrentA,
-                                  info.diagnosticsActive,
+                                  info.supplyCommandsBlockedReason,
                                   offline,
                               )
                             : nothing
@@ -282,14 +282,15 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
     }
 
     private _renderChargingActions(info: EnergyEvseInfo, offline: boolean): TemplateResult {
-        const diagnosticsActive = info.diagnosticsActive;
+        const blocked = info.supplyCommandsBlockedReason;
         const canStartDiagnostics = info.canStartDiagnostics;
         return html`
             <h4>Charging control</h4>
             <div class="command-row">
                 <md-outlined-button
                     @click=${handleAsync(() => this._handleDisable())}
-                    ?disabled=${this._busy || offline}
+                    ?disabled=${this._busy || offline || blocked !== undefined}
+                    title=${blocked ?? nothing}
                 >
                     Disable
                 </md-outlined-button>
@@ -352,8 +353,8 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 </label>
                 <md-filled-button
                     @click=${handleAsync(() => this._handleEnableCharging())}
-                    ?disabled=${this._busy || offline || diagnosticsActive}
-                    title=${diagnosticsActive ? "Not available while self-diagnostics are active — click Disable first" : nothing}
+                    ?disabled=${this._busy || offline || blocked !== undefined}
+                    title=${blocked ?? nothing}
                 >
                     Enable Charging
                 </md-filled-button>
@@ -365,7 +366,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
     private _renderV2x(
         dischargingEnabledUntil: number | null | undefined,
         maximumDischargeCurrentA: number | undefined,
-        diagnosticsActive: boolean,
+        blocked: string | undefined,
         offline: boolean,
     ): TemplateResult {
         return html`
@@ -422,8 +423,8 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 </label>
                 <md-filled-button
                     @click=${handleAsync(() => this._handleEnableDischarging())}
-                    ?disabled=${this._busy || offline || diagnosticsActive}
-                    title=${diagnosticsActive ? "Not available while self-diagnostics are active — click Disable first" : nothing}
+                    ?disabled=${this._busy || offline || blocked !== undefined}
+                    title=${blocked ?? nothing}
                 >
                     Enable Discharging
                 </md-filled-button>
@@ -670,7 +671,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         try {
             await startDiagnostics(this.client, node.node_id, endpoint);
         } catch (error) {
-            this.#reportFailure("Start diagnostics failed", error, DIAGNOSTICS_OR_ALREADY_ENABLED_HINT, busyGeneration);
+            this.#reportFailure("Start diagnostics failed", error, COMMAND_REFUSED_HINT, busyGeneration);
         } finally {
             if (this.#busyGeneration === busyGeneration) this._busy = false;
         }
@@ -709,7 +710,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 maximumChargeCurrentA,
             });
         } catch (error) {
-            this.#reportFailure("Enable charging failed", error, DIAGNOSTICS_OR_ALREADY_ENABLED_HINT, busyGeneration);
+            this.#reportFailure("Enable charging failed", error, COMMAND_REFUSED_HINT, busyGeneration);
         } finally {
             if (this.#busyGeneration === busyGeneration) this._busy = false;
         }
@@ -742,12 +743,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 maximumDischargeCurrentA,
             });
         } catch (error) {
-            this.#reportFailure(
-                "Enable discharging failed",
-                error,
-                DIAGNOSTICS_OR_ALREADY_ENABLED_HINT,
-                busyGeneration,
-            );
+            this.#reportFailure("Enable discharging failed", error, COMMAND_REFUSED_HINT, busyGeneration);
         } finally {
             if (this.#busyGeneration === busyGeneration) this._busy = false;
         }

--- a/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
@@ -29,6 +29,11 @@ import {
     type SessionInfo,
 } from "../../../util/energy-evse.js";
 import type { EnergyEvseInfo } from "../../../util/energy-evse.js";
+import {
+    chargingScheduleError,
+    MAX_CHARGING_SCHEDULES,
+    MAX_CHARGING_TARGETS_PER_SCHEDULE,
+} from "../../../util/energy-evse.js";
 import { errorText } from "../../../util/error-text.js";
 import {
     formatEpochTime,
@@ -41,8 +46,6 @@ import { registerClusterCommands } from "../registry.js";
 
 const DEFAULT_MIN_CHARGE_CURRENT_A = 6;
 const DEFAULT_MAX_CURRENT_A = 16;
-const MAX_SCHEDULES = 7;
-const MAX_TARGETS_PER_SCHEDULE = 10;
 
 /** Matter only reports a status code (e.g. "Failure(1)"), not the device's reason, so name the likely cause. */
 const DIAGNOSTICS_OR_ALREADY_ENABLED_HINT =
@@ -72,12 +75,12 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
 
     @state() private _chargeNoExpiry = true;
     @state() private _chargeUntil = "";
-    @state() private _minChargeCurrentA = DEFAULT_MIN_CHARGE_CURRENT_A;
-    @state() private _maxChargeCurrentA = DEFAULT_MAX_CURRENT_A;
+    @state() private _minChargeCurrentA = String(DEFAULT_MIN_CHARGE_CURRENT_A);
+    @state() private _maxChargeCurrentA = String(DEFAULT_MAX_CURRENT_A);
 
     @state() private _dischargeNoExpiry = true;
     @state() private _dischargeUntil = "";
-    @state() private _maxDischargeCurrentA = DEFAULT_MAX_CURRENT_A;
+    @state() private _maxDischargeCurrentA = String(DEFAULT_MAX_CURRENT_A);
 
     @state() private _schedules?: EditableChargingSchedule[];
     @state() private _scheduleBusy = false;
@@ -107,9 +110,9 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
 
         const info = energyEvseInfo(this.node.attributes, this.endpoint);
         // Falling back to the current field values would prefill the new EVSE with the old one's limits.
-        this._minChargeCurrentA = info.minimumChargeCurrentA ?? DEFAULT_MIN_CHARGE_CURRENT_A;
-        this._maxChargeCurrentA = info.maximumChargeCurrentA ?? DEFAULT_MAX_CURRENT_A;
-        this._maxDischargeCurrentA = info.maximumDischargeCurrentA ?? DEFAULT_MAX_CURRENT_A;
+        this._minChargeCurrentA = String(info.minimumChargeCurrentA ?? DEFAULT_MIN_CHARGE_CURRENT_A);
+        this._maxChargeCurrentA = String(info.maximumChargeCurrentA ?? DEFAULT_MAX_CURRENT_A);
+        this._maxDischargeCurrentA = String(info.maximumDischargeCurrentA ?? DEFAULT_MAX_CURRENT_A);
     }
 
     override render() {
@@ -325,8 +328,8 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                         type="number"
                         min="0"
                         step="0.1"
-                        .value=${String(this._minChargeCurrentA)}
-                        @input=${(e: Event) => (this._minChargeCurrentA = this.#parsePositiveNumber(e, this._minChargeCurrentA))}
+                        .value=${this._minChargeCurrentA}
+                        @input=${(e: Event) => (this._minChargeCurrentA = (e.target as HTMLInputElement).value)}
                     />
                     A
                 </label>
@@ -336,8 +339,8 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                         type="number"
                         min="0"
                         step="0.1"
-                        .value=${String(this._maxChargeCurrentA)}
-                        @input=${(e: Event) => (this._maxChargeCurrentA = this.#parsePositiveNumber(e, this._maxChargeCurrentA))}
+                        .value=${this._maxChargeCurrentA}
+                        @input=${(e: Event) => (this._maxChargeCurrentA = (e.target as HTMLInputElement).value)}
                     />
                     A
                 </label>
@@ -404,9 +407,8 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                         type="number"
                         min="0"
                         step="0.1"
-                        .value=${String(this._maxDischargeCurrentA)}
-                        @input=${(e: Event) =>
-                            (this._maxDischargeCurrentA = this.#parsePositiveNumber(e, this._maxDischargeCurrentA))}
+                        .value=${this._maxDischargeCurrentA}
+                        @input=${(e: Event) => (this._maxDischargeCurrentA = (e.target as HTMLInputElement).value)}
                     />
                     A
                 </label>
@@ -508,7 +510,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 <div class="command-row">
                     <md-text-button
                         @click=${() => this._handleAddSchedule()}
-                        ?disabled=${(this._schedules ?? []).length >= MAX_SCHEDULES}
+                        ?disabled=${(this._schedules ?? []).length >= MAX_CHARGING_SCHEDULES}
                     >
                         Add schedule
                     </md-text-button>
@@ -551,7 +553,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 )}
                 <md-text-button
                     @click=${() => this._handleAddTarget(scheduleIndex)}
-                    ?disabled=${schedule.targets.length >= MAX_TARGETS_PER_SCHEDULE}
+                    ?disabled=${schedule.targets.length >= MAX_CHARGING_TARGETS_PER_SCHEDULE}
                 >
                     Add target
                 </md-text-button>
@@ -614,9 +616,12 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         return Number.isFinite(value) ? value : undefined;
     }
 
-    #parsePositiveNumber(e: Event, previous: number): number {
-        const value = this.#optionalNumber(e);
-        return value !== undefined && value >= 0 ? value : previous;
+    /** The amperage a current field would send, or null while it holds no submittable value. */
+    #currentAmps(raw: string): number | null {
+        const trimmed = raw.trim();
+        if (trimmed === "") return null;
+        const amps = Number(trimmed);
+        return Number.isFinite(amps) && amps >= 0 ? amps : null;
     }
 
     private async _handleDisable() {
@@ -661,7 +666,13 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
             }
             chargingEnabledUntil = parsed;
         }
-        if (this._minChargeCurrentA > this._maxChargeCurrentA) {
+        const minimumChargeCurrentA = this.#currentAmps(this._minChargeCurrentA);
+        const maximumChargeCurrentA = this.#currentAmps(this._maxChargeCurrentA);
+        if (minimumChargeCurrentA === null || maximumChargeCurrentA === null) {
+            this._formError = "Enter a charging current of 0 A or more.";
+            return;
+        }
+        if (minimumChargeCurrentA > maximumChargeCurrentA) {
             this._formError = "The minimum current cannot exceed the maximum current.";
             return;
         }
@@ -672,8 +683,8 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         try {
             await enableCharging(this.client, node.node_id, endpoint, {
                 chargingEnabledUntil,
-                minimumChargeCurrentA: this._minChargeCurrentA,
-                maximumChargeCurrentA: this._maxChargeCurrentA,
+                minimumChargeCurrentA,
+                maximumChargeCurrentA,
             });
         } catch (error) {
             this.#reportFailure("Enable charging failed", error, DIAGNOSTICS_OR_ALREADY_ENABLED_HINT, busyGeneration);
@@ -694,6 +705,11 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
             }
             dischargingEnabledUntil = parsed;
         }
+        const maximumDischargeCurrentA = this.#currentAmps(this._maxDischargeCurrentA);
+        if (maximumDischargeCurrentA === null) {
+            this._formError = "Enter a discharging current of 0 A or more.";
+            return;
+        }
         const node = this.node;
         const endpoint = this.endpoint;
         const busyGeneration = this.#busyGeneration;
@@ -701,7 +717,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
         try {
             await enableDischarging(this.client, node.node_id, endpoint, {
                 dischargingEnabledUntil,
-                maximumDischargeCurrentA: this._maxDischargeCurrentA,
+                maximumDischargeCurrentA,
             });
         } catch (error) {
             this.#reportFailure(
@@ -753,33 +769,10 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
     private async _handleSaveSchedule() {
         const schedules = this._schedules;
         if (!schedules || schedules.length === 0 || this._scheduleBusy) return;
-        if (schedules.some(schedule => Object.values(schedule.days).every(selected => selected !== true))) {
-            this._scheduleError = "Select at least one day for every schedule.";
-            return;
-        }
-        if (schedules.some(schedule => schedule.targets.length === 0)) {
-            this._scheduleError = "Add at least one target time to every schedule.";
-            return;
-        }
-        // ChargingTargetSchedules: a weekday may appear in only one schedule.
-        const claimedDays = new Set<string>();
-        for (const schedule of schedules) {
-            for (const [day, selected] of Object.entries(schedule.days)) {
-                if (selected !== true) continue;
-                if (claimedDays.has(day)) {
-                    this._scheduleError = "Each day may be used by only one schedule.";
-                    return;
-                }
-                claimedDays.add(day);
-            }
-        }
-        // ChargingTargetStruct's O.a+ group: a target must carry a SoC or an added-energy goal.
-        if (
-            schedules.some(schedule =>
-                schedule.targets.some(target => target.targetSoC === undefined && target.addedEnergyKWh === undefined),
-            )
-        ) {
-            this._scheduleError = "Give every target a SoC or an added-energy goal.";
+        const soCSupported = energyEvseInfo(this.node.attributes, this.endpoint).soCReportingSupported;
+        const error = chargingScheduleError(schedules, soCSupported);
+        if (error !== null) {
+            this._scheduleError = error;
             return;
         }
         const node = this.node;
@@ -823,7 +816,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
 
     private _handleAddSchedule() {
         const schedules = this._schedules ?? [];
-        if (schedules.length >= MAX_SCHEDULES) return;
+        if (schedules.length >= MAX_CHARGING_SCHEDULES) return;
         this._schedules = [...schedules, { days: {}, targets: [{ timeMinutes: 360 }] }];
     }
 
@@ -841,7 +834,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
 
     private _handleAddTarget(scheduleIndex: number) {
         this.#updateSchedule(scheduleIndex, schedule =>
-            schedule.targets.length >= MAX_TARGETS_PER_SCHEDULE
+            schedule.targets.length >= MAX_CHARGING_TARGETS_PER_SCHEDULE
                 ? schedule
                 : { ...schedule, targets: [...schedule.targets, { timeMinutes: 360 }] },
         );
@@ -862,21 +855,17 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
 
     private _handleTargetSoCChange(scheduleIndex: number, targetIndex: number, e: Event) {
         const value = this.#optionalNumber(e);
-        const targetSoC = value === undefined ? undefined : Math.min(100, Math.max(0, value));
         this.#updateTarget(scheduleIndex, targetIndex, target => ({
-            timeMinutes: target.timeMinutes,
-            targetSoC,
-            addedEnergyKWh: targetSoC === undefined ? target.addedEnergyKWh : undefined,
+            ...target,
+            targetSoC: value === undefined ? undefined : Math.min(100, Math.max(0, value)),
         }));
     }
 
     private _handleTargetEnergyChange(scheduleIndex: number, targetIndex: number, e: Event) {
         const value = this.#optionalNumber(e);
-        const addedEnergyKWh = value === undefined || value < 0 ? undefined : value;
         this.#updateTarget(scheduleIndex, targetIndex, target => ({
-            timeMinutes: target.timeMinutes,
-            targetSoC: addedEnergyKWh === undefined ? target.targetSoC : undefined,
-            addedEnergyKWh,
+            ...target,
+            addedEnergyKWh: value === undefined || value < 0 ? undefined : value,
         }));
     }
 

--- a/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/energy-evse-commands.ts
@@ -194,7 +194,12 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                     ${this._renderSession(info.session, info.v2xSupported)}
                     ${
                         info.v2xSupported
-                            ? this._renderV2x(info.dischargingEnabledUntil, info.maximumDischargeCurrentA, offline)
+                            ? this._renderV2x(
+                                  info.dischargingEnabledUntil,
+                                  info.maximumDischargeCurrentA,
+                                  info.diagnosticsActive,
+                                  offline,
+                              )
                             : nothing
                     }
                     ${
@@ -277,6 +282,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
     }
 
     private _renderChargingActions(info: EnergyEvseInfo, offline: boolean): TemplateResult {
+        const diagnosticsActive = info.diagnosticsActive;
         const canStartDiagnostics = info.canStartDiagnostics;
         return html`
             <h4>Charging control</h4>
@@ -346,7 +352,8 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 </label>
                 <md-filled-button
                     @click=${handleAsync(() => this._handleEnableCharging())}
-                    ?disabled=${this._busy || offline}
+                    ?disabled=${this._busy || offline || diagnosticsActive}
+                    title=${diagnosticsActive ? "Not available while self-diagnostics are active — click Disable first" : nothing}
                 >
                     Enable Charging
                 </md-filled-button>
@@ -358,6 +365,7 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
     private _renderV2x(
         dischargingEnabledUntil: number | null | undefined,
         maximumDischargeCurrentA: number | undefined,
+        diagnosticsActive: boolean,
         offline: boolean,
     ): TemplateResult {
         return html`
@@ -414,7 +422,8 @@ export class EnergyEvseClusterCommands extends BaseClusterCommands {
                 </label>
                 <md-filled-button
                     @click=${handleAsync(() => this._handleEnableDischarging())}
-                    ?disabled=${this._busy || offline}
+                    ?disabled=${this._busy || offline || diagnosticsActive}
+                    title=${diagnosticsActive ? "Not available while self-diagnostics are active — click Disable first" : nothing}
                 >
                     Enable Discharging
                 </md-filled-button>

--- a/packages/dashboard/src/pages/cluster-commands/index.ts
+++ b/packages/dashboard/src/pages/cluster-commands/index.ts
@@ -30,6 +30,7 @@ import "./clusters/chime-commands.js";
 import "./clusters/closure-control-commands.js";
 import "./clusters/commodity-tariff-commands.js";
 import "./clusters/door-lock-commands.js";
+import "./clusters/energy-evse-commands.js";
 import "./clusters/icd-management-commands.js";
 import "./clusters/level-control-commands.js";
 import "./clusters/meter-identification-commands.js";

--- a/packages/dashboard/src/util/energy-evse.ts
+++ b/packages/dashboard/src/util/energy-evse.ts
@@ -1,0 +1,210 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { toNumber, toText } from "./attribute-shapes.js";
+
+export const ENERGY_EVSE_CLUSTER_ID = 153; // 0x99
+
+const ATTR_STATE = 0x00;
+const ATTR_SUPPLY_STATE = 0x01;
+const ATTR_FAULT_STATE = 0x02;
+const ATTR_CHARGING_ENABLED_UNTIL = 0x03;
+const ATTR_DISCHARGING_ENABLED_UNTIL = 0x04;
+const ATTR_CIRCUIT_CAPACITY = 0x05;
+const ATTR_MINIMUM_CHARGE_CURRENT = 0x06;
+const ATTR_MAXIMUM_CHARGE_CURRENT = 0x07;
+const ATTR_MAXIMUM_DISCHARGE_CURRENT = 0x08;
+const ATTR_USER_MAXIMUM_CHARGE_CURRENT = 0x09;
+const ATTR_RANDOMIZATION_DELAY_WINDOW = 0x0a;
+const ATTR_NEXT_CHARGE_START_TIME = 0x23;
+const ATTR_NEXT_CHARGE_TARGET_TIME = 0x24;
+const ATTR_NEXT_CHARGE_REQUIRED_ENERGY = 0x25;
+const ATTR_NEXT_CHARGE_TARGET_SOC = 0x26;
+const ATTR_APPROXIMATE_EV_EFFICIENCY = 0x27;
+const ATTR_STATE_OF_CHARGE = 0x30;
+const ATTR_BATTERY_CAPACITY = 0x31;
+const ATTR_VEHICLE_ID = 0x32;
+const ATTR_SESSION_ID = 0x40;
+const ATTR_SESSION_DURATION = 0x41;
+const ATTR_SESSION_ENERGY_CHARGED = 0x42;
+const ATTR_SESSION_ENERGY_DISCHARGED = 0x43;
+const ATTR_FEATURE_MAP = 0xfffc;
+
+/** EnergyEvse FeatureMap bits per Matter 1.6 §9.3.4. */
+const FEATURE_BIT_CHARGING_PREFERENCES = 0b1;
+const FEATURE_BIT_SOC_REPORTING = 0b10;
+const FEATURE_BIT_PLUG_AND_CHARGE = 0b100;
+const FEATURE_BIT_V2X = 0b10000;
+
+const STATE_NAMES: Record<number, string> = {
+    0: "Not plugged in",
+    1: "Plugged in, no demand",
+    2: "Plugged in, demand (not allowed)",
+    3: "Plugged in, charging",
+    4: "Plugged in, discharging",
+    5: "Session ending",
+    6: "Fault",
+};
+
+const SUPPLY_STATE_NAMES: Record<number, string> = {
+    0: "Disabled",
+    1: "Charging enabled",
+    2: "Discharging enabled",
+    3: "Disabled (error)",
+    4: "Disabled (diagnostics)",
+    5: "Charging and discharging enabled",
+};
+
+const FAULT_STATE_NAMES: Record<number, string> = {
+    0: "No error",
+    1: "Meter failure",
+    2: "Over voltage",
+    3: "Under voltage",
+    4: "Over current",
+    5: "Contact wet failure",
+    6: "Contact dry failure",
+    7: "Ground fault",
+    8: "Power loss",
+    9: "Power quality",
+    10: "Pilot short circuit",
+    11: "Emergency stop",
+    12: "EV disconnected",
+    13: "Wrong power supply",
+    14: "Live/neutral swap",
+    15: "Over temperature",
+    255: "Other",
+};
+
+export interface SessionInfo {
+    id: number;
+    durationS?: number;
+    energyChargedKWh?: number;
+    energyDischargedKWh?: number;
+}
+
+export interface EnergyEvseInfo {
+    supported: boolean;
+    state?: string;
+    supplyState?: string;
+    faultState?: string;
+    faultActive: boolean;
+    /** undefined: not reported. null: no expiry, i.e. charging stays enabled until disabled explicitly. */
+    chargingEnabledUntil?: number | null;
+    circuitCapacityA?: number;
+    minimumChargeCurrentA?: number;
+    maximumChargeCurrentA?: number;
+    userMaximumChargeCurrentA?: number;
+    randomizationDelayWindowS?: number;
+    /** undefined when the EV has never been plugged in (SessionID is still null). */
+    session?: SessionInfo;
+
+    v2xSupported: boolean;
+    dischargingEnabledUntil?: number | null;
+    maximumDischargeCurrentA?: number;
+
+    chargingPreferencesSupported: boolean;
+    nextChargeStartTime?: number | null;
+    nextChargeTargetTime?: number | null;
+    nextChargeRequiredEnergyKWh?: number | null;
+    nextChargeTargetSoC?: number | null;
+    approximateEvEfficiencyKmPerKWh?: number | null;
+
+    soCReportingSupported: boolean;
+    stateOfCharge?: number | null;
+    batteryCapacityKWh?: number | null;
+
+    plugAndChargeSupported: boolean;
+    vehicleId?: string | null;
+}
+
+function attr(attributes: Record<string, unknown>, endpoint: number, attributeId: number): unknown {
+    return attributes[`${endpoint}/${ENERGY_EVSE_CLUSTER_ID}/${attributeId}`];
+}
+
+function enumName(value: unknown, names: Record<number, string>): string | undefined {
+    const raw = toNumber(value);
+    if (raw === undefined) return undefined;
+    return names[raw] ?? `Unknown (${raw})`;
+}
+
+/** Distinguishes an attribute that hasn't been reported (undefined) from its explicit null value. */
+function nullableNumber(value: unknown): number | null | undefined {
+    if (value === null) return null;
+    if (value === undefined) return undefined;
+    return toNumber(value);
+}
+
+function nullableText(value: unknown): string | null | undefined {
+    if (value === null) return null;
+    if (value === undefined) return undefined;
+    return toText(value) ?? null;
+}
+
+/** Scales a nullable reading (e.g. energy-mWh) to its display unit, passing null/undefined through unchanged. */
+function scaleNullable(value: number | null | undefined, factor: number): number | null | undefined {
+    return typeof value === "number" ? value / factor : value;
+}
+
+function toAmps(valueMa: number | undefined): number | undefined {
+    return valueMa === undefined ? undefined : valueMa / 1000;
+}
+
+function decodeSession(attributes: Record<string, unknown>, endpoint: number): SessionInfo | undefined {
+    const id = nullableNumber(attr(attributes, endpoint, ATTR_SESSION_ID));
+    if (id === undefined || id === null) return undefined;
+    return {
+        id,
+        durationS: toNumber(attr(attributes, endpoint, ATTR_SESSION_DURATION)),
+        energyChargedKWh:
+            scaleNullable(toNumber(attr(attributes, endpoint, ATTR_SESSION_ENERGY_CHARGED)), 1_000_000) ?? undefined,
+        energyDischargedKWh:
+            scaleNullable(toNumber(attr(attributes, endpoint, ATTR_SESSION_ENERGY_DISCHARGED)), 1_000_000) ?? undefined,
+    };
+}
+
+export function energyEvseInfo(attributes: Record<string, unknown>, endpoint: number): EnergyEvseInfo {
+    const featureMap = toNumber(attr(attributes, endpoint, ATTR_FEATURE_MAP));
+    const faultStateRaw = toNumber(attr(attributes, endpoint, ATTR_FAULT_STATE));
+
+    return {
+        supported: featureMap !== undefined,
+        state: enumName(attr(attributes, endpoint, ATTR_STATE), STATE_NAMES),
+        supplyState: enumName(attr(attributes, endpoint, ATTR_SUPPLY_STATE), SUPPLY_STATE_NAMES),
+        faultState: enumName(faultStateRaw, FAULT_STATE_NAMES),
+        faultActive: faultStateRaw !== undefined && faultStateRaw !== 0,
+        chargingEnabledUntil: nullableNumber(attr(attributes, endpoint, ATTR_CHARGING_ENABLED_UNTIL)),
+        circuitCapacityA: toAmps(toNumber(attr(attributes, endpoint, ATTR_CIRCUIT_CAPACITY))),
+        minimumChargeCurrentA: toAmps(toNumber(attr(attributes, endpoint, ATTR_MINIMUM_CHARGE_CURRENT))),
+        maximumChargeCurrentA: toAmps(toNumber(attr(attributes, endpoint, ATTR_MAXIMUM_CHARGE_CURRENT))),
+        userMaximumChargeCurrentA: toAmps(toNumber(attr(attributes, endpoint, ATTR_USER_MAXIMUM_CHARGE_CURRENT))),
+        randomizationDelayWindowS: toNumber(attr(attributes, endpoint, ATTR_RANDOMIZATION_DELAY_WINDOW)),
+        session: decodeSession(attributes, endpoint),
+
+        v2xSupported: ((featureMap ?? 0) & FEATURE_BIT_V2X) !== 0,
+        dischargingEnabledUntil: nullableNumber(attr(attributes, endpoint, ATTR_DISCHARGING_ENABLED_UNTIL)),
+        maximumDischargeCurrentA: toAmps(toNumber(attr(attributes, endpoint, ATTR_MAXIMUM_DISCHARGE_CURRENT))),
+
+        chargingPreferencesSupported: ((featureMap ?? 0) & FEATURE_BIT_CHARGING_PREFERENCES) !== 0,
+        nextChargeStartTime: nullableNumber(attr(attributes, endpoint, ATTR_NEXT_CHARGE_START_TIME)),
+        nextChargeTargetTime: nullableNumber(attr(attributes, endpoint, ATTR_NEXT_CHARGE_TARGET_TIME)),
+        nextChargeRequiredEnergyKWh: scaleNullable(
+            nullableNumber(attr(attributes, endpoint, ATTR_NEXT_CHARGE_REQUIRED_ENERGY)),
+            1_000_000,
+        ),
+        nextChargeTargetSoC: nullableNumber(attr(attributes, endpoint, ATTR_NEXT_CHARGE_TARGET_SOC)),
+        approximateEvEfficiencyKmPerKWh: scaleNullable(
+            nullableNumber(attr(attributes, endpoint, ATTR_APPROXIMATE_EV_EFFICIENCY)),
+            1000,
+        ),
+
+        soCReportingSupported: ((featureMap ?? 0) & FEATURE_BIT_SOC_REPORTING) !== 0,
+        stateOfCharge: nullableNumber(attr(attributes, endpoint, ATTR_STATE_OF_CHARGE)),
+        batteryCapacityKWh: scaleNullable(nullableNumber(attr(attributes, endpoint, ATTR_BATTERY_CAPACITY)), 1_000_000),
+
+        plugAndChargeSupported: ((featureMap ?? 0) & FEATURE_BIT_PLUG_AND_CHARGE) !== 0,
+        vehicleId: nullableText(attr(attributes, endpoint, ATTR_VEHICLE_ID)),
+    };
+}

--- a/packages/dashboard/src/util/energy-evse.ts
+++ b/packages/dashboard/src/util/energy-evse.ts
@@ -40,6 +40,10 @@ const FEATURE_BIT_SOC_REPORTING = 0b10;
 const FEATURE_BIT_PLUG_AND_CHARGE = 0b100;
 const FEATURE_BIT_V2X = 0b10000;
 
+const SUPPLY_STATE_DISABLED = 0;
+/** Self-diagnostics mode: EnableCharging/EnableDischarging are rejected until Disable clears it. */
+const SUPPLY_STATE_DISABLED_DIAGNOSTICS = 4;
+
 const STATE_NAMES: Record<number, string> = {
     0: "Not plugged in",
     1: "Plugged in, no demand",
@@ -90,6 +94,10 @@ export interface EnergyEvseInfo {
     supported: boolean;
     state?: string;
     supplyState?: string;
+    /** SupplyState is DisabledDiagnostics: EnableCharging/EnableDischarging are rejected until Disable clears it. */
+    diagnosticsActive: boolean;
+    /** Whether StartDiagnostics is expected to succeed right now (the device only accepts it while fully disabled). */
+    canStartDiagnostics: boolean;
     faultState?: string;
     faultActive: boolean;
     /** undefined: not reported. null: no expiry, i.e. charging stays enabled until disabled explicitly. */
@@ -169,11 +177,14 @@ function decodeSession(attributes: Record<string, unknown>, endpoint: number): S
 export function energyEvseInfo(attributes: Record<string, unknown>, endpoint: number): EnergyEvseInfo {
     const featureMap = toNumber(attr(attributes, endpoint, ATTR_FEATURE_MAP));
     const faultStateRaw = toNumber(attr(attributes, endpoint, ATTR_FAULT_STATE));
+    const supplyStateRaw = toNumber(attr(attributes, endpoint, ATTR_SUPPLY_STATE));
 
     return {
         supported: featureMap !== undefined,
         state: enumName(attr(attributes, endpoint, ATTR_STATE), STATE_NAMES),
-        supplyState: enumName(attr(attributes, endpoint, ATTR_SUPPLY_STATE), SUPPLY_STATE_NAMES),
+        supplyState: enumName(supplyStateRaw, SUPPLY_STATE_NAMES),
+        diagnosticsActive: supplyStateRaw === SUPPLY_STATE_DISABLED_DIAGNOSTICS,
+        canStartDiagnostics: supplyStateRaw === undefined || supplyStateRaw === SUPPLY_STATE_DISABLED,
         faultState: enumName(faultStateRaw, FAULT_STATE_NAMES),
         faultActive: faultStateRaw !== undefined && faultStateRaw !== 0,
         chargingEnabledUntil: nullableNumber(attr(attributes, endpoint, ATTR_CHARGING_ENABLED_UNTIL)),

--- a/packages/dashboard/src/util/energy-evse.ts
+++ b/packages/dashboard/src/util/energy-evse.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { toNumber, toText } from "./attribute-shapes.js";
+import type { MatterClient } from "@matter-server/ws-client";
+import { asObject, pickArray, pickBoolean, pickNumber, toNumber, toText } from "./attribute-shapes.js";
 
 export const ENERGY_EVSE_CLUSTER_ID = 153; // 0x99
 
@@ -207,4 +208,152 @@ export function energyEvseInfo(attributes: Record<string, unknown>, endpoint: nu
         plugAndChargeSupported: ((featureMap ?? 0) & FEATURE_BIT_PLUG_AND_CHARGE) !== 0,
         vehicleId: nullableText(attr(attributes, endpoint, ATTR_VEHICLE_ID)),
     };
+}
+
+export async function disableEvse(client: MatterClient, nodeId: number | bigint, endpoint: number): Promise<void> {
+    await client.deviceCommand(nodeId, endpoint, ENERGY_EVSE_CLUSTER_ID, "Disable");
+}
+
+export interface EnableChargingParams {
+    /** null: no expiry. */
+    chargingEnabledUntil: number | null;
+    minimumChargeCurrentA: number;
+    maximumChargeCurrentA: number;
+}
+
+export async function enableCharging(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    params: EnableChargingParams,
+): Promise<void> {
+    await client.deviceCommand(nodeId, endpoint, ENERGY_EVSE_CLUSTER_ID, "EnableCharging", {
+        chargingEnabledUntil: params.chargingEnabledUntil,
+        minimumChargeCurrent: Math.round(params.minimumChargeCurrentA * 1000),
+        maximumChargeCurrent: Math.round(params.maximumChargeCurrentA * 1000),
+    });
+}
+
+export async function startDiagnostics(client: MatterClient, nodeId: number | bigint, endpoint: number): Promise<void> {
+    await client.deviceCommand(nodeId, endpoint, ENERGY_EVSE_CLUSTER_ID, "StartDiagnostics");
+}
+
+export interface EnableDischargingParams {
+    /** null: no expiry. */
+    dischargingEnabledUntil: number | null;
+    maximumDischargeCurrentA: number;
+}
+
+export async function enableDischarging(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    params: EnableDischargingParams,
+): Promise<void> {
+    await client.deviceCommand(nodeId, endpoint, ENERGY_EVSE_CLUSTER_ID, "EnableDischarging", {
+        dischargingEnabledUntil: params.dischargingEnabledUntil,
+        maximumDischargeCurrent: Math.round(params.maximumDischargeCurrentA * 1000),
+    });
+}
+
+export type EvseWeekday = "sunday" | "monday" | "tuesday" | "wednesday" | "thursday" | "friday" | "saturday";
+
+/** TargetDayOfWeekBitmap fields per Matter 1.6 §9.3.7.1, in calendar (Monday-first) display order. */
+export const EVSE_WEEKDAYS: { key: EvseWeekday; label: string }[] = [
+    { key: "monday", label: "Mon" },
+    { key: "tuesday", label: "Tue" },
+    { key: "wednesday", label: "Wed" },
+    { key: "thursday", label: "Thu" },
+    { key: "friday", label: "Fri" },
+    { key: "saturday", label: "Sat" },
+    { key: "sunday", label: "Sun" },
+];
+
+export interface EditableChargingTarget {
+    /** Minutes since local midnight, 0-1439. */
+    timeMinutes: number;
+    /** Percent. Mutually exclusive with addedEnergyKWh: set at most one. */
+    targetSoC?: number;
+    /** Mutually exclusive with targetSoC: set at most one. */
+    addedEnergyKWh?: number;
+}
+
+export interface EditableChargingSchedule {
+    days: Partial<Record<EvseWeekday, boolean>>;
+    targets: EditableChargingTarget[];
+}
+
+function decodeChargingTarget(value: unknown): EditableChargingTarget | undefined {
+    const obj = asObject(value);
+    if (obj === null) return undefined;
+    const timeMinutes = pickNumber(obj, "targetTimeMinutesPastMidnight");
+    if (timeMinutes === null) return undefined;
+    const addedEnergy = toNumber(obj.addedEnergy);
+    return {
+        timeMinutes,
+        targetSoC: pickNumber(obj, "targetSoC") ?? undefined,
+        addedEnergyKWh: addedEnergy !== undefined ? addedEnergy / 1_000_000 : undefined,
+    };
+}
+
+function decodeChargingTargetSchedule(value: unknown): EditableChargingSchedule | undefined {
+    const obj = asObject(value);
+    if (obj === null) return undefined;
+    const daysObj = asObject(obj.dayOfWeekForSequence) ?? {};
+    const days: Partial<Record<EvseWeekday, boolean>> = {};
+    for (const { key } of EVSE_WEEKDAYS) {
+        if (pickBoolean(daysObj, key) === true) days[key] = true;
+    }
+    const targets = pickArray(obj, "chargingTargets")
+        .map(decodeChargingTarget)
+        .filter((target): target is EditableChargingTarget => target !== undefined);
+    return { days, targets };
+}
+
+/** Decodes a GetTargets/SetTargets response's ChargingTargetSchedules list. */
+export function decodeChargingTargetSchedules(response: unknown): EditableChargingSchedule[] {
+    const obj = asObject(response);
+    if (obj === null) return [];
+    return pickArray(obj, "chargingTargetSchedules")
+        .map(decodeChargingTargetSchedule)
+        .filter((schedule): schedule is EditableChargingSchedule => schedule !== undefined);
+}
+
+export async function getChargingTargets(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+): Promise<EditableChargingSchedule[]> {
+    const response = await client.deviceCommand(nodeId, endpoint, ENERGY_EVSE_CLUSTER_ID, "GetTargets");
+    return decodeChargingTargetSchedules(response);
+}
+
+export async function setChargingTargets(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+    schedules: EditableChargingSchedule[],
+): Promise<void> {
+    await client.deviceCommand(nodeId, endpoint, ENERGY_EVSE_CLUSTER_ID, "SetTargets", {
+        chargingTargetSchedules: schedules.map(schedule => ({
+            dayOfWeekForSequence: Object.fromEntries(
+                EVSE_WEEKDAYS.filter(({ key }) => schedule.days[key] === true).map(({ key }) => [key, true]),
+            ),
+            chargingTargets: schedule.targets.map(target => ({
+                targetTimeMinutesPastMidnight: target.timeMinutes,
+                ...(target.targetSoC !== undefined ? { targetSoC: target.targetSoC } : {}),
+                ...(target.addedEnergyKWh !== undefined
+                    ? { addedEnergy: Math.round(target.addedEnergyKWh * 1_000_000) }
+                    : {}),
+            })),
+        })),
+    });
+}
+
+export async function clearChargingTargets(
+    client: MatterClient,
+    nodeId: number | bigint,
+    endpoint: number,
+): Promise<void> {
+    await client.deviceCommand(nodeId, endpoint, ENERGY_EVSE_CLUSTER_ID, "ClearTargets");
 }

--- a/packages/dashboard/src/util/energy-evse.ts
+++ b/packages/dashboard/src/util/energy-evse.ts
@@ -5,9 +5,12 @@
  */
 
 import type { MatterClient } from "@matter-server/ws-client";
-import { asObject, pickArray, pickBoolean, pickNumber, toNumber, toText } from "./attribute-shapes.js";
+import { asObject, pickArray, pickNumber, toNumber, toText } from "./attribute-shapes.js";
 
 export const ENERGY_EVSE_CLUSTER_ID = 153; // 0x99
+
+const ATTR_ACCEPTED_COMMAND_LIST = 0xfff9;
+const COMMAND_START_DIAGNOSTICS = 0x04;
 
 const ATTR_STATE = 0x00;
 const ATTR_SUPPLY_STATE = 0x01;
@@ -98,6 +101,8 @@ export interface EnergyEvseInfo {
     diagnosticsActive: boolean;
     /** Whether StartDiagnostics is expected to succeed right now (the device only accepts it while fully disabled). */
     canStartDiagnostics: boolean;
+    /** StartDiagnostics is an optional command, so it only exists where AcceptedCommandList lists it. */
+    startDiagnosticsSupported: boolean;
     faultState?: string;
     faultActive: boolean;
     /** undefined: not reported. null: no expiry, i.e. charging stays enabled until disabled explicitly. */
@@ -174,6 +179,11 @@ function decodeSession(attributes: Record<string, unknown>, endpoint: number): S
     };
 }
 
+function acceptsCommand(attributes: Record<string, unknown>, endpoint: number, commandId: number): boolean {
+    const accepted = attr(attributes, endpoint, ATTR_ACCEPTED_COMMAND_LIST);
+    return Array.isArray(accepted) && accepted.some(value => Number(value) === commandId);
+}
+
 export function energyEvseInfo(attributes: Record<string, unknown>, endpoint: number): EnergyEvseInfo {
     const featureMap = toNumber(attr(attributes, endpoint, ATTR_FEATURE_MAP));
     const faultStateRaw = toNumber(attr(attributes, endpoint, ATTR_FAULT_STATE));
@@ -185,6 +195,7 @@ export function energyEvseInfo(attributes: Record<string, unknown>, endpoint: nu
         supplyState: enumName(supplyStateRaw, SUPPLY_STATE_NAMES),
         diagnosticsActive: supplyStateRaw === SUPPLY_STATE_DISABLED_DIAGNOSTICS,
         canStartDiagnostics: supplyStateRaw === undefined || supplyStateRaw === SUPPLY_STATE_DISABLED,
+        startDiagnosticsSupported: acceptsCommand(attributes, endpoint, COMMAND_START_DIAGNOSTICS),
         faultState: enumName(faultStateRaw, FAULT_STATE_NAMES),
         faultActive: faultStateRaw !== undefined && faultStateRaw !== 0,
         chargingEnabledUntil: nullableNumber(attr(attributes, endpoint, ATTR_CHARGING_ENABLED_UNTIL)),
@@ -269,16 +280,33 @@ export async function enableDischarging(
 
 export type EvseWeekday = "sunday" | "monday" | "tuesday" | "wednesday" | "thursday" | "friday" | "saturday";
 
-/** TargetDayOfWeekBitmap fields per Matter 1.6 §9.3.7.1, in calendar (Monday-first) display order. */
-export const EVSE_WEEKDAYS: { key: EvseWeekday; label: string }[] = [
-    { key: "monday", label: "Mon" },
-    { key: "tuesday", label: "Tue" },
-    { key: "wednesday", label: "Wed" },
-    { key: "thursday", label: "Thu" },
-    { key: "friday", label: "Fri" },
-    { key: "saturday", label: "Sat" },
-    { key: "sunday", label: "Sun" },
+/**
+ * TargetDayOfWeekBitmap, listed in calendar (Monday-first) display order. `bit` is the bitmap
+ * position the cluster assigns, which starts at Sunday.
+ */
+export const EVSE_WEEKDAYS: { key: EvseWeekday; label: string; bit: number }[] = [
+    { key: "monday", label: "Mon", bit: 1 },
+    { key: "tuesday", label: "Tue", bit: 2 },
+    { key: "wednesday", label: "Wed", bit: 3 },
+    { key: "thursday", label: "Thu", bit: 4 },
+    { key: "friday", label: "Fri", bit: 5 },
+    { key: "saturday", label: "Sat", bit: 6 },
+    { key: "sunday", label: "Sun", bit: 0 },
 ];
+
+/** Bitmaps reach the dashboard as an integer, never as an object of booleans (see Converters.ts). */
+export function decodeWeekdayBitmap(value: unknown): Partial<Record<EvseWeekday, boolean>> {
+    const bitmap = toNumber(value) ?? 0;
+    const days: Partial<Record<EvseWeekday, boolean>> = {};
+    for (const { key, bit } of EVSE_WEEKDAYS) {
+        if ((bitmap & (1 << bit)) !== 0) days[key] = true;
+    }
+    return days;
+}
+
+export function encodeWeekdayBitmap(days: Partial<Record<EvseWeekday, boolean>>): number {
+    return EVSE_WEEKDAYS.reduce((bitmap, { key, bit }) => (days[key] === true ? bitmap | (1 << bit) : bitmap), 0);
+}
 
 export interface EditableChargingTarget {
     /** Minutes since local midnight, 0-1439. */
@@ -310,11 +338,7 @@ function decodeChargingTarget(value: unknown): EditableChargingTarget | undefine
 function decodeChargingTargetSchedule(value: unknown): EditableChargingSchedule | undefined {
     const obj = asObject(value);
     if (obj === null) return undefined;
-    const daysObj = asObject(obj.dayOfWeekForSequence) ?? {};
-    const days: Partial<Record<EvseWeekday, boolean>> = {};
-    for (const { key } of EVSE_WEEKDAYS) {
-        if (pickBoolean(daysObj, key) === true) days[key] = true;
-    }
+    const days = decodeWeekdayBitmap(obj.dayOfWeekForSequence);
     const targets = pickArray(obj, "chargingTargets")
         .map(decodeChargingTarget)
         .filter((target): target is EditableChargingTarget => target !== undefined);
@@ -347,9 +371,7 @@ export async function setChargingTargets(
 ): Promise<void> {
     await client.deviceCommand(nodeId, endpoint, ENERGY_EVSE_CLUSTER_ID, "SetTargets", {
         chargingTargetSchedules: schedules.map(schedule => ({
-            dayOfWeekForSequence: Object.fromEntries(
-                EVSE_WEEKDAYS.filter(({ key }) => schedule.days[key] === true).map(({ key }) => [key, true]),
-            ),
+            dayOfWeekForSequence: encodeWeekdayBitmap(schedule.days),
             chargingTargets: schedule.targets.map(target => ({
                 targetTimeMinutesPastMidnight: target.timeMinutes,
                 ...(target.targetSoC !== undefined ? { targetSoC: target.targetSoC } : {}),

--- a/packages/dashboard/src/util/energy-evse.ts
+++ b/packages/dashboard/src/util/energy-evse.ts
@@ -45,7 +45,6 @@ const FEATURE_BIT_V2X = 0b10000;
 
 const SUPPLY_STATE_DISABLED = 0;
 /** Self-diagnostics mode: EnableCharging/EnableDischarging are rejected until Disable clears it. */
-const SUPPLY_STATE_DISABLED_DIAGNOSTICS = 4;
 
 const STATE_NAMES: Record<number, string> = {
     0: "Not plugged in",
@@ -97,8 +96,6 @@ export interface EnergyEvseInfo {
     supported: boolean;
     state?: string;
     supplyState?: string;
-    /** SupplyState is DisabledDiagnostics: EnableCharging/EnableDischarging are rejected until Disable clears it. */
-    diagnosticsActive: boolean;
     /** Whether StartDiagnostics is expected to succeed right now (the device only accepts it while fully disabled). */
     canStartDiagnostics: boolean;
     /** StartDiagnostics is an optional command, so it only exists where AcceptedCommandList lists it. */
@@ -193,7 +190,6 @@ export function energyEvseInfo(attributes: Record<string, unknown>, endpoint: nu
         supported: featureMap !== undefined,
         state: enumName(attr(attributes, endpoint, ATTR_STATE), STATE_NAMES),
         supplyState: enumName(supplyStateRaw, SUPPLY_STATE_NAMES),
-        diagnosticsActive: supplyStateRaw === SUPPLY_STATE_DISABLED_DIAGNOSTICS,
         canStartDiagnostics: supplyStateRaw === undefined || supplyStateRaw === SUPPLY_STATE_DISABLED,
         startDiagnosticsSupported: acceptsCommand(attributes, endpoint, COMMAND_START_DIAGNOSTICS),
         faultState: enumName(faultStateRaw, FAULT_STATE_NAMES),

--- a/packages/dashboard/src/util/energy-evse.ts
+++ b/packages/dashboard/src/util/energy-evse.ts
@@ -108,6 +108,12 @@ export interface EnergyEvseInfo {
     startDiagnosticsSupported: boolean;
     faultState?: string;
     faultActive: boolean;
+    /**
+     * Why Disable, EnableCharging and EnableDischarging would be refused, or undefined when they are
+     * accepted. The reference delegate guards all three with the same CheckFaultOrDiagnostic(), which
+     * fails on any FaultState other than NoError and while SupplyState is DisabledDiagnostics.
+     */
+    supplyCommandsBlockedReason?: string;
     /** undefined: not reported. null: no expiry, i.e. charging stays enabled until disabled explicitly. */
     chargingEnabledUntil?: number | null;
     circuitCapacityA?: number;
@@ -182,6 +188,20 @@ function decodeSession(attributes: Record<string, unknown>, endpoint: number): S
     };
 }
 
+function supplyCommandsBlockedReason(
+    faultStateRaw: number | undefined,
+    supplyStateRaw: number | undefined,
+): string | undefined {
+    if (faultStateRaw !== undefined && faultStateRaw !== 0) {
+        return "The EVSE reports a fault, and refuses charging commands until it clears.";
+    }
+    if (supplyStateRaw === SUPPLY_STATE_DISABLED_DIAGNOSTICS) {
+        // Only the device leaves this state, by finishing its diagnostics; Disable is refused too.
+        return "The EVSE is running self-diagnostics, and refuses charging commands until it finishes.";
+    }
+    return undefined;
+}
+
 function acceptsCommand(attributes: Record<string, unknown>, endpoint: number, commandId: number): boolean {
     const accepted = attr(attributes, endpoint, ATTR_ACCEPTED_COMMAND_LIST);
     return Array.isArray(accepted) && accepted.some(value => Number(value) === commandId);
@@ -201,6 +221,7 @@ export function energyEvseInfo(attributes: Record<string, unknown>, endpoint: nu
         startDiagnosticsSupported: acceptsCommand(attributes, endpoint, COMMAND_START_DIAGNOSTICS),
         faultState: enumName(faultStateRaw, FAULT_STATE_NAMES),
         faultActive: faultStateRaw !== undefined && faultStateRaw !== 0,
+        supplyCommandsBlockedReason: supplyCommandsBlockedReason(faultStateRaw, supplyStateRaw),
         chargingEnabledUntil: nullableNumber(attr(attributes, endpoint, ATTR_CHARGING_ENABLED_UNTIL)),
         circuitCapacityA: toAmps(toNumber(attr(attributes, endpoint, ATTR_CIRCUIT_CAPACITY))),
         minimumChargeCurrentA: toAmps(toNumber(attr(attributes, endpoint, ATTR_MINIMUM_CHARGE_CURRENT))),

--- a/packages/dashboard/src/util/energy-evse.ts
+++ b/packages/dashboard/src/util/energy-evse.ts
@@ -96,7 +96,10 @@ export interface EnergyEvseInfo {
     supported: boolean;
     state?: string;
     supplyState?: string;
-    /** Whether StartDiagnostics is expected to succeed right now (the device only accepts it while fully disabled). */
+    /**
+     * Whether StartDiagnostics is expected to succeed right now. The device only accepts it while fully
+     * disabled, so an unread SupplyState is not evidence that it would be accepted.
+     */
     canStartDiagnostics: boolean;
     /** StartDiagnostics is an optional command, so it only exists where AcceptedCommandList lists it. */
     startDiagnosticsSupported: boolean;
@@ -190,7 +193,7 @@ export function energyEvseInfo(attributes: Record<string, unknown>, endpoint: nu
         supported: featureMap !== undefined,
         state: enumName(attr(attributes, endpoint, ATTR_STATE), STATE_NAMES),
         supplyState: enumName(supplyStateRaw, SUPPLY_STATE_NAMES),
-        canStartDiagnostics: supplyStateRaw === undefined || supplyStateRaw === SUPPLY_STATE_DISABLED,
+        canStartDiagnostics: supplyStateRaw === SUPPLY_STATE_DISABLED,
         startDiagnosticsSupported: acceptsCommand(attributes, endpoint, COMMAND_START_DIAGNOSTICS),
         faultState: enumName(faultStateRaw, FAULT_STATE_NAMES),
         faultActive: faultStateRaw !== undefined && faultStateRaw !== 0,
@@ -302,6 +305,51 @@ export function decodeWeekdayBitmap(value: unknown): Partial<Record<EvseWeekday,
 
 export function encodeWeekdayBitmap(days: Partial<Record<EvseWeekday, boolean>>): number {
     return EVSE_WEEKDAYS.reduce((bitmap, { key, bit }) => (days[key] === true ? bitmap | (1 << bit) : bitmap), 0);
+}
+
+/** ChargingTargetSchedules is `max 7`; ChargingTargets within a schedule is `max 10`. */
+export const MAX_CHARGING_SCHEDULES = 7;
+export const MAX_CHARGING_TARGETS_PER_SCHEDULE = 10;
+
+/**
+ * Why SetTargets would be rejected, or null when the schedules are sendable. The rules come from
+ * ChargingTargetStruct's conformance, which depends on the device's features: TargetSoC is `SOC, O.a+`
+ * — mandatory once the SOC feature is active — and AddedEnergy is `[SOC], O.a+`, so it may accompany a
+ * SoC goal but cannot replace one. ChargingTargets itself is `max 10` with no minimum: an empty target
+ * list is how a day's targets are cleared.
+ */
+export function chargingScheduleError(schedules: EditableChargingSchedule[], soCSupported: boolean): string | null {
+    if (schedules.length > MAX_CHARGING_SCHEDULES) {
+        return `A lock stores at most ${MAX_CHARGING_SCHEDULES} schedules.`;
+    }
+    if (schedules.some(schedule => EVSE_WEEKDAYS.every(({ key }) => schedule.days[key] !== true))) {
+        return "Select at least one day for every schedule.";
+    }
+    // ChargingTargetSchedules: a weekday may appear in only one schedule.
+    const claimedDays = new Set<EvseWeekday>();
+    for (const schedule of schedules) {
+        for (const { key } of EVSE_WEEKDAYS) {
+            if (schedule.days[key] !== true) continue;
+            if (claimedDays.has(key)) return "Each day may be used by only one schedule.";
+            claimedDays.add(key);
+        }
+    }
+    for (const schedule of schedules) {
+        if (schedule.targets.length > MAX_CHARGING_TARGETS_PER_SCHEDULE) {
+            return `A schedule holds at most ${MAX_CHARGING_TARGETS_PER_SCHEDULE} targets.`;
+        }
+        for (const target of schedule.targets) {
+            if (!Number.isInteger(target.timeMinutes) || target.timeMinutes < 0 || target.timeMinutes > 1439) {
+                return "Every target needs a time of day.";
+            }
+            if (soCSupported) {
+                if (target.targetSoC === undefined) return "Give every target a target state of charge.";
+            } else if (target.addedEnergyKWh === undefined) {
+                return "Give every target an added-energy goal.";
+            }
+        }
+    }
+    return null;
 }
 
 export interface EditableChargingTarget {

--- a/packages/dashboard/src/util/energy-evse.ts
+++ b/packages/dashboard/src/util/energy-evse.ts
@@ -45,6 +45,7 @@ const FEATURE_BIT_V2X = 0b10000;
 
 const SUPPLY_STATE_DISABLED = 0;
 /** Self-diagnostics mode: EnableCharging/EnableDischarging are rejected until Disable clears it. */
+const SUPPLY_STATE_DISABLED_DIAGNOSTICS = 4;
 
 const STATE_NAMES: Record<number, string> = {
     0: "Not plugged in",
@@ -96,6 +97,8 @@ export interface EnergyEvseInfo {
     supported: boolean;
     state?: string;
     supplyState?: string;
+    /** SupplyState is DisabledDiagnostics: EnableCharging/EnableDischarging are rejected until Disable clears it. */
+    diagnosticsActive: boolean;
     /**
      * Whether StartDiagnostics is expected to succeed right now. The device only accepts it while fully
      * disabled, so an unread SupplyState is not evidence that it would be accepted.
@@ -193,6 +196,7 @@ export function energyEvseInfo(attributes: Record<string, unknown>, endpoint: nu
         supported: featureMap !== undefined,
         state: enumName(attr(attributes, endpoint, ATTR_STATE), STATE_NAMES),
         supplyState: enumName(supplyStateRaw, SUPPLY_STATE_NAMES),
+        diagnosticsActive: supplyStateRaw === SUPPLY_STATE_DISABLED_DIAGNOSTICS,
         canStartDiagnostics: supplyStateRaw === SUPPLY_STATE_DISABLED,
         startDiagnosticsSupported: acceptsCommand(attributes, endpoint, COMMAND_START_DIAGNOSTICS),
         faultState: enumName(faultStateRaw, FAULT_STATE_NAMES),

--- a/packages/dashboard/src/util/energy-evse.ts
+++ b/packages/dashboard/src/util/energy-evse.ts
@@ -44,7 +44,7 @@ const FEATURE_BIT_PLUG_AND_CHARGE = 0b100;
 const FEATURE_BIT_V2X = 0b10000;
 
 const SUPPLY_STATE_DISABLED = 0;
-/** Self-diagnostics mode: EnableCharging/EnableDischarging are rejected until Disable clears it. */
+/** Self-diagnostics mode: the device leaves it by finishing, and refuses Disable meanwhile. */
 const SUPPLY_STATE_DISABLED_DIAGNOSTICS = 4;
 
 const STATE_NAMES: Record<number, string> = {
@@ -97,7 +97,7 @@ export interface EnergyEvseInfo {
     supported: boolean;
     state?: string;
     supplyState?: string;
-    /** SupplyState is DisabledDiagnostics: EnableCharging/EnableDischarging are rejected until Disable clears it. */
+    /** SupplyState is DisabledDiagnostics; see supplyCommandsBlockedReason for what that refuses. */
     diagnosticsActive: boolean;
     /**
      * Whether StartDiagnostics is expected to succeed right now. The device only accepts it while fully
@@ -345,7 +345,7 @@ export const MAX_CHARGING_TARGETS_PER_SCHEDULE = 10;
  */
 export function chargingScheduleError(schedules: EditableChargingSchedule[], soCSupported: boolean): string | null {
     if (schedules.length > MAX_CHARGING_SCHEDULES) {
-        return `A lock stores at most ${MAX_CHARGING_SCHEDULES} schedules.`;
+        return `An EVSE stores at most ${MAX_CHARGING_SCHEDULES} schedules.`;
     }
     if (schedules.some(schedule => EVSE_WEEKDAYS.every(({ key }) => schedule.days[key] !== true))) {
         return "Select at least one day for every schedule.";
@@ -364,8 +364,13 @@ export function chargingScheduleError(schedules: EditableChargingSchedule[], soC
             return `A schedule holds at most ${MAX_CHARGING_TARGETS_PER_SCHEDULE} targets.`;
         }
         for (const target of schedule.targets) {
-            if (!Number.isInteger(target.timeMinutes) || target.timeMinutes < 0 || target.timeMinutes > 1439) {
+            const timeMinutes = target.timeMinutes;
+            if (timeMinutes === undefined || !Number.isInteger(timeMinutes) || timeMinutes < 0 || timeMinutes > 1439) {
                 return "Every target needs a time of day.";
+            }
+            if (target.targetSoC !== undefined && !Number.isInteger(target.targetSoC)) {
+                // TargetSoC is a `percent`, i.e. a whole-number uint8.
+                return "A target state of charge has to be a whole percentage.";
             }
             if (soCSupported) {
                 if (target.targetSoC === undefined) return "Give every target a target state of charge.";
@@ -378,11 +383,11 @@ export function chargingScheduleError(schedules: EditableChargingSchedule[], soC
 }
 
 export interface EditableChargingTarget {
-    /** Minutes since local midnight, 0-1439. */
-    timeMinutes: number;
-    /** Percent. Mutually exclusive with addedEnergyKWh: set at most one. */
+    /** Minutes since local midnight, 0-1439; undefined while the editor's time field is empty. */
+    timeMinutes: number | undefined;
+    /** Whole percent. Mandatory once the SOC feature is active; see chargingScheduleError(). */
     targetSoC?: number;
-    /** Mutually exclusive with targetSoC: set at most one. */
+    /** May accompany targetSoC, and replaces it only on a device without the SOC feature. */
     addedEnergyKWh?: number;
 }
 
@@ -432,6 +437,12 @@ export async function getChargingTargets(
     return decodeChargingTargetSchedules(response);
 }
 
+/** chargingScheduleError() gates every send, so an unset time here is a bug rather than user input. */
+function requireTargetTime(timeMinutes: number | undefined): number {
+    if (timeMinutes === undefined) throw new Error("A charging target has no time of day.");
+    return timeMinutes;
+}
+
 export async function setChargingTargets(
     client: MatterClient,
     nodeId: number | bigint,
@@ -442,7 +453,7 @@ export async function setChargingTargets(
         chargingTargetSchedules: schedules.map(schedule => ({
             dayOfWeekForSequence: encodeWeekdayBitmap(schedule.days),
             chargingTargets: schedule.targets.map(target => ({
-                targetTimeMinutesPastMidnight: target.timeMinutes,
+                targetTimeMinutesPastMidnight: requireTargetTime(target.timeMinutes),
                 ...(target.targetSoC !== undefined ? { targetSoC: target.targetSoC } : {}),
                 ...(target.addedEnergyKWh !== undefined
                     ? { addedEnergy: Math.round(target.addedEnergyKWh * 1_000_000) }

--- a/packages/dashboard/src/util/time.ts
+++ b/packages/dashboard/src/util/time.ts
@@ -24,3 +24,22 @@ export function formatEpochTime(matterEpochSeconds: number, relativeTo: Date = n
             : { year: "numeric", month: "2-digit", day: "2-digit" };
     return `${date.toLocaleDateString(undefined, dateOptions)} ${time}`;
 }
+
+/** Formats a Matter epoch-s instant as the value of an `<input type="datetime-local">`, in the viewer's own time zone. */
+export function toLocalDateTimeInputValue(matterEpochSeconds: number): string {
+    const date = new Date((matterEpochSeconds + MATTER_EPOCH_OFFSET_SECONDS) * 1000);
+    const pad = (value: number) => String(value).padStart(2, "0");
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+/**
+ * Reads an `<input type="datetime-local">` value back as a Matter epoch-s instant, or undefined when it
+ * is empty or unparsable. The browser reports such values with no time zone, so `new Date(value)` reads
+ * it as the viewer's own local time, the same zone `toLocalDateTimeInputValue` formatted it in.
+ */
+export function fromLocalDateTimeInputValue(value: string): number | undefined {
+    if (value.trim() === "") return undefined;
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return undefined;
+    return Math.floor(date.getTime() / 1000) - MATTER_EPOCH_OFFSET_SECONDS;
+}

--- a/packages/dashboard/src/util/time.ts
+++ b/packages/dashboard/src/util/time.ts
@@ -43,9 +43,12 @@ export function fromLocalDateTimeInputValue(value: string): number | undefined {
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) return undefined;
     const seconds = Math.floor(date.getTime() / 1000) - MATTER_EPOCH_OFFSET_SECONDS;
-    return seconds < 0 || seconds > MATTER_EPOCH_MAX_SECONDS ? undefined : seconds;
+    if (seconds < 0 || seconds > MATTER_EPOCH_MAX_SECONDS) return undefined;
+    // A local time inside a DST spring-forward gap does not exist; `new Date` silently moves it forward
+    // rather than rejecting it, which would send an expiry an hour off the one that was typed.
+    return toLocalDateTimeInputValue(seconds) === value.trim() ? seconds : undefined;
 }
 
-/** `min`/`max` for an `<input type="datetime-local">` bound to a Matter epoch-s field. */
-export const MATTER_EPOCH_MIN_INPUT_VALUE = "2000-01-01T00:00";
-export const MATTER_EPOCH_MAX_INPUT_VALUE = "2136-02-07T06:28";
+/** `min`/`max` for an `<input type="datetime-local">` bound to a Matter epoch-s field, in the viewer's zone. */
+export const MATTER_EPOCH_MIN_INPUT_VALUE = toLocalDateTimeInputValue(0);
+export const MATTER_EPOCH_MAX_INPUT_VALUE = toLocalDateTimeInputValue(MATTER_EPOCH_MAX_SECONDS);

--- a/packages/dashboard/src/util/time.ts
+++ b/packages/dashboard/src/util/time.ts
@@ -34,12 +34,18 @@ export function toLocalDateTimeInputValue(matterEpochSeconds: number): string {
 
 /**
  * Reads an `<input type="datetime-local">` value back as a Matter epoch-s instant, or undefined when it
- * is empty or unparsable. The browser reports such values with no time zone, so `new Date(value)` reads
- * it as the viewer's own local time, the same zone `toLocalDateTimeInputValue` formatted it in.
+ * is empty, unparsable, or outside the uint32 wire field. The browser reports such values with no time
+ * zone, so `new Date(value)` reads it as the viewer's own local time, the same zone
+ * `toLocalDateTimeInputValue` formatted it in.
  */
 export function fromLocalDateTimeInputValue(value: string): number | undefined {
     if (value.trim() === "") return undefined;
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) return undefined;
-    return Math.floor(date.getTime() / 1000) - MATTER_EPOCH_OFFSET_SECONDS;
+    const seconds = Math.floor(date.getTime() / 1000) - MATTER_EPOCH_OFFSET_SECONDS;
+    return seconds < 0 || seconds > MATTER_EPOCH_MAX_SECONDS ? undefined : seconds;
 }
+
+/** `min`/`max` for an `<input type="datetime-local">` bound to a Matter epoch-s field. */
+export const MATTER_EPOCH_MIN_INPUT_VALUE = "2000-01-01T00:00";
+export const MATTER_EPOCH_MAX_INPUT_VALUE = "2136-02-07T06:28";

--- a/packages/dashboard/test/EnergyEvseUtilTest.ts
+++ b/packages/dashboard/test/EnergyEvseUtilTest.ts
@@ -55,6 +55,24 @@ describe("energy evse util", () => {
         expect(info.maximumChargeCurrentA).to.equal(16);
     });
 
+    it("gates StartDiagnostics and EnableCharging/Discharging on SupplyState", () => {
+        const chargingEnabled = energyEvseInfo(BASE_ATTRS, 1); // SupplyState: ChargingEnabled (1)
+        expect(chargingEnabled.diagnosticsActive).to.equal(false);
+        expect(chargingEnabled.canStartDiagnostics).to.equal(false);
+
+        const disabled = energyEvseInfo({ ...BASE_ATTRS, "1/153/1": 0 }, 1);
+        expect(disabled.diagnosticsActive).to.equal(false);
+        expect(disabled.canStartDiagnostics).to.equal(true);
+
+        const diagnostics = energyEvseInfo({ ...BASE_ATTRS, "1/153/1": 4 }, 1);
+        expect(diagnostics.diagnosticsActive).to.equal(true);
+        expect(diagnostics.canStartDiagnostics).to.equal(false);
+
+        const unknown = energyEvseInfo({ ...BASE_ATTRS, "1/153/1": undefined }, 1);
+        expect(unknown.diagnosticsActive).to.equal(false);
+        expect(unknown.canStartDiagnostics).to.equal(true);
+    });
+
     it("flags an active fault", () => {
         const info = energyEvseInfo({ ...BASE_ATTRS, "1/153/2": 4 }, 1);
         expect(info.faultState).to.equal("Over current");

--- a/packages/dashboard/test/EnergyEvseUtilTest.ts
+++ b/packages/dashboard/test/EnergyEvseUtilTest.ts
@@ -4,7 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { energyEvseInfo } from "../src/util/energy-evse.js";
+import type { MatterClient } from "@matter-server/ws-client";
+import {
+    clearChargingTargets,
+    decodeChargingTargetSchedules,
+    disableEvse,
+    enableCharging,
+    energyEvseInfo,
+    getChargingTargets,
+    setChargingTargets,
+    startDiagnostics,
+    type EditableChargingSchedule,
+} from "../src/util/energy-evse.js";
+import { fromLocalDateTimeInputValue, toLocalDateTimeInputValue } from "../src/util/time.js";
 
 const FEATURE_V2X = 0b10000;
 const FEATURE_SOC = 0b10;
@@ -121,5 +133,126 @@ describe("energy evse util", () => {
         const info = energyEvseInfo({ ...BASE_ATTRS, "1/153/65532": FEATURE_PNC, "1/153/50": "EMAID-123" }, 1);
         expect(info.plugAndChargeSupported).to.equal(true);
         expect(info.vehicleId).to.equal("EMAID-123");
+    });
+});
+
+function fakeCommandClient() {
+    const calls = new Array<{ commandName: string; payload: Record<string, unknown> }>();
+    let response: unknown;
+    const client = {
+        deviceCommand: (
+            _nodeId: number | bigint,
+            _endpointId: number,
+            _clusterId: number,
+            commandName: string,
+            payload: Record<string, unknown> = {},
+        ) => {
+            calls.push({ commandName, payload });
+            return Promise.resolve(response);
+        },
+    } as unknown as MatterClient;
+    return { client, calls, setResponse: (value: unknown) => (response = value) };
+}
+
+describe("energy evse commands", () => {
+    it("sends Disable and StartDiagnostics with no payload", async () => {
+        const { client, calls } = fakeCommandClient();
+        await disableEvse(client, 1, 1);
+        await startDiagnostics(client, 1, 1);
+        expect(calls.map(call => call.commandName)).to.deep.equal(["Disable", "StartDiagnostics"]);
+        expect(calls[0]?.payload).to.deep.equal({});
+    });
+
+    it("converts EnableCharging amps to mA and passes a null expiry through", async () => {
+        const { client, calls } = fakeCommandClient();
+        await enableCharging(client, 1, 1, {
+            chargingEnabledUntil: null,
+            minimumChargeCurrentA: 6,
+            maximumChargeCurrentA: 16,
+        });
+        expect(calls[0]?.payload).to.deep.equal({
+            chargingEnabledUntil: null,
+            minimumChargeCurrent: 6000,
+            maximumChargeCurrent: 16000,
+        });
+    });
+
+    it("sends ClearTargets with no payload", async () => {
+        const { client, calls } = fakeCommandClient();
+        await clearChargingTargets(client, 1, 1);
+        expect(calls[0]?.commandName).to.equal("ClearTargets");
+    });
+});
+
+describe("charging target schedule decoding", () => {
+    it("decodes a GetTargetsResponse, keeping only the selected days", () => {
+        const schedules = decodeChargingTargetSchedules({
+            chargingTargetSchedules: [
+                {
+                    dayOfWeekForSequence: { monday: true, wednesday: true, sunday: false },
+                    chargingTargets: [
+                        { targetTimeMinutesPastMidnight: 360, targetSoC: 80 },
+                        { targetTimeMinutesPastMidnight: 1200, addedEnergy: 10_000_000 },
+                    ],
+                },
+            ],
+        });
+        expect(schedules).to.have.lengthOf(1);
+        expect(schedules[0]?.days).to.deep.equal({ monday: true, wednesday: true });
+        expect(schedules[0]?.targets).to.deep.equal([
+            { timeMinutes: 360, targetSoC: 80, addedEnergyKWh: undefined },
+            { timeMinutes: 1200, targetSoC: undefined, addedEnergyKWh: 10 },
+        ]);
+    });
+
+    it("returns an empty list for a response with no schedules", () => {
+        expect(decodeChargingTargetSchedules({ chargingTargetSchedules: [] })).to.deep.equal([]);
+        expect(decodeChargingTargetSchedules(null)).to.deep.equal([]);
+    });
+
+    it("round-trips through setChargingTargets as named boolean days and scaled energy", async () => {
+        const { client, calls } = fakeCommandClient();
+        const schedules: EditableChargingSchedule[] = [
+            {
+                days: { saturday: true, sunday: true },
+                targets: [{ timeMinutes: 480, addedEnergyKWh: 12.5 }],
+            },
+        ];
+        await setChargingTargets(client, 1, 1, schedules);
+        expect(calls[0]?.payload).to.deep.equal({
+            chargingTargetSchedules: [
+                {
+                    dayOfWeekForSequence: { saturday: true, sunday: true },
+                    chargingTargets: [{ targetTimeMinutesPastMidnight: 480, addedEnergy: 12_500_000 }],
+                },
+            ],
+        });
+    });
+
+    it("fetches and decodes through getChargingTargets", async () => {
+        const { client, setResponse } = fakeCommandClient();
+        setResponse({
+            chargingTargetSchedules: [
+                { dayOfWeekForSequence: { friday: true }, chargingTargets: [{ targetTimeMinutesPastMidnight: 60 }] },
+            ],
+        });
+        const schedules = await getChargingTargets(client, 1, 1);
+        expect(schedules).to.deep.equal([
+            { days: { friday: true }, targets: [{ timeMinutes: 60, targetSoC: undefined, addedEnergyKWh: undefined }] },
+        ]);
+    });
+});
+
+describe("local datetime-local <-> Matter epoch-s conversion", () => {
+    it("round-trips a local datetime-local value through the Matter epoch", () => {
+        const input = "2027-03-15T08:30";
+        const epoch = fromLocalDateTimeInputValue(input);
+        expect(epoch).to.not.equal(undefined);
+        expect(toLocalDateTimeInputValue(epoch as number)).to.equal(input);
+    });
+
+    it("treats an empty or unparsable value as undefined", () => {
+        expect(fromLocalDateTimeInputValue("")).to.equal(undefined);
+        expect(fromLocalDateTimeInputValue("not a date")).to.equal(undefined);
     });
 });

--- a/packages/dashboard/test/EnergyEvseUtilTest.ts
+++ b/packages/dashboard/test/EnergyEvseUtilTest.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { energyEvseInfo } from "../src/util/energy-evse.js";
+
+const FEATURE_V2X = 0b10000;
+const FEATURE_SOC = 0b10;
+const FEATURE_PNC = 0b100;
+
+const BASE_ATTRS: Record<string, unknown> = {
+    "1/153/0": 3, // State: PluggedInCharging
+    "1/153/1": 1, // SupplyState: ChargingEnabled
+    "1/153/2": 0, // FaultState: NoError
+    "1/153/3": null, // ChargingEnabledUntil: no expiry
+    "1/153/5": 32000, // CircuitCapacity mA
+    "1/153/6": 6000, // MinimumChargeCurrent mA
+    "1/153/7": 16000, // MaximumChargeCurrent mA
+    "1/153/64": 42, // SessionId
+    "1/153/65": 3661, // SessionDuration s
+    "1/153/66": 12_345_678, // SessionEnergyCharged mWh
+    "1/153/65532": 0, // FeatureMap
+};
+
+describe("energy evse util", () => {
+    it("reports unsupported when the cluster is absent", () => {
+        const info = energyEvseInfo({ "1/40/5": "label" }, 1);
+        expect(info.supported).to.equal(false);
+        expect(info.v2xSupported).to.equal(false);
+    });
+
+    it("decodes the status enums and current limits", () => {
+        const info = energyEvseInfo(BASE_ATTRS, 1);
+        expect(info.supported).to.equal(true);
+        expect(info.state).to.equal("Plugged in, charging");
+        expect(info.supplyState).to.equal("Charging enabled");
+        expect(info.faultState).to.equal("No error");
+        expect(info.faultActive).to.equal(false);
+        expect(info.circuitCapacityA).to.equal(32);
+        expect(info.minimumChargeCurrentA).to.equal(6);
+        expect(info.maximumChargeCurrentA).to.equal(16);
+    });
+
+    it("flags an active fault", () => {
+        const info = energyEvseInfo({ ...BASE_ATTRS, "1/153/2": 4 }, 1);
+        expect(info.faultState).to.equal("Over current");
+        expect(info.faultActive).to.equal(true);
+    });
+
+    it("names an unknown fault code", () => {
+        const info = energyEvseInfo({ ...BASE_ATTRS, "1/153/2": 42 }, 1);
+        expect(info.faultState).to.equal("Unknown (42)");
+    });
+
+    it("distinguishes a null (no expiry) charging window from one not yet reported", () => {
+        const noExpiry = energyEvseInfo(BASE_ATTRS, 1);
+        expect(noExpiry.chargingEnabledUntil).to.equal(null);
+
+        const notReported = energyEvseInfo({ ...BASE_ATTRS, "1/153/3": undefined }, 1);
+        expect(notReported.chargingEnabledUntil).to.equal(undefined);
+
+        const expiring = energyEvseInfo({ ...BASE_ATTRS, "1/153/3": 946_684_900 }, 1);
+        expect(expiring.chargingEnabledUntil).to.equal(946_684_900);
+    });
+
+    it("decodes an active session and converts mWh to kWh", () => {
+        const info = energyEvseInfo(BASE_ATTRS, 1);
+        expect(info.session?.id).to.equal(42);
+        expect(info.session?.durationS).to.equal(3661);
+        expect(info.session?.energyChargedKWh).to.equal(12.345678);
+    });
+
+    it("reports no session while SessionId is still null", () => {
+        const info = energyEvseInfo({ ...BASE_ATTRS, "1/153/64": null }, 1);
+        expect(info.session).to.equal(undefined);
+    });
+
+    it("gates V2X attributes on the V2X feature bit", () => {
+        const withoutV2x = energyEvseInfo(BASE_ATTRS, 1);
+        expect(withoutV2x.v2xSupported).to.equal(false);
+
+        const withV2x = energyEvseInfo(
+            { ...BASE_ATTRS, "1/153/65532": FEATURE_V2X, "1/153/4": null, "1/153/8": 20000 },
+            1,
+        );
+        expect(withV2x.v2xSupported).to.equal(true);
+        expect(withV2x.dischargingEnabledUntil).to.equal(null);
+        expect(withV2x.maximumDischargeCurrentA).to.equal(20);
+    });
+
+    it("decodes charging preferences, distinguishing 'none scheduled' from a target value", () => {
+        const noneScheduled = energyEvseInfo(
+            { ...BASE_ATTRS, "1/153/35": null, "1/153/36": null, "1/153/37": null, "1/153/38": null },
+            1,
+        );
+        expect(noneScheduled.nextChargeStartTime).to.equal(null);
+        expect(noneScheduled.nextChargeRequiredEnergyKWh).to.equal(null);
+
+        const scheduled = energyEvseInfo(
+            { ...BASE_ATTRS, "1/153/35": 946_684_900, "1/153/37": 10_000_000, "1/153/38": 80 },
+            1,
+        );
+        expect(scheduled.nextChargeStartTime).to.equal(946_684_900);
+        expect(scheduled.nextChargeRequiredEnergyKWh).to.equal(10);
+        expect(scheduled.nextChargeTargetSoC).to.equal(80);
+    });
+
+    it("gates SoC reporting attributes on the SOC feature bit", () => {
+        const info = energyEvseInfo(
+            { ...BASE_ATTRS, "1/153/65532": FEATURE_SOC, "1/153/48": 55, "1/153/49": 75_000_000 },
+            1,
+        );
+        expect(info.soCReportingSupported).to.equal(true);
+        expect(info.stateOfCharge).to.equal(55);
+        expect(info.batteryCapacityKWh).to.equal(75);
+    });
+
+    it("gates the vehicle ID on the PlugAndCharge feature bit", () => {
+        const info = energyEvseInfo({ ...BASE_ATTRS, "1/153/65532": FEATURE_PNC, "1/153/50": "EMAID-123" }, 1);
+        expect(info.plugAndChargeSupported).to.equal(true);
+        expect(info.vehicleId).to.equal("EMAID-123");
+    });
+});

--- a/packages/dashboard/test/EnergyEvseUtilTest.ts
+++ b/packages/dashboard/test/EnergyEvseUtilTest.ts
@@ -203,11 +203,12 @@ describe("energy evse commands", () => {
 });
 
 describe("charging target schedule decoding", () => {
+    // TargetDayOfWeekBitmap reaches the dashboard as an integer: bit 0 Sunday .. bit 6 Saturday.
     it("decodes a GetTargetsResponse, keeping only the selected days", () => {
         const schedules = decodeChargingTargetSchedules({
             chargingTargetSchedules: [
                 {
-                    dayOfWeekForSequence: { monday: true, wednesday: true, sunday: false },
+                    dayOfWeekForSequence: 0b0001010,
                     chargingTargets: [
                         { targetTimeMinutesPastMidnight: 360, targetSoC: 80 },
                         { targetTimeMinutesPastMidnight: 1200, addedEnergy: 10_000_000 },
@@ -228,7 +229,45 @@ describe("charging target schedule decoding", () => {
         expect(decodeChargingTargetSchedules(null)).to.deep.equal([]);
     });
 
-    it("round-trips through setChargingTargets as named boolean days and scaled energy", async () => {
+    it("reads no day from a bitmap of 0", () => {
+        const schedules = decodeChargingTargetSchedules({
+            chargingTargetSchedules: [
+                { dayOfWeekForSequence: 0, chargingTargets: [{ targetTimeMinutesPastMidnight: 60 }] },
+            ],
+        });
+        expect(schedules[0]?.days).to.deep.equal({});
+    });
+
+    it("reads every day from a full bitmap", () => {
+        const schedules = decodeChargingTargetSchedules({
+            chargingTargetSchedules: [
+                { dayOfWeekForSequence: 0b1111111, chargingTargets: [{ targetTimeMinutesPastMidnight: 60 }] },
+            ],
+        });
+        expect(schedules[0]?.days).to.deep.equal({
+            sunday: true,
+            monday: true,
+            tuesday: true,
+            wednesday: true,
+            thursday: true,
+            friday: true,
+            saturday: true,
+        });
+    });
+
+    it("reads an addedEnergy that arrives as an int64 bigint", () => {
+        const schedules = decodeChargingTargetSchedules({
+            chargingTargetSchedules: [
+                {
+                    dayOfWeekForSequence: 2,
+                    chargingTargets: [{ targetTimeMinutesPastMidnight: 60, addedEnergy: 10_000_000n }],
+                },
+            ],
+        });
+        expect(schedules[0]?.targets[0]?.addedEnergyKWh).to.equal(10);
+    });
+
+    it("round-trips through setChargingTargets as a day bitmap and scaled energy", async () => {
         const { client, calls } = fakeCommandClient();
         const schedules: EditableChargingSchedule[] = [
             {
@@ -240,18 +279,30 @@ describe("charging target schedule decoding", () => {
         expect(calls[0]?.payload).to.deep.equal({
             chargingTargetSchedules: [
                 {
-                    dayOfWeekForSequence: { saturday: true, sunday: true },
+                    dayOfWeekForSequence: 0b1000001,
                     chargingTargets: [{ targetTimeMinutesPastMidnight: 480, addedEnergy: 12_500_000 }],
                 },
             ],
         });
     });
 
+    it("round-trips a decoded schedule back to the bitmap it came from", async () => {
+        const decoded = decodeChargingTargetSchedules({
+            chargingTargetSchedules: [
+                { dayOfWeekForSequence: 0b0101010, chargingTargets: [{ targetTimeMinutesPastMidnight: 480 }] },
+            ],
+        });
+        const { client, calls } = fakeCommandClient();
+        await setChargingTargets(client, 1, 1, decoded);
+        const sent = calls[0]?.payload as { chargingTargetSchedules: { dayOfWeekForSequence: number }[] };
+        expect(sent.chargingTargetSchedules[0]?.dayOfWeekForSequence).to.equal(0b0101010);
+    });
+
     it("fetches and decodes through getChargingTargets", async () => {
         const { client, setResponse } = fakeCommandClient();
         setResponse({
             chargingTargetSchedules: [
-                { dayOfWeekForSequence: { friday: true }, chargingTargets: [{ targetTimeMinutesPastMidnight: 60 }] },
+                { dayOfWeekForSequence: 1 << 5, chargingTargets: [{ targetTimeMinutesPastMidnight: 60 }] },
             ],
         });
         const schedules = await getChargingTargets(client, 1, 1);
@@ -262,6 +313,12 @@ describe("charging target schedule decoding", () => {
 });
 
 describe("local datetime-local <-> Matter epoch-s conversion", () => {
+    it("rejects a date the uint32 epoch-s field cannot carry", () => {
+        expect(fromLocalDateTimeInputValue("1999-12-31T23:59")).to.equal(undefined);
+        expect(fromLocalDateTimeInputValue("2137-01-01T00:00")).to.equal(undefined);
+        expect(fromLocalDateTimeInputValue("2000-01-01T12:00")).to.not.equal(undefined);
+    });
+
     it("round-trips a local datetime-local value through the Matter epoch", () => {
         const input = "2027-03-15T08:30";
         const epoch = fromLocalDateTimeInputValue(input);

--- a/packages/dashboard/test/EnergyEvseUtilTest.ts
+++ b/packages/dashboard/test/EnergyEvseUtilTest.ts
@@ -79,6 +79,22 @@ describe("energy evse util", () => {
         expect(unknown.canStartDiagnostics).to.equal(false);
     });
 
+    it("blocks the supply commands while a fault is active or diagnostics are running", () => {
+        // The reference delegate guards Disable, EnableCharging and EnableDischarging with the same
+        // CheckFaultOrDiagnostic(), so all three are refused in either state.
+        expect(energyEvseInfo(BASE_ATTRS, 1).supplyCommandsBlockedReason).to.equal(undefined);
+
+        const diagnostics = energyEvseInfo({ ...BASE_ATTRS, "1/153/1": 4 }, 1);
+        expect(diagnostics.supplyCommandsBlockedReason).to.contain("self-diagnostics");
+
+        const faulted = energyEvseInfo({ ...BASE_ATTRS, "1/153/2": 3 }, 1);
+        expect(faulted.supplyCommandsBlockedReason).to.contain("fault");
+
+        // A fault outranks diagnostics: it is the condition the operator has to deal with first.
+        const both = energyEvseInfo({ ...BASE_ATTRS, "1/153/1": 4, "1/153/2": 3 }, 1);
+        expect(both.supplyCommandsBlockedReason).to.contain("fault");
+    });
+
     it("flags an active fault", () => {
         const info = energyEvseInfo({ ...BASE_ATTRS, "1/153/2": 4 }, 1);
         expect(info.faultState).to.equal("Over current");

--- a/packages/dashboard/test/EnergyEvseUtilTest.ts
+++ b/packages/dashboard/test/EnergyEvseUtilTest.ts
@@ -62,16 +62,20 @@ describe("energy evse util", () => {
 
     it("offers StartDiagnostics only while SupplyState is Disabled", () => {
         const chargingEnabled = energyEvseInfo(BASE_ATTRS, 1); // SupplyState: ChargingEnabled (1)
+        expect(chargingEnabled.diagnosticsActive).to.equal(false);
         expect(chargingEnabled.canStartDiagnostics).to.equal(false);
 
         const disabled = energyEvseInfo({ ...BASE_ATTRS, "1/153/1": 0 }, 1);
+        expect(disabled.diagnosticsActive).to.equal(false);
         expect(disabled.canStartDiagnostics).to.equal(true);
 
         const diagnostics = energyEvseInfo({ ...BASE_ATTRS, "1/153/1": 4 }, 1);
+        expect(diagnostics.diagnosticsActive).to.equal(true);
         expect(diagnostics.canStartDiagnostics).to.equal(false);
 
         // An unread SupplyState is not evidence that the command would be accepted.
         const unknown = energyEvseInfo({ ...BASE_ATTRS, "1/153/1": undefined }, 1);
+        expect(unknown.diagnosticsActive).to.equal(false);
         expect(unknown.canStartDiagnostics).to.equal(false);
     });
 

--- a/packages/dashboard/test/EnergyEvseUtilTest.ts
+++ b/packages/dashboard/test/EnergyEvseUtilTest.ts
@@ -5,6 +5,9 @@
  */
 
 import type { MatterClient } from "@matter-server/ws-client";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import {
     chargingScheduleError,
     clearChargingTargets,
@@ -390,6 +393,16 @@ describe("chargingScheduleError", () => {
         expect(chargingScheduleError(many, true)).to.contain("at most");
     });
 
+    it("rejects a fractional state of charge, which the percent field cannot carry", () => {
+        const targets = [{ timeMinutes: 360, targetSoC: 50.5 }];
+        expect(chargingScheduleError([schedule({ monday: true }, targets)], true)).to.contain("whole percentage");
+    });
+
+    it("rejects a target whose time field was cleared", () => {
+        const targets = [{ timeMinutes: undefined, targetSoC: 50 }];
+        expect(chargingScheduleError([schedule({ monday: true }, targets)], true)).to.contain("time of day");
+    });
+
     it("rejects a target time outside the day", () => {
         const targets = [{ timeMinutes: 1440, targetSoC: 50 }];
         expect(chargingScheduleError([schedule({ monday: true }, targets)], true)).to.contain("time of day");
@@ -398,10 +411,25 @@ describe("chargingScheduleError", () => {
 
 describe("local datetime-local <-> Matter epoch-s conversion", () => {
     it("rejects a local time that does not exist because of a DST jump", () => {
-        // Only meaningful in a zone with a spring-forward gap; elsewhere the value round-trips and is kept.
-        const gap = "2027-03-14T02:30";
-        const parsed = fromLocalDateTimeInputValue(gap);
-        if (parsed !== undefined) expect(toLocalDateTimeInputValue(parsed)).to.equal(gap);
+        // The conversion reads the host's zone, so the gap is exercised in a child process pinned to one
+        // that has it. 2027-03-14T02:30 does not exist in America/New_York: the clock skips 02:00 to 03:00.
+        const timeModule = pathToFileURL(resolve("dist/esm/util/time.js")).href;
+        const script = `
+            const { fromLocalDateTimeInputValue } = await import(${JSON.stringify(timeModule)});
+            process.stdout.write(JSON.stringify({
+                gap: fromLocalDateTimeInputValue("2027-03-14T02:30") ?? null,
+                justBefore: fromLocalDateTimeInputValue("2027-03-14T01:30") ?? null,
+                justAfter: fromLocalDateTimeInputValue("2027-03-14T03:30") ?? null,
+            }));
+        `;
+        const out = execFileSync(process.execPath, ["--input-type=module", "-e", script], {
+            env: { ...process.env, TZ: "America/New_York" },
+            encoding: "utf8",
+        });
+        const result = JSON.parse(out) as { gap: number | null; justBefore: number | null; justAfter: number | null };
+        expect(result.gap).to.equal(null);
+        expect(result.justBefore).to.not.equal(null);
+        expect(result.justAfter).to.not.equal(null);
     });
 
     it("rejects a date the uint32 epoch-s field cannot carry", () => {

--- a/packages/dashboard/test/EnergyEvseUtilTest.ts
+++ b/packages/dashboard/test/EnergyEvseUtilTest.ts
@@ -57,19 +57,15 @@ describe("energy evse util", () => {
 
     it("gates StartDiagnostics and EnableCharging/Discharging on SupplyState", () => {
         const chargingEnabled = energyEvseInfo(BASE_ATTRS, 1); // SupplyState: ChargingEnabled (1)
-        expect(chargingEnabled.diagnosticsActive).to.equal(false);
         expect(chargingEnabled.canStartDiagnostics).to.equal(false);
 
         const disabled = energyEvseInfo({ ...BASE_ATTRS, "1/153/1": 0 }, 1);
-        expect(disabled.diagnosticsActive).to.equal(false);
         expect(disabled.canStartDiagnostics).to.equal(true);
 
         const diagnostics = energyEvseInfo({ ...BASE_ATTRS, "1/153/1": 4 }, 1);
-        expect(diagnostics.diagnosticsActive).to.equal(true);
         expect(diagnostics.canStartDiagnostics).to.equal(false);
 
         const unknown = energyEvseInfo({ ...BASE_ATTRS, "1/153/1": undefined }, 1);
-        expect(unknown.diagnosticsActive).to.equal(false);
         expect(unknown.canStartDiagnostics).to.equal(true);
     });
 

--- a/packages/dashboard/test/EnergyEvseUtilTest.ts
+++ b/packages/dashboard/test/EnergyEvseUtilTest.ts
@@ -6,6 +6,7 @@
 
 import type { MatterClient } from "@matter-server/ws-client";
 import {
+    chargingScheduleError,
     clearChargingTargets,
     decodeChargingTargetSchedules,
     disableEvse,
@@ -13,8 +14,12 @@ import {
     energyEvseInfo,
     getChargingTargets,
     setChargingTargets,
+    MAX_CHARGING_SCHEDULES,
+    MAX_CHARGING_TARGETS_PER_SCHEDULE,
     startDiagnostics,
     type EditableChargingSchedule,
+    type EditableChargingTarget,
+    type EvseWeekday,
 } from "../src/util/energy-evse.js";
 import { fromLocalDateTimeInputValue, toLocalDateTimeInputValue } from "../src/util/time.js";
 
@@ -55,7 +60,7 @@ describe("energy evse util", () => {
         expect(info.maximumChargeCurrentA).to.equal(16);
     });
 
-    it("gates StartDiagnostics and EnableCharging/Discharging on SupplyState", () => {
+    it("offers StartDiagnostics only while SupplyState is Disabled", () => {
         const chargingEnabled = energyEvseInfo(BASE_ATTRS, 1); // SupplyState: ChargingEnabled (1)
         expect(chargingEnabled.canStartDiagnostics).to.equal(false);
 
@@ -65,8 +70,9 @@ describe("energy evse util", () => {
         const diagnostics = energyEvseInfo({ ...BASE_ATTRS, "1/153/1": 4 }, 1);
         expect(diagnostics.canStartDiagnostics).to.equal(false);
 
+        // An unread SupplyState is not evidence that the command would be accepted.
         const unknown = energyEvseInfo({ ...BASE_ATTRS, "1/153/1": undefined }, 1);
-        expect(unknown.canStartDiagnostics).to.equal(true);
+        expect(unknown.canStartDiagnostics).to.equal(false);
     });
 
     it("flags an active fault", () => {
@@ -308,7 +314,76 @@ describe("charging target schedule decoding", () => {
     });
 });
 
+describe("chargingScheduleError", () => {
+    const schedule = (
+        days: Partial<Record<EvseWeekday, boolean>>,
+        targets: EditableChargingTarget[],
+    ): EditableChargingSchedule => ({ days, targets });
+
+    it("accepts a SoC target on a SoC-reporting EVSE", () => {
+        expect(
+            chargingScheduleError([schedule({ monday: true }, [{ timeMinutes: 360, targetSoC: 80 }])], true),
+        ).to.equal(null);
+    });
+
+    it("accepts a SoC target that also carries an added-energy goal", () => {
+        // AddedEnergy is "[SOC], O.a+": allowed alongside TargetSoC, not instead of it.
+        const targets = [{ timeMinutes: 360, targetSoC: 80, addedEnergyKWh: 10 }];
+        expect(chargingScheduleError([schedule({ monday: true }, targets)], true)).to.equal(null);
+    });
+
+    it("requires a SoC goal on a SoC-reporting EVSE even when energy is given", () => {
+        const targets = [{ timeMinutes: 360, addedEnergyKWh: 10 }];
+        expect(chargingScheduleError([schedule({ monday: true }, targets)], true)).to.contain("state of charge");
+    });
+
+    it("requires an added-energy goal when the EVSE does not report SoC", () => {
+        expect(chargingScheduleError([schedule({ monday: true }, [{ timeMinutes: 360 }])], false)).to.contain(
+            "added-energy",
+        );
+        const targets = [{ timeMinutes: 360, addedEnergyKWh: 10 }];
+        expect(chargingScheduleError([schedule({ monday: true }, targets)], false)).to.equal(null);
+    });
+
+    it("accepts a schedule with no targets, which is how a day is cleared", () => {
+        // ChargingTargets is "max 10" with no minimum.
+        expect(chargingScheduleError([schedule({ monday: true }, [])], true)).to.equal(null);
+    });
+
+    it("rejects a schedule with no day selected", () => {
+        expect(chargingScheduleError([schedule({}, [])], true)).to.contain("at least one day");
+    });
+
+    it("rejects a weekday claimed by more than one schedule", () => {
+        const schedules = [schedule({ monday: true, friday: true }, []), schedule({ friday: true }, [])];
+        expect(chargingScheduleError(schedules, true)).to.contain("only one schedule");
+    });
+
+    it("rejects more targets or schedules than the device stores", () => {
+        const targets = Array.from({ length: MAX_CHARGING_TARGETS_PER_SCHEDULE + 1 }, (_, i) => ({
+            timeMinutes: i,
+            targetSoC: 50,
+        }));
+        expect(chargingScheduleError([schedule({ monday: true }, targets)], true)).to.contain("at most");
+
+        const many = Array.from({ length: MAX_CHARGING_SCHEDULES + 1 }, () => schedule({ monday: true }, []));
+        expect(chargingScheduleError(many, true)).to.contain("at most");
+    });
+
+    it("rejects a target time outside the day", () => {
+        const targets = [{ timeMinutes: 1440, targetSoC: 50 }];
+        expect(chargingScheduleError([schedule({ monday: true }, targets)], true)).to.contain("time of day");
+    });
+});
+
 describe("local datetime-local <-> Matter epoch-s conversion", () => {
+    it("rejects a local time that does not exist because of a DST jump", () => {
+        // Only meaningful in a zone with a spring-forward gap; elsewhere the value round-trips and is kept.
+        const gap = "2027-03-14T02:30";
+        const parsed = fromLocalDateTimeInputValue(gap);
+        if (parsed !== undefined) expect(toLocalDateTimeInputValue(parsed)).to.equal(gap);
+    });
+
     it("rejects a date the uint32 epoch-s field cannot carry", () => {
         expect(fromLocalDateTimeInputValue("1999-12-31T23:59")).to.equal(undefined);
         expect(fromLocalDateTimeInputValue("2137-01-01T00:00")).to.equal(undefined);


### PR DESCRIPTION
## Summary

Adds a dashboard panel that decodes and controls the **EnergyEvse** cluster (0x99 / 153), following the existing MeterIdentification / CommodityTariff panel pattern.

### Read-only decoding
- State, SupplyState, FaultState (highlighted when active), charging limits, session info
- Feature-gated sections: V2X (bidirectional charging), Charging preferences, SoC reporting, Plug and Charge
- Fixes a pre-existing label bug in the generated cluster/feature descriptions where an embedded acronym (`SoC`, `V2X`) was mis-split by `decamelize` into "So Creporting" / "V2 X"

### Commands
- `Disable`, `EnableCharging`, `StartDiagnostics`, and (when V2X is supported) `EnableDischarging`, each with the relevant inputs (expiry, min/max current)
- A weekly charging schedule editor (`GetTargets` / `SetTargets` / `ClearTargets`) under Charging preferences
- Actions the device's current `SupplyState` would reject (e.g. enabling charging while self-diagnostics are active) are greyed out instead of surfacing a bare `Failure (code 1)`, with a hint pointing at `Disable` when a command fails anyway

## Testing

- `npm run format`, `npm run lint`, `npm run build` — all pass
- `npm test -w @matter-server/dashboard` — 444/444 pass (added `EnergyEvseUtilTest.ts` covering decoding, feature gating, command payload shapes, and the local-datetime ↔ Matter epoch-s conversion)
- Manually exercised against a Matterbridge-simulated EVSE device (`EvseFullFeatures`) with all optional features enabled

