### PR TITLE
fix(ble-proxy): detect proxy clients that vanish without closing the socket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This page shows a detailed overview of the changes between versions without the 
 
 - Enhancement: (lboue) Added a command panel for the DoorLock cluster to Dashboard
 - Enhancement: (lboue) Added Presets and Thermostat Suggestions (Thermostat cluster PRES/TSUGGEST features) panels to Dashboard
+- Fix: BLE proxy connections are pinged every 15 seconds and terminated after 45 to 60 seconds of silence, so a proxy client that loses power is detected instead of staying registered indefinitely
 
 ## 1.4.0 (2026-08-07)
 

--- a/docs/ble-proxy-protocol.md
+++ b/docs/ble-proxy-protocol.md
@@ -31,7 +31,7 @@ BLE proxies) to a Matter.js server for BLE-based device commissioning.
 
 ## Connection Lifecycle
 
-1. The server exposes the `/ble` WebSocket endpoint accepting a single client connection
+1. The server exposes the `/ble` WebSocket endpoint
 2. The client connects as soon as BLE is available, latest when BLE operations are needed (e.g., at commissioning time)
 3. The client sends a `hello` handshake message (see below)
 4. The server responds with `hello_response` confirming the protocol version
@@ -39,8 +39,23 @@ BLE proxies) to a Matter.js server for BLE-based device commissioning.
 6. Either side may close the WebSocket when BLE operations are complete
 7. The client should clean up all active BLE connections when the WebSocket closes
 
-Only one client connection is allowed at a time. If a second client attempts to connect while
-one is already active, the server rejects the new connection.
+Any number of clients may be connected at the same time. The server broadcasts scan commands to
+all of them and routes per-peripheral traffic to the one client that owns the peripheral, which is
+the first client that reported it via `device_discovered`. When the last client that reported a
+peripheral disconnects, ownership of that peripheral is released, and a connect attempt on it
+fails until a connected client reports it again.
+
+### Liveness
+
+After the handshake the server sends a WebSocket ping every 15 seconds. A client must answer with
+a pong — every compliant WebSocket implementation does this automatically. When neither a pong nor
+a protocol message has arrived for more than 45 seconds, the server terminates the connection and
+runs the normal disconnect cleanup. The check runs on the same 15-second schedule as the ping, so
+a dead client is dropped between 45 and 60 seconds after its last sign of life.
+
+This is what detects a client that lost power: such a client sends neither a close frame nor a
+TCP FIN, and the server enables no TCP keepalive, so without the ping the socket stays open
+indefinitely and its peripherals stay routed to a client that can no longer answer.
 
 ### Handshake
 

--- a/packages/ble-proxy/src/BleProxyConnection.ts
+++ b/packages/ble-proxy/src/BleProxyConnection.ts
@@ -4,7 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { createPromise, Logger, Observable, Seconds, Time, withTimeout } from "@matter/main";
+import {
+    createPromise,
+    Duration,
+    Logger,
+    Millis,
+    Observable,
+    Seconds,
+    Time,
+    type Timer,
+    withTimeout,
+} from "@matter/main";
 import { Mark } from "@matter/main/protocol";
 import { WebSocket } from "ws";
 import {
@@ -52,6 +62,10 @@ const HANDSHAKE_TIMEOUT = Seconds(10);
  */
 const COMMAND_TIMEOUT = Seconds(60);
 
+const PING_INTERVAL = Seconds(15);
+/** Evaluated on the ping schedule, so a dead client is detected between this and one extra {@link PING_INTERVAL}. */
+const LIVENESS_TIMEOUT = Seconds(45);
+
 /**
  * One BLE proxy client socket. Owns that client's handshake state, pending
  * command map, and command/event/binary-frame plumbing. The hub
@@ -62,12 +76,16 @@ export class BleProxyConnection {
     readonly #id = generateConnectionId();
     #handshakeComplete = false;
     #closedEmitted = false;
+    /** Cleanup is terminal: a torn-down connection must never handshake again on a late `hello`. */
+    #destroyed = false;
     #pendingCommands = new Map<
         number,
         { resolver: (result: Record<string, unknown> | undefined) => void; rejecter: (reason?: unknown) => void }
     >();
     /** Command ID counter. Rolls over at 0xFFFF to stay in safe integer range. */
     #nextCommandId = 0;
+    #lastSeen = Time.nowUs;
+    #livenessTimer?: Timer;
 
     readonly binaryFrameReceived = new Observable<[frame: BinaryFrame]>();
     readonly eventReceived = new Observable<[event: BleProxyEventName, data: Record<string, unknown>]>();
@@ -88,7 +106,12 @@ export class BleProxyConnection {
             }
         }).start();
 
