### PR TITLE
feat(dashboard): decode the DeviceEnergyManagement Forecast attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 ## **WORK IN PROGRESS**
 
+- Enhancement: (lboue) Added a Forecast panel for the DeviceEnergyManagement cluster to Dashboard, decoding per-slot power/energy, timing and adjustment limits
 - Enhancement: (lboue) Added a command panel for the DoorLock cluster to Dashboard
 - Enhancement: (lboue) Added Presets and Thermostat Suggestions (Thermostat cluster PRES/TSUGGEST features) panels to Dashboard
 - Fix: BLE proxy connections are pinged every 15 seconds and terminated after 45 to 60 seconds of silence, so a proxy client that loses power is detected instead of staying registered indefinitely

--- a/packages/dashboard/src/pages/cluster-commands/clusters/device-energy-management-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/device-energy-management-commands.ts
@@ -179,12 +179,14 @@ export class DeviceEnergyManagementClusterCommands extends BaseClusterCommands {
 
     /** Nominal draw when the device commits to one, otherwise the band it stays inside. */
     private _slotPower(slot: ForecastSlotInfo, info: DeviceEnergyManagementInfo): TemplateResult | typeof nothing {
-        const generating = (slot.nominalPowerW ?? slot.energyWh ?? 0) < 0;
+        const generating = (slot.nominalPowerW ?? slot.energyWh ?? slot.minPowerW ?? slot.maxPowerW ?? 0) < 0;
         const value =
             slot.nominalPowerW !== undefined
                 ? formatPower(Math.abs(slot.nominalPowerW))
                 : slot.minPowerW !== undefined && slot.maxPowerW !== undefined
-                  ? `${formatPower(Math.abs(slot.minPowerW))}–${formatPower(Math.abs(slot.maxPowerW))}`
+                  ? generating
+                      ? `${formatPower(Math.abs(slot.maxPowerW))}–${formatPower(Math.abs(slot.minPowerW))}`
+                      : `${formatPower(Math.abs(slot.minPowerW))}–${formatPower(Math.abs(slot.maxPowerW))}`
                   : undefined;
         if (value === undefined) return nothing;
         return html`

--- a/packages/dashboard/src/pages/cluster-commands/clusters/device-energy-management-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/device-energy-management-commands.ts
@@ -145,6 +145,11 @@ export class DeviceEnergyManagementClusterCommands extends BaseClusterCommands {
                     </div>
                     <div class="slot-sub">${this._slotDetail(slot)}</div>
                     ${
+                        this._slotAdjustment(slot) !== undefined
+                            ? html`<div class="slot-sub">${this._slotAdjustment(slot)}</div>`
+                            : nothing
+                    }
+                    ${
                         slot.costs.length > 0
                             ? html`<div class="slot-sub">
                                   ${slot.costs
@@ -162,19 +167,35 @@ export class DeviceEnergyManagementClusterCommands extends BaseClusterCommands {
     /** Duration and energy for the slot; the running one shows its live clock instead of the plan. */
     private _slotDetail(slot: ForecastSlotInfo): string {
         const parts = new Array<string>();
+        parts.push(STATUS_LABELS[slot.status]);
         if (slot.status === "active" && slot.elapsedSeconds !== undefined && slot.remainingSeconds !== undefined) {
             parts.push(
                 `${formatDuration(slot.elapsedSeconds)} elapsed`,
                 `${formatDuration(slot.remainingSeconds)} left`,
             );
-        } else {
-            parts.push(STATUS_LABELS[slot.status]);
-            if (slot.durationSeconds !== undefined) parts.push(formatDuration(slot.durationSeconds));
+        } else if (slot.durationSeconds !== undefined) {
+            parts.push(formatDuration(slot.durationSeconds));
         }
         if (slot.energyWh !== undefined) {
             parts.push(`${formatEnergy(Math.abs(slot.energyWh))}${slot.energyEstimated ? " est." : ""}`);
         }
         return parts.join(" · ");
+    }
+
+    /** How far a shiftable load says this slot may be moved, under the ForecastAdjustment feature. */
+    private _slotAdjustment(slot: ForecastSlotInfo): string | undefined {
+        const parts = new Array<string>();
+        if (slot.minPowerAdjustmentW !== undefined && slot.maxPowerAdjustmentW !== undefined) {
+            parts.push(`power ${formatPower(slot.minPowerAdjustmentW)}–${formatPower(slot.maxPowerAdjustmentW)}`);
+        }
+        if (slot.minDurationAdjustmentSeconds !== undefined && slot.maxDurationAdjustmentSeconds !== undefined) {
+            parts.push(
+                `duration ${formatDuration(slot.minDurationAdjustmentSeconds)}–${formatDuration(
+                    slot.maxDurationAdjustmentSeconds,
+                )}`,
+            );
+        }
+        return parts.length > 0 ? `Adjustable: ${parts.join(" · ")}` : undefined;
     }
 
     /** Nominal draw when the device commits to one, otherwise the band it stays inside. */
@@ -207,7 +228,7 @@ export class DeviceEnergyManagementClusterCommands extends BaseClusterCommands {
                 ${
                     consumedEnergyWh > 0
                         ? html`<div class="total-row">
-                              <span>Forecast consumption${forecast.energyEstimated ? " (est.)" : ""}</span>
+                              <span>Forecast consumption${forecast.consumedEnergyEstimated ? " (est.)" : ""}</span>
                               <b>${formatEnergy(consumedEnergyWh)}</b>
                           </div>`
                         : nothing
@@ -215,7 +236,7 @@ export class DeviceEnergyManagementClusterCommands extends BaseClusterCommands {
                 ${
                     generatedEnergyWh > 0
                         ? html`<div class="total-row">
-                              <span>Forecast generation${forecast.energyEstimated ? " (est.)" : ""}</span>
+                              <span>Forecast generation${forecast.generatedEnergyEstimated ? " (est.)" : ""}</span>
                               <b class="generating">${formatEnergy(generatedEnergyWh)}</b>
                           </div>`
                         : nothing
@@ -350,8 +371,8 @@ export class DeviceEnergyManagementClusterCommands extends BaseClusterCommands {
                 font-size: 12px;
                 padding: 1px 6px;
                 border-radius: 8px;
-                background: var(--md-sys-color-surface-container-high);
-                color: var(--md-sys-color-on-surface-variant);
+                background: var(--md-sys-color-secondary-container);
+                color: var(--md-sys-color-on-secondary-container);
             }
             .slot-power {
                 text-align: right;

--- a/packages/dashboard/src/pages/cluster-commands/clusters/device-energy-management-commands.ts
+++ b/packages/dashboard/src/pages/cluster-commands/clusters/device-energy-management-commands.ts
@@ -1,0 +1,403 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { css, html, nothing, type CSSResultGroup, type TemplateResult } from "lit";
+import { customElement } from "lit/decorators.js";
+import {
+    DEVICE_ENERGY_MANAGEMENT_CLUSTER_ID,
+    deviceEnergyManagementInfo,
+    formatEnergy,
+    formatPower,
+    type DeviceEnergyManagementInfo,
+    type ForecastInfo,
+    type ForecastSlotInfo,
+} from "../../../util/device-energy-management.js";
+import { formatDuration } from "../../../util/duration.js";
+import { formatEpochTime } from "../../../util/time.js";
+import { BaseClusterCommands } from "../base-cluster-commands.js";
+import { registerClusterCommands } from "../registry.js";
+
+const SLOT_MARKERS: Record<ForecastSlotInfo["status"], string> = {
+    completed: "✓",
+    active: "●",
+    scheduled: "○",
+};
+
+const STATUS_LABELS: Record<ForecastSlotInfo["status"], string> = {
+    completed: "Completed",
+    active: "Running",
+    scheduled: "Scheduled",
+};
+
+/**
+ * Read-only decoding panel for the DeviceEnergyManagement cluster (ID: 0x98 / 152), centred on the
+ * Forecast attribute: what each slot of the plan draws or generates, and what the whole plan costs.
+ */
+@customElement("device-energy-management-cluster-commands")
+export class DeviceEnergyManagementClusterCommands extends BaseClusterCommands {
+    override render() {
+        if (!this.node || this.cluster !== DEVICE_ENERGY_MANAGEMENT_CLUSTER_ID) return nothing;
+        const info = deviceEnergyManagementInfo(this.node.attributes, this.endpoint);
+        if (!info.supported) return nothing;
+
+        return html`
+            <details class="command-panel" open>
+                <summary>Device Energy Management</summary>
+                <div class="command-content">
+                    ${this._renderHeader(info)} ${this._renderForecast(info)} ${this._renderDeviceLimits(info)}
+                </div>
+            </details>
+        `;
+    }
+
+    private _renderHeader(info: DeviceEnergyManagementInfo): TemplateResult {
+        const reporting = info.features.powerForecastReporting
+            ? "Power forecast"
+            : info.features.stateForecastReporting
+              ? "State forecast"
+              : undefined;
+        const slotCount = info.forecast?.slots.length ?? 0;
+        const active = info.forecast?.activeSlotNumber;
+        const position = active !== undefined && slotCount > 0 ? `slot ${active + 1} of ${slotCount}` : undefined;
+
+        return html`
+            <p class="esa-header">
+                <b>${info.esaType ?? "Energy smart appliance"}</b>
+                <span class="esa-meta">
+                    ${[info.esaState, reporting, position].filter(part => part !== undefined).join(" · ")}
+                </span>
+            </p>
+        `;
+    }
+
+    private _renderForecast(info: DeviceEnergyManagementInfo): TemplateResult | typeof nothing {
+        const forecast = info.forecast;
+        if (!forecast) return html`<p class="empty">No forecast published.</p>`;
+
+        return html`
+            ${this._renderWindow(forecast)}
+            ${
+                forecast.slots.length > 0
+                    ? html`<ol class="slots">
+                          ${forecast.slots.map(slot => this._renderSlot(slot, info))}
+                      </ol>`
+                    : html`<p class="empty">The forecast carries no slots.</p>`
+            }
+            ${this._renderTotals(forecast)} ${this._renderForecastMeta(forecast)}
+        `;
+    }
+
+    private _renderWindow(forecast: ForecastInfo): TemplateResult | typeof nothing {
+        if (forecast.startTime === undefined) return nothing;
+        const end = forecast.endTime !== undefined ? html`–${formatEpochTime(forecast.endTime)}` : nothing;
+        const flexibility =
+            forecast.earliestStartTime !== undefined || forecast.latestEndTime !== undefined
+                ? html`<span class="flexibility">
+                      can shift within
+                      ${
+                          forecast.earliestStartTime !== undefined
+                              ? formatEpochTime(forecast.earliestStartTime)
+                              : "start"
+                      }–${forecast.latestEndTime !== undefined ? formatEpochTime(forecast.latestEndTime) : "end"}
+                  </span>`
+                : nothing;
+
+        return html`
+            <div class="window">
+                <span class="window-range">${formatEpochTime(forecast.startTime)}${end}</span>
+                ${
+                    forecast.durationSeconds !== undefined
+                        ? html`<span class="window-duration">${formatDuration(forecast.durationSeconds)}</span>`
+                        : nothing
+                }
+                ${flexibility}
+            </div>
+        `;
+    }
+
+    private _renderSlot(slot: ForecastSlotInfo, info: DeviceEnergyManagementInfo): TemplateResult {
+        return html`
+            <li class="slot ${slot.status}">
+                <span class="marker" aria-hidden="true">${SLOT_MARKERS[slot.status]}</span>
+                <div class="slot-main">
+                    <div class="slot-title">
+                        <span class="slot-name">Slot ${slot.index + 1}</span>
+                        ${
+                            slot.startTime !== undefined
+                                ? html`<span class="slot-time">
+                                      ${formatEpochTime(slot.startTime)}${
+                                          slot.endTime !== undefined ? `–${formatEpochTime(slot.endTime)}` : ""
+                                      }
+                                  </span>`
+                                : nothing
+                        }
+                        ${
+                            slot.manufacturerEsaState !== undefined
+                                ? html`<span class="chip" title="Manufacturer-defined ESA state">
+                                      state ${slot.manufacturerEsaState}
+                                  </span>`
+                                : nothing
+                        }
+                        ${slot.pausable === true ? html`<span class="chip">pausable</span>` : nothing}
+                    </div>
+                    <div class="slot-sub">${this._slotDetail(slot)}</div>
+                    ${
+                        slot.costs.length > 0
+                            ? html`<div class="slot-sub">
+                                  ${slot.costs
+                                      .map(cost => `${cost.type}${cost.amount !== undefined ? ` ${cost.amount}` : ""}`)
+                                      .join(" · ")}
+                              </div>`
+                            : nothing
+                    }
+                </div>
+                <div class="slot-power">${this._slotPower(slot, info)}</div>
+            </li>
+        `;
+    }
+
+    /** Duration and energy for the slot; the running one shows its live clock instead of the plan. */
+    private _slotDetail(slot: ForecastSlotInfo): string {
+        const parts = new Array<string>();
+        if (slot.status === "active" && slot.elapsedSeconds !== undefined && slot.remainingSeconds !== undefined) {
+            parts.push(
+                `${formatDuration(slot.elapsedSeconds)} elapsed`,
+                `${formatDuration(slot.remainingSeconds)} left`,
+            );
+        } else {
+            parts.push(STATUS_LABELS[slot.status]);
+            if (slot.durationSeconds !== undefined) parts.push(formatDuration(slot.durationSeconds));
+        }
+        if (slot.energyWh !== undefined) {
+            parts.push(`${formatEnergy(Math.abs(slot.energyWh))}${slot.energyEstimated ? " est." : ""}`);
+        }
+        return parts.join(" · ");
+    }
+
+    /** Nominal draw when the device commits to one, otherwise the band it stays inside. */
+    private _slotPower(slot: ForecastSlotInfo, info: DeviceEnergyManagementInfo): TemplateResult | typeof nothing {
+        const generating = (slot.nominalPowerW ?? slot.energyWh ?? 0) < 0;
+        const value =
+            slot.nominalPowerW !== undefined
+                ? formatPower(Math.abs(slot.nominalPowerW))
+                : slot.minPowerW !== undefined && slot.maxPowerW !== undefined
+                  ? `${formatPower(Math.abs(slot.minPowerW))}–${formatPower(Math.abs(slot.maxPowerW))}`
+                  : undefined;
+        if (value === undefined) return nothing;
+        return html`
+            <span class=${generating ? "generating" : "consuming"}>${value}</span>
+            ${
+                generating || info.canGenerate === true
+                    ? html`<span class="direction">${generating ? "out" : "in"}</span>`
+                    : nothing
+            }
+        `;
+    }
+
+    private _renderTotals(forecast: ForecastInfo): TemplateResult | typeof nothing {
+        const { consumedEnergyWh, generatedEnergyWh } = forecast;
+        if (consumedEnergyWh === 0 && generatedEnergyWh === 0) return nothing;
+        return html`
+            <div class="totals">
+                ${
+                    consumedEnergyWh > 0
+                        ? html`<div class="total-row">
+                              <span>Forecast consumption${forecast.energyEstimated ? " (est.)" : ""}</span>
+                              <b>${formatEnergy(consumedEnergyWh)}</b>
+                          </div>`
+                        : nothing
+                }
+                ${
+                    generatedEnergyWh > 0
+                        ? html`<div class="total-row">
+                              <span>Forecast generation${forecast.energyEstimated ? " (est.)" : ""}</span>
+                              <b class="generating">${formatEnergy(generatedEnergyWh)}</b>
+                          </div>`
+                        : nothing
+                }
+            </div>
+        `;
+    }
+
+    private _renderForecastMeta(forecast: ForecastInfo): TemplateResult {
+        return html`
+            <dl class="info-grid">
+                ${
+                    forecast.forecastId !== undefined
+                        ? html`<dt>Forecast ID</dt>
+                              <dd>${forecast.forecastId}</dd>`
+                        : nothing
+                }
+                ${
+                    forecast.updateReason !== undefined
+                        ? html`<dt>Updated for</dt>
+                              <dd>${forecast.updateReason}</dd>`
+                        : nothing
+                }
+                ${
+                    forecast.isPausable !== undefined
+                        ? html`<dt>Pausable</dt>
+                              <dd>${forecast.isPausable ? "Yes" : "No"}</dd>`
+                        : nothing
+                }
+            </dl>
+        `;
+    }
+
+    private _renderDeviceLimits(info: DeviceEnergyManagementInfo): TemplateResult {
+        const range =
+            info.absMinPowerW !== undefined && info.absMaxPowerW !== undefined
+                ? `${formatPower(info.absMinPowerW)}–${formatPower(info.absMaxPowerW)}`
+                : undefined;
+        return html`
+            <dl class="info-grid">
+                ${
+                    range !== undefined
+                        ? html`<dt>Power range</dt>
+                              <dd>${range}</dd>`
+                        : nothing
+                }
+                ${
+                    info.canGenerate !== undefined
+                        ? html`<dt>Can generate</dt>
+                              <dd>${info.canGenerate ? "Yes" : "No"}</dd>`
+                        : nothing
+                }
+                ${
+                    info.optOutState !== undefined
+                        ? html`<dt>Opt-out</dt>
+                              <dd>${info.optOutState}</dd>`
+                        : nothing
+                }
+            </dl>
+        `;
+    }
+
+    static override styles: CSSResultGroup = [
+        BaseClusterCommands.styles,
+        css`
+            .command-content {
+                font-size: 14px;
+            }
+            .esa-header {
+                margin: 0 0 8px 0;
+                display: flex;
+                flex-wrap: wrap;
+                align-items: baseline;
+                gap: 8px;
+            }
+            .esa-meta,
+            .empty {
+                color: var(--text-color, rgba(0, 0, 0, 0.6));
+            }
+            .window {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 8px;
+                margin-bottom: 12px;
+                color: var(--text-color, rgba(0, 0, 0, 0.6));
+            }
+            .window-range {
+                font-weight: 500;
+                color: var(--md-sys-color-on-surface);
+            }
+            .slots {
+                list-style: none;
+                margin: 0 0 12px 0;
+                padding: 0;
+            }
+            .slot {
+                display: flex;
+                align-items: flex-start;
+                gap: 12px;
+                padding: 8px 0;
+                border-bottom: 1px solid var(--md-sys-color-outline-variant);
+            }
+            .slot .marker {
+                width: 16px;
+                text-align: center;
+                color: var(--text-color, rgba(0, 0, 0, 0.6));
+            }
+            .slot.active .marker {
+                color: var(--md-sys-color-primary);
+            }
+            .slot.active .slot-name {
+                font-weight: 700;
+            }
+            .slot.completed .slot-name {
+                color: var(--text-color, rgba(0, 0, 0, 0.6));
+            }
+            .slot-main {
+                flex: 1;
+                min-width: 0;
+            }
+            .slot-title {
+                display: flex;
+                flex-wrap: wrap;
+                align-items: baseline;
+                gap: 8px;
+            }
+            .slot-time,
+            .slot-sub {
+                color: var(--text-color, rgba(0, 0, 0, 0.6));
+            }
+            .chip {
+                font-size: 12px;
+                padding: 1px 6px;
+                border-radius: 8px;
+                background: var(--md-sys-color-surface-container-high);
+                color: var(--md-sys-color-on-surface-variant);
+            }
+            .slot-power {
+                text-align: right;
+                white-space: nowrap;
+                font-weight: 500;
+            }
+            .slot-power .generating,
+            .totals .generating {
+                color: var(--md-sys-color-primary);
+            }
+            .slot-power .direction {
+                display: block;
+                font-size: 12px;
+                font-weight: 400;
+                color: var(--text-color, rgba(0, 0, 0, 0.6));
+            }
+            .totals {
+                margin-bottom: 12px;
+            }
+            .total-row {
+                display: flex;
+                justify-content: space-between;
+                gap: 16px;
+                padding: 4px 0;
+            }
+            .info-grid {
+                display: grid;
+                grid-template-columns: auto 1fr;
+                gap: 6px 16px;
+                margin: 0;
+            }
+            .info-grid dt {
+                color: var(--text-color, rgba(0, 0, 0, 0.6));
+            }
+            .info-grid dd {
+                margin: 0;
+                font-weight: 500;
+            }
+        `,
+    ];
+}
+
+registerClusterCommands(DEVICE_ENERGY_MANAGEMENT_CLUSTER_ID, "device-energy-management-cluster-commands", {
+    renderWhenOffline: true,
+});
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "device-energy-management-cluster-commands": DeviceEnergyManagementClusterCommands;
+    }
+}

--- a/packages/dashboard/src/pages/cluster-commands/index.ts
+++ b/packages/dashboard/src/pages/cluster-commands/index.ts
@@ -29,6 +29,7 @@ import "./clusters/binding-commands.js";
 import "./clusters/chime-commands.js";
 import "./clusters/closure-control-commands.js";
 import "./clusters/commodity-tariff-commands.js";
+import "./clusters/device-energy-management-commands.js";
 import "./clusters/door-lock-commands.js";
 import "./clusters/icd-management-commands.js";
 import "./clusters/level-control-commands.js";

--- a/packages/dashboard/src/util/commodity-tariff.ts
+++ b/packages/dashboard/src/util/commodity-tariff.ts
@@ -150,12 +150,16 @@ function enumName(value: unknown, names: Record<number, string>): string | undef
     return names[raw] ?? `Unknown (${raw})`;
 }
 
+export function currencyInfo(code: unknown, decimalPoints: unknown): CurrencyInfo | undefined {
+    const codeValue = toNumber(code);
+    const decimalPointsValue = toNumber(decimalPoints);
+    if (codeValue === undefined || decimalPointsValue === undefined) return undefined;
+    if (decimalPointsValue < 0 || decimalPointsValue > MAX_DECIMAL_POINTS) return undefined;
+    return { code: codeValue, decimalPoints: decimalPointsValue, symbol: CURRENCY_SYMBOLS[codeValue] };
+}
+
 function decodeCurrency(value: unknown): CurrencyInfo | undefined {
-    const code = toNumber(field(value, 0));
-    const decimalPoints = toNumber(field(value, 1));
-    if (code === undefined || decimalPoints === undefined) return undefined;
-    if (decimalPoints < 0 || decimalPoints > MAX_DECIMAL_POINTS) return undefined;
-    return { code, decimalPoints, symbol: CURRENCY_SYMBOLS[code] };
+    return currencyInfo(field(value, 0), field(value, 1));
 }
 
 /**

--- a/packages/dashboard/src/util/device-energy-management.ts
+++ b/packages/dashboard/src/util/device-energy-management.ts
@@ -41,8 +41,8 @@ const ESA_TYPE_NAMES: Record<number, string> = {
     10: "Cooking",
     11: "Home water pump",
     12: "Irrigation water pump",
-    13: "Water pump",
-    14: "Pool pump",
+    13: "Pool pump",
+    14: "Water pump",
     255: "Other",
 };
 

--- a/packages/dashboard/src/util/device-energy-management.ts
+++ b/packages/dashboard/src/util/device-energy-management.ts
@@ -1,0 +1,372 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { tagField as field, toNumber } from "./attribute-shapes.js";
+import { currencyInfo, formatPrice, type CurrencyInfo } from "./commodity-tariff.js";
+
+export const DEVICE_ENERGY_MANAGEMENT_CLUSTER_ID = 152;
+
+const ATTR_ESA_TYPE = 0;
+const ATTR_ESA_CAN_GENERATE = 1;
+const ATTR_ESA_STATE = 2;
+const ATTR_ABS_MIN_POWER = 3;
+const ATTR_ABS_MAX_POWER = 4;
+const ATTR_FORECAST = 6;
+const ATTR_OPT_OUT_STATE = 7;
+const ATTR_FEATURE_MAP = 0xfffc;
+
+/** DeviceEnergyManagement FeatureMap bits per Matter 1.6 §9.2.4. */
+const FEATURE_POWER_ADJUSTMENT = 1 << 0;
+const FEATURE_POWER_FORECAST_REPORTING = 1 << 1;
+const FEATURE_STATE_FORECAST_REPORTING = 1 << 2;
+const FEATURE_START_TIME_ADJUSTMENT = 1 << 3;
+const FEATURE_PAUSABLE = 1 << 4;
+const FEATURE_FORECAST_ADJUSTMENT = 1 << 5;
+const FEATURE_CONSTRAINT_BASED_ADJUSTMENT = 1 << 6;
+
+const ESA_TYPE_NAMES: Record<number, string> = {
+    0: "EV Supply Equipment",
+    1: "Space heating",
+    2: "Water heating",
+    3: "Space cooling",
+    4: "Space heating & cooling",
+    5: "Battery storage",
+    6: "Solar PV",
+    7: "Fridge / freezer",
+    8: "Washing machine",
+    9: "Dishwasher",
+    10: "Cooking",
+    11: "Home water pump",
+    12: "Irrigation water pump",
+    13: "Water pump",
+    14: "Pool pump",
+    255: "Other",
+};
+
+const ESA_STATE_NAMES: Record<number, string> = {
+    0: "Offline",
+    1: "Online",
+    2: "Fault",
+    3: "Power adjust active",
+    4: "Paused",
+};
+
+const OPT_OUT_STATE_NAMES: Record<number, string> = {
+    0: "No opt-out",
+    1: "Local opt-out",
+    2: "Grid opt-out",
+    3: "Opted out",
+};
+
+const FORECAST_UPDATE_REASON_NAMES: Record<number, string> = {
+    0: "Internal optimization",
+    1: "Local optimization",
+    2: "Grid optimization",
+};
+
+const COST_TYPE_NAMES: Record<number, string> = {
+    0: "Financial",
+    1: "GHG emissions",
+    2: "Comfort",
+    3: "Temperature",
+};
+
+/** Where a slot sits relative to Forecast.ActiveSlotNumber. */
+export type SlotStatus = "completed" | "active" | "scheduled";
+
+export interface DeviceEnergyManagementFeatures {
+    powerAdjustment: boolean;
+    powerForecastReporting: boolean;
+    stateForecastReporting: boolean;
+    startTimeAdjustment: boolean;
+    pausable: boolean;
+    forecastAdjustment: boolean;
+    constraintBasedAdjustment: boolean;
+}
+
+export interface ForecastCostInfo {
+    type: string;
+    /** Value scaled by DecimalPoints, with the currency symbol when the cost carries one. */
+    amount?: string;
+}
+
+export interface ForecastSlotInfo {
+    /** Position in Forecast.Slots; ActiveSlotNumber indexes this same list. */
+    index: number;
+    status: SlotStatus;
+    minDurationSeconds?: number;
+    maxDurationSeconds?: number;
+    defaultDurationSeconds?: number;
+    elapsedSeconds?: number;
+    remainingSeconds?: number;
+    /** Live clock (elapsed + remaining) for the running slot, planned duration otherwise. */
+    durationSeconds?: number;
+    /** Matter epoch-s, accumulated from Forecast.StartTime over the preceding slots' durations. */
+    startTime?: number;
+    endTime?: number;
+    pausable?: boolean;
+    minPauseSeconds?: number;
+    maxPauseSeconds?: number;
+    /** Opaque device-defined state under SFR; only the manufacturer knows what it names. */
+    manufacturerEsaState?: number;
+    nominalPowerW?: number;
+    minPowerW?: number;
+    maxPowerW?: number;
+    /** Negative for a slot that generates rather than consumes. */
+    energyWh?: number;
+    /** The slot reported no NominalEnergy, so its energy is nominal power over the slot duration. */
+    energyEstimated: boolean;
+    minPowerAdjustmentW?: number;
+    maxPowerAdjustmentW?: number;
+    minDurationAdjustmentSeconds?: number;
+    maxDurationAdjustmentSeconds?: number;
+    costs: ForecastCostInfo[];
+}
+
+export interface ForecastInfo {
+    forecastId?: number;
+    /** Index into `slots` of the running slot; absent when the device reports none. */
+    activeSlotNumber?: number;
+    startTime?: number;
+    endTime?: number;
+    earliestStartTime?: number;
+    latestEndTime?: number;
+    isPausable?: boolean;
+    updateReason?: string;
+    slots: ForecastSlotInfo[];
+    durationSeconds?: number;
+    consumedEnergyWh: number;
+    generatedEnergyWh: number;
+    /** Any slot's energy was derived from its nominal power rather than reported. */
+    energyEstimated: boolean;
+}
+
+export interface DeviceEnergyManagementInfo {
+    supported: boolean;
+    esaTypeId?: number;
+    esaType?: string;
+    canGenerate?: boolean;
+    esaState?: string;
+    absMinPowerW?: number;
+    absMaxPowerW?: number;
+    optOutState?: string;
+    features: DeviceEnergyManagementFeatures;
+    forecast?: ForecastInfo;
+}
+
+function attr(attributes: Record<string, unknown>, endpoint: number, attributeId: number): unknown {
+    return attributes[`${endpoint}/${DEVICE_ENERGY_MANAGEMENT_CLUSTER_ID}/${attributeId}`];
+}
+
+function enumName(value: unknown, names: Record<number, string>): string | undefined {
+    const raw = toNumber(value);
+    if (raw === undefined) return undefined;
+    return names[raw] ?? `Unknown (${raw})`;
+}
+
+function toBoolean(value: unknown): boolean | undefined {
+    return typeof value === "boolean" ? value : undefined;
+}
+
+/** power-mW and energy-mWh fields carry milli-units; the dashboard works in W and Wh. */
+function milliToUnit(value: unknown): number | undefined {
+    const raw = toNumber(value);
+    return raw !== undefined ? raw / 1000 : undefined;
+}
+
+function decodeFeatures(featureMap: unknown): DeviceEnergyManagementFeatures {
+    const bits = toNumber(featureMap) ?? 0;
+    return {
+        powerAdjustment: (bits & FEATURE_POWER_ADJUSTMENT) !== 0,
+        powerForecastReporting: (bits & FEATURE_POWER_FORECAST_REPORTING) !== 0,
+        stateForecastReporting: (bits & FEATURE_STATE_FORECAST_REPORTING) !== 0,
+        startTimeAdjustment: (bits & FEATURE_START_TIME_ADJUSTMENT) !== 0,
+        pausable: (bits & FEATURE_PAUSABLE) !== 0,
+        forecastAdjustment: (bits & FEATURE_FORECAST_ADJUSTMENT) !== 0,
+        constraintBasedAdjustment: (bits & FEATURE_CONSTRAINT_BASED_ADJUSTMENT) !== 0,
+    };
+}
+
+/** DecimalPoints is a uint8; a scale past a few digits is not a cost this can render, and toFixed rejects 101+. */
+const MAX_COST_DECIMAL_POINTS = 6;
+
+function formatCost(value: number, decimalPoints: number, currency: CurrencyInfo | undefined): string | undefined {
+    if (decimalPoints < 0 || decimalPoints > MAX_COST_DECIMAL_POINTS) return undefined;
+    return formatPrice(value, currency) ?? (value / 10 ** decimalPoints).toFixed(decimalPoints);
+}
+
+function decodeCost(value: unknown): ForecastCostInfo | undefined {
+    const type = enumName(field(value, 0), COST_TYPE_NAMES);
+    const rawValue = toNumber(field(value, 1));
+    if (type === undefined && rawValue === undefined) return undefined;
+    const decimalPoints = toNumber(field(value, 2)) ?? 0;
+    return {
+        type: type ?? "Unknown",
+        amount:
+            rawValue === undefined
+                ? undefined
+                : formatCost(rawValue, decimalPoints, currencyInfo(field(value, 3), decimalPoints)),
+    };
+}
+
+function decodeCosts(value: unknown): ForecastCostInfo[] {
+    return Array.isArray(value) ? value.map(decodeCost).filter((c): c is ForecastCostInfo => c !== undefined) : [];
+}
+
+function slotStatus(index: number, activeSlotNumber: number | undefined): SlotStatus {
+    if (activeSlotNumber === undefined) return "scheduled";
+    if (index < activeSlotNumber) return "completed";
+    return index === activeSlotNumber ? "active" : "scheduled";
+}
+
+/**
+ * The running slot's own clock is the only figure that tracks a device drifting from its plan;
+ * for every other slot DefaultDuration is all the forecast commits to.
+ */
+function slotDuration(
+    status: SlotStatus,
+    elapsed: number | undefined,
+    remaining: number | undefined,
+    defaultDuration: number | undefined,
+    minDuration: number | undefined,
+): number | undefined {
+    if (status === "active" && elapsed !== undefined && remaining !== undefined) return elapsed + remaining;
+    return defaultDuration ?? (remaining !== undefined && remaining > 0 ? remaining : undefined) ?? minDuration;
+}
+
+function decodeSlot(value: unknown, index: number, activeSlotNumber: number | undefined): ForecastSlotInfo {
+    const status = slotStatus(index, activeSlotNumber);
+    const minDurationSeconds = toNumber(field(value, 0));
+    const defaultDurationSeconds = toNumber(field(value, 2));
+    const elapsedSeconds = toNumber(field(value, 3));
+    const remainingSeconds = toNumber(field(value, 4));
+    const durationSeconds = slotDuration(
+        status,
+        elapsedSeconds,
+        remainingSeconds,
+        defaultDurationSeconds,
+        minDurationSeconds,
+    );
+    const nominalPowerW = milliToUnit(field(value, 9));
+    const nominalEnergyWh = milliToUnit(field(value, 12));
+    const energyWh =
+        nominalEnergyWh ??
+        (nominalPowerW !== undefined && durationSeconds !== undefined
+            ? (nominalPowerW * durationSeconds) / 3600
+            : undefined);
+
+    return {
+        index,
+        status,
+        minDurationSeconds,
+        maxDurationSeconds: toNumber(field(value, 1)),
+        defaultDurationSeconds,
+        elapsedSeconds,
+        remainingSeconds,
+        durationSeconds,
+        pausable: toBoolean(field(value, 5)),
+        minPauseSeconds: toNumber(field(value, 6)),
+        maxPauseSeconds: toNumber(field(value, 7)),
+        manufacturerEsaState: toNumber(field(value, 8)),
+        nominalPowerW,
+        minPowerW: milliToUnit(field(value, 10)),
+        maxPowerW: milliToUnit(field(value, 11)),
+        energyWh,
+        energyEstimated: nominalEnergyWh === undefined && energyWh !== undefined,
+        minPowerAdjustmentW: milliToUnit(field(value, 14)),
+        maxPowerAdjustmentW: milliToUnit(field(value, 15)),
+        minDurationAdjustmentSeconds: toNumber(field(value, 16)),
+        maxDurationAdjustmentSeconds: toNumber(field(value, 17)),
+        costs: decodeCosts(field(value, 13)),
+    };
+}
+
+/**
+ * Slots carry durations, not instants, so a slot's clock time is Forecast.StartTime plus everything
+ * ahead of it. A slot whose duration is unknown breaks the chain: the ones after it get no times.
+ */
+function applySlotTimes(slots: ForecastSlotInfo[], forecastStartTime: number | undefined): void {
+    let cursor = forecastStartTime;
+    for (const slot of slots) {
+        if (cursor === undefined) return;
+        slot.startTime = cursor;
+        if (slot.durationSeconds === undefined) {
+            cursor = undefined;
+            continue;
+        }
+        cursor += slot.durationSeconds;
+        slot.endTime = cursor;
+    }
+}
+
+function decodeForecast(value: unknown): ForecastInfo | undefined {
+    const rawSlots = field(value, 7);
+    const startTime = toNumber(field(value, 2));
+    const endTime = toNumber(field(value, 3));
+    if (!Array.isArray(rawSlots) && startTime === undefined) return undefined;
+
+    const activeSlotNumber = toNumber(field(value, 1));
+    const slots = Array.isArray(rawSlots)
+        ? rawSlots.map((slot, index) => decodeSlot(slot, index, activeSlotNumber))
+        : [];
+    applySlotTimes(slots, startTime);
+
+    const energies = slots.map(slot => slot.energyWh).filter((wh): wh is number => wh !== undefined);
+    const slotSeconds = slots.reduce((total, slot) => total + (slot.durationSeconds ?? 0), 0);
+
+    return {
+        forecastId: toNumber(field(value, 0)),
+        activeSlotNumber,
+        startTime,
+        endTime,
+        earliestStartTime: toNumber(field(value, 4)),
+        latestEndTime: toNumber(field(value, 5)),
+        isPausable: toBoolean(field(value, 6)),
+        updateReason: enumName(field(value, 8), FORECAST_UPDATE_REASON_NAMES),
+        slots,
+        durationSeconds:
+            startTime !== undefined && endTime !== undefined
+                ? endTime - startTime
+                : slotSeconds > 0
+                  ? slotSeconds
+                  : undefined,
+        consumedEnergyWh: energies.filter(wh => wh > 0).reduce((total, wh) => total + wh, 0),
+        generatedEnergyWh: energies.filter(wh => wh < 0).reduce((total, wh) => total - wh, 0),
+        energyEstimated: slots.some(slot => slot.energyEstimated),
+    };
+}
+
+export function deviceEnergyManagementInfo(
+    attributes: Record<string, unknown>,
+    endpoint: number,
+): DeviceEnergyManagementInfo {
+    const featureMap = attr(attributes, endpoint, ATTR_FEATURE_MAP);
+    const esaTypeId = toNumber(attr(attributes, endpoint, ATTR_ESA_TYPE));
+
+    return {
+        supported: featureMap !== undefined,
+        esaTypeId,
+        esaType: enumName(esaTypeId, ESA_TYPE_NAMES),
+        canGenerate: toBoolean(attr(attributes, endpoint, ATTR_ESA_CAN_GENERATE)),
+        esaState: enumName(attr(attributes, endpoint, ATTR_ESA_STATE), ESA_STATE_NAMES),
+        absMinPowerW: milliToUnit(attr(attributes, endpoint, ATTR_ABS_MIN_POWER)),
+        absMaxPowerW: milliToUnit(attr(attributes, endpoint, ATTR_ABS_MAX_POWER)),
+        optOutState: enumName(attr(attributes, endpoint, ATTR_OPT_OUT_STATE), OPT_OUT_STATE_NAMES),
+        features: decodeFeatures(featureMap),
+        forecast: decodeForecast(attr(attributes, endpoint, ATTR_FORECAST)),
+    };
+}
+
+/** Formats watts, switching to kW past 10 kW where the extra digits stop carrying meaning. */
+export function formatPower(watts: number): string {
+    if (Math.abs(watts) >= 10_000) return `${(watts / 1000).toFixed(2)} kW`;
+    return `${Number(watts.toFixed(1))} W`;
+}
+
+export function formatEnergy(wattHours: number): string {
+    if (Math.abs(wattHours) >= 1000) return `${(wattHours / 1000).toFixed(2)} kWh`;
+    return `${Number(wattHours.toFixed(1))} Wh`;
+}

--- a/packages/dashboard/src/util/device-energy-management.ts
+++ b/packages/dashboard/src/util/device-energy-management.ts
@@ -42,7 +42,6 @@ const ESA_TYPE_NAMES: Record<number, string> = {
     11: "Home water pump",
     12: "Irrigation water pump",
     13: "Pool pump",
-    14: "Water pump",
     255: "Other",
 };
 
@@ -140,8 +139,10 @@ export interface ForecastInfo {
     durationSeconds?: number;
     consumedEnergyWh: number;
     generatedEnergyWh: number;
-    /** Any slot's energy was derived from its nominal power rather than reported. */
-    energyEstimated: boolean;
+    /** A consuming slot's energy was derived from its nominal power rather than reported. */
+    consumedEnergyEstimated: boolean;
+    /** A generating slot's energy was derived from its nominal power rather than reported. */
+    generatedEnergyEstimated: boolean;
 }
 
 export interface DeviceEnergyManagementInfo {
@@ -335,7 +336,8 @@ function decodeForecast(value: unknown): ForecastInfo | undefined {
                   : undefined,
         consumedEnergyWh: energies.filter(wh => wh > 0).reduce((total, wh) => total + wh, 0),
         generatedEnergyWh: energies.filter(wh => wh < 0).reduce((total, wh) => total - wh, 0),
-        energyEstimated: slots.some(slot => slot.energyEstimated),
+        consumedEnergyEstimated: slots.some(slot => slot.energyEstimated && (slot.energyWh ?? 0) > 0),
+        generatedEnergyEstimated: slots.some(slot => slot.energyEstimated && (slot.energyWh ?? 0) < 0),
     };
 }
 

--- a/packages/dashboard/src/util/device-energy-management.ts
+++ b/packages/dashboard/src/util/device-energy-management.ts
@@ -316,7 +316,11 @@ function decodeForecast(value: unknown): ForecastInfo | undefined {
     applySlotTimes(slots, startTime);
 
     const energies = slots.map(slot => slot.energyWh).filter((wh): wh is number => wh !== undefined);
-    const slotSeconds = slots.reduce((total, slot) => total + (slot.durationSeconds ?? 0), 0);
+    // A partial sum would be shown as the whole forecast's length, so the fallback only applies when
+    // every slot contributes.
+    const slotSeconds = slots.every(slot => slot.durationSeconds !== undefined)
+        ? slots.reduce((total, slot) => total + (slot.durationSeconds ?? 0), 0)
+        : 0;
 
     return {
         forecastId: toNumber(field(value, 0)),

--- a/packages/dashboard/test/DeviceEnergyManagementUtilTest.ts
+++ b/packages/dashboard/test/DeviceEnergyManagementUtilTest.ts
@@ -171,10 +171,13 @@ describe("device energy management util", () => {
             "2": FORECAST_START,
             "7": [{ "2": 600 }, { "8": 1 }, { "2": 600 }],
         };
-        const slots = deviceEnergyManagementInfo({ ...DISHWASHER_ATTRS, "1/152/6": forecast }, 1).forecast!.slots;
+        const info = deviceEnergyManagementInfo({ ...DISHWASHER_ATTRS, "1/152/6": forecast }, 1).forecast!;
+        const slots = info.slots;
         expect(slots[1].startTime).to.equal(FORECAST_START + 600);
         expect(slots[1].endTime).to.equal(undefined);
         expect(slots[2].startTime).to.equal(undefined);
+        // The slots that do have a duration sum to 1200 s, which is not the forecast's length.
+        expect(info.durationSeconds).to.equal(undefined);
     });
 
     it("totals the forecast's consumption over its slots", () => {

--- a/packages/dashboard/test/DeviceEnergyManagementUtilTest.ts
+++ b/packages/dashboard/test/DeviceEnergyManagementUtilTest.ts
@@ -1,0 +1,269 @@
+/**
+ * @license
+ * Copyright 2025-2026 Open Home Foundation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { deviceEnergyManagementInfo, formatEnergy, formatPower } from "../src/util/device-energy-management.js";
+
+/**
+ * ForecastStruct is field-tag keyed: "0" ForecastId, "1" ActiveSlotNumber, "2" StartTime, "3" EndTime,
+ * "4" EarliestStartTime, "5" LatestEndTime, "6" IsPausable, "7" Slots, "8" ForecastUpdateReason.
+ * SlotStruct: "0"–"2" min/max/default duration, "3" ElapsedSlotTime, "4" RemainingSlotTime,
+ * "5" SlotIsPausable, "8" ManufacturerESAState, "9"–"11" nominal/min/max power (mW),
+ * "12" NominalEnergy (mWh), "13" Costs, "14"–"17" adjustment limits.
+ */
+const FORECAST_START = 800_000_000;
+
+const DISHWASHER_ATTRS: Record<string, unknown> = {
+    "1/152/0": 9, // Dishwasher
+    "1/152/1": false,
+    "1/152/2": 1, // Online
+    "1/152/3": 0,
+    "1/152/4": 2_000_000n,
+    "1/152/6": {
+        "0": 12,
+        "1": 1,
+        "2": FORECAST_START,
+        "3": FORECAST_START + 4980,
+        "6": true,
+        "7": [
+            { "0": 300, "1": 400, "2": 360, "3": 360, "4": 0, "8": 1, "9": 180_000n, "12": 18_000n },
+            { "0": 2000, "1": 3000, "2": 2400, "3": 1320, "4": 1080, "5": true, "8": 2, "9": 1_900_000n },
+            { "0": 600, "2": 720, "3": 0, "4": 0, "8": 3, "9": 150_000n, "12": 30_000n },
+            { "0": 1200, "2": 1500, "3": 0, "4": 0, "8": 4, "9": 900_000n, "12": 400_000n },
+        ],
+        "8": 1, // Local optimization
+    },
+    "1/152/7": 0,
+    "1/152/65532": 0b0001_1110, // PFR | SFR | STA | PAU
+};
+
+const SOLAR_ATTRS: Record<string, unknown> = {
+    "1/152/0": 6, // Solar PV
+    "1/152/1": true,
+    "1/152/2": 1,
+    "1/152/6": {
+        "0": 7,
+        "1": 0,
+        "2": FORECAST_START,
+        "3": FORECAST_START + 7200,
+        "7": [
+            { "2": 3600, "3": 600, "4": 3000, "9": -2_500_000n, "10": -3_000_000n, "11": -1_000_000n },
+            {
+                "2": 3600,
+                "9": -1_200_000n,
+                "12": -1_200_000n,
+                "13": [{ "0": 0, "1": 1579, "2": 4, "3": 978 }],
+            },
+        ],
+        "8": 0,
+    },
+    "1/152/65532": 0b0000_0010, // PFR
+};
+
+const EVSE_ATTRS: Record<string, unknown> = {
+    "1/152/0": 0, // EV Supply Equipment
+    "1/152/1": false,
+    "1/152/2": 1,
+    "1/152/3": 1_400_000n,
+    "1/152/4": 7_400_000n,
+    "1/152/6": {
+        "0": 3,
+        "1": null,
+        "2": FORECAST_START + 3600,
+        "3": FORECAST_START + 14_400,
+        "4": FORECAST_START,
+        "5": FORECAST_START + 28_800,
+        "6": true,
+        "7": [
+            {
+                "0": 3600,
+                "1": 14_400,
+                "2": 10_800,
+                "3": 0,
+                "4": 0,
+                "5": true,
+                "9": 7_400_000n,
+                "12": 22_200_000n,
+                "14": 1_400_000n,
+                "15": 7_400_000n,
+                "16": 1800,
+                "17": 21_600,
+            },
+        ],
+        "8": 2, // Grid optimization
+    },
+    "1/152/7": 1,
+    "1/152/65532": 0b0010_1011, // PA | PFR | STA | FA
+};
+
+describe("device energy management util", () => {
+    it("reports unsupported when the cluster is absent", () => {
+        const info = deviceEnergyManagementInfo({ "1/40/5": "label" }, 1);
+        expect(info.supported).to.equal(false);
+        expect(info.forecast).to.equal(undefined);
+        expect(info.features.powerForecastReporting).to.equal(false);
+    });
+
+    it("decodes the ESA context attributes", () => {
+        const info = deviceEnergyManagementInfo(DISHWASHER_ATTRS, 1);
+        expect(info.supported).to.equal(true);
+        expect(info.esaType).to.equal("Dishwasher");
+        expect(info.esaState).to.equal("Online");
+        expect(info.canGenerate).to.equal(false);
+        expect(info.absMaxPowerW).to.equal(2000);
+        expect(info.optOutState).to.equal("No opt-out");
+    });
+
+    it("decodes the FeatureMap bits", () => {
+        const info = deviceEnergyManagementInfo(DISHWASHER_ATTRS, 1);
+        expect(info.features.powerForecastReporting).to.equal(true);
+        expect(info.features.stateForecastReporting).to.equal(true);
+        expect(info.features.startTimeAdjustment).to.equal(true);
+        expect(info.features.pausable).to.equal(true);
+        expect(info.features.powerAdjustment).to.equal(false);
+        expect(info.features.constraintBasedAdjustment).to.equal(false);
+    });
+
+    it("marks each slot completed, active or scheduled around ActiveSlotNumber", () => {
+        const slots = deviceEnergyManagementInfo(DISHWASHER_ATTRS, 1).forecast!.slots;
+        expect(slots.map(slot => slot.status)).to.deep.equal(["completed", "active", "scheduled", "scheduled"]);
+        expect(slots.map(slot => slot.manufacturerEsaState)).to.deep.equal([1, 2, 3, 4]);
+    });
+
+    it("converts each slot's power to W and its energy to Wh", () => {
+        const slots = deviceEnergyManagementInfo(DISHWASHER_ATTRS, 1).forecast!.slots;
+        expect(slots.map(slot => slot.nominalPowerW)).to.deep.equal([180, 1900, 150, 900]);
+        expect(slots[0].energyWh).to.equal(18);
+        expect(slots[0].energyEstimated).to.equal(false);
+        expect(slots[2].energyWh).to.equal(30);
+        expect(slots[3].energyWh).to.equal(400);
+    });
+
+    it("derives a slot's energy from its nominal power when NominalEnergy is absent", () => {
+        const activeSlot = deviceEnergyManagementInfo(DISHWASHER_ATTRS, 1).forecast!.slots[1];
+        expect(activeSlot.durationSeconds).to.equal(2400);
+        expect(activeSlot.energyWh).to.be.closeTo(1266.67, 0.01);
+        expect(activeSlot.energyEstimated).to.equal(true);
+    });
+
+    it("times the running slot by its own clock and the others by their default duration", () => {
+        const slots = deviceEnergyManagementInfo(DISHWASHER_ATTRS, 1).forecast!.slots;
+        expect(slots.map(slot => slot.durationSeconds)).to.deep.equal([360, 2400, 720, 1500]);
+        expect(slots[1].elapsedSeconds).to.equal(1320);
+        expect(slots[1].remainingSeconds).to.equal(1080);
+    });
+
+    it("lays the slots on the clock starting from Forecast.StartTime", () => {
+        const slots = deviceEnergyManagementInfo(DISHWASHER_ATTRS, 1).forecast!.slots;
+        expect(slots.map(slot => slot.startTime)).to.deep.equal([
+            FORECAST_START,
+            FORECAST_START + 360,
+            FORECAST_START + 2760,
+            FORECAST_START + 3480,
+        ]);
+        expect(slots[3].endTime).to.equal(FORECAST_START + 4980);
+    });
+
+    it("stops timing slots once a duration is unknown rather than guessing", () => {
+        const forecast = {
+            "2": FORECAST_START,
+            "7": [{ "2": 600 }, { "8": 1 }, { "2": 600 }],
+        };
+        const slots = deviceEnergyManagementInfo({ ...DISHWASHER_ATTRS, "1/152/6": forecast }, 1).forecast!.slots;
+        expect(slots[1].startTime).to.equal(FORECAST_START + 600);
+        expect(slots[1].endTime).to.equal(undefined);
+        expect(slots[2].startTime).to.equal(undefined);
+    });
+
+    it("totals the forecast's consumption over its slots", () => {
+        const forecast = deviceEnergyManagementInfo(DISHWASHER_ATTRS, 1).forecast!;
+        expect(forecast.consumedEnergyWh).to.be.closeTo(1714.67, 0.01);
+        expect(forecast.generatedEnergyWh).to.equal(0);
+        expect(forecast.energyEstimated).to.equal(true);
+        expect(forecast.durationSeconds).to.equal(4980);
+        expect(forecast.updateReason).to.equal("Local optimization");
+        expect(forecast.isPausable).to.equal(true);
+    });
+
+    it("counts a solar forecast's negative power as generation", () => {
+        const forecast = deviceEnergyManagementInfo(SOLAR_ATTRS, 1).forecast!;
+        expect(forecast.slots[0].nominalPowerW).to.equal(-2500);
+        expect(forecast.slots[0].minPowerW).to.equal(-3000);
+        expect(forecast.slots[0].maxPowerW).to.equal(-1000);
+        expect(forecast.slots[0].energyWh).to.equal(-2500);
+        expect(forecast.slots[1].energyWh).to.equal(-1200);
+        expect(forecast.generatedEnergyWh).to.equal(3700);
+        expect(forecast.consumedEnergyWh).to.equal(0);
+        expect(deviceEnergyManagementInfo(SOLAR_ATTRS, 1).canGenerate).to.equal(true);
+    });
+
+    it("scales a slot cost by its decimal points and names its currency", () => {
+        const costs = deviceEnergyManagementInfo(SOLAR_ATTRS, 1).forecast!.slots[1].costs;
+        expect(costs).to.deep.equal([{ type: "Financial", amount: "0.1579 €" }]);
+    });
+
+    it("scales a currency-less cost without labelling it as money", () => {
+        const forecast = { "2": FORECAST_START, "7": [{ "2": 3600, "13": [{ "0": 1, "1": 2500, "2": 2 }] }] };
+        const costs = deviceEnergyManagementInfo({ ...SOLAR_ATTRS, "1/152/6": forecast }, 1).forecast!.slots[0].costs;
+        expect(costs).to.deep.equal([{ type: "GHG emissions", amount: "25.00" }]);
+    });
+
+    it("drops a cost whose decimal points no scale can render", () => {
+        const forecast = { "2": FORECAST_START, "7": [{ "2": 3600, "13": [{ "0": 0, "1": 100, "2": 200 }] }] };
+        const costs = deviceEnergyManagementInfo({ ...SOLAR_ATTRS, "1/152/6": forecast }, 1).forecast!.slots[0].costs;
+        expect(costs).to.deep.equal([{ type: "Financial", amount: undefined }]);
+    });
+
+    it("decodes an EVSE charging session with its shiftable window", () => {
+        const info = deviceEnergyManagementInfo(EVSE_ATTRS, 1);
+        const forecast = info.forecast!;
+        expect(info.esaType).to.equal("EV Supply Equipment");
+        expect(info.optOutState).to.equal("Local opt-out");
+        expect(forecast.startTime).to.equal(FORECAST_START + 3600);
+        expect(forecast.earliestStartTime).to.equal(FORECAST_START);
+        expect(forecast.latestEndTime).to.equal(FORECAST_START + 28_800);
+        expect(forecast.updateReason).to.equal("Grid optimization");
+        expect(forecast.consumedEnergyWh).to.equal(22_200);
+    });
+
+    it("leaves every slot scheduled when the device reports no active slot", () => {
+        const slots = deviceEnergyManagementInfo(EVSE_ATTRS, 1).forecast!.slots;
+        expect(deviceEnergyManagementInfo(EVSE_ATTRS, 1).forecast!.activeSlotNumber).to.equal(undefined);
+        expect(slots.map(slot => slot.status)).to.deep.equal(["scheduled"]);
+    });
+
+    it("decodes the adjustment limits an EVSE offers", () => {
+        const slot = deviceEnergyManagementInfo(EVSE_ATTRS, 1).forecast!.slots[0];
+        expect(slot.pausable).to.equal(true);
+        expect(slot.minPowerAdjustmentW).to.equal(1400);
+        expect(slot.maxPowerAdjustmentW).to.equal(7400);
+        expect(slot.minDurationAdjustmentSeconds).to.equal(1800);
+        expect(slot.maxDurationAdjustmentSeconds).to.equal(21_600);
+    });
+
+    it("treats a null forecast as no forecast", () => {
+        expect(deviceEnergyManagementInfo({ ...DISHWASHER_ATTRS, "1/152/6": null }, 1).forecast).to.equal(undefined);
+    });
+
+    it("names an ESA type the spec revision does not define", () => {
+        expect(deviceEnergyManagementInfo({ ...DISHWASHER_ATTRS, "1/152/0": 42 }, 1).esaType).to.equal("Unknown (42)");
+    });
+
+    it("reads the number form of power fields, which small values take on the wire", () => {
+        const forecast = { "2": FORECAST_START, "7": [{ "2": 3600, "9": 750_000, "12": 750_000 }] };
+        const slot = deviceEnergyManagementInfo({ ...DISHWASHER_ATTRS, "1/152/6": forecast }, 1).forecast!.slots[0];
+        expect(slot.nominalPowerW).to.equal(750);
+        expect(slot.energyWh).to.equal(750);
+        expect(slot.energyEstimated).to.equal(false);
+    });
+
+    it("formats power in W below 10 kW and energy in kWh above 1 kWh", () => {
+        expect(formatPower(180)).to.equal("180 W");
+        expect(formatPower(1900)).to.equal("1900 W");
+        expect(formatPower(12_500)).to.equal("12.50 kW");
+        expect(formatEnergy(18)).to.equal("18 Wh");
+        expect(formatEnergy(1266.67)).to.equal("1.27 kWh");
+    });
+});

--- a/packages/dashboard/test/DeviceEnergyManagementUtilTest.ts
+++ b/packages/dashboard/test/DeviceEnergyManagementUtilTest.ts
@@ -181,10 +181,37 @@ describe("device energy management util", () => {
         const forecast = deviceEnergyManagementInfo(DISHWASHER_ATTRS, 1).forecast!;
         expect(forecast.consumedEnergyWh).to.be.closeTo(1714.67, 0.01);
         expect(forecast.generatedEnergyWh).to.equal(0);
-        expect(forecast.energyEstimated).to.equal(true);
+        expect(forecast.consumedEnergyEstimated).to.equal(true);
+        expect(forecast.generatedEnergyEstimated).to.equal(false);
         expect(forecast.durationSeconds).to.equal(4980);
         expect(forecast.updateReason).to.equal("Local optimization");
         expect(forecast.isPausable).to.equal(true);
+    });
+
+    it("tracks the estimated flag per direction on a mixed forecast", () => {
+        const forecast = {
+            "2": FORECAST_START,
+            // Slot 0 consumes and reports NominalEnergy; slot 1 generates and only reports NominalPower.
+            "7": [
+                { "2": 3600, "9": 1000, "12": 1000 },
+                { "2": 3600, "9": -2000 },
+            ],
+        };
+        const info = deviceEnergyManagementInfo({ ...DISHWASHER_ATTRS, "1/152/6": forecast }, 1).forecast!;
+        expect(info.consumedEnergyEstimated).to.equal(false);
+        expect(info.generatedEnergyEstimated).to.equal(true);
+    });
+
+    it("times the running slot by its own clock even when the device drifts from its plan", () => {
+        const forecast = {
+            "1": 0,
+            "2": FORECAST_START,
+            // DefaultDuration says 600 s, but the device reports 900 s elapsed plus 300 s left.
+            "7": [{ "2": 600, "3": 900, "4": 300 }, { "2": 600 }],
+        };
+        const slots = deviceEnergyManagementInfo({ ...DISHWASHER_ATTRS, "1/152/6": forecast }, 1).forecast!.slots;
+        expect(slots[0].durationSeconds).to.equal(1200);
+        expect(slots[1].startTime).to.equal(FORECAST_START + 1200);
     });
 
     it("counts a solar forecast's negative power as generation", () => {


### PR DESCRIPTION
## Type of change

- [ ] 🐛 **Fix** — corrects a defect or wrong behavior
- [x] ✨ **Feature** — adds new functionality or capability

## Description

Adds a read-only Dashboard panel decoding the DeviceEnergyManagement cluster's (0x98) `Forecast` attribute — the piece that publishes what an energy smart appliance is about to draw or generate, slot by slot.

Each slot in `ForecastStruct.Slots` resolves to a row with its status (completed / active / scheduled, relative to `ActiveSlotNumber`), power, duration and energy:

- Slots carry durations, not instants, so clock times are accumulated from `Forecast.StartTime` across preceding slots. A slot with no usable duration stops the chain instead of guessing the ones after it.
- The active slot is timed by its own `ElapsedSlotTime`/`RemainingSlotTime` (the only figure that tracks a device drifting from its plan); every other slot falls back to `DefaultDuration`.
- Energy uses `NominalEnergy` when the device reports it, otherwise derives it from `NominalPower × duration` and flags the result as estimated.
- Negative power is generation (PV, batteries discharging): totals split into `consumedEnergyWh` / `generatedEnergyWh` rather than netting them together.
- `StartTimeAdjustment`'s earliest/latest bounds and each slot's power/duration adjustment limits are surfaced for shiftable loads (EVSE charging windows, etc.).
- Slot `CostStruct` entries reuse CommodityTariff's currency-scaling logic (now exposed as `currencyInfo()`) to render a priced amount.

Covers the three use cases this was built for: 
 * a dishwasher's SFR-based state forecast, 
 * a solar PV device's PFR-based generation forecast,
 * an EVSE's shiftable charging session with adjustment limits.

Known limitation: 
* `ManufacturerESAState` (used under SFR) is an opaque per-vendor integer
* The panel shows it as a chip (`state N`) rather than a name, since naming it would need a vendor/product-specific mapping.

## Backing evidence

N/A — this is a feature addition, not a fix; no defect is being corrected.

- Related issue: #
- [ ] This fix/change is backed by a **complete log file** — attached here or in the linked issue (not just a few quoted lines).

## Checklist

- [x] I understand the code I am submitting and can explain how it works ([AI policy](https://github.com/matter-js/matterjs-server/blob/main/AI_POLICY.md))
- [x] Tests added or updated to cover the change
- [x] `npm test` passes
- [x] `npm run format-verify` and `npm run lint` pass
- [x] CHANGELOG updated (if applicable)