+        ws.on("pong", () => {
+            this.#lastSeen = Time.nowUs;
+        });
+
         ws.on("message", (data, isBinary) => {
+            this.#lastSeen = Time.nowUs;
             if (isBinary) {
                 this.#handleBinaryMessage(data as Buffer);
             } else {
@@ -163,6 +186,10 @@ export class BleProxyConnection {
     }
 
     #handleTextMessage(raw: string, handshakeTimer: { stop: () => void }): void {
+        if (this.#destroyed) {
+            return;
+        }
+
         let parsed: unknown;
         try {
             parsed = JSON.parse(raw);
@@ -221,6 +248,7 @@ export class BleProxyConnection {
         }
 
         this.#handshakeComplete = true;
+        this.#startLivenessCheck();
         this.#ws.send(JSON.stringify({ type: "hello_response", version: BLE_PROXY_PROTOCOL_VERSION }));
         logger.info(`[${this.#id}] BLE proxy handshake complete (version ${BLE_PROXY_PROTOCOL_VERSION})`);
         this.handshakeCompleted.emit();
@@ -242,6 +270,10 @@ export class BleProxyConnection {
     }
 
     #handleBinaryMessage(data: Buffer): void {
+        if (this.#destroyed) {
+            return;
+        }
+
         if (!this.#handshakeComplete) {
             logger.warn(`[${this.#id}] Received binary frame before handshake`);
             return;
@@ -266,8 +298,27 @@ export class BleProxyConnection {
         this.#cleanup();
     }
 
+    #startLivenessCheck(): void {
+        this.#lastSeen = Time.nowUs;
+        this.#livenessTimer = Time.getPeriodicTimer("BLE proxy liveness check", PING_INTERVAL, () => {
+            const silence = Millis(Time.nowUs - this.#lastSeen);
+            if (silence > LIVENESS_TIMEOUT) {
+                logger.warn(
+                    `[${this.#id}] No response for ${Duration.format(silence)} - terminating dead BLE proxy connection`,
+                );
+                this.#ws.terminate();
+                this.#cleanup();
+                return;
+            }
+            this.#ws.ping();
+        }).start();
+    }
+
     #cleanup(): void {
+        this.#destroyed = true;
         this.#handshakeComplete = false;
+        this.#livenessTimer?.stop();
+        this.#livenessTimer = undefined;
 
         for (const [id, pending] of this.#pendingCommands) {
             pending.rejecter(new Error("BLE proxy client disconnected"));

--- a/packages/ble-proxy/test/BleProxyConnectionTest.ts
+++ b/packages/ble-proxy/test/BleProxyConnectionTest.ts
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Seconds } from "@matter/main";
 import { createServer } from "node:http";
-import { WebSocketServer } from "ws";
+import { WebSocket, WebSocketServer } from "ws";
 import { BleProxyConnection } from "../src/BleProxyConnection.js";
-import { BinaryFrameOpcode, BleProxyCommand } from "../src/BleProxyProtocol.js";
+import { BLE_PROXY_PROTOCOL_VERSION, BinaryFrameOpcode, BleProxyCommand } from "../src/BleProxyProtocol.js";
 import { BleProxyTestClient } from "./BleProxyTestClient.js";
 
 const TEST_PORT = 15581;
@@ -103,6 +104,56 @@ describe("BleProxyConnection", function () {
         expect(got.opcode).to.equal(BinaryFrameOpcode.Notification);
         expect(got.connectionHandle).to.equal(5);
         expect(Array.from(got.payload)).to.deep.equal([1, 2, 3]);
+    });
+
+    it("stays torn down when a hello arrives after the handshake timeout fired", async () => {
+        const latePort = TEST_PORT + 1;
+        const lateHttpServer = createServer();
+        const lateWss = new WebSocketServer({ server: lateHttpServer });
+
+        let lateConnection: BleProxyConnection | undefined;
+        let handshakes = 0;
+        const accepted = new Promise<void>(resolve => {
+            lateWss.on("connection", ws => {
+                lateConnection = new BleProxyConnection(ws);
+                lateConnection.handshakeCompleted.on(() => {
+                    handshakes++;
+                });
+                resolve();
+            });
+        });
+
+        await new Promise<void>((resolve, reject) => {
+            lateHttpServer.listen(latePort, () => resolve());
+            lateHttpServer.on("error", reject);
+        });
+
+        // The handshake timer is created when the connection is accepted, so the mocked clock has
+        // to be in place before that happens.
+        MockTime.enable();
+        const lateClient = new WebSocket(`ws://localhost:${latePort}/ble`);
+        try {
+            await new Promise<void>(resolve => lateClient.on("open", () => resolve()));
+            await accepted;
+            // The client reads nothing, so the server's close frame cannot end the socket and the
+            // late hello still reaches a connection the server already tore down.
+            lateClient.pause();
+
+            await MockTime.advance(Seconds(11));
+
+            lateClient.send(JSON.stringify({ type: "hello", version: BLE_PROXY_PROTOCOL_VERSION }));
+            await new Promise<void>(resolve => setTimeout(resolve, 50));
+
+            expect(handshakes).to.equal(0);
+            expect(lateConnection?.connected).to.be.false;
+        } finally {
+            MockTime.disable();
+            lateClient.terminate();
+            await new Promise<void>(resolve => lateWss.close(() => resolve()));
+            await new Promise<void>((resolve, reject) => {
+                lateHttpServer.close(err => (err ? reject(err) : resolve()));
+            });
+        }
     });
 
     it("emits closed and rejects pending commands when the socket closes", async () => {

--- a/packages/ble-proxy/test/BleProxyIntegrationTest.ts
+++ b/packages/ble-proxy/test/BleProxyIntegrationTest.ts
@@ -9,7 +9,7 @@
  * Tests the full flow: BleProxyHandler <-> BleProxyTestClient with mock data.
  */
 
-import { Seconds } from "@matter/main";
+import { InternalError, Seconds } from "@matter/main";
 import { createServer } from "node:http";
 import { BleProxyHandler } from "../src/BleProxyHandler.js";
 import { BinaryFrameOpcode, BleProxyCommand } from "../src/BleProxyProtocol.js";
@@ -19,6 +19,17 @@ import { BleProxyTestClient } from "./BleProxyTestClient.js";
 import { MockBleDevice } from "./MockBleDevice.js";
 
 const TEST_PORT = 15580;
+
+/** Polls a condition against real IO, which the WebSocket round-trips in these tests run on. */
+async function waitFor(condition: () => boolean, timeoutMs = 2000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (!condition()) {
+        if (Date.now() > deadline) {
+            throw new InternalError("Timeout waiting for condition");
+        }
+        await new Promise<void>(resolve => setTimeout(resolve, 10));
+    }
+}
 const TEST_BLE_URL = `ws://localhost:${TEST_PORT}/ble`;
 
 describe("BLE Proxy Integration", function () {
@@ -53,6 +64,62 @@ describe("BLE Proxy Integration", function () {
     describe("handshake", () => {
         it("should complete handshake and report connected", () => {
             expect(handler.connected).to.be.true;
+        });
+    });
+
+    describe("liveness", () => {
+        /**
+         * The liveness timer is created during the handshake, so MockTime must already be enabled
+         * when the connection is accepted — otherwise the timer binds to the real clock and
+         * `MockTime.advance` never drives it. The connection from `beforeEach` is dropped first so
+         * `handler.connected`, an OR across all connections, speaks about this connection alone.
+         */
+        const connectAloneUnderMockTime = async (): Promise<BleProxyTestClient> => {
+            testClient.close();
+            await waitFor(() => !handler.connected);
+            MockTime.enable();
+            const client = new BleProxyTestClient();
+            await client.connect(TEST_BLE_URL);
+            return client;
+        };
+
+        /**
+         * `MockTime.advance` never yields to the event loop's poll phase, so an incoming pong can
+         * only be read between two advances. Both liveness tests therefore push the mocked clock
+         * across the timeout in two hops with a real-IO hop in between; without it neither test can
+         * tell a client that answers from one that does not.
+         */
+        const advancePastLivenessTimeout = async (client: BleProxyTestClient): Promise<void> => {
+            const ping = client.waitForPing().catch(() => {});
+            await MockTime.advance(Seconds(40));
+            await ping;
+            await new Promise<void>(resolve => setTimeout(resolve, 50));
+            await MockTime.advance(Seconds(40));
+        };
+
+        it("terminates a connection whose client stopped answering", async () => {
+            const deadClient = await connectAloneUnderMockTime();
+            try {
+                deadClient.simulateHalfOpen();
+                await advancePastLivenessTimeout(deadClient);
+
+                expect(handler.connected).to.be.false;
+            } finally {
+                MockTime.disable();
+                deadClient.close();
+            }
+        });
+
+        it("keeps a connection alive while its client answers pings", async () => {
+            const liveClient = await connectAloneUnderMockTime();
+            try {
+                await advancePastLivenessTimeout(liveClient);
+
+                expect(handler.connected).to.be.true;
+            } finally {
+                MockTime.disable();
+                liveClient.close();
+            }
         });
     });
 

--- a/packages/ble-proxy/test/BleProxyTestClient.ts
+++ b/packages/ble-proxy/test/BleProxyTestClient.ts
@@ -10,6 +10,7 @@
  * registering command handlers and sending events/binary frames.
  */
 
+import { InternalError } from "@matter/main";
 import { WebSocket } from "ws";
 import {
     BLE_PROXY_PROTOCOL_VERSION,
@@ -112,6 +113,33 @@ export class BleProxyTestClient {
 
     close(): void {
         this.#ws?.close();
+    }
+
+    /** Resolves once the server's ping has been received and answered by the `ws` auto-pong. */
+    async waitForPing(timeoutMs = 1000): Promise<void> {
+        const ws = this.#ws;
+        if (ws === undefined) {
+            throw new InternalError("Not connected");
+        }
+        await new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                ws.off("ping", onPing);
+                reject(new InternalError("Timeout waiting for ping"));
+            }, timeoutMs);
+            const onPing = () => {
+                clearTimeout(timer);
+                resolve();
+            };
+            ws.once("ping", onPing);
+        });
+    }
+
+    /**
+     * Simulate an abruptly powered-off proxy: the socket stays open from the server's point of
+     * view but the client processes nothing, so no automatic pong answers the server's pings.
+     */
+    simulateHalfOpen(): void {
+        this.#ws?.pause();
     }
 
     async #dispatchCommand(msg: CommandMessage): Promise<void> {


### PR DESCRIPTION
## What

A BLE proxy client that loses power sends neither a WebSocket close frame nor a TCP FIN, and the server configures no TCP keepalive, so its connection stayed `OPEN` indefinitely. The peripherals it had reported stayed owned by it, and the loss was first noticed when a later BLE command happened to hit the dead socket — in the reported log, three stale connections surfaced only when `start_scan` was sent, minutes after the clients were gone.

`BleProxyConnection` now pings each handshaked connection every 15 seconds and terminates it once neither a pong nor a protocol message has arrived for more than 45 seconds. The check runs on the ping schedule, so detection takes 45 to 60 seconds; termination runs the existing disconnect cleanup, which releases peripheral ownership and rejects pending commands.

While testing that path, a second defect surfaced and is fixed here too: `#cleanup()` was not terminal. A `hello` still in flight when the handshake timer fired was processed afterwards, re-setting `#handshakeComplete`, arming a fresh liveness timer and emitting `handshakeCompleted` on a connection the hub had already removed — while `closed` stayed latched, so its entries in the ownership map could never be released. A `#destroyed` guard closes it.

Addresses #1049

Related to #1048: releasing ownership promptly is a precondition for that issue, but not a fix for it. The cache that decides whether a peripheral is offered for commissioning lives in matter.js, and the change that lets a transport say a peripheral is unreachable is proposed upstream separately.

## Protocol impact

Clients must answer WebSocket pings. Every compliant WebSocket implementation does this automatically at protocol level, independent of application message handling; the example client and the reference clients in this repo need no change. `docs/ble-proxy-protocol.md` gains a Liveness section stating the requirement.

The same doc's Connection Lifecycle section still claimed only one client connection was allowed at a time, which multi-client support (#708) made false. Corrected here.

## Tests

Three added, each mutation-checked:

- a client that stops answering is terminated — removing `simulateHalfOpen()` makes it fail
- a client that answers stays connected — removing the `pong` handler makes it fail
- a `hello` arriving after the handshake timeout does not re-establish the connection — removing the `#destroyed` guard makes it fail with `expected 1 to equal +0`

Both liveness tests cross the timeout in two `MockTime` hops with a real ping/pong round trip in between, because `MockTime.advance` never yields to the event loop's poll phase; without that hop neither test can tell a client that answers from one that does not.

## Verification

```
$ npm run build          # clean
$ npm run format-verify  # All matched files use the correct format. (260 files)
$ npm run lint           # clean (oxlint --type-aware)
$ PRIMARY_INTERFACE=en0 MATTER_MDNS_NETWORKINTERFACE=en0 npm test
  ✓ ESM 277/277
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
